### PR TITLE
fix: appointment grouping

### DIFF
--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -143,15 +143,27 @@ async function getAppointments(
 
   // Date range filtering for appointments. This is the primary filter.
   // It looks for appointments where any of its slots overlap with the given date range.
+  // Also includes appointments with no slots (they'll be shown but sorted to the end)
   if (startDate && endDate) {
-    whereClause.slotsOfAppointment = {
-      some: {
-        AND: [
-          { startsAt: { lt: new Date(endDate) } },
-          { endsAt: { gt: new Date(startDate) } },
-        ],
+    whereClause.OR = [
+      // Appointments with slots overlapping the date range
+      {
+        slotsOfAppointment: {
+          some: {
+            AND: [
+              { startsAt: { lt: new Date(endDate) } },
+              { endsAt: { gt: new Date(startDate) } },
+            ],
+          },
+        },
       },
-    };
+      // OR appointments with no slots at all
+      {
+        slotsOfAppointment: {
+          none: {},
+        },
+      },
+    ];
   }
 
   const userFilterClauses: Prisma.AppointmentWhereInput[] = [];
@@ -320,14 +332,18 @@ async function getAppointments(
   });
 
   // Sort appointments by slot start time
-  return appointments
-    .filter((appointment) => appointment.slotsOfAppointment?.length > 0)
-    .sort((a, b) => {
-      const aTime = a.slotsOfAppointment[0]?.startsAt;
-      const bTime = b.slotsOfAppointment[0]?.startsAt;
-      if (!aTime || !bTime) return 0;
-      return new Date(aTime).getTime() - new Date(bTime).getTime();
-    });
+  // Include appointments with 0 slots (push them to the end)
+  return appointments.sort((a, b) => {
+    const aTime = a.slotsOfAppointment?.[0]?.startsAt;
+    const bTime = b.slotsOfAppointment?.[0]?.startsAt;
+
+    // Appointments without slots go to the end
+    if (!aTime && !bTime) return 0;
+    if (!aTime) return 1;
+    if (!bTime) return -1;
+
+    return new Date(aTime).getTime() - new Date(bTime).getTime();
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -171,6 +171,12 @@ export function AppointmentsTab({
   // Further group recurring appointments (subscriptions/classes) within each type
   const groupedAppointments = Object.entries(appointmentsByType).reduce(
     (acc, [type, typeAppointments]) => {
+      // If this type has no appointments, create an empty group to show the section
+      if (typeAppointments.length === 0) {
+        acc[`${type}-empty`] = [];
+        return acc;
+      }
+
       // For SUBSCRIPTION and CLASS types, further group by recurring sessions
       if (type === "SUBSCRIPTION" || type === "CLASS") {
         const recurringGroups = groupRecurringAppointments(typeAppointments);
@@ -242,17 +248,25 @@ export function AppointmentsTab({
                     </div>
                   )}
 
-                  {/* Existing appointment group card */}
-                  <div
-                    ref={(el) => {
-                      if (el) groupRefs.current.set(groupKey, el);
-                    }}
-                    className={`border rounded-lg overflow-hidden shadow-sm transition-all duration-300 ${
-                      highlightedGroup === groupKey
-                        ? "ring-4 ring-yellow-400 shadow-xl"
-                        : ""
-                    }`}
-                  >
+                  {/* Empty state for type with no appointments */}
+                  {groupAppointments.length === 0 ? (
+                    <div className="border rounded-lg p-8 bg-gray-50 text-center">
+                      <p className="text-gray-500 text-sm">
+                        No {getAppointmentTypeDisplayName(groupType).toLowerCase()} scheduled
+                      </p>
+                    </div>
+                  ) : (
+                    /* Existing appointment group card */
+                    <div
+                      ref={(el) => {
+                        if (el) groupRefs.current.set(groupKey, el);
+                      }}
+                      className={`border rounded-lg overflow-hidden shadow-sm transition-all duration-300 ${
+                        highlightedGroup === groupKey
+                          ? "ring-4 ring-yellow-400 shadow-xl"
+                          : ""
+                      }`}
+                    >
                 {/* Group Header */}
                 {isRecurring && (
                   <div className="bg-gray-50 p-4 border-b border-gray-200">
@@ -586,7 +600,8 @@ export function AppointmentsTab({
                     );
                   })()}
                 </ul>
-                  </div>
+                    </div>
+                  )}
                 </div>
               );
             },

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -23,6 +23,8 @@ import {
   getGroupTitle,
   getStartTime,
   groupRecurringAppointments,
+  groupAppointmentsByType,
+  getAppointmentTypeDisplayName,
 } from "../../utils/appointmentHelpers";
 import { EventTimingsCalendar } from "./components/EventTimingsCalendar";
 import {
@@ -163,44 +165,94 @@ export function AppointmentsTab({
       });
     }
   };
-  // Group appointments by subscription/class
-  const groupedAppointments = groupRecurringAppointments(appointments || []);
+  // Group appointments by type (CONSULTATION, SUBSCRIPTION, WEBINAR, CLASS)
+  const appointmentsByType = groupAppointmentsByType(appointments || []);
+
+  // Further group recurring appointments (subscriptions/classes) within each type
+  const groupedAppointments = Object.entries(appointmentsByType).reduce(
+    (acc, [type, typeAppointments]) => {
+      // For SUBSCRIPTION and CLASS types, further group by recurring sessions
+      if (type === "SUBSCRIPTION" || type === "CLASS") {
+        const recurringGroups = groupRecurringAppointments(typeAppointments);
+        Object.entries(recurringGroups).forEach(([key, appointments]) => {
+          acc[`${type}-${key}`] = appointments;
+        });
+      } else {
+        // For CONSULTATION and WEBINAR, each appointment is its own group
+        typeAppointments.forEach((appointment) => {
+          acc[`${type}-${appointment.id}`] = [appointment];
+        });
+      }
+      return acc;
+    },
+    {} as { [key: string]: TAppointment[] },
+  );
+
+  // Sort groups by appointment type order
+  const typeOrder = ["CONSULTATION", "SUBSCRIPTION", "WEBINAR", "CLASS"];
+  const sortedGroupedAppointments = Object.entries(groupedAppointments).sort(
+    ([keyA], [keyB]) => {
+      const typeA = keyA.split("-")[0];
+      const typeB = keyB.split("-")[0];
+      return typeOrder.indexOf(typeA) - typeOrder.indexOf(typeB);
+    },
+  );
 
   return (
     <div className="bg-white p-4 sm:p-6 rounded-lg shadow">
       <h2 className="text-xl font-semibold mb-4 text-gray-800">
         All Appointments
       </h2>
-      <div className="space-y-4 sm:space-y-6">
-        {Object.entries(groupedAppointments).map(
-          ([groupKey, groupAppointments]) => {
-            const isRecurring =
-              groupKey.startsWith("subscription-") ||
-              groupKey.startsWith("class-");
-            const groupTitle = getGroupTitle(groupAppointments);
-            const groupStatus = getGroupStatus(groupAppointments);
-            const firstAppointment = groupAppointments[0];
+      <div className="space-y-6">
+        {(() => {
+          let currentType: string | null = null;
 
-            // Calculate session progress for recurring appointments
-            const {
-              totalSessions,
-              completedSessions,
-              remainingSessions,
-              progressPercentage,
-            } = calculateSessionProgress(groupAppointments);
+          return sortedGroupedAppointments.map(
+            ([groupKey, groupAppointments]) => {
+              const groupType = groupKey.split("-")[0];
+              const isNewTypeSection = currentType !== groupType;
 
-            return (
-              <div
-                key={groupKey}
-                ref={(el) => {
-                  if (el) groupRefs.current.set(groupKey, el);
-                }}
-                className={`border rounded-lg overflow-hidden shadow-sm transition-all duration-300 ${
-                  highlightedGroup === groupKey
-                    ? "ring-4 ring-yellow-400 shadow-xl"
-                    : ""
-                }`}
-              >
+              if (isNewTypeSection) {
+                currentType = groupType;
+              }
+
+              const isRecurring =
+                groupKey.startsWith("SUBSCRIPTION-subscription-") ||
+                groupKey.startsWith("CLASS-class-");
+              const groupTitle = getGroupTitle(groupAppointments);
+              const groupStatus = getGroupStatus(groupAppointments);
+              const firstAppointment = groupAppointments[0];
+
+              // Calculate session progress for recurring appointments
+              const {
+                totalSessions,
+                completedSessions,
+                remainingSessions,
+                progressPercentage,
+              } = calculateSessionProgress(groupAppointments);
+
+              return (
+                <div key={groupKey}>
+                  {/* Type Section Header */}
+                  {isNewTypeSection && (
+                    <div className="mb-4 pt-6 first:pt-0">
+                      <h3 className="text-lg font-semibold text-gray-900 border-b-2 border-gray-300 pb-2">
+                        {getAppointmentTypeDisplayName(groupType)}
+                      </h3>
+                    </div>
+                  )}
+
+                  {/* Existing appointment group card */}
+                  <div
+                    ref={(el) => {
+                      if (el) groupRefs.current.set(groupKey, el);
+                    }}
+                    className={`border rounded-lg overflow-hidden shadow-sm transition-all duration-300 ${
+                      highlightedGroup === groupKey
+                        ? "ring-4 ring-yellow-400 shadow-xl"
+                        : ""
+                    }`}
+                  >
                 {/* Group Header */}
                 {isRecurring && (
                   <div className="bg-gray-50 p-4 border-b border-gray-200">
@@ -384,11 +436,15 @@ export function AppointmentsTab({
                                       {(() => {
                                         const startTime =
                                           getStartTime(appointment);
-                                        return startTime
-                                          ? formatAppointmentTime(
-                                              startTime.toISOString(),
-                                            )
-                                          : "Time not set";
+                                        return startTime ? (
+                                          formatAppointmentTime(
+                                            startTime.toISOString(),
+                                          )
+                                        ) : (
+                                          <span className="text-orange-600 font-medium">
+                                            Not Scheduled
+                                          </span>
+                                        );
                                       })()}
                                     </div>
                                   </div>
@@ -445,27 +501,28 @@ export function AppointmentsTab({
                                   >
                                     {status}
                                   </Badge>
-                                  {status !== "Completed" && (
-                                    <Button
-                                      variant="default"
-                                      size="sm"
-                                      className={`${joinButtonStyle} h-8 px-4 text-xs`}
-                                      disabled={
-                                        process.env.NODE_ENV === "production"
-                                          ? !isJoinable
-                                          : false
-                                      }
-                                      onClick={() =>
-                                        handleJoinMeeting(appointment)
-                                      }
-                                    >
-                                      {process.env.NODE_ENV === "production"
-                                        ? isJoinable
-                                          ? "Join meet"
-                                          : "Not available"
-                                        : "Join (Dev)"}
-                                    </Button>
-                                  )}
+                                  {status !== "Completed" &&
+                                    status !== "Not Scheduled" && (
+                                      <Button
+                                        variant="default"
+                                        size="sm"
+                                        className={`${joinButtonStyle} h-8 px-4 text-xs`}
+                                        disabled={
+                                          process.env.NODE_ENV === "production"
+                                            ? !isJoinable
+                                            : false
+                                        }
+                                        onClick={() =>
+                                          handleJoinMeeting(appointment)
+                                        }
+                                      >
+                                        {process.env.NODE_ENV === "production"
+                                          ? isJoinable
+                                            ? "Join meet"
+                                            : "Not available"
+                                          : "Join (Dev)"}
+                                      </Button>
+                                    )}
                                 </div>
                               </div>
                             </li>
@@ -529,10 +586,12 @@ export function AppointmentsTab({
                     );
                   })()}
                 </ul>
-              </div>
-            );
-          },
-        )}
+                  </div>
+                </div>
+              );
+            },
+          );
+        })()}
         {!Object.keys(groupedAppointments).length && (
           <div className="flex flex-col items-center justify-center min-h-[400px] p-8 bg-gray-50 rounded-lg">
             <div className="w-16 h-16 mb-4 text-gray-400">

--- a/app/dashboard/consultant/[consultantId]/types.ts
+++ b/app/dashboard/consultant/[consultantId]/types.ts
@@ -232,10 +232,12 @@ export const BADGE_STYLES: BadgeStyleMap = {
   Completed: "bg-gray-400 text-white",
   "Meeting in 5 min": "bg-red-500 text-white",
   "Meeting in 2 hours": "bg-blue-500 text-white",
+  Today: "bg-blue-600 text-white",
   Tomorrow: "bg-purple-500 text-white",
   "In week": "bg-green-500 text-white",
   "In month": "bg-yellow-500 text-white",
   "In year": "bg-orange-500 text-white",
+  "Not Scheduled": "bg-orange-600 text-white",
   default: "bg-gray-500 text-white",
 };
 

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -187,7 +187,9 @@ export const formatAppointmentTime = (utcTime: string): string => {
 // Get appointment status
 export const getAppointmentStatus = (appointment: TAppointment): string => {
   const startTime = getStartTime(appointment);
-  if (!startTime) return "Unknown";
+
+  // Handle appointments with no slots
+  if (!startTime) return "Not Scheduled";
 
   const now = new Date();
 
@@ -381,6 +383,59 @@ export const groupRecurringAppointments = (
   });
 
   return groups;
+};
+
+/**
+ * Groups appointments by their type (CONSULTATION, SUBSCRIPTION, WEBINAR, CLASS)
+ * and sorts them chronologically within each group
+ * @param appointments - Array of appointments to group
+ * @returns Object with appointment types as keys and sorted appointment arrays as values
+ */
+export const groupAppointmentsByType = (
+  appointments: TAppointment[],
+): { [key: string]: TAppointment[] } => {
+  const groups: { [key: string]: TAppointment[] } = {
+    CONSULTATION: [],
+    SUBSCRIPTION: [],
+    WEBINAR: [],
+    CLASS: [],
+  };
+
+  // Group appointments by their type
+  appointments.forEach((appointment) => {
+    if (appointment.appointmentType && groups[appointment.appointmentType]) {
+      groups[appointment.appointmentType].push(appointment);
+    }
+  });
+
+  // Sort each group chronologically
+  Object.keys(groups).forEach((type) => {
+    groups[type] = sortAppointmentsByStartTime(groups[type]);
+  });
+
+  // Remove empty groups
+  Object.keys(groups).forEach((type) => {
+    if (groups[type].length === 0) {
+      delete groups[type];
+    }
+  });
+
+  return groups;
+};
+
+/**
+ * Gets a human-readable display name for an appointment type
+ * @param type - The AppointmentsType enum value
+ * @returns Formatted display name
+ */
+export const getAppointmentTypeDisplayName = (type: string): string => {
+  const typeMap: { [key: string]: string } = {
+    CONSULTATION: "Consultations",
+    SUBSCRIPTION: "Subscriptions",
+    WEBINAR: "Webinars",
+    CLASS: "Classes",
+  };
+  return typeMap[type] || type;
 };
 
 // Get group title

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -413,13 +413,7 @@ export const groupAppointmentsByType = (
     groups[type] = sortAppointmentsByStartTime(groups[type]);
   });
 
-  // Remove empty groups
-  Object.keys(groups).forEach((type) => {
-    if (groups[type].length === 0) {
-      delete groups[type];
-    }
-  });
-
+  // Keep empty groups to show all sections even when no appointments exist
   return groups;
 };
 


### PR DESCRIPTION
Modified Files:

  1. ✅ app/api/slots/appointments/route.ts - Backend API changes
  2. ✅
  app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx -
  UI updates
  3. ✅ app/dashboard/consultant/[consultantId]/types.ts - Badge styling
  4. ✅ app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts - Helper
  functions


  Summary of Implementation:

  The Appointments tab now:
  - Shows all appointments, including those with 0 slots
  - Groups appointments by type: Consultations → Subscriptions → Webinars → Classes
  - Displays clear section headers for each type
  - Shows "Not Scheduled" status in orange for unscheduled events
  - Provides "Timings" button to schedule zero-slot appointments
  - Maintains chronological sorting within each group
  
  What You'll See Now:

  All four sections will always be visible:
  - Consultations ← Shows even if empty
  - Subscriptions ← Shows even if empty
  - Webinars ← Shows even if empty (your P0-W-1 Test Webinar will appear here!)
  - Classes ← Shows even if empty

  When a section has no appointments, it displays:
  ┌──────────────────────┐
  │ No classes scheduled │
  └──────────────────────┘
