### PR TITLE
fix: enforce onboarding redirect for new users in production

### DIFF
--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -67,7 +67,7 @@ export default function SignUp() {
         router.push("/auth/signin");
       } else if (signInResult?.ok) {
         toast({ title: "Signed In Successfully!" });
-        router.push("/"); // Redirect to home/dashboard
+        router.push("/form/onboarding"); // New users always need to complete onboarding
       } else {
         toast({
           title: "Sign In Failed After Signup",

--- a/middleware.ts
+++ b/middleware.ts
@@ -210,15 +210,19 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     return NextResponse.next();
   }
 
-  // Handle root and other routes for authenticated users
-  if (isAuthenticated && pathname === "/") {
+  // Handle root path for authenticated users
+  if (isAuthenticated && pathname === "/" && token) {
     if (!isOnboarded) {
       return NextResponse.redirect(new URL(URLS.ONBOARDING, req.url));
     }
-    if (token) {
-      const dashboardUrl = getDashboardUrl(token);
-      return NextResponse.redirect(new URL(dashboardUrl, req.url));
-    }
+    const dashboardUrl = getDashboardUrl(token);
+    return NextResponse.redirect(new URL(dashboardUrl, req.url));
+  }
+
+  // Enforce onboarding for all authenticated users on any route (production only)
+  // This ensures new signups via OAuth are redirected to onboarding
+  if (isAuthenticated && !isOnboarded && pathname !== URLS.ONBOARDING) {
+    return NextResponse.redirect(new URL(URLS.ONBOARDING, req.url));
   }
 
   // Allow access to all other routes

--- a/middleware.ts
+++ b/middleware.ts
@@ -211,7 +211,7 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   }
 
   // Handle root path for authenticated users
-  if (isAuthenticated && pathname === "/" && token) {
+  if (token && pathname === "/") {
     if (!isOnboarded) {
       return NextResponse.redirect(new URL(URLS.ONBOARDING, req.url));
     }


### PR DESCRIPTION
## Summary

- Fixed onboarding form not appearing after signup in production
- Credentials signup now redirects directly to `/form/onboarding`
- Added catch-all onboarding check in middleware for all authenticated users (including OAuth signups)
- Development mode remains unchanged (onboarding can be skipped)

## Root Cause

1. **Credentials signup:** `router.push("/")` had timing issues with token caching before middleware could check onboarding status
2. **OAuth signup:** Redirected to `/explore/experts` which wasn't a protected route, so middleware's onboarding check never ran

## Changes

| File | Change |
|------|--------|
| `app/auth/signup/page.tsx` | Redirect new credentials signups directly to `/form/onboarding` |
| `middleware.ts` | Added catch-all onboarding enforcement for all authenticated users on any route |

## Test Plan

- [ ] Sign up with email/password in production → should redirect to onboarding form
- [ ] Sign up with Google/GitHub/Facebook in production → should redirect to onboarding form
- [ ] Sign in as existing user (onboarding completed) → should land on `/explore/experts`
- [ ] In development mode, onboarding should still be skippable

🤖 Generated with [Claude Code](https://claude.com/claude-code)