### PR TITLE
fix: resolve critical booking algorithm bugs (5 fixes)

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -33,6 +33,7 @@ import {
   RequestedBy,
   SubscriptionApiResponse,
 } from "./types";
+import { countSundayWeeksInclusive } from "../shared/utils/calendarUtils";
 
 // --- API Response Type Definitions ---
 // interface UserInfo { ... } // Removed
@@ -220,11 +221,29 @@ export function RequestSlotAllocationTab({
                     appt.slotsOfAppointment?.map((slot) => slot.startsAt) || [],
                 ) || [],
               status: subscription.requestStatus,
-              requiredSlots:
-                (subscription.subscriptionPlan?.callsPerWeek ?? 0) *
-                  4 *
-                  (subscription.subscriptionPlan?.durationInMonths ?? 0) *
-                  slotsPerSession || 0,
+              // FIXED: Use accurate week counting instead of hardcoded * 4
+              requiredSlots: (() => {
+                const startDate = subscription.schedulingPeriodStartsAt
+                  ? new Date(subscription.schedulingPeriodStartsAt)
+                  : undefined;
+                const endDate = subscription.schedulingPeriodEndsAt
+                  ? new Date(subscription.schedulingPeriodEndsAt)
+                  : undefined;
+                const callsPerWeek =
+                  subscription.subscriptionPlan?.callsPerWeek ?? 0;
+
+                if (startDate && endDate) {
+                  const weeks = countSundayWeeksInclusive(startDate, endDate);
+                  return weeks * callsPerWeek * slotsPerSession;
+                }
+                // Fallback to month-based calculation if dates not set
+                return (
+                  callsPerWeek *
+                    4 *
+                    (subscription.subscriptionPlan?.durationInMonths ?? 0) *
+                    slotsPerSession || 0
+                );
+              })(),
               durationInMonths: subscription.subscriptionPlan?.durationInMonths,
               callsPerWeek: subscription.subscriptionPlan?.callsPerWeek,
               sessionDurationInHours: sessionDuration,

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -817,7 +817,7 @@ function validateClassSessionDistributionByCount(
     slotsByDate.get(key)!.push(slot);
   }
   // FIXED: Use for...of instead of forEach so return works correctly
-  for (const [, daySlots] of slotsByDate) {
+  for (const [, daySlots] of Array.from(slotsByDate)) {
     const { sessions } = countSessionsForDay(daySlots, slotsPerSession);
     if (sessions > maxSessions) return false;
   }
@@ -846,9 +846,9 @@ function validateWeeklySessionsDistribution(
     byDay.get(dayKey)!.push(slot);
   }
   // FIXED: Use for...of instead of forEach so return works correctly
-  for (const [, byDay] of weeks) {
+  for (const [, byDay] of Array.from(weeks)) {
     let weekSessions = 0;
-    for (const [, daySlots] of byDay) {
+    for (const [, daySlots] of Array.from(byDay)) {
       weekSessions += countSessionsForDay(daySlots, slotsPerSession).sessions;
     }
     if (weekSessions > callsPerWeek) return false;

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -816,10 +816,11 @@ function validateClassSessionDistributionByCount(
     if (!slotsByDate.has(key)) slotsByDate.set(key, []);
     slotsByDate.get(key)!.push(slot);
   }
-  slotsByDate.forEach((daySlots) => {
+  // FIXED: Use for...of instead of forEach so return works correctly
+  for (const [, daySlots] of slotsByDate) {
     const { sessions } = countSessionsForDay(daySlots, slotsPerSession);
     if (sessions > maxSessions) return false;
-  });
+  }
   return true;
 }
 
@@ -844,13 +845,14 @@ function validateWeeklySessionsDistribution(
     if (!byDay.has(dayKey)) byDay.set(dayKey, []);
     byDay.get(dayKey)!.push(slot);
   }
-  weeks.forEach((byDay) => {
+  // FIXED: Use for...of instead of forEach so return works correctly
+  for (const [, byDay] of weeks) {
     let weekSessions = 0;
-    byDay.forEach((daySlots) => {
+    for (const [, daySlots] of byDay) {
       weekSessions += countSessionsForDay(daySlots, slotsPerSession).sessions;
-    });
+    }
     if (weekSessions > callsPerWeek) return false;
-  });
+  }
   return true;
 }
 
@@ -1039,7 +1041,7 @@ function validateSubscriptionSlots(
   // Create array of weeks with confirmed calls
   const weekCalls = new Map<
     string,
-    { confirmed: boolean; totalSlots: number }
+    { completeCallsCount: number; totalSlots: number }
   >();
 
   // Process each day to determine confirmed calls
@@ -1047,7 +1049,7 @@ function validateSubscriptionSlots(
     const weekString = getWeekString(daySlots[0].startTime);
 
     if (!weekCalls.has(weekString)) {
-      weekCalls.set(weekString, { confirmed: false, totalSlots: 0 });
+      weekCalls.set(weekString, { completeCallsCount: 0, totalSlots: 0 });
     }
 
     const weekData = weekCalls.get(weekString)!;
@@ -1055,7 +1057,7 @@ function validateSubscriptionSlots(
 
     // A call is confirmed if it has the exact number of slots and they are consecutive
     if (isCompleteCall(daySlots, slotsPerCall)) {
-      weekData.confirmed = true;
+      weekData.completeCallsCount++;
     }
   });
 
@@ -1083,10 +1085,10 @@ function validateSubscriptionSlots(
     }
   });
 
-  // FIXED: Validate weekly calls using only complete calls
+  // FIXED: Validate weekly calls using actual count of complete calls
   weekCalls.forEach((weekData, weekString) => {
-    // Only count complete calls, not potential calls
-    const completeCalls = weekData.confirmed ? 1 : 0;
+    // Count all complete calls in this week (supports multiple calls per week)
+    const completeCalls = weekData.completeCallsCount;
     const partialSlots = weekData.totalSlots % slotsPerCall;
 
     // If there are partial slots, it means incomplete calls
@@ -1095,18 +1097,18 @@ function validateSubscriptionSlots(
       incompleteCallWarning = `Week of ${weekDate.toLocaleDateString()} has incomplete call. Need ${slotsPerCall - partialSlots} more consecutive slots.`;
     }
 
-    // Check if this week exceeds the call limit (only count complete calls)
+    // Check if this week exceeds the call limit (now correctly counts multiple calls)
     if (completeCalls > callsPerWeek) {
       const weekDate = new Date(weekString);
       weeklyCallsValid = false;
-      weeklyCallsError = `Week of ${weekDate.toLocaleDateString()} has too many complete calls. Maximum ${callsPerWeek} calls per week allowed.`;
+      weeklyCallsError = `Week of ${weekDate.toLocaleDateString()} has ${completeCalls} complete calls. Maximum ${callsPerWeek} calls per week allowed.`;
       return;
     }
   });
 
-  // FIXED: Validate total calls using only complete calls
+  // FIXED: Validate total calls using actual count across all weeks
   const totalConfirmedCalls = Array.from(weekCalls.values()).reduce(
-    (sum, week) => sum + (week.confirmed ? 1 : 0),
+    (sum, week) => sum + week.completeCallsCount,
     0,
   );
 

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -1,4 +1,8 @@
-import { TimeSlot, calculateRequiredSlots } from "./calendarUtils";
+import {
+  TimeSlot,
+  calculateRequiredSlots,
+  countSundayWeeksInclusive,
+} from "./calendarUtils";
 import { AllocationService } from "./allocationService";
 
 /**
@@ -453,13 +457,15 @@ export class AllocationAlgorithms {
 
     let selectedSlots: TimeSlot[] = []; // to store best found slots if exact consecutive not found fo better error handling
 
-    for (let i = 0; i <= sortedSlots.length - durationHours; i++) {
+    // FIXED: Use Math.ceil(durationHours) to handle non-integer durations (e.g., 1.5 hours)
+    const oneHourSlotsNeeded = Math.ceil(durationHours);
+    for (let i = 0; i <= sortedSlots.length - oneHourSlotsNeeded; i++) {
       const consecutiveSlots = [];
       const consecutive1HourSlots = []; // for storing original 1-hour slots to validate consecutiveness
       let isConsecutive = true;
 
-      // Check if we have enough consecutive slots starting from this position
-      for (let j = 0; j < durationHours; j++) {
+      // Check if we have enough consecutive 1-hour slots starting from this position
+      for (let j = 0; j < oneHourSlotsNeeded; j++) {
         const currentSlot = sortedSlots[i + j];
         if (!currentSlot) {
           isConsecutive = false;
@@ -610,7 +616,11 @@ export class AllocationAlgorithms {
 
     // Sort weeks by date
     const sortedWeeks = Array.from(slotsByWeek.keys()).sort();
-    const totalWeeks = sortedWeeks.length;
+    // FIXED: Calculate weeks based on subscription duration, not available slots
+    const totalWeeks = countSundayWeeksInclusive(
+      options.startDate,
+      options.endDate,
+    );
 
     // Allocate slots week by week with smart distribution
     let currentWeek = 0;


### PR DESCRIPTION
This commit fixes 5 critical and high-priority bugs in the booking algorithm:

Bug 1: Weekly call validation logic error (CRITICAL)
- Changed from boolean 'confirmed' to counter 'completeCallsCount'
- Now correctly counts multiple calls per week (e.g., 3 calls/week plans)
- Previously limited to 1 call/week maximum regardless of plan
- Location: useSlotAllocation.ts:1040-1110

Bug 2: Ineffective forEach validation returns (CRITICAL)
- Replaced forEach with for...of loops in validation functions
- Return statements now properly exit parent function
- Fixes max sessions per day and weekly session validations
- Location: useSlotAllocation.ts:819-856

Bug 3: Incorrect slot calculation display (HIGH)
- Uses accurate countSundayWeeksInclusive() instead of hardcoded * 4
- Correctly handles months with 5 weeks
- Matches backend validation logic
- Location: RequestSlotAllocationTab.tsx:224-246

Bug 4: Consultation loop boundary error (HIGH)
- Uses Math.ceil(durationHours) for correct loop bounds
- Fixes allocation for non-integer durations (1.5, 2.5 hours)
- Prevents out-of-bounds access and skipped valid slots
- Location: allocationAlgorithms.ts:456-464

Bug 5: Week count mismatch in recurring allocation (HIGH)
- Calculates weeks from subscription duration, not availability
- Handles consultant vacation gaps correctly
- Uses countSundayWeeksInclusive() for accuracy
- Location: allocationAlgorithms.ts:619-623

Impact:
- Multi-call subscriptions now work correctly
- Validation properly enforces session limits
- Accurate slot requirements displayed to users
- Consultation allocation handles all durations
- Recurring allocations respect full subscription period