### PR TITLE
fix: Expert details page failing in production (localhost:3000 fallback)

### DIFF
--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,27 +1,13 @@
-// Server-side data fetching functions
+// Client-side data fetching functions
+// NOTE: These functions use relative URLs which work correctly in browser context.
+// The browser automatically resolves relative URLs to the current domain.
 import { User, ConsultantReview } from "@prisma/client";
 import { TConsultantProfile } from "@/types/consultant";
 import { TConsulteeProfile } from "@/types/consultee";
 import { TStaffProfile } from "@/types/staff";
 
-// Helper function to get the base URL for server-side API calls
-const getBaseUrl = () => {
-  // For server-side API calls in Next.js, we need to use absolute URLs
-  // First try to get the base URL from environment variables
-  if (process.env.NEXT_PUBLIC_SITE_URL) {
-    return `https://${process.env.NEXT_PUBLIC_SITE_URL}`;
-  }
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
-
-  // Default to localhost for development
-  return "http://localhost:3000";
-};
-
 export const fetchUserDetails = async (userId: string): Promise<User> => {
-  const baseUrl = getBaseUrl();
-  const response = await fetch(`${baseUrl}/api/user/${userId}`);
+  const response = await fetch(`/api/user/${userId}`);
   if (!response.ok)
     throw new Error(`Failed to fetch user details: ${response.statusText}`);
   const userData: { data: User } = await response.json();
@@ -31,10 +17,7 @@ export const fetchUserDetails = async (userId: string): Promise<User> => {
 export const fetchConsultantDetails = async (
   consultantId: string,
 ): Promise<TConsultantProfile> => {
-  const baseUrl = getBaseUrl();
-  const response = await fetch(
-    `${baseUrl}/api/user/consultants/${consultantId}`,
-  );
+  const response = await fetch(`/api/user/consultants/${consultantId}`);
   if (!response.ok)
     throw new Error(
       `Failed to fetch consultant details: ${response.statusText}`,
@@ -46,8 +29,7 @@ export const fetchConsultantDetails = async (
 export const fetchConsulteeDetails = async (
   consulteeId: string,
 ): Promise<TConsulteeProfile> => {
-  const baseUrl = getBaseUrl();
-  const response = await fetch(`${baseUrl}/api/user/consultees/${consulteeId}`);
+  const response = await fetch(`/api/user/consultees/${consulteeId}`);
   if (!response.ok)
     throw new Error(
       `Failed to fetch consultee details: ${response.statusText}`,
@@ -59,8 +41,7 @@ export const fetchConsulteeDetails = async (
 export const fetchStaffDetails = async (
   staffId: string,
 ): Promise<TStaffProfile> => {
-  const baseUrl = getBaseUrl();
-  const response = await fetch(`${baseUrl}/api/user/staff/${staffId}`);
+  const response = await fetch(`/api/user/staff/${staffId}`);
   if (!response.ok)
     throw new Error(`Failed to fetch staff details: ${response.statusText}`);
   const staffData: { data: TStaffProfile } = await response.json();
@@ -70,9 +51,8 @@ export const fetchStaffDetails = async (
 export const fetchReviews = async (
   consultantId: string,
 ): Promise<ConsultantReview[]> => {
-  const baseUrl = getBaseUrl();
   const response = await fetch(
-    `${baseUrl}/api/user/reviews?consultantId=${consultantId}`,
+    `/api/user/reviews?consultantId=${consultantId}`,
   );
   if (!response.ok)
     throw new Error(`Failed to fetch reviews: ${response.statusText}`);


### PR DESCRIPTION
## Problem
The expert details page (`/explore/experts/[consultantId]`) was failing in production with:
- "Expert Not Found" error
- "Error fetching data - Failed to fetch" toast
- Browser asking for local network access permission

## Root Cause
The [lib/user.ts](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Elluminar%20repo%20new%20NOV.06.2025/familiarise_web/lib/user.ts:0:0-0:0) file used `getBaseUrl()` to construct absolute URLs for API calls. When running client-side in the browser, the environment variables were not available, causing it to fall back to `http://localhost:3000`.

Other pages (like class details) worked correctly because they used relative URLs directly.

## Solution
Removed the `getBaseUrl()` function and changed all fetch calls in [lib/user.ts](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Elluminar%20repo%20new%20NOV.06.2025/familiarise_web/lib/user.ts:0:0-0:0) to use relative URLs (e.g., `/api/user/consultants/${id}`). The browser automatically resolves these to the current domain.

## Changes
- [lib/user.ts](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Elluminar%20repo%20new%20NOV.06.2025/familiarise_web/lib/user.ts:0:0-0:0): Removed `getBaseUrl()` function, converted all fetch calls to use relative URLs

## Testing
- Expert details page now loads correctly in production
- All other pages continue to work as expected