### PR TITLE
feat(support): implement customer support and refund system

### DIFF
--- a/app/api/admin/analytics/cancellations/route.ts
+++ b/app/api/admin/analytics/cancellations/route.ts
@@ -1,0 +1,240 @@
+/**
+ * Cancellation Analytics API
+ * Admin-only endpoint for cancellation insights
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import prisma from "@/lib/prisma";
+import { UserRole, CancellationReason } from "@prisma/client";
+
+/**
+ * GET /api/admin/analytics/cancellations
+ * Returns aggregated cancellation data
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check admin role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Parse query parameters
+    const { searchParams } = new URL(req.url);
+    const startDateParam = searchParams.get("startDate");
+    const endDateParam = searchParams.get("endDate");
+
+    // Default to last 90 days if no dates provided
+    const endDate = endDateParam ? new Date(endDateParam) : new Date();
+    const startDate = startDateParam
+      ? new Date(startDateParam)
+      : new Date(endDate.getTime() - 90 * 24 * 60 * 60 * 1000);
+
+    // Get cancelled consultations with reasons
+    const cancelledConsultations = await prisma.consultation.findMany({
+      where: {
+        requestStatus: "CANCELLED",
+        cancelledAt: {
+          gte: startDate,
+          lte: endDate,
+        },
+      },
+      select: {
+        id: true,
+        cancellationReason: true,
+        cancelledAt: true,
+        cancelledBy: true,
+        createdAt: true,
+        consultationPlan: {
+          select: {
+            price: true,
+            priceCurrency: true,
+          },
+        },
+      },
+    });
+
+    // Get cancelled subscriptions with reasons
+    const cancelledSubscriptions = await prisma.subscription.findMany({
+      where: {
+        requestStatus: "CANCELLED",
+        cancelledAt: {
+          gte: startDate,
+          lte: endDate,
+        },
+      },
+      select: {
+        id: true,
+        cancellationReason: true,
+        cancelledAt: true,
+        cancelledBy: true,
+        createdAt: true,
+        subscriptionPlan: {
+          select: {
+            price: true,
+            priceCurrency: true,
+          },
+        },
+      },
+    });
+
+    // Combine all cancellations
+    const allCancellations = [
+      ...cancelledConsultations.map((c) => ({
+        ...c,
+        type: "CONSULTATION" as const,
+        price: c.consultationPlan.price,
+        currency: c.consultationPlan.priceCurrency,
+      })),
+      ...cancelledSubscriptions.map((s) => ({
+        ...s,
+        type: "SUBSCRIPTION" as const,
+        price: s.subscriptionPlan.price,
+        currency: s.subscriptionPlan.priceCurrency,
+      })),
+    ];
+
+    // Calculate totals
+    const totalCancellations = allCancellations.length;
+
+    // Get total bookings in period for cancellation rate
+    const [totalConsultations, totalSubscriptions] = await Promise.all([
+      prisma.consultation.count({
+        where: {
+          createdAt: {
+            gte: startDate,
+            lte: endDate,
+          },
+        },
+      }),
+      prisma.subscription.count({
+        where: {
+          createdAt: {
+            gte: startDate,
+            lte: endDate,
+          },
+        },
+      }),
+    ]);
+
+    const totalBookings = totalConsultations + totalSubscriptions;
+    const cancellationRate =
+      totalBookings > 0
+        ? ((totalCancellations / totalBookings) * 100).toFixed(1)
+        : "0";
+
+    // Count by reason
+    const reasonCounts: Record<string, number> = {};
+    for (const cancellation of allCancellations) {
+      const reason = cancellation.cancellationReason || "NOT_SPECIFIED";
+      reasonCounts[reason] = (reasonCounts[reason] || 0) + 1;
+    }
+
+    const byReason = Object.entries(reasonCounts)
+      .map(([reason, count]) => ({
+        reason,
+        count,
+        percentage:
+          totalCancellations > 0
+            ? ((count / totalCancellations) * 100).toFixed(1)
+            : "0",
+      }))
+      .sort((a, b) => b.count - a.count);
+
+    // Count by type
+    const byType = {
+      CONSULTATION: allCancellations.filter((c) => c.type === "CONSULTATION")
+        .length,
+      SUBSCRIPTION: allCancellations.filter((c) => c.type === "SUBSCRIPTION")
+        .length,
+    };
+
+    // Group by month
+    const byMonth: Record<string, number> = {};
+    for (const cancellation of allCancellations) {
+      if (cancellation.cancelledAt) {
+        const month = new Date(cancellation.cancelledAt).toISOString().slice(0, 7);
+        byMonth[month] = (byMonth[month] || 0) + 1;
+      }
+    }
+
+    const monthlyTrend = Object.entries(byMonth)
+      .map(([month, count]) => ({ month, count }))
+      .sort((a, b) => a.month.localeCompare(b.month));
+
+    // Calculate potential refund amount (sum of cancelled booking values)
+    const potentialRefundAmount = allCancellations.reduce(
+      (sum, c) => sum + (c.price || 0),
+      0
+    );
+
+    // Get actual refunds in period
+    const refunds = await prisma.refund.aggregate({
+      where: {
+        createdAt: {
+          gte: startDate,
+          lte: endDate,
+        },
+        status: "SUCCEEDED",
+      },
+      _sum: {
+        amount: true,
+      },
+      _count: true,
+    });
+
+    // Recent cancellations (last 7 days)
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const last7Days = allCancellations.filter(
+      (c) => c.cancelledAt && new Date(c.cancelledAt) >= sevenDaysAgo
+    ).length;
+
+    // Last 30 days
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const last30Days = allCancellations.filter(
+      (c) => c.cancelledAt && new Date(c.cancelledAt) >= thirtyDaysAgo
+    ).length;
+
+    return NextResponse.json({
+      summary: {
+        totalCancellations,
+        cancellationRate: `${cancellationRate}%`,
+        totalBookingsInPeriod: totalBookings,
+        potentialRefundAmount,
+        actualRefundedAmount: refunds._sum.amount || 0,
+        refundCount: refunds._count,
+      },
+      byReason,
+      byType,
+      monthlyTrend,
+      recentTrend: {
+        last7Days,
+        last30Days,
+        total: totalCancellations,
+      },
+      period: {
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      },
+      // Include available reasons for UI dropdown
+      availableReasons: Object.values(CancellationReason),
+    });
+  } catch (error) {
+    console.error("Error fetching cancellation analytics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch cancellation analytics" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -2,10 +2,16 @@ import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { CancellationReason } from "@prisma/client";
+
+interface CancelRequestBody {
+  reason?: CancellationReason;
+  notes?: string;
+}
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ appointmentId: string }> },
+  { params }: { params: Promise<{ appointmentId: string }> }
 ) {
   try {
     const session = await getServerSession(authOptions);
@@ -14,6 +20,28 @@ export async function POST(
     }
 
     const { appointmentId } = await params;
+
+    // Parse optional request body for cancellation reason
+    let body: CancelRequestBody = {};
+    try {
+      const text = await request.text();
+      if (text) {
+        body = JSON.parse(text);
+      }
+    } catch {
+      // Body parsing is optional - continue without it
+    }
+
+    // Validate cancellation reason if provided
+    if (
+      body.reason &&
+      !Object.values(CancellationReason).includes(body.reason)
+    ) {
+      return NextResponse.json(
+        { error: "Invalid cancellation reason" },
+        { status: 400 }
+      );
+    }
 
     // Start transaction
     const result = await prisma.$transaction(async (tx) => {
@@ -32,16 +60,25 @@ export async function POST(
         throw new Error("Appointment not found");
       }
 
+      // Prepare cancellation data
+      const cancellationData = {
+        requestStatus: "CANCELLED" as const,
+        cancellationReason: body.reason || null,
+        cancellationNotes: body.notes || null,
+        cancelledAt: new Date(),
+        cancelledBy: session.user.id,
+      };
+
       // Update appointment status based on type
       if (appointment.consultation) {
         await tx.consultation.update({
           where: { id: appointment.consultation.id },
-          data: { requestStatus: "CANCELLED" },
+          data: cancellationData,
         });
       } else if (appointment.subscription) {
         await tx.subscription.update({
           where: { id: appointment.subscription.id },
-          data: { requestStatus: "CANCELLED" },
+          data: cancellationData,
         });
       } else if (appointment.webinar) {
         await tx.webinar.update({
@@ -65,15 +102,27 @@ export async function POST(
         where: { id: appointmentId },
       });
 
-      return { success: true };
+      return {
+        success: true,
+        cancellationReason: body.reason,
+        cancelledAt: cancellationData.cancelledAt,
+      };
     });
 
     return NextResponse.json(result);
   } catch (error) {
     console.error("Error canceling appointment:", error);
+
+    if (error instanceof Error && error.message === "Appointment not found") {
+      return NextResponse.json(
+        { error: "Appointment not found" },
+        { status: 404 }
+      );
+    }
+
     return NextResponse.json(
       { error: "Failed to cancel appointment" },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/app/api/staff/feedbacks/[feedbackId]/route.ts
+++ b/app/api/staff/feedbacks/[feedbackId]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "lib/prisma";
+import { getServerSession } from "next-auth";
+import authOptions from "../../../auth/[...nextauth]/options";
+import { FeedbackStatus } from "@prisma/client";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ feedbackId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (!user || !["STAFF", "ADMIN"].includes(user.role || "")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { feedbackId } = await params;
+
+    const feedback = await prisma.feedback.findUnique({
+      where: { id: feedbackId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+            phone: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!feedback) {
+      return NextResponse.json({ error: "Feedback not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(feedback);
+  } catch (error) {
+    console.error("Error fetching feedback:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch feedback" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ feedbackId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (!user || !["STAFF", "ADMIN"].includes(user.role || "")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { feedbackId } = await params;
+    const body = await req.json();
+
+    // Validate status if provided
+    if (body.status && !Object.values(FeedbackStatus).includes(body.status)) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+
+    const feedback = await prisma.feedback.update({
+      where: { id: feedbackId },
+      data: {
+        ...(body.status && { status: body.status }),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(feedback);
+  } catch (error) {
+    console.error("Error updating feedback:", error);
+    return NextResponse.json(
+      { error: "Failed to update feedback" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/staff/feedbacks/route.ts
+++ b/app/api/staff/feedbacks/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "lib/prisma";
+import { getServerSession } from "next-auth";
+import authOptions from "../../auth/[...nextauth]/options";
+import { FeedbackStatus } from "@prisma/client";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check if user is staff or admin
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (!user || !["STAFF", "ADMIN"].includes(user.role || "")) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status");
+    const search = searchParams.get("search");
+    const page = parseInt(searchParams.get("page") || "1");
+    const limit = parseInt(searchParams.get("limit") || "20");
+
+    // Build where clause
+    const where: any = {};
+
+    if (status && status !== "all") {
+      where.status = status as FeedbackStatus;
+    }
+
+    if (search) {
+      where.OR = [
+        { title: { contains: search, mode: "insensitive" } },
+        { description: { contains: search, mode: "insensitive" } },
+        { user: { name: { contains: search, mode: "insensitive" } } },
+        { user: { email: { contains: search, mode: "insensitive" } } },
+      ];
+    }
+
+    // Get feedbacks with pagination
+    const [feedbacks, total] = await Promise.all([
+      prisma.feedback.findMany({
+        where,
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      prisma.feedback.count({ where }),
+    ]);
+
+    // Get status counts
+    const [pending, acknowledged, inProgress, resolved, closed] =
+      await Promise.all([
+        prisma.feedback.count({ where: { status: "PENDING" } }),
+        prisma.feedback.count({ where: { status: "ACKNOWLEDGED" } }),
+        prisma.feedback.count({ where: { status: "IN_PROGRESS" } }),
+        prisma.feedback.count({ where: { status: "RESOLVED" } }),
+        prisma.feedback.count({ where: { status: "CLOSED" } }),
+      ]);
+
+    return NextResponse.json({
+      feedbacks,
+      counts: {
+        total,
+        pending,
+        acknowledged,
+        inProgress,
+        resolved,
+        closed,
+      },
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching feedbacks:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch feedbacks" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/staff/support-tickets/[ticketId]/responses/route.ts
+++ b/app/api/staff/support-tickets/[ticketId]/responses/route.ts
@@ -1,0 +1,146 @@
+/**
+ * Staff Support Ticket Responses API
+ * Staff can respond to any support ticket
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import prisma from "@/lib/prisma";
+import { UserRole } from "@prisma/client";
+
+interface RouteParams {
+  params: Promise<{ ticketId: string }>;
+}
+
+/**
+ * POST /api/staff/support-tickets/[ticketId]/responses
+ * Staff/Admin can respond to any support ticket
+ */
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check staff or admin role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true, name: true },
+    });
+
+    if (user?.role !== UserRole.STAFF && user?.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { ticketId } = await params;
+    const body = await req.json();
+
+    // Validate required fields
+    if (!body.message || typeof body.message !== "string" || !body.message.trim()) {
+      return NextResponse.json(
+        { error: "Message is required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify the ticket exists
+    const ticket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+    });
+
+    if (!ticket) {
+      return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+    }
+
+    // Create the response
+    const response = await prisma.supportResponse.create({
+      data: {
+        message: body.message.trim(),
+        isInternal: body.isInternal || false, // Internal notes not visible to user
+        supportTicket: { connect: { id: ticketId } },
+        user: { connect: { id: session.user.id } },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            role: true,
+            image: true,
+          },
+        },
+      },
+    });
+
+    // Update ticket status to IN_PROGRESS if it was OPEN
+    // Only update if this is not an internal note
+    if (ticket.status === "OPEN" && !body.isInternal) {
+      await prisma.supportTicket.update({
+        where: { id: ticketId },
+        data: {
+          status: "IN_PROGRESS",
+          // Auto-assign to responding staff if not already assigned
+          assignedToId: ticket.assignedToId || session.user.id,
+        },
+      });
+    }
+
+    return NextResponse.json(response, { status: 201 });
+  } catch (error) {
+    console.error("Error creating support response:", error);
+    return NextResponse.json(
+      { error: "Failed to create response" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/staff/support-tickets/[ticketId]/responses
+ * Get all responses for a ticket (including internal notes for staff)
+ */
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check staff or admin role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== UserRole.STAFF && user?.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { ticketId } = await params;
+
+    const responses = await prisma.supportResponse.findMany({
+      where: { supportTicketId: ticketId },
+      orderBy: { createdAt: "asc" },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            role: true,
+            image: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(responses);
+  } catch (error) {
+    console.error("Error fetching support responses:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch responses" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/staff/support-tickets/[ticketId]/route.ts
+++ b/app/api/staff/support-tickets/[ticketId]/route.ts
@@ -1,0 +1,276 @@
+/**
+ * Staff Support Ticket Detail API
+ * Get ticket details and update ticket (status, priority, assignment)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import prisma from "@/lib/prisma";
+import {
+  SupportTicketStatus,
+  SupportPriority,
+  UserRole,
+} from "@prisma/client";
+
+interface RouteParams {
+  params: Promise<{ ticketId: string }>;
+}
+
+/**
+ * GET /api/staff/support-tickets/[ticketId]
+ * Get full ticket details with responses, attachments, and linked entities
+ */
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check staff or admin role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== UserRole.STAFF && user?.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { ticketId } = await params;
+
+    const ticket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            image: true,
+            phone: true,
+            createdAt: true,
+          },
+        },
+        responses: {
+          orderBy: { createdAt: "asc" },
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                image: true,
+                role: true,
+              },
+            },
+          },
+        },
+        attachments: {
+          orderBy: { uploadedAt: "desc" },
+        },
+      },
+    });
+
+    if (!ticket) {
+      return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+    }
+
+    // Fetch linked entities if they exist
+    let linkedConsultation = null;
+    let linkedSubscription = null;
+    let linkedPayment = null;
+    let linkedRefund = null;
+
+    if (ticket.consultationId) {
+      linkedConsultation = await prisma.consultation.findUnique({
+        where: { id: ticket.consultationId },
+        include: {
+          consultationPlan: {
+            select: {
+              title: true,
+              price: true,
+              priceCurrency: true,
+              consultantProfile: {
+                include: {
+                  user: { select: { name: true, email: true } },
+                },
+              },
+            },
+          },
+          appointment: {
+            select: {
+              id: true,
+              slotsOfAppointment: {
+                select: {
+                  startsAt: true,
+                },
+                orderBy: {
+                  startsAt: "asc",
+                },
+                take: 1,
+              },
+            },
+          },
+        },
+      });
+    }
+
+    if (ticket.subscriptionId) {
+      linkedSubscription = await prisma.subscription.findUnique({
+        where: { id: ticket.subscriptionId },
+        include: {
+          subscriptionPlan: {
+            select: {
+              title: true,
+              price: true,
+              priceCurrency: true,
+              consultantProfile: {
+                include: {
+                  user: { select: { name: true, email: true } },
+                },
+              },
+            },
+          },
+        },
+      });
+    }
+
+    if (ticket.paymentId) {
+      linkedPayment = await prisma.payment.findUnique({
+        where: { id: ticket.paymentId },
+        select: {
+          id: true,
+          amount: true,
+          currency: true,
+          paymentStatus: true,
+          paymentGateway: true,
+          createdAt: true,
+        },
+      });
+    }
+
+    if (ticket.refundId) {
+      linkedRefund = await prisma.refund.findUnique({
+        where: { id: ticket.refundId },
+        select: {
+          id: true,
+          amount: true,
+          currency: true,
+          status: true,
+          reason: true,
+          createdAt: true,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      ...ticket,
+      linkedConsultation,
+      linkedSubscription,
+      linkedPayment,
+      linkedRefund,
+    });
+  } catch (error) {
+    console.error("Error fetching support ticket:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch support ticket" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/staff/support-tickets/[ticketId]
+ * Update ticket status, priority, or assignment
+ */
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check staff or admin role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== UserRole.STAFF && user?.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { ticketId } = await params;
+    const body = await req.json();
+
+    // Validate ticket exists
+    const existingTicket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+    });
+
+    if (!existingTicket) {
+      return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+    }
+
+    // Build update data
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updateData: any = {};
+
+    if (body.status && Object.values(SupportTicketStatus).includes(body.status)) {
+      updateData.status = body.status;
+    }
+
+    if (body.priority && Object.values(SupportPriority).includes(body.priority)) {
+      updateData.priority = body.priority;
+    }
+
+    if (body.assignedToId !== undefined) {
+      // Validate assignee is staff/admin if not null
+      if (body.assignedToId !== null) {
+        const assignee = await prisma.user.findUnique({
+          where: { id: body.assignedToId },
+          select: { role: true },
+        });
+
+        if (
+          !assignee ||
+          (assignee.role !== UserRole.STAFF && assignee.role !== UserRole.ADMIN)
+        ) {
+          return NextResponse.json(
+            { error: "Invalid assignee - must be staff or admin" },
+            { status: 400 }
+          );
+        }
+      }
+      updateData.assignedToId = body.assignedToId;
+    }
+
+    // Link to refund if provided
+    if (body.refundId) {
+      updateData.refundId = body.refundId;
+    }
+
+    const updatedTicket = await prisma.supportTicket.update({
+      where: { id: ticketId },
+      data: updateData,
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(updatedTicket);
+  } catch (error) {
+    console.error("Error updating support ticket:", error);
+    return NextResponse.json(
+      { error: "Failed to update support ticket" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/staff/support-tickets/route.ts
+++ b/app/api/staff/support-tickets/route.ts
@@ -1,0 +1,168 @@
+/**
+ * Staff Support Tickets API
+ * Staff/Admin access to all support tickets with filtering and pagination
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import prisma from "@/lib/prisma";
+import {
+  SupportTicketStatus,
+  SupportPriority,
+  SupportIssueType,
+  UserRole,
+} from "@prisma/client";
+
+/**
+ * GET /api/staff/support-tickets
+ * List all support tickets with filters (staff/admin access)
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check staff or admin role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== UserRole.STAFF && user?.role !== UserRole.ADMIN) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Parse query parameters
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status") as SupportTicketStatus | null;
+    const priority = searchParams.get("priority") as SupportPriority | null;
+    const issueType = searchParams.get("issueType") as SupportIssueType | null;
+    const assignedToId = searchParams.get("assignedToId");
+    const search = searchParams.get("search");
+    const page = parseInt(searchParams.get("page") || "1");
+    const limit = parseInt(searchParams.get("limit") || "20");
+    const offset = (page - 1) * limit;
+
+    // Build where clause
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const where: any = {};
+
+    if (status) {
+      where.status = status;
+    }
+    if (priority) {
+      where.priority = priority;
+    }
+    if (issueType) {
+      where.issueType = issueType;
+    }
+    if (assignedToId) {
+      where.assignedToId = assignedToId === "unassigned" ? null : assignedToId;
+    }
+    if (search) {
+      where.OR = [
+        { title: { contains: search, mode: "insensitive" } },
+        { description: { contains: search, mode: "insensitive" } },
+        { id: { contains: search, mode: "insensitive" } },
+        {
+          user: {
+            OR: [
+              { name: { contains: search, mode: "insensitive" } },
+              { email: { contains: search, mode: "insensitive" } },
+            ],
+          },
+        },
+      ];
+    }
+
+    // Get tickets with related data
+    const [tickets, total] = await Promise.all([
+      prisma.supportTicket.findMany({
+        where,
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+            },
+          },
+          responses: {
+            select: { id: true },
+          },
+          attachments: {
+            select: { id: true },
+          },
+        },
+        orderBy: [
+          { priority: "desc" }, // URGENT first
+          { createdAt: "desc" },
+        ],
+        take: limit,
+        skip: offset,
+      }),
+      prisma.supportTicket.count({ where }),
+    ]);
+
+    // Format response
+    const formattedTickets = tickets.map((ticket) => ({
+      id: ticket.id,
+      title: ticket.title,
+      description: ticket.description,
+      priority: ticket.priority,
+      status: ticket.status,
+      category: ticket.category,
+      issueType: ticket.issueType,
+      user: ticket.user,
+      assignedToId: ticket.assignedToId,
+      responseCount: ticket.responses.length,
+      attachmentCount: ticket.attachments.length,
+      // Entity links
+      consultationId: ticket.consultationId,
+      subscriptionId: ticket.subscriptionId,
+      paymentId: ticket.paymentId,
+      refundId: ticket.refundId,
+      createdAt: ticket.createdAt,
+      updatedAt: ticket.updatedAt,
+    }));
+
+    // Get counts by status for dashboard
+    const statusCounts = await prisma.supportTicket.groupBy({
+      by: ["status"],
+      _count: { id: true },
+    });
+
+    const counts = {
+      total,
+      open: statusCounts.find((s) => s.status === "OPEN")?._count.id || 0,
+      inProgress:
+        statusCounts.find((s) => s.status === "IN_PROGRESS")?._count.id || 0,
+      onHold: statusCounts.find((s) => s.status === "ON_HOLD")?._count.id || 0,
+      resolved:
+        statusCounts.find((s) => s.status === "RESOLVED")?._count.id || 0,
+      closed: statusCounts.find((s) => s.status === "CLOSED")?._count.id || 0,
+    };
+
+    return NextResponse.json({
+      tickets: formattedTickets,
+      counts,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+        hasMore: offset + limit < total,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching support tickets:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch support tickets" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/support-tickets/[ticketId]/attachments/route.ts
+++ b/app/api/support-tickets/[ticketId]/attachments/route.ts
@@ -1,0 +1,259 @@
+/**
+ * Support Ticket Attachments API
+ * Upload and list attachments for support tickets
+ * Accessible by ticket owner or staff/admin
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import prisma from "@/lib/prisma";
+import {
+  uploadSupportTicketAttachment,
+  deleteSupportTicketAttachment,
+  getManualBucketInstructions,
+} from "@/lib/supabase";
+import { UserRole } from "@prisma/client";
+
+interface RouteParams {
+  params: Promise<{ ticketId: string }>;
+}
+
+/**
+ * GET /api/support-tickets/[ticketId]/attachments
+ * List all attachments for a support ticket
+ */
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { ticketId } = await params;
+
+    // Get user role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    const isStaffOrAdmin =
+      user?.role === UserRole.STAFF || user?.role === UserRole.ADMIN;
+
+    // Verify ticket exists and user has access
+    const ticket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      select: { userId: true },
+    });
+
+    if (!ticket) {
+      return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+    }
+
+    // Only ticket owner or staff/admin can view attachments
+    if (ticket.userId !== session.user.id && !isStaffOrAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const attachments = await prisma.supportTicketAttachment.findMany({
+      where: { ticketId },
+      orderBy: { uploadedAt: "desc" },
+    });
+
+    return NextResponse.json({ attachments });
+  } catch (error) {
+    console.error("Error fetching attachments:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch attachments" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/support-tickets/[ticketId]/attachments
+ * Upload a new attachment to a support ticket
+ */
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { ticketId } = await params;
+
+    // Get user role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    const isStaffOrAdmin =
+      user?.role === UserRole.STAFF || user?.role === UserRole.ADMIN;
+
+    // Verify ticket exists and user has access
+    const ticket = await prisma.supportTicket.findUnique({
+      where: { id: ticketId },
+      select: { userId: true },
+    });
+
+    if (!ticket) {
+      return NextResponse.json({ error: "Ticket not found" }, { status: 404 });
+    }
+
+    // Only ticket owner or staff/admin can upload attachments
+    if (ticket.userId !== session.user.id && !isStaffOrAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Check attachment count (max 5 attachments per ticket)
+    const existingCount = await prisma.supportTicketAttachment.count({
+      where: { ticketId },
+    });
+
+    if (existingCount >= 5) {
+      return NextResponse.json(
+        { error: "Maximum 5 attachments allowed per ticket" },
+        { status: 400 }
+      );
+    }
+
+    // Parse form data
+    let formData;
+    try {
+      formData = await req.formData();
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid file upload" },
+        { status: 400 }
+      );
+    }
+
+    const file = formData.get("file") as File;
+
+    if (!file || file.size === 0) {
+      return NextResponse.json(
+        { error: "No file provided" },
+        { status: 400 }
+      );
+    }
+
+    // Upload to Supabase
+    const uploadResult = await uploadSupportTicketAttachment({
+      ticketId,
+      file,
+    });
+
+    if (!uploadResult.success) {
+      const isBucketError =
+        uploadResult.error?.includes("bucket") ||
+        uploadResult.error?.includes("storage");
+
+      return NextResponse.json(
+        {
+          error: "Upload failed",
+          message: uploadResult.error,
+          ...(isBucketError && {
+            instructions: getManualBucketInstructions("support-attachments"),
+          }),
+        },
+        { status: 400 }
+      );
+    }
+
+    // Save attachment record
+    const attachment = await prisma.supportTicketAttachment.create({
+      data: {
+        ticketId,
+        fileName: uploadResult.fileName!,
+        originalName: file.name,
+        fileSize: uploadResult.fileSize!,
+        mimeType: uploadResult.mimeType!,
+        fileUrl: uploadResult.fileUrl!,
+        storagePath: uploadResult.storagePath!,
+      },
+    });
+
+    return NextResponse.json(
+      { attachment, message: "Attachment uploaded successfully" },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error uploading attachment:", error);
+    return NextResponse.json(
+      { error: "Failed to upload attachment" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/support-tickets/[ticketId]/attachments
+ * Delete an attachment (requires attachmentId in body)
+ */
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { ticketId } = await params;
+    const body = await req.json();
+    const { attachmentId } = body;
+
+    if (!attachmentId) {
+      return NextResponse.json(
+        { error: "Attachment ID required" },
+        { status: 400 }
+      );
+    }
+
+    // Get user role
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    const isStaffOrAdmin =
+      user?.role === UserRole.STAFF || user?.role === UserRole.ADMIN;
+
+    // Get attachment and verify ownership
+    const attachment = await prisma.supportTicketAttachment.findUnique({
+      where: { id: attachmentId },
+      include: {
+        ticket: { select: { userId: true } },
+      },
+    });
+
+    if (!attachment || attachment.ticketId !== ticketId) {
+      return NextResponse.json(
+        { error: "Attachment not found" },
+        { status: 404 }
+      );
+    }
+
+    // Only ticket owner or staff/admin can delete
+    if (attachment.ticket.userId !== session.user.id && !isStaffOrAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // Delete from storage
+    await deleteSupportTicketAttachment(attachment.storagePath);
+
+    // Delete from database
+    await prisma.supportTicketAttachment.delete({
+      where: { id: attachmentId },
+    });
+
+    return NextResponse.json({ message: "Attachment deleted successfully" });
+  } catch (error) {
+    console.error("Error deleting attachment:", error);
+    return NextResponse.json(
+      { error: "Failed to delete attachment" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/user/support-tickets/route.ts
+++ b/app/api/user/support-tickets/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "lib/prisma";
 import { getServerSession } from "next-auth";
 import authOptions from "../../auth/[...nextauth]/options";
+import { SupportIssueType, SupportPriority } from "@prisma/client";
 
 export async function GET() {
   try {
@@ -9,7 +10,7 @@ export async function GET() {
     if (!session?.user?.id) {
       return NextResponse.json(
         { error: "You must be logged in to access your support tickets" },
-        { status: 401 },
+        { status: 401 }
       );
     }
 
@@ -19,6 +20,9 @@ export async function GET() {
       },
       include: {
         responses: {
+          where: {
+            isInternal: false, // Don't show internal notes to users
+          },
           orderBy: {
             createdAt: "asc",
           },
@@ -29,6 +33,11 @@ export async function GET() {
                 role: true,
               },
             },
+          },
+        },
+        attachments: {
+          orderBy: {
+            uploadedAt: "desc",
           },
         },
       },
@@ -46,9 +55,21 @@ export async function GET() {
           "An unexpected error occurred while fetching your support tickets",
         details: error instanceof Error ? error.message : "Unknown error",
       },
-      { status: 500 },
+      { status: 500 }
     );
   }
+}
+
+interface CreateTicketBody {
+  title: string;
+  description: string;
+  priority?: SupportPriority;
+  category?: string;
+  issueType?: SupportIssueType;
+  // Optional entity links
+  consultationId?: string;
+  subscriptionId?: string;
+  paymentId?: string;
 }
 
 export async function POST(req: NextRequest) {
@@ -57,22 +78,96 @@ export async function POST(req: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json(
         { error: "You must be logged in to create a support ticket" },
-        { status: 401 },
+        { status: 401 }
       );
     }
 
-    const body = await req.json();
+    const body: CreateTicketBody = await req.json();
+
+    // Validate required fields
+    if (!body.title || !body.description) {
+      return NextResponse.json(
+        { error: "Title and description are required" },
+        { status: 400 }
+      );
+    }
+
+    // Validate issueType if provided
+    if (
+      body.issueType &&
+      !Object.values(SupportIssueType).includes(body.issueType)
+    ) {
+      return NextResponse.json(
+        { error: "Invalid issue type" },
+        { status: 400 }
+      );
+    }
+
+    // Validate entity links - ensure they belong to this user
+    if (body.consultationId) {
+      const consultation = await prisma.consultation.findFirst({
+        where: {
+          id: body.consultationId,
+          requestedBy: {
+            userId: session.user.id,
+          },
+        },
+      });
+      if (!consultation) {
+        return NextResponse.json(
+          { error: "Invalid consultation ID" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (body.subscriptionId) {
+      const subscription = await prisma.subscription.findFirst({
+        where: {
+          id: body.subscriptionId,
+          requestedBy: {
+            userId: session.user.id,
+          },
+        },
+      });
+      if (!subscription) {
+        return NextResponse.json(
+          { error: "Invalid subscription ID" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (body.paymentId) {
+      const payment = await prisma.payment.findFirst({
+        where: {
+          id: body.paymentId,
+          userId: session.user.id,
+        },
+      });
+      if (!payment) {
+        return NextResponse.json(
+          { error: "Invalid payment ID" },
+          { status: 400 }
+        );
+      }
+    }
 
     const ticket = await prisma.supportTicket.create({
       data: {
         title: body.title,
         description: body.description,
-        priority: body.priority,
+        priority: body.priority || "MEDIUM",
         category: body.category,
+        issueType: body.issueType,
+        consultationId: body.consultationId,
+        subscriptionId: body.subscriptionId,
+        paymentId: body.paymentId,
         user: { connect: { id: session.user.id } },
       },
       include: {
         responses: true,
+        attachments: true,
       },
     });
 
@@ -85,7 +180,7 @@ export async function POST(req: NextRequest) {
           "An unexpected error occurred while creating your support ticket",
         details: error instanceof Error ? error.message : "Unknown error",
       },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/app/dashboard/admin/feedback/page.tsx
+++ b/app/dashboard/admin/feedback/page.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Search,
+  MessageSquare,
+  Clock,
+  CheckCircle2,
+  AlertCircle,
+  MoreHorizontal,
+  RefreshCw,
+  Star,
+  Loader2,
+  Eye,
+  Mail,
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { FeedbackStatus } from "@prisma/client";
+
+interface FeedbackUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  phone?: string | null;
+  createdAt?: string;
+}
+
+interface Feedback {
+  id: string;
+  title: string;
+  description: string;
+  rating: number | null;
+  category: string | null;
+  status: FeedbackStatus;
+  user: FeedbackUser;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FeedbackCounts {
+  total: number;
+  pending: number;
+  acknowledged: number;
+  inProgress: number;
+  resolved: number;
+  closed: number;
+}
+
+const STATUS_OPTIONS: { value: FeedbackStatus | "all"; label: string }[] = [
+  { value: "all", label: "All Status" },
+  { value: "PENDING", label: "Pending" },
+  { value: "ACKNOWLEDGED", label: "Acknowledged" },
+  { value: "IN_PROGRESS", label: "In Progress" },
+  { value: "RESOLVED", label: "Resolved" },
+  { value: "CLOSED", label: "Closed" },
+];
+
+const getStatusColor = (status: FeedbackStatus) => {
+  switch (status) {
+    case "PENDING":
+      return "bg-amber-100 text-amber-700 border-amber-200";
+    case "ACKNOWLEDGED":
+      return "bg-blue-100 text-blue-700 border-blue-200";
+    case "IN_PROGRESS":
+      return "bg-purple-100 text-purple-700 border-purple-200";
+    case "RESOLVED":
+      return "bg-green-100 text-green-700 border-green-200";
+    case "CLOSED":
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+    default:
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+  }
+};
+
+const getStatusIcon = (status: FeedbackStatus) => {
+  switch (status) {
+    case "PENDING":
+      return <AlertCircle className="h-4 w-4 text-amber-500" />;
+    case "ACKNOWLEDGED":
+      return <Eye className="h-4 w-4 text-blue-500" />;
+    case "IN_PROGRESS":
+      return <Clock className="h-4 w-4 text-purple-500" />;
+    case "RESOLVED":
+    case "CLOSED":
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    default:
+      return <AlertCircle className="h-4 w-4 text-zinc-500" />;
+  }
+};
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+
+  if (hours < 1) return "Just now";
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString();
+};
+
+export default function AdminFeedbackPage() {
+  const { toast } = useToast();
+  const [feedbacks, setFeedbacks] = useState<Feedback[]>([]);
+  const [counts, setCounts] = useState<FeedbackCounts>({
+    total: 0,
+    pending: 0,
+    acknowledged: 0,
+    inProgress: 0,
+    resolved: 0,
+    closed: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Detail view state
+  const [selectedFeedback, setSelectedFeedback] = useState<Feedback | null>(null);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
+  // Fetch feedbacks - uses same API as staff (already supports ADMIN role)
+  const fetchFeedbacks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        limit: "20",
+        ...(statusFilter !== "all" && { status: statusFilter }),
+        ...(searchQuery && { search: searchQuery }),
+      });
+
+      const response = await fetch(`/api/staff/feedbacks?${params}`);
+      if (!response.ok) throw new Error("Failed to fetch feedbacks");
+
+      const data = await response.json();
+      setFeedbacks(data.feedbacks);
+      setCounts(data.counts);
+      setTotalPages(data.pagination.totalPages);
+    } catch (error) {
+      console.error("Error fetching feedbacks:", error);
+      toast({ title: "Error", description: "Failed to load feedbacks", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }, [page, statusFilter, searchQuery, toast]);
+
+  useEffect(() => {
+    fetchFeedbacks();
+  }, [fetchFeedbacks]);
+
+  // Update feedback status
+  const handleUpdateStatus = async (feedbackId: string, newStatus: FeedbackStatus) => {
+    setUpdatingStatus(true);
+    try {
+      const response = await fetch(`/api/staff/feedbacks/${feedbackId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+
+      if (!response.ok) throw new Error("Failed to update status");
+
+      toast({ title: "Success", description: "Status updated successfully" });
+      fetchFeedbacks();
+      if (selectedFeedback?.id === feedbackId) {
+        setSelectedFeedback({ ...selectedFeedback, status: newStatus });
+      }
+    } catch (error) {
+      console.error("Error updating status:", error);
+      toast({ title: "Error", description: "Failed to update status", variant: "destructive" });
+    } finally {
+      setUpdatingStatus(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-900">
+            User Feedback
+          </h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            Manage and respond to user feedback across the platform
+          </p>
+        </div>
+        <Button onClick={fetchFeedbacks} variant="outline" size="sm">
+          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <Card className="border-0 shadow-sm bg-white">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Pending</p>
+                <p className="text-2xl font-bold text-amber-600">{counts.pending}</p>
+              </div>
+              <AlertCircle className="h-8 w-8 text-amber-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm bg-white">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Acknowledged</p>
+                <p className="text-2xl font-bold text-blue-600">{counts.acknowledged}</p>
+              </div>
+              <Eye className="h-8 w-8 text-blue-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm bg-white">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">In Progress</p>
+                <p className="text-2xl font-bold text-purple-600">{counts.inProgress}</p>
+              </div>
+              <Clock className="h-8 w-8 text-purple-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm bg-white">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Resolved</p>
+                <p className="text-2xl font-bold text-green-600">{counts.resolved}</p>
+              </div>
+              <CheckCircle2 className="h-8 w-8 text-green-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm bg-white">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Total</p>
+                <p className="text-2xl font-bold text-zinc-900">{counts.total}</p>
+              </div>
+              <MessageSquare className="h-8 w-8 text-zinc-200" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters */}
+      <Card className="border-0 shadow-sm bg-white">
+        <CardContent className="p-4">
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-400" />
+              <Input
+                placeholder="Search by title, description, or user..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-full sm:w-48">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Feedback Table */}
+      <Card className="border-0 shadow-sm bg-white">
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+            </div>
+          ) : feedbacks.length === 0 ? (
+            <div className="text-center py-12">
+              <MessageSquare className="h-12 w-12 text-zinc-300 mx-auto mb-4" />
+              <p className="text-zinc-500">No feedback found</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-24">ID</TableHead>
+                  <TableHead>Title</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Rating</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Submitted</TableHead>
+                  <TableHead className="w-12"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {feedbacks.map((feedback) => (
+                  <TableRow
+                    key={feedback.id}
+                    className="cursor-pointer hover:bg-zinc-50"
+                    onClick={() => setSelectedFeedback(feedback)}
+                  >
+                    <TableCell className="font-mono text-xs text-zinc-500">
+                      {feedback.id.slice(0, 8).toUpperCase()}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {getStatusIcon(feedback.status)}
+                        <span className="font-medium truncate max-w-[200px]">
+                          {feedback.title}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Avatar className="h-7 w-7">
+                          <AvatarImage src={feedback.user.image || ""} />
+                          <AvatarFallback className="text-xs">
+                            {feedback.user.name?.charAt(0) || "U"}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="text-sm">{feedback.user.name || "Unknown"}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {feedback.rating ? (
+                        <div className="flex items-center gap-1">
+                          {Array.from({ length: 5 }).map((_, i) => (
+                            <Star
+                              key={i}
+                              className={`h-3.5 w-3.5 ${
+                                i < feedback.rating!
+                                  ? "text-amber-500 fill-amber-500"
+                                  : "text-zinc-300"
+                              }`}
+                            />
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-zinc-400 text-sm">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={getStatusColor(feedback.status)}>
+                        {feedback.status.replace("_", " ")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-zinc-500 text-sm">
+                      {formatDate(feedback.createdAt)}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setSelectedFeedback(feedback); }}>
+                            View Details
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleUpdateStatus(feedback.id, "ACKNOWLEDGED"); }}>
+                            Mark Acknowledged
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleUpdateStatus(feedback.id, "RESOLVED"); }}>
+                            Mark Resolved
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleUpdateStatus(feedback.id, "CLOSED"); }}>
+                            Close
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-zinc-500">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+
+      {/* Detail Dialog */}
+      <Dialog open={!!selectedFeedback} onOpenChange={(open) => !open && setSelectedFeedback(null)}>
+        <DialogContent className="max-w-lg">
+          {selectedFeedback && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  {getStatusIcon(selectedFeedback.status)}
+                  {selectedFeedback.title}
+                </DialogTitle>
+                <DialogDescription>
+                  Submitted {formatDate(selectedFeedback.createdAt)}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4">
+                {/* User Info */}
+                <div className="flex items-center gap-3 p-3 rounded-lg bg-zinc-50">
+                  <Avatar>
+                    <AvatarImage src={selectedFeedback.user.image || ""} />
+                    <AvatarFallback>
+                      {selectedFeedback.user.name?.charAt(0) || "U"}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1">
+                    <p className="font-medium">{selectedFeedback.user.name || "Unknown"}</p>
+                    <div className="flex items-center gap-3 text-sm text-zinc-500">
+                      {selectedFeedback.user.email && (
+                        <span className="flex items-center gap-1">
+                          <Mail className="h-3 w-3" />
+                          {selectedFeedback.user.email}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Rating */}
+                {selectedFeedback.rating && (
+                  <div>
+                    <p className="text-xs text-zinc-500 uppercase tracking-wide mb-1">Rating</p>
+                    <div className="flex items-center gap-1">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Star
+                          key={i}
+                          className={`h-5 w-5 ${
+                            i < selectedFeedback.rating!
+                              ? "text-amber-500 fill-amber-500"
+                              : "text-zinc-300"
+                          }`}
+                        />
+                      ))}
+                      <span className="ml-2 text-sm text-zinc-600">
+                        {selectedFeedback.rating} / 5
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Description */}
+                <div>
+                  <p className="text-xs text-zinc-500 uppercase tracking-wide mb-1">Description</p>
+                  <p className="text-sm text-zinc-700 whitespace-pre-wrap">
+                    {selectedFeedback.description}
+                  </p>
+                </div>
+
+                {/* Status Update */}
+                <div>
+                  <p className="text-xs text-zinc-500 uppercase tracking-wide mb-2">Update Status</p>
+                  <Select
+                    value={selectedFeedback.status}
+                    onValueChange={(value) => handleUpdateStatus(selectedFeedback.id, value as FeedbackStatus)}
+                    disabled={updatingStatus}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="PENDING">Pending</SelectItem>
+                      <SelectItem value="ACKNOWLEDGED">Acknowledged</SelectItem>
+                      <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                      <SelectItem value="RESOLVED">Resolved</SelectItem>
+                      <SelectItem value="CLOSED">Closed</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/dashboard/admin/layout.tsx
+++ b/app/dashboard/admin/layout.tsx
@@ -22,6 +22,13 @@ const NAV_SECTIONS: NavSection[] = [
     items: [{ name: "Overview", path: "home" }],
   },
   {
+    title: "Support",
+    items: [
+      { name: "Support Tickets", path: "tickets" },
+      { name: "User Feedback", path: "feedback" },
+    ],
+  },
+  {
     title: "Payments",
     items: [
       { name: "All Payments", path: "payments" },

--- a/app/dashboard/admin/tickets/page.tsx
+++ b/app/dashboard/admin/tickets/page.tsx
@@ -1,0 +1,634 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  Search,
+  MessageSquare,
+  Clock,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+  MoreHorizontal,
+  RefreshCw,
+  DollarSign,
+  Calendar,
+  Send,
+  Loader2,
+  CreditCard,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useToast } from "@/hooks/use-toast";
+
+interface TicketUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+}
+
+interface TicketResponse {
+  id: string;
+  message: string;
+  isInternal: boolean;
+  createdAt: string;
+  user: {
+    name: string | null;
+    role: string | null;
+  } | null;
+}
+
+interface Ticket {
+  id: string;
+  title: string;
+  description: string;
+  priority: string;
+  status: string;
+  category: string | null;
+  issueType: string | null;
+  user: TicketUser;
+  responses: TicketResponse[];
+  createdAt: string;
+  updatedAt: string;
+  linkedConsultation?: any;
+  linkedSubscription?: any;
+  linkedPayment?: any;
+  linkedRefund?: any;
+}
+
+interface TicketCounts {
+  total: number;
+  open: number;
+  inProgress: number;
+  onHold: number;
+  resolved: number;
+  closed: number;
+}
+
+const getStatusColor = (status: string) => {
+  switch (status.toUpperCase()) {
+    case "OPEN":
+      return "bg-blue-100 text-blue-700 border-blue-200";
+    case "IN_PROGRESS":
+      return "bg-amber-100 text-amber-700 border-amber-200";
+    case "ON_HOLD":
+      return "bg-orange-100 text-orange-700 border-orange-200";
+    case "RESOLVED":
+      return "bg-green-100 text-green-700 border-green-200";
+    case "CLOSED":
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+    default:
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+  }
+};
+
+const getPriorityColor = (priority: string) => {
+  switch (priority.toUpperCase()) {
+    case "URGENT":
+    case "HIGH":
+      return "bg-red-100 text-red-700 border-red-200";
+    case "MEDIUM":
+      return "bg-amber-100 text-amber-700 border-amber-200";
+    case "LOW":
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+    default:
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+  }
+};
+
+const getStatusIcon = (status: string) => {
+  switch (status.toUpperCase()) {
+    case "OPEN":
+      return <AlertCircle className="h-4 w-4 text-blue-500" />;
+    case "IN_PROGRESS":
+      return <Clock className="h-4 w-4 text-yellow-500" />;
+    case "ON_HOLD":
+      return <Clock className="h-4 w-4 text-orange-500" />;
+    case "RESOLVED":
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    case "CLOSED":
+      return <XCircle className="h-4 w-4 text-zinc-500" />;
+    default:
+      return <AlertCircle className="h-4 w-4 text-zinc-500" />;
+  }
+};
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+
+  if (hours < 1) return "Just now";
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString();
+};
+
+const formatCurrency = (amount: number, currency: string) => {
+  return new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: currency || "INR",
+  }).format(amount / 100);
+};
+
+const formatIssueType = (issueType: string | null) => {
+  if (!issueType) return "-";
+  return issueType.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+};
+
+export default function AdminSupportTicketsPage() {
+  const { toast } = useToast();
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [counts, setCounts] = useState<TicketCounts>({
+    total: 0,
+    open: 0,
+    inProgress: 0,
+    onHold: 0,
+    resolved: 0,
+    closed: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [priorityFilter, setPriorityFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [ticketDetail, setTicketDetail] = useState<Ticket | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [isInternalNote, setIsInternalNote] = useState(false);
+  const [sendingReply, setSendingReply] = useState(false);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
+  const fetchTickets = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        limit: "20",
+        ...(statusFilter !== "all" && { status: statusFilter }),
+        ...(priorityFilter !== "all" && { priority: priorityFilter }),
+        ...(searchQuery && { search: searchQuery }),
+      });
+
+      const response = await fetch(`/api/staff/support-tickets?${params}`);
+      if (!response.ok) throw new Error("Failed to fetch tickets");
+
+      const data = await response.json();
+      setTickets(data.tickets);
+      setCounts(data.counts);
+      setTotalPages(data.pagination.totalPages);
+    } catch (error) {
+      console.error("Error fetching tickets:", error);
+      toast({ title: "Error", description: "Failed to load support tickets", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }, [page, statusFilter, priorityFilter, searchQuery, toast]);
+
+  useEffect(() => {
+    fetchTickets();
+  }, [fetchTickets]);
+
+  const fetchTicketDetail = async (ticketId: string) => {
+    setLoadingDetail(true);
+    try {
+      const response = await fetch(`/api/staff/support-tickets/${ticketId}`);
+      if (!response.ok) throw new Error("Failed to fetch ticket detail");
+      const data = await response.json();
+      setTicketDetail(data);
+    } catch (error) {
+      console.error("Error fetching ticket detail:", error);
+      toast({ title: "Error", description: "Failed to load ticket details", variant: "destructive" });
+    } finally {
+      setLoadingDetail(false);
+    }
+  };
+
+  const handleSelectTicket = async (ticket: Ticket) => {
+    setSelectedTicket(ticket);
+    await fetchTicketDetail(ticket.id);
+  };
+
+  const handleUpdateStatus = async (newStatus: string) => {
+    if (!selectedTicket) return;
+    setUpdatingStatus(true);
+    try {
+      const response = await fetch(`/api/staff/support-tickets/${selectedTicket.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!response.ok) throw new Error("Failed to update status");
+      toast({ title: "Success", description: "Status updated successfully" });
+      fetchTickets();
+      fetchTicketDetail(selectedTicket.id);
+    } catch (error) {
+      console.error("Error updating status:", error);
+      toast({ title: "Error", description: "Failed to update status", variant: "destructive" });
+    } finally {
+      setUpdatingStatus(false);
+    }
+  };
+
+  const handleSendReply = async () => {
+    if (!selectedTicket || !replyText.trim()) return;
+    setSendingReply(true);
+    try {
+      const response = await fetch(`/api/staff/support-tickets/${selectedTicket.id}/responses`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: replyText, isInternal: isInternalNote }),
+      });
+      if (!response.ok) throw new Error("Failed to send reply");
+      toast({ title: "Success", description: isInternalNote ? "Internal note added" : "Reply sent" });
+      setReplyText("");
+      setIsInternalNote(false);
+      fetchTicketDetail(selectedTicket.id);
+      fetchTickets();
+    } catch (error) {
+      console.error("Error sending reply:", error);
+      toast({ title: "Error", description: "Failed to send reply", variant: "destructive" });
+    } finally {
+      setSendingReply(false);
+    }
+  };
+
+  const handleQuickAction = async (ticketId: string, action: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      if (action === "close") {
+        await fetch(`/api/staff/support-tickets/${ticketId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "CLOSED" }),
+        });
+        toast({ title: "Success", description: "Ticket closed" });
+      } else if (action === "resolve") {
+        await fetch(`/api/staff/support-tickets/${ticketId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "RESOLVED" }),
+        });
+        toast({ title: "Success", description: "Ticket resolved" });
+      }
+      fetchTickets();
+    } catch (error) {
+      console.error("Error:", error);
+      toast({ title: "Error", description: "Action failed", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">Support Tickets</h1>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
+            Manage all customer support tickets
+          </p>
+        </div>
+        <Button onClick={fetchTickets} variant="outline" size="sm">
+          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
+        {[
+          { label: "Open", value: counts.open, color: "text-blue-600" },
+          { label: "In Progress", value: counts.inProgress, color: "text-amber-600" },
+          { label: "On Hold", value: counts.onHold, color: "text-orange-600" },
+          { label: "Resolved", value: counts.resolved, color: "text-green-600" },
+          { label: "Closed", value: counts.closed, color: "text-zinc-500" },
+          { label: "Total", value: counts.total, color: "text-zinc-900 dark:text-zinc-100" },
+        ].map((stat) => (
+          <Card key={stat.label} className="border-0 shadow-sm">
+            <CardContent className="p-4">
+              <p className="text-xs text-zinc-500 uppercase tracking-wide">{stat.label}</p>
+              <p className={`text-2xl font-bold ${stat.color}`}>{stat.value}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <Card className="border-0 shadow-sm">
+        <CardContent className="p-4">
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-400" />
+              <Input
+                placeholder="Search tickets..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-full sm:w-40">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Status</SelectItem>
+                <SelectItem value="OPEN">Open</SelectItem>
+                <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                <SelectItem value="ON_HOLD">On Hold</SelectItem>
+                <SelectItem value="RESOLVED">Resolved</SelectItem>
+                <SelectItem value="CLOSED">Closed</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={priorityFilter} onValueChange={setPriorityFilter}>
+              <SelectTrigger className="w-full sm:w-40">
+                <SelectValue placeholder="Priority" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Priority</SelectItem>
+                <SelectItem value="URGENT">Urgent</SelectItem>
+                <SelectItem value="HIGH">High</SelectItem>
+                <SelectItem value="MEDIUM">Medium</SelectItem>
+                <SelectItem value="LOW">Low</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tickets Table */}
+      <Card className="border-0 shadow-sm">
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+            </div>
+          ) : tickets.length === 0 ? (
+            <div className="text-center py-12">
+              <MessageSquare className="h-12 w-12 text-zinc-300 mx-auto mb-4" />
+              <p className="text-zinc-500">No tickets found</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-24">Ticket ID</TableHead>
+                  <TableHead>Subject</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Priority</TableHead>
+                  <TableHead>Issue Type</TableHead>
+                  <TableHead>Updated</TableHead>
+                  <TableHead className="w-12"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tickets.map((ticket) => (
+                  <TableRow
+                    key={ticket.id}
+                    className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                    onClick={() => handleSelectTicket(ticket)}
+                  >
+                    <TableCell className="font-mono text-xs text-zinc-500">
+                      {ticket.id.slice(0, 8).toUpperCase()}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {getStatusIcon(ticket.status)}
+                        <span className="font-medium truncate max-w-[200px]">{ticket.title}</span>
+                        {ticket.responses?.length > 0 && (
+                          <Badge variant="secondary" className="text-xs">
+                            <MessageSquare className="h-3 w-3 mr-1" />
+                            {ticket.responses.length}
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Avatar className="h-7 w-7">
+                          <AvatarImage src={ticket.user?.image || ""} />
+                          <AvatarFallback className="text-xs">
+                            {ticket.user?.name?.charAt(0) || "U"}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="text-sm">{ticket.user?.name || "Unknown"}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={getStatusColor(ticket.status)}>
+                        {ticket.status.replace("_", " ")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={getPriorityColor(ticket.priority)}>
+                        {ticket.priority}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-zinc-500">
+                      {formatIssueType(ticket.issueType)}
+                    </TableCell>
+                    <TableCell className="text-sm text-zinc-500">{formatDate(ticket.updatedAt)}</TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleSelectTicket(ticket); }}>
+                            View Details
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={(e) => handleQuickAction(ticket.id, "resolve", e)}>
+                            Mark Resolved
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => handleQuickAction(ticket.id, "close", e)}>
+                            Close Ticket
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+            Previous
+          </Button>
+          <span className="text-sm text-zinc-500">Page {page} of {totalPages}</span>
+          <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+            Next
+          </Button>
+        </div>
+      )}
+
+      {/* Ticket Detail Dialog */}
+      <Dialog open={!!selectedTicket} onOpenChange={(open) => { if (!open) { setSelectedTicket(null); setTicketDetail(null); setReplyText(""); } }}>
+        <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
+          {loadingDetail ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+            </div>
+          ) : ticketDetail && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  {getStatusIcon(ticketDetail.status)}
+                  {ticketDetail.title}
+                </DialogTitle>
+                <DialogDescription>
+                  {ticketDetail.id.slice(0, 8).toUpperCase()} • Created {formatDate(ticketDetail.createdAt)}
+                  {ticketDetail.issueType && <> • {formatIssueType(ticketDetail.issueType)}</>}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="flex-1 overflow-y-auto max-h-[60vh] space-y-4 pb-4">
+                {/* User Info */}
+                <div className="flex items-center gap-3 p-3 rounded-lg bg-zinc-50 dark:bg-zinc-900">
+                  <Avatar>
+                    <AvatarImage src={ticketDetail.user?.image || ""} />
+                    <AvatarFallback>{ticketDetail.user?.name?.charAt(0) || "U"}</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="font-medium">{ticketDetail.user?.name || "Unknown"}</p>
+                    <p className="text-sm text-zinc-500">{ticketDetail.user?.email}</p>
+                  </div>
+                </div>
+
+                {/* Description */}
+                <div>
+                  <p className="text-xs text-zinc-500 uppercase tracking-wide mb-1">Description</p>
+                  <p className="text-sm text-zinc-700 dark:text-zinc-300 whitespace-pre-wrap">{ticketDetail.description}</p>
+                </div>
+
+                {/* Linked Entities */}
+                {(ticketDetail.linkedConsultation || ticketDetail.linkedPayment) && (
+                  <div className="p-3 rounded-lg border border-zinc-200 dark:border-zinc-700">
+                    <p className="text-xs text-zinc-500 uppercase tracking-wide mb-2">Linked Information</p>
+                    {ticketDetail.linkedPayment && (
+                      <div className="flex items-center gap-2 text-sm">
+                        <CreditCard className="h-4 w-4 text-zinc-400" />
+                        <span>Payment: {formatCurrency(ticketDetail.linkedPayment.amount, ticketDetail.linkedPayment.currency)}</span>
+                        <Badge variant="outline">{ticketDetail.linkedPayment.paymentStatus}</Badge>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Status Update */}
+                <div>
+                  <Label className="text-xs text-zinc-500 uppercase tracking-wide">Update Status</Label>
+                  <Select value={ticketDetail.status} onValueChange={handleUpdateStatus} disabled={updatingStatus}>
+                    <SelectTrigger className="mt-1">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="OPEN">Open</SelectItem>
+                      <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                      <SelectItem value="ON_HOLD">On Hold</SelectItem>
+                      <SelectItem value="RESOLVED">Resolved</SelectItem>
+                      <SelectItem value="CLOSED">Closed</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Separator />
+
+                {/* Responses */}
+                <div>
+                  <p className="text-xs text-zinc-500 uppercase tracking-wide mb-2">Conversation</p>
+                  <div className="space-y-3">
+                    {ticketDetail.responses?.map((response) => (
+                      <div key={response.id} className={`p-3 rounded-lg ${response.isInternal ? "bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800" : "bg-zinc-50 dark:bg-zinc-800"}`}>
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="text-xs font-medium">{response.user?.name || "Unknown"}</span>
+                          {response.isInternal && <Badge variant="outline" className="text-xs bg-amber-100 text-amber-700 border-amber-300">Internal</Badge>}
+                          <span className="text-xs text-zinc-400">{formatDate(response.createdAt)}</span>
+                        </div>
+                        <p className="text-sm text-zinc-700 dark:text-zinc-300">{response.message}</p>
+                      </div>
+                    ))}
+                    {(!ticketDetail.responses || ticketDetail.responses.length === 0) && (
+                      <p className="text-sm text-zinc-400 text-center py-4">No responses yet</p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Reply Form */}
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Label>Reply</Label>
+                    <label className="flex items-center gap-1.5 text-xs">
+                      <input type="checkbox" checked={isInternalNote} onChange={(e) => setIsInternalNote(e.target.checked)} className="rounded" />
+                      Internal note
+                    </label>
+                  </div>
+                  <Textarea placeholder={isInternalNote ? "Add internal note..." : "Type your reply..."} value={replyText} onChange={(e) => setReplyText(e.target.value)} />
+                </div>
+              </div>
+
+              <DialogFooter className="mt-4">
+                <Button variant="outline" onClick={() => { setSelectedTicket(null); setTicketDetail(null); setReplyText(""); }}>
+                  Close
+                </Button>
+                <Button onClick={handleSendReply} disabled={sendingReply || !replyText.trim()}>
+                  {sendingReply ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Send className="h-4 w-4 mr-2" />}
+                  {isInternalNote ? "Add Note" : "Send Reply"}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
+import { Card, CardContent } from "components/ui/card";
 import { Button } from "components/ui/button";
 import { Input } from "components/ui/input";
 import { Label } from "components/ui/label";
@@ -18,14 +18,51 @@ import {
   FeedbackStatus,
   SupportPriority,
   SupportTicketStatus,
+  SupportIssueType,
 } from "@prisma/client";
 import { useFeedbackSupport } from "./useFeedbackSupport";
+import {
+  MessageSquare,
+  HelpCircle,
+  Star,
+  Send,
+  Clock,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  ChevronRight,
+  Sparkles,
+} from "lucide-react";
 
 interface FeedbackSupportTabProps {
   consulteeId: string;
 }
 
+// Human-readable labels for issue types
+const ISSUE_TYPE_OPTIONS: { value: SupportIssueType; label: string; description: string }[] = [
+  { value: "CONSULTANT_NO_SHOW", label: "Consultant didn't show up", description: "Expert was absent from scheduled session" },
+  { value: "SESSION_QUALITY_POOR", label: "Poor session quality", description: "Unsatisfied with consultation quality" },
+  { value: "TECHNICAL_ISSUES", label: "Technical problems", description: "Audio, video, or connection issues" },
+  { value: "WRONG_CONSULTANT", label: "Wrong consultant assigned", description: "Matched with incorrect expert" },
+  { value: "PAYMENT_FAILED", label: "Payment failed", description: "Issue completing payment" },
+  { value: "CHARGED_TWICE", label: "Charged twice", description: "Duplicate charge on payment" },
+  { value: "REFUND_REQUEST", label: "Refund request", description: "Request money back for a booking" },
+  { value: "WANT_TO_CANCEL", label: "Want to cancel booking", description: "Need to cancel an upcoming session" },
+  { value: "CANCELLATION_ISSUE", label: "Cancellation problem", description: "Issue with cancellation process" },
+  { value: "ACCOUNT_ISSUE", label: "Account issue", description: "Profile, login, or settings problem" },
+  { value: "GENERAL_INQUIRY", label: "General inquiry", description: "Questions about the platform" },
+  { value: "OTHER", label: "Other", description: "Something else not listed" },
+];
+
+const PRIORITY_OPTIONS: { value: SupportPriority; label: string; color: string }[] = [
+  { value: "LOW", label: "Low", color: "text-green-600" },
+  { value: "MEDIUM", label: "Medium", color: "text-amber-600" },
+  { value: "HIGH", label: "High", color: "text-orange-600" },
+  { value: "URGENT", label: "Urgent", color: "text-red-600" },
+];
+
 export default function FeedbackSupportTab({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   consulteeId,
 }: FeedbackSupportTabProps) {
   const {
@@ -51,325 +88,474 @@ export default function FeedbackSupportTab({
     switch (status) {
       case "PENDING":
       case "OPEN":
-        return "bg-yellow-100 text-yellow-800";
+        return "bg-blue-50 text-blue-700 border-blue-200";
       case "IN_PROGRESS":
-        return "bg-blue-100 text-blue-800";
+        return "bg-amber-50 text-amber-700 border-amber-200";
       case "RESOLVED":
-        return "bg-green-100 text-green-800";
+        return "bg-green-50 text-green-700 border-green-200";
       case "CLOSED":
-        return "bg-gray-100 text-gray-800";
+        return "bg-zinc-100 text-zinc-600 border-zinc-200";
       default:
-        return "bg-gray-100 text-gray-800";
+        return "bg-zinc-100 text-zinc-600 border-zinc-200";
+    }
+  };
+
+  const getStatusIcon = (status: FeedbackStatus | SupportTicketStatus) => {
+    switch (status) {
+      case "PENDING":
+      case "OPEN":
+        return <AlertCircle className="h-3.5 w-3.5" />;
+      case "IN_PROGRESS":
+        return <Clock className="h-3.5 w-3.5" />;
+      case "RESOLVED":
+      case "CLOSED":
+        return <CheckCircle2 className="h-3.5 w-3.5" />;
+      default:
+        return <AlertCircle className="h-3.5 w-3.5" />;
     }
   };
 
   const getPriorityColor = (priority: SupportPriority) => {
     switch (priority) {
       case "LOW":
-        return "bg-green-100 text-green-800";
+        return "bg-green-50 text-green-700 border-green-200";
       case "MEDIUM":
-        return "bg-yellow-100 text-yellow-800";
+        return "bg-amber-50 text-amber-700 border-amber-200";
       case "HIGH":
-        return "bg-orange-100 text-orange-800";
+        return "bg-orange-50 text-orange-700 border-orange-200";
       case "URGENT":
-        return "bg-red-100 text-red-800";
+        return "bg-red-50 text-red-700 border-red-200";
       default:
-        return "bg-gray-100 text-gray-800";
+        return "bg-zinc-100 text-zinc-600 border-zinc-200";
     }
   };
 
+  const formatIssueType = (issueType: SupportIssueType | null) => {
+    if (!issueType) return null;
+    const option = ISSUE_TYPE_OPTIONS.find(o => o.value === issueType);
+    return option?.label || issueType.replace(/_/g, " ");
+  };
+
   return (
-    <div className="space-y-6">
-      <div className="bg-white rounded-xl p-8 shadow-sm border border-gray-100 mb-6">
-        <h2 className="text-3xl font-bold text-gray-900">Feedback & Support</h2>
-        <p className="mt-2 text-gray-600">
-          Submit feedback or get support for any issues
-        </p>
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-800 p-8">
+        <div className="absolute inset-0 bg-grid-white/5 [mask-image:linear-gradient(0deg,transparent,black)]" />
+        <div className="relative">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2 rounded-lg bg-white/10">
+              <Sparkles className="h-5 w-5 text-white" />
+            </div>
+            <h2 className="text-2xl font-semibold text-white">Feedback & Support</h2>
+          </div>
+          <p className="text-zinc-400 max-w-lg">
+            Share your experience or get help with any issues. We&apos;re here to assist you.
+          </p>
+        </div>
       </div>
 
-      <div className="flex space-x-4 mb-6">
-        <Button
+      {/* Tab Navigation */}
+      <div className="flex gap-2 p-1 rounded-xl bg-zinc-100 dark:bg-zinc-800 w-fit">
+        <button
           onClick={() => setActiveTab("feedback")}
-          variant={activeTab === "feedback" ? "default" : "outline"}
+          className={`flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium transition-all ${
+            activeTab === "feedback"
+              ? "bg-white dark:bg-zinc-700 text-zinc-900 dark:text-white shadow-sm"
+              : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white"
+          }`}
         >
+          <MessageSquare className="h-4 w-4" />
           Feedback
-        </Button>
-        <Button
+        </button>
+        <button
           onClick={() => setActiveTab("support")}
-          variant={activeTab === "support" ? "default" : "outline"}
+          className={`flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium transition-all ${
+            activeTab === "support"
+              ? "bg-white dark:bg-zinc-700 text-zinc-900 dark:text-white shadow-sm"
+              : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white"
+          }`}
         >
+          <HelpCircle className="h-4 w-4" />
           Support
-        </Button>
+        </button>
       </div>
 
       {activeTab === "feedback" ? (
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Submit Feedback</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="title">Title</Label>
-                <Input
-                  id="title"
-                  value={feedbackForm.title}
-                  onChange={(e) =>
-                    setFeedbackForm((prev) => ({
-                      ...prev,
-                      title: e.target.value,
-                    }))
-                  }
-                  placeholder="Feedback title"
-                />
+        <div className="grid gap-8 lg:grid-cols-5">
+          {/* Feedback Form */}
+          <Card className="lg:col-span-2 border-0 shadow-sm bg-white dark:bg-zinc-900">
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2 mb-6">
+                <div className="p-1.5 rounded-md bg-violet-100 dark:bg-violet-900/30">
+                  <Star className="h-4 w-4 text-violet-600 dark:text-violet-400" />
+                </div>
+                <h3 className="font-semibold text-zinc-900 dark:text-white">Submit Feedback</h3>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="description">Description</Label>
-                <Textarea
-                  id="description"
-                  value={feedbackForm.description}
-                  onChange={(e) =>
-                    setFeedbackForm((prev) => ({
-                      ...prev,
-                      description: e.target.value,
-                    }))
-                  }
-                  placeholder="Describe your feedback"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="rating">Rating (Optional)</Label>
-                <Select
-                  value={feedbackForm.rating?.toString()}
-                  onValueChange={(value) =>
-                    setFeedbackForm((prev) => ({
-                      ...prev,
-                      rating: parseInt(value),
-                    }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a rating" />
-                  </SelectTrigger>
-                  <SelectContent>
+
+              <div className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="feedback-title" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Title <span className="text-red-500">*</span>
+                  </Label>
+                  <Input
+                    id="feedback-title"
+                    value={feedbackForm.title}
+                    onChange={(e) =>
+                      setFeedbackForm((prev) => ({ ...prev, title: e.target.value }))
+                    }
+                    placeholder="Brief summary of your feedback"
+                    className="h-11 border-zinc-200 dark:border-zinc-700 focus:ring-2 focus:ring-violet-500/20"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="feedback-description" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Description <span className="text-red-500">*</span>
+                  </Label>
+                  <Textarea
+                    id="feedback-description"
+                    value={feedbackForm.description}
+                    onChange={(e) =>
+                      setFeedbackForm((prev) => ({ ...prev, description: e.target.value }))
+                    }
+                    placeholder="Tell us more about your experience..."
+                    className="min-h-[120px] border-zinc-200 dark:border-zinc-700 focus:ring-2 focus:ring-violet-500/20 resize-none"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="feedback-rating" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Rating (Optional)
+                  </Label>
+                  <div className="flex gap-1">
                     {[1, 2, 3, 4, 5].map((rating) => (
-                      <SelectItem key={rating} value={rating.toString()}>
-                        {rating} Star{rating !== 1 ? "s" : ""}
-                      </SelectItem>
+                      <button
+                        key={rating}
+                        type="button"
+                        onClick={() => setFeedbackForm((prev) => ({ ...prev, rating }))}
+                        className={`p-2 rounded-lg transition-all ${
+                          feedbackForm.rating && feedbackForm.rating >= rating
+                            ? "text-amber-500"
+                            : "text-zinc-300 dark:text-zinc-600 hover:text-amber-400"
+                        }`}
+                      >
+                        <Star className={`h-6 w-6 ${feedbackForm.rating && feedbackForm.rating >= rating ? "fill-current" : ""}`} />
+                      </button>
                     ))}
-                  </SelectContent>
-                </Select>
+                  </div>
+                </div>
+
+                <Button
+                  onClick={handleFeedbackSubmit}
+                  disabled={isLoading || !feedbackForm.title || !feedbackForm.description}
+                  className="w-full h-11 bg-violet-600 hover:bg-violet-700 text-white"
+                >
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Submitting...
+                    </>
+                  ) : (
+                    <>
+                      <Send className="h-4 w-4 mr-2" />
+                      Submit Feedback
+                    </>
+                  )}
+                </Button>
               </div>
-              <Button
-                onClick={handleFeedbackSubmit}
-                disabled={
-                  isLoading || !feedbackForm.title || !feedbackForm.description
-                }
-              >
-                {isLoading ? "Submitting..." : "Submit Feedback"}
-              </Button>
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Your Feedbacks</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
+          {/* Feedback History */}
+          <Card className="lg:col-span-3 border-0 shadow-sm bg-white dark:bg-zinc-900">
+            <CardContent className="p-6">
+              <h3 className="font-semibold text-zinc-900 dark:text-white mb-4">Your Feedback History</h3>
+
+              <div className="space-y-3">
                 {feedbacks.map((feedback) => (
                   <div
                     key={feedback.id}
-                    className="p-4 border rounded-lg space-y-2"
+                    className="p-4 rounded-xl bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-sm"
                   >
-                    <div className="flex justify-between items-start">
-                      <h3 className="font-semibold">{feedback.title}</h3>
-                      <Badge
-                        className={getStatusColor(
-                          feedback.status as FeedbackStatus,
-                        )}
-                      >
+                    <div className="flex justify-between items-start gap-4 mb-2">
+                      <h4 className="font-medium text-zinc-900 dark:text-white">{feedback.title}</h4>
+                      <Badge variant="outline" className={`${getStatusColor(feedback.status as FeedbackStatus)} flex items-center gap-1.5 shrink-0`}>
+                        {getStatusIcon(feedback.status as FeedbackStatus)}
                         {feedback.status}
                       </Badge>
                     </div>
-                    <p className="text-gray-600">{feedback.description}</p>
+                    <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2">{feedback.description}</p>
                     {feedback.rating && (
-                      <div className="text-sm text-gray-500">
-                        Rating: {feedback.rating} star
-                        {feedback.rating !== 1 ? "s" : ""}
+                      <div className="flex items-center gap-1 mt-2">
+                        {Array.from({ length: 5 }).map((_, i) => (
+                          <Star
+                            key={i}
+                            className={`h-3.5 w-3.5 ${i < feedback.rating! ? "text-amber-500 fill-amber-500" : "text-zinc-300"}`}
+                          />
+                        ))}
                       </div>
                     )}
                   </div>
                 ))}
                 {feedbacks.length === 0 && (
-                  <p className="text-gray-500 text-center py-4">
-                    No feedbacks submitted yet
-                  </p>
+                  <div className="text-center py-12">
+                    <div className="mx-auto w-12 h-12 rounded-full bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center mb-3">
+                      <MessageSquare className="h-6 w-6 text-zinc-400" />
+                    </div>
+                    <p className="text-zinc-500 dark:text-zinc-400">No feedback submitted yet</p>
+                    <p className="text-sm text-zinc-400 dark:text-zinc-500 mt-1">Share your thoughts with us!</p>
+                  </div>
                 )}
               </div>
             </CardContent>
           </Card>
         </div>
       ) : (
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Create Support Ticket</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="title">Title</Label>
-                <Input
-                  id="title"
-                  value={ticketForm.title}
-                  onChange={(e) =>
-                    setTicketForm((prev) => ({
-                      ...prev,
-                      title: e.target.value,
-                    }))
-                  }
-                  placeholder="Ticket title"
-                />
+        <div className="grid gap-8 lg:grid-cols-5">
+          {/* Support Ticket Form */}
+          <Card className="lg:col-span-2 border-0 shadow-sm bg-white dark:bg-zinc-900">
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2 mb-6">
+                <div className="p-1.5 rounded-md bg-blue-100 dark:bg-blue-900/30">
+                  <HelpCircle className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                </div>
+                <h3 className="font-semibold text-zinc-900 dark:text-white">Create Support Ticket</h3>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="description">Description</Label>
-                <Textarea
-                  id="description"
-                  value={ticketForm.description}
-                  onChange={(e) =>
-                    setTicketForm((prev) => ({
-                      ...prev,
-                      description: e.target.value,
-                    }))
-                  }
-                  placeholder="Describe your issue"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="priority">Priority</Label>
-                <Select
-                  value={ticketForm.priority}
-                  onValueChange={(value) =>
-                    setTicketForm((prev) => ({
-                      ...prev,
-                      priority: value as SupportPriority,
-                    }))
-                  }
+
+              <div className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="ticket-issueType" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    What&apos;s this about? <span className="text-red-500">*</span>
+                  </Label>
+                  <Select
+                    value={ticketForm.issueType}
+                    onValueChange={(value) =>
+                      setTicketForm((prev) => ({ ...prev, issueType: value as SupportIssueType }))
+                    }
+                  >
+                    <SelectTrigger className="h-11 border-zinc-200 dark:border-zinc-700">
+                      <SelectValue placeholder="Select issue type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide">Booking Issues</div>
+                      {ISSUE_TYPE_OPTIONS.slice(0, 4).map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div className="flex flex-col">
+                            <span>{option.label}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide mt-2">Payment Issues</div>
+                      {ISSUE_TYPE_OPTIONS.slice(4, 7).map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div className="flex flex-col">
+                            <span>{option.label}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide mt-2">Cancellation</div>
+                      {ISSUE_TYPE_OPTIONS.slice(7, 9).map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div className="flex flex-col">
+                            <span>{option.label}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide mt-2">General</div>
+                      {ISSUE_TYPE_OPTIONS.slice(9).map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div className="flex flex-col">
+                            <span>{option.label}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="ticket-title" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Subject <span className="text-red-500">*</span>
+                  </Label>
+                  <Input
+                    id="ticket-title"
+                    value={ticketForm.title}
+                    onChange={(e) =>
+                      setTicketForm((prev) => ({ ...prev, title: e.target.value }))
+                    }
+                    placeholder="Brief summary of your issue"
+                    className="h-11 border-zinc-200 dark:border-zinc-700 focus:ring-2 focus:ring-blue-500/20"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="ticket-description" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Description <span className="text-red-500">*</span>
+                  </Label>
+                  <Textarea
+                    id="ticket-description"
+                    value={ticketForm.description}
+                    onChange={(e) =>
+                      setTicketForm((prev) => ({ ...prev, description: e.target.value }))
+                    }
+                    placeholder="Please provide as much detail as possible..."
+                    className="min-h-[120px] border-zinc-200 dark:border-zinc-700 focus:ring-2 focus:ring-blue-500/20 resize-none"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="ticket-priority" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                    Priority
+                  </Label>
+                  <Select
+                    value={ticketForm.priority}
+                    onValueChange={(value) =>
+                      setTicketForm((prev) => ({ ...prev, priority: value as SupportPriority }))
+                    }
+                  >
+                    <SelectTrigger className="h-11 border-zinc-200 dark:border-zinc-700">
+                      <SelectValue placeholder="Select priority" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PRIORITY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <span className={option.color}>{option.label}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Button
+                  onClick={handleTicketSubmit}
+                  disabled={isLoading || !ticketForm.title || !ticketForm.description || !ticketForm.issueType}
+                  className="w-full h-11 bg-blue-600 hover:bg-blue-700 text-white"
                 >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select priority" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.values(SupportPriority).map((priority) => (
-                      <SelectItem key={priority} value={priority}>
-                        {priority.charAt(0) + priority.slice(1).toLowerCase()}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Creating...
+                    </>
+                  ) : (
+                    <>
+                      <Send className="h-4 w-4 mr-2" />
+                      Create Ticket
+                    </>
+                  )}
+                </Button>
               </div>
-              <Button
-                onClick={handleTicketSubmit}
-                disabled={
-                  isLoading || !ticketForm.title || !ticketForm.description
-                }
-              >
-                {isLoading ? "Creating..." : "Create Ticket"}
-              </Button>
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>Your Support Tickets</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
+          {/* Support Ticket List */}
+          <Card className="lg:col-span-3 border-0 shadow-sm bg-white dark:bg-zinc-900">
+            <CardContent className="p-6">
+              <h3 className="font-semibold text-zinc-900 dark:text-white mb-4">Your Support Tickets</h3>
+
+              <div className="space-y-3">
                 {tickets.map((ticket) => (
                   <div
                     key={ticket.id}
-                    className="p-4 border rounded-lg space-y-4"
+                    className="p-4 rounded-xl bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-sm"
                   >
-                    <div className="flex justify-between items-start">
-                      <h3 className="font-semibold">{ticket.title}</h3>
-                      <div className="flex gap-2">
-                        <Badge
-                          className={getPriorityColor(
-                            ticket.priority as SupportPriority,
-                          )}
-                        >
+                    <div className="flex justify-between items-start gap-4 mb-2">
+                      <div className="flex-1 min-w-0">
+                        <h4 className="font-medium text-zinc-900 dark:text-white truncate">{ticket.title}</h4>
+                        {ticket.issueType && (
+                          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                            {formatIssueType(ticket.issueType)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex gap-2 shrink-0">
+                        <Badge variant="outline" className={`${getPriorityColor(ticket.priority as SupportPriority)} text-xs`}>
                           {ticket.priority}
                         </Badge>
-                        <Badge
-                          className={getStatusColor(
-                            ticket.status as SupportTicketStatus,
-                          )}
-                        >
-                          {ticket.status}
+                        <Badge variant="outline" className={`${getStatusColor(ticket.status as SupportTicketStatus)} flex items-center gap-1 text-xs`}>
+                          {getStatusIcon(ticket.status as SupportTicketStatus)}
+                          {ticket.status.replace("_", " ")}
                         </Badge>
                       </div>
                     </div>
-                    <p className="text-gray-600">{ticket.description}</p>
+                    <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3">{ticket.description}</p>
 
                     {/* Responses */}
-                    <div className="pl-4 border-l-2 border-gray-200 space-y-3">
-                      {ticket.responses?.map((response: any) => (
-                        <div
-                          key={response.id}
-                          className="bg-gray-50 p-3 rounded"
-                        >
-                          <p className="text-sm text-gray-600">
-                            {response.message}
-                          </p>
-                          <p className="text-xs text-gray-400 mt-1">
-                            {new Date(response.createdAt).toLocaleString()}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
+                    {ticket.responses && ticket.responses.length > 0 && (
+                      <div className="mt-3 pt-3 border-t border-zinc-200 dark:border-zinc-700 space-y-2">
+                        <p className="text-xs font-medium text-zinc-500 uppercase tracking-wide">Responses</p>
+                        {ticket.responses.map((response: any) => (
+                          <div
+                            key={response.id}
+                            className="p-3 rounded-lg bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700"
+                          >
+                            <div className="flex items-center gap-2 mb-1">
+                              <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                                {response.user?.name || "Support Team"}
+                              </span>
+                              <span className="text-xs text-zinc-400">
+                                {new Date(response.createdAt).toLocaleDateString()}
+                              </span>
+                            </div>
+                            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                              {response.message}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
 
                     {/* Response Form */}
-                    {selectedTicket === ticket.id && (
-                      <div className="space-y-2">
+                    {selectedTicket === ticket.id ? (
+                      <div className="mt-3 pt-3 border-t border-zinc-200 dark:border-zinc-700 space-y-3">
                         <Textarea
                           value={responseForm.message}
-                          onChange={(e) =>
-                            setResponseForm({ message: e.target.value })
-                          }
-                          placeholder="Type your response..."
+                          onChange={(e) => setResponseForm({ message: e.target.value })}
+                          placeholder="Type your reply..."
+                          className="min-h-[80px] border-zinc-200 dark:border-zinc-700 resize-none"
                         />
                         <div className="flex justify-end gap-2">
                           <Button
                             variant="outline"
+                            size="sm"
                             onClick={() => setSelectedTicket(null)}
                           >
                             Cancel
                           </Button>
                           <Button
+                            size="sm"
                             onClick={() => handleResponseSubmit(ticket.id)}
                             disabled={isLoading || !responseForm.message}
+                            className="bg-blue-600 hover:bg-blue-700 text-white"
                           >
-                            Send Response
+                            {isLoading ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              "Send"
+                            )}
                           </Button>
                         </div>
                       </div>
-                    )}
-
-                    {/* Show Response Button */}
-                    {selectedTicket !== ticket.id && (
+                    ) : (
                       <Button
-                        variant="outline"
+                        variant="ghost"
+                        size="sm"
                         onClick={() => setSelectedTicket(ticket.id)}
+                        className="mt-2 text-blue-600 hover:text-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/20 p-0 h-auto"
                       >
-                        Add Response
+                        Reply to this ticket
+                        <ChevronRight className="h-4 w-4 ml-1" />
                       </Button>
                     )}
                   </div>
                 ))}
                 {tickets.length === 0 && (
-                  <p className="text-gray-500 text-center py-4">
-                    No support tickets created yet
-                  </p>
+                  <div className="text-center py-12">
+                    <div className="mx-auto w-12 h-12 rounded-full bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center mb-3">
+                      <HelpCircle className="h-6 w-6 text-zinc-400" />
+                    </div>
+                    <p className="text-zinc-500 dark:text-zinc-400">No support tickets yet</p>
+                    <p className="text-sm text-zinc-400 dark:text-zinc-500 mt-1">Create one if you need assistance</p>
+                  </div>
                 )}
               </div>
             </CardContent>

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/useFeedbackSupport.ts
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/useFeedbackSupport.ts
@@ -3,6 +3,7 @@
 import {
   Feedback,
   SupportPriority,
+  SupportIssueType,
   SupportTicket,
   SupportResponse as PrismaSupportResponse,
   UserRole,
@@ -21,6 +22,7 @@ interface SupportTicketFormData {
   title: string;
   description: string;
   priority: SupportPriority;
+  issueType?: SupportIssueType;
   category?: string;
 }
 
@@ -186,6 +188,7 @@ export function useFeedbackSupport() {
         title: "",
         description: "",
         priority: SupportPriority.MEDIUM,
+        issueType: undefined,
       });
       loadTickets();
     } catch (error: any) {

--- a/app/dashboard/staff/[staffId]/(features)/feedback/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/feedback/page.tsx
@@ -1,0 +1,552 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Search,
+  MessageSquare,
+  Clock,
+  CheckCircle2,
+  AlertCircle,
+  MoreHorizontal,
+  RefreshCw,
+  Star,
+  Loader2,
+  Eye,
+  Mail,
+  Phone,
+  Calendar,
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { FeedbackStatus } from "@prisma/client";
+
+interface FeedbackUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  phone?: string | null;
+  createdAt?: string;
+}
+
+interface Feedback {
+  id: string;
+  title: string;
+  description: string;
+  rating: number | null;
+  category: string | null;
+  status: FeedbackStatus;
+  user: FeedbackUser;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FeedbackCounts {
+  total: number;
+  pending: number;
+  acknowledged: number;
+  inProgress: number;
+  resolved: number;
+  closed: number;
+}
+
+const STATUS_OPTIONS: { value: FeedbackStatus | "all"; label: string }[] = [
+  { value: "all", label: "All Status" },
+  { value: "PENDING", label: "Pending" },
+  { value: "ACKNOWLEDGED", label: "Acknowledged" },
+  { value: "IN_PROGRESS", label: "In Progress" },
+  { value: "RESOLVED", label: "Resolved" },
+  { value: "CLOSED", label: "Closed" },
+];
+
+const getStatusColor = (status: FeedbackStatus) => {
+  switch (status) {
+    case "PENDING":
+      return "bg-amber-100 text-amber-700 border-amber-200";
+    case "ACKNOWLEDGED":
+      return "bg-blue-100 text-blue-700 border-blue-200";
+    case "IN_PROGRESS":
+      return "bg-purple-100 text-purple-700 border-purple-200";
+    case "RESOLVED":
+      return "bg-green-100 text-green-700 border-green-200";
+    case "CLOSED":
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+    default:
+      return "bg-zinc-100 text-zinc-600 border-zinc-200";
+  }
+};
+
+const getStatusIcon = (status: FeedbackStatus) => {
+  switch (status) {
+    case "PENDING":
+      return <AlertCircle className="h-4 w-4 text-amber-500" />;
+    case "ACKNOWLEDGED":
+      return <Eye className="h-4 w-4 text-blue-500" />;
+    case "IN_PROGRESS":
+      return <Clock className="h-4 w-4 text-purple-500" />;
+    case "RESOLVED":
+    case "CLOSED":
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    default:
+      return <AlertCircle className="h-4 w-4 text-zinc-500" />;
+  }
+};
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+
+  if (hours < 1) return "Just now";
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString();
+};
+
+export default function StaffFeedbackPage() {
+  const { toast } = useToast();
+  const [feedbacks, setFeedbacks] = useState<Feedback[]>([]);
+  const [counts, setCounts] = useState<FeedbackCounts>({
+    total: 0,
+    pending: 0,
+    acknowledged: 0,
+    inProgress: 0,
+    resolved: 0,
+    closed: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Detail view state
+  const [selectedFeedback, setSelectedFeedback] = useState<Feedback | null>(null);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+
+  // Fetch feedbacks
+  const fetchFeedbacks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        limit: "20",
+        ...(statusFilter !== "all" && { status: statusFilter }),
+        ...(searchQuery && { search: searchQuery }),
+      });
+
+      const response = await fetch(`/api/staff/feedbacks?${params}`);
+      if (!response.ok) throw new Error("Failed to fetch feedbacks");
+
+      const data = await response.json();
+      setFeedbacks(data.feedbacks);
+      setCounts(data.counts);
+      setTotalPages(data.pagination.totalPages);
+    } catch (error) {
+      console.error("Error fetching feedbacks:", error);
+      toast({ title: "Error", description: "Failed to load feedbacks", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }, [page, statusFilter, searchQuery, toast]);
+
+  useEffect(() => {
+    fetchFeedbacks();
+  }, [fetchFeedbacks]);
+
+  // Update feedback status
+  const handleUpdateStatus = async (feedbackId: string, newStatus: FeedbackStatus) => {
+    setUpdatingStatus(true);
+    try {
+      const response = await fetch(`/api/staff/feedbacks/${feedbackId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+
+      if (!response.ok) throw new Error("Failed to update status");
+
+      toast({ title: "Success", description: "Status updated successfully" });
+      fetchFeedbacks();
+      if (selectedFeedback?.id === feedbackId) {
+        setSelectedFeedback({ ...selectedFeedback, status: newStatus });
+      }
+    } catch (error) {
+      console.error("Error updating status:", error);
+      toast({ title: "Error", description: "Failed to update status", variant: "destructive" });
+    } finally {
+      setUpdatingStatus(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            User Feedback
+          </h1>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1">
+            View and manage feedback submitted by users
+          </p>
+        </div>
+        <Button onClick={fetchFeedbacks} variant="outline" size="sm">
+          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <Card className="border-0 shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Pending</p>
+                <p className="text-2xl font-bold text-amber-600">{counts.pending}</p>
+              </div>
+              <AlertCircle className="h-8 w-8 text-amber-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Acknowledged</p>
+                <p className="text-2xl font-bold text-blue-600">{counts.acknowledged}</p>
+              </div>
+              <Eye className="h-8 w-8 text-blue-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">In Progress</p>
+                <p className="text-2xl font-bold text-purple-600">{counts.inProgress}</p>
+              </div>
+              <Clock className="h-8 w-8 text-purple-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Resolved</p>
+                <p className="text-2xl font-bold text-green-600">{counts.resolved}</p>
+              </div>
+              <CheckCircle2 className="h-8 w-8 text-green-200" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 uppercase tracking-wide">Total</p>
+                <p className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{counts.total}</p>
+              </div>
+              <MessageSquare className="h-8 w-8 text-zinc-200" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters */}
+      <Card className="border-0 shadow-sm">
+        <CardContent className="p-4">
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-400" />
+              <Input
+                placeholder="Search by title, description, or user..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-full sm:w-48">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUS_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Feedback Table */}
+      <Card className="border-0 shadow-sm">
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+            </div>
+          ) : feedbacks.length === 0 ? (
+            <div className="text-center py-12">
+              <MessageSquare className="h-12 w-12 text-zinc-300 mx-auto mb-4" />
+              <p className="text-zinc-500">No feedback found</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-24">ID</TableHead>
+                  <TableHead>Title</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Rating</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Submitted</TableHead>
+                  <TableHead className="w-12"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {feedbacks.map((feedback) => (
+                  <TableRow
+                    key={feedback.id}
+                    className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                    onClick={() => setSelectedFeedback(feedback)}
+                  >
+                    <TableCell className="font-mono text-xs text-zinc-500">
+                      {feedback.id.slice(0, 8).toUpperCase()}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {getStatusIcon(feedback.status)}
+                        <span className="font-medium truncate max-w-[200px]">
+                          {feedback.title}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Avatar className="h-7 w-7">
+                          <AvatarImage src={feedback.user.image || ""} />
+                          <AvatarFallback className="text-xs">
+                            {feedback.user.name?.charAt(0) || "U"}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="text-sm">{feedback.user.name || "Unknown"}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {feedback.rating ? (
+                        <div className="flex items-center gap-1">
+                          {Array.from({ length: 5 }).map((_, i) => (
+                            <Star
+                              key={i}
+                              className={`h-3.5 w-3.5 ${
+                                i < feedback.rating!
+                                  ? "text-amber-500 fill-amber-500"
+                                  : "text-zinc-300"
+                              }`}
+                            />
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-zinc-400 text-sm">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={getStatusColor(feedback.status)}>
+                        {feedback.status.replace("_", " ")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-zinc-500 text-sm">
+                      {formatDate(feedback.createdAt)}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setSelectedFeedback(feedback); }}>
+                            View Details
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleUpdateStatus(feedback.id, "ACKNOWLEDGED"); }}>
+                            Mark Acknowledged
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleUpdateStatus(feedback.id, "RESOLVED"); }}>
+                            Mark Resolved
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleUpdateStatus(feedback.id, "CLOSED"); }}>
+                            Close
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-zinc-500">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+
+      {/* Detail Dialog */}
+      <Dialog open={!!selectedFeedback} onOpenChange={(open) => !open && setSelectedFeedback(null)}>
+        <DialogContent className="max-w-lg">
+          {selectedFeedback && (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  {getStatusIcon(selectedFeedback.status)}
+                  {selectedFeedback.title}
+                </DialogTitle>
+                <DialogDescription>
+                  Submitted {formatDate(selectedFeedback.createdAt)}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4">
+                {/* User Info */}
+                <div className="flex items-center gap-3 p-3 rounded-lg bg-zinc-50 dark:bg-zinc-800/50">
+                  <Avatar>
+                    <AvatarImage src={selectedFeedback.user.image || ""} />
+                    <AvatarFallback>
+                      {selectedFeedback.user.name?.charAt(0) || "U"}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1">
+                    <p className="font-medium">{selectedFeedback.user.name || "Unknown"}</p>
+                    <div className="flex items-center gap-3 text-sm text-zinc-500">
+                      {selectedFeedback.user.email && (
+                        <span className="flex items-center gap-1">
+                          <Mail className="h-3 w-3" />
+                          {selectedFeedback.user.email}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Rating */}
+                {selectedFeedback.rating && (
+                  <div>
+                    <p className="text-xs text-zinc-500 uppercase tracking-wide mb-1">Rating</p>
+                    <div className="flex items-center gap-1">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Star
+                          key={i}
+                          className={`h-5 w-5 ${
+                            i < selectedFeedback.rating!
+                              ? "text-amber-500 fill-amber-500"
+                              : "text-zinc-300"
+                          }`}
+                        />
+                      ))}
+                      <span className="ml-2 text-sm text-zinc-600">
+                        {selectedFeedback.rating} / 5
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Description */}
+                <div>
+                  <p className="text-xs text-zinc-500 uppercase tracking-wide mb-1">Description</p>
+                  <p className="text-sm text-zinc-700 dark:text-zinc-300 whitespace-pre-wrap">
+                    {selectedFeedback.description}
+                  </p>
+                </div>
+
+                {/* Status Update */}
+                <div>
+                  <p className="text-xs text-zinc-500 uppercase tracking-wide mb-2">Update Status</p>
+                  <Select
+                    value={selectedFeedback.status}
+                    onValueChange={(value) => handleUpdateStatus(selectedFeedback.id, value as FeedbackStatus)}
+                    disabled={updatingStatus}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="PENDING">Pending</SelectItem>
+                      <SelectItem value="ACKNOWLEDGED">Acknowledged</SelectItem>
+                      <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                      <SelectItem value="RESOLVED">Resolved</SelectItem>
+                      <SelectItem value="CLOSED">Closed</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/dashboard/staff/[staffId]/(features)/tickets/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/tickets/page.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Card,
   CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -37,110 +34,160 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import {
   Search,
-  Filter,
-  Plus,
   MessageSquare,
   Clock,
-  User,
   AlertCircle,
   CheckCircle2,
   XCircle,
   MoreHorizontal,
+  RefreshCw,
+  DollarSign,
+  Calendar,
+  Paperclip,
+  Send,
+  FileText,
+  Loader2,
+  CreditCard,
+  ExternalLink,
 } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToast } from "@/hooks/use-toast";
 
-// Mock data
-const tickets = [
-  {
-    id: "TKT-001",
-    subject: "Payment not processed",
-    description:
-      "My payment was declined but amount was deducted from my account.",
-    user: { name: "John Doe", email: "john@example.com", avatar: "" },
-    status: "open",
-    priority: "high",
-    category: "payment",
-    createdAt: "2025-12-20T10:30:00",
-    updatedAt: "2025-12-20T10:30:00",
-    assignedTo: null,
-    messages: 3,
-  },
-  {
-    id: "TKT-002",
-    subject: "Cannot schedule appointment",
-    description:
-      "The calendar is not loading when I try to book a consultation.",
-    user: { name: "Jane Smith", email: "jane@example.com", avatar: "" },
-    status: "in_progress",
-    priority: "medium",
-    category: "technical",
-    createdAt: "2025-12-20T09:15:00",
-    updatedAt: "2025-12-20T11:00:00",
-    assignedTo: "Staff Member",
-    messages: 5,
-  },
-  {
-    id: "TKT-003",
-    subject: "Profile verification issue",
-    description:
-      "My consultant profile is pending verification for over a week.",
-    user: { name: "Mike Wilson", email: "mike@example.com", avatar: "" },
-    status: "pending",
-    priority: "low",
-    category: "account",
-    createdAt: "2025-12-19T14:00:00",
-    updatedAt: "2025-12-20T08:00:00",
-    assignedTo: "Staff Member",
-    messages: 2,
-  },
-  {
-    id: "TKT-004",
-    subject: "Refund request for cancelled session",
-    description:
-      "The consultant cancelled the session but I haven't received my refund.",
-    user: { name: "Sarah Connor", email: "sarah@example.com", avatar: "" },
-    status: "open",
-    priority: "high",
-    category: "refund",
-    createdAt: "2025-12-20T08:00:00",
-    updatedAt: "2025-12-20T08:00:00",
-    assignedTo: null,
-    messages: 1,
-  },
-  {
-    id: "TKT-005",
-    subject: "Unable to join video call",
-    description: "Getting a black screen when trying to join the consultation.",
-    user: { name: "Alex Brown", email: "alex@example.com", avatar: "" },
-    status: "resolved",
-    priority: "medium",
-    category: "technical",
-    createdAt: "2025-12-18T16:30:00",
-    updatedAt: "2025-12-19T10:00:00",
-    assignedTo: "Staff Member",
-    messages: 8,
-  },
-];
+// Types
+interface TicketUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  phone?: string | null;
+}
+
+interface TicketResponse {
+  id: string;
+  message: string;
+  isInternal: boolean;
+  createdAt: string;
+  user: {
+    id: string;
+    name: string | null;
+    role: string | null;
+    image: string | null;
+  };
+}
+
+interface TicketAttachment {
+  id: string;
+  fileName: string;
+  originalName: string;
+  fileSize: number;
+  mimeType: string;
+  fileUrl: string;
+  uploadedAt: string;
+}
+
+interface LinkedConsultation {
+  id: string;
+  requestStatus: string;
+  consultationPlan: {
+    title: string;
+    price: number;
+    priceCurrency: string;
+    consultantProfile: {
+      user: { name: string | null; email: string | null };
+    };
+  };
+  appointment: {
+    id: string;
+    scheduledAt: string;
+    status: string;
+  } | null;
+}
+
+interface LinkedPayment {
+  id: string;
+  amount: number;
+  currency: string;
+  paymentStatus: string;
+  paymentGateway: string;
+  createdAt: string;
+}
+
+interface LinkedRefund {
+  id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  createdAt: string;
+}
+
+interface Ticket {
+  id: string;
+  title: string;
+  description: string;
+  priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  status: "OPEN" | "IN_PROGRESS" | "ON_HOLD" | "RESOLVED" | "CLOSED";
+  category: string | null;
+  issueType: string | null;
+  user: TicketUser;
+  assignedToId: string | null;
+  responseCount: number;
+  attachmentCount: number;
+  consultationId: string | null;
+  subscriptionId: string | null;
+  paymentId: string | null;
+  refundId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  // Extended fields for detail view
+  responses?: TicketResponse[];
+  attachments?: TicketAttachment[];
+  linkedConsultation?: LinkedConsultation | null;
+  linkedPayment?: LinkedPayment | null;
+  linkedRefund?: LinkedRefund | null;
+}
+
+interface TicketCounts {
+  total: number;
+  open: number;
+  inProgress: number;
+  onHold: number;
+  resolved: number;
+  closed: number;
+}
+
+interface TicketListResponse {
+  tickets: Ticket[];
+  counts: TicketCounts;
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    hasMore: boolean;
+  };
+}
 
 const getStatusColor = (status: string) => {
-  switch (status) {
-    case "open":
+  switch (status.toUpperCase()) {
+    case "OPEN":
       return "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300";
-    case "in_progress":
+    case "IN_PROGRESS":
       return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300";
-    case "pending":
+    case "ON_HOLD":
       return "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300";
-    case "resolved":
+    case "RESOLVED":
       return "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300";
-    case "closed":
+    case "CLOSED":
       return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
     default:
       return "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
@@ -148,12 +195,14 @@ const getStatusColor = (status: string) => {
 };
 
 const getPriorityColor = (priority: string) => {
-  switch (priority) {
-    case "high":
+  switch (priority.toUpperCase()) {
+    case "URGENT":
       return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
-    case "medium":
+    case "HIGH":
+      return "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300";
+    case "MEDIUM":
       return "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300";
-    case "low":
+    case "LOW":
       return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
     default:
       return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
@@ -161,16 +210,16 @@ const getPriorityColor = (priority: string) => {
 };
 
 const getStatusIcon = (status: string) => {
-  switch (status) {
-    case "open":
+  switch (status.toUpperCase()) {
+    case "OPEN":
       return <AlertCircle className="h-4 w-4 text-blue-500" />;
-    case "in_progress":
+    case "IN_PROGRESS":
       return <Clock className="h-4 w-4 text-yellow-500" />;
-    case "pending":
+    case "ON_HOLD":
       return <Clock className="h-4 w-4 text-orange-500" />;
-    case "resolved":
+    case "RESOLVED":
       return <CheckCircle2 className="h-4 w-4 text-green-500" />;
-    case "closed":
+    case "CLOSED":
       return <XCircle className="h-4 w-4 text-zinc-500" />;
     default:
       return <AlertCircle className="h-4 w-4 text-zinc-500" />;
@@ -190,33 +239,229 @@ const formatDate = (dateString: string) => {
   return date.toLocaleDateString();
 };
 
+const formatCurrency = (amount: number, currency: string) => {
+  return new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: currency || "INR",
+  }).format(amount / 100);
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
 export default function SupportTicketsPage() {
+  const { toast } = useToast();
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [counts, setCounts] = useState<TicketCounts>({
+    total: 0,
+    open: 0,
+    inProgress: 0,
+    onHold: 0,
+    resolved: 0,
+    closed: 0,
+  });
+  const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [priorityFilter, setPriorityFilter] = useState("all");
-  const [selectedTicket, setSelectedTicket] = useState<
-    (typeof tickets)[0] | null
-  >(null);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  // Detail view state
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [ticketDetail, setTicketDetail] = useState<Ticket | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
   const [replyText, setReplyText] = useState("");
+  const [isInternalNote, setIsInternalNote] = useState(false);
+  const [sendingReply, setSendingReply] = useState(false);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+  const [initiatingRefund, setInitiatingRefund] = useState(false);
 
-  const filteredTickets = tickets.filter((ticket) => {
-    const matchesSearch =
-      ticket.subject.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      ticket.user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      ticket.id.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesStatus =
-      statusFilter === "all" || ticket.status === statusFilter;
-    const matchesPriority =
-      priorityFilter === "all" || ticket.priority === priorityFilter;
-    return matchesSearch && matchesStatus && matchesPriority;
-  });
+  // Fetch tickets
+  const fetchTickets = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("page", page.toString());
+      params.set("limit", "20");
+      if (statusFilter !== "all") params.set("status", statusFilter);
+      if (priorityFilter !== "all") params.set("priority", priorityFilter);
+      if (searchQuery) params.set("search", searchQuery);
 
-  const ticketCounts = {
-    all: tickets.length,
-    open: tickets.filter((t) => t.status === "open").length,
-    in_progress: tickets.filter((t) => t.status === "in_progress").length,
-    pending: tickets.filter((t) => t.status === "pending").length,
-    resolved: tickets.filter((t) => t.status === "resolved").length,
+      const response = await fetch(`/api/staff/support-tickets?${params}`);
+      if (!response.ok) throw new Error("Failed to fetch tickets");
+
+      const data: TicketListResponse = await response.json();
+      setTickets(data.tickets);
+      setCounts(data.counts);
+      setTotalPages(data.pagination.totalPages);
+    } catch (error) {
+      console.error("Error fetching tickets:", error);
+      toast({ title: "Error", description: "Failed to load support tickets", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }, [page, statusFilter, priorityFilter, searchQuery]);
+
+  useEffect(() => {
+    fetchTickets();
+  }, [fetchTickets]);
+
+  // Fetch ticket detail
+  const fetchTicketDetail = async (ticketId: string) => {
+    setLoadingDetail(true);
+    try {
+      const response = await fetch(`/api/staff/support-tickets/${ticketId}`);
+      if (!response.ok) throw new Error("Failed to fetch ticket detail");
+
+      const data = await response.json();
+      setTicketDetail(data);
+    } catch (error) {
+      console.error("Error fetching ticket detail:", error);
+      toast({ title: "Error", description: "Failed to load ticket details", variant: "destructive" });
+    } finally {
+      setLoadingDetail(false);
+    }
+  };
+
+  // Handle ticket selection
+  const handleSelectTicket = async (ticket: Ticket) => {
+    setSelectedTicket(ticket);
+    await fetchTicketDetail(ticket.id);
+  };
+
+  // Update ticket status
+  const handleUpdateStatus = async (newStatus: string) => {
+    if (!selectedTicket) return;
+    setUpdatingStatus(true);
+    try {
+      const response = await fetch(
+        `/api/staff/support-tickets/${selectedTicket.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: newStatus }),
+        }
+      );
+
+      if (!response.ok) throw new Error("Failed to update status");
+
+      toast({ title: "Success", description: "Status updated successfully" });
+      fetchTickets();
+      fetchTicketDetail(selectedTicket.id);
+    } catch (error) {
+      console.error("Error updating status:", error);
+      toast({ title: "Error", description: "Failed to update status", variant: "destructive" });
+    } finally {
+      setUpdatingStatus(false);
+    }
+  };
+
+  // Send reply
+  const handleSendReply = async () => {
+    if (!selectedTicket || !replyText.trim()) return;
+    setSendingReply(true);
+    try {
+      const response = await fetch(
+        `/api/staff/support-tickets/${selectedTicket.id}/responses`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            message: replyText,
+            isInternal: isInternalNote,
+          }),
+        }
+      );
+
+      if (!response.ok) throw new Error("Failed to send reply");
+
+      toast({ title: "Success", description: isInternalNote ? "Internal note added" : "Reply sent" });
+      setReplyText("");
+      setIsInternalNote(false);
+      fetchTicketDetail(selectedTicket.id);
+      fetchTickets();
+    } catch (error) {
+      console.error("Error sending reply:", error);
+      toast({ title: "Error", description: "Failed to send reply", variant: "destructive" });
+    } finally {
+      setSendingReply(false);
+    }
+  };
+
+  // Initiate refund
+  const handleInitiateRefund = async () => {
+    if (!ticketDetail?.linkedPayment) return;
+    setInitiatingRefund(true);
+    try {
+      const response = await fetch("/api/payments/refunds", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          paymentId: ticketDetail.linkedPayment.id,
+          reason: `Refund initiated from support ticket ${ticketDetail.id}`,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to initiate refund");
+      }
+
+      const refund = await response.json();
+
+      // Update ticket with refund ID
+      await fetch(`/api/staff/support-tickets/${ticketDetail.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refundId: refund.id }),
+      });
+
+      toast({ title: "Success", description: "Refund initiated successfully" });
+      fetchTicketDetail(ticketDetail.id);
+    } catch (error) {
+      console.error("Error initiating refund:", error);
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to initiate refund",
+        variant: "destructive"
+      });
+    } finally {
+      setInitiatingRefund(false);
+    }
+  };
+
+  // Quick actions
+  const handleQuickAction = async (
+    ticketId: string,
+    action: string,
+    e: React.MouseEvent
+  ) => {
+    e.stopPropagation();
+    try {
+      if (action === "close") {
+        await fetch(`/api/staff/support-tickets/${ticketId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "CLOSED" }),
+        });
+        toast({ title: "Success", description: "Ticket closed" });
+      } else if (action === "resolve") {
+        await fetch(`/api/staff/support-tickets/${ticketId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "RESOLVED" }),
+        });
+        toast({ title: "Success", description: "Ticket resolved" });
+      }
+      fetchTickets();
+    } catch (error) {
+      console.error("Error:", error);
+      toast({ title: "Error", description: "Action failed", variant: "destructive" });
+    }
   };
 
   return (
@@ -231,30 +476,30 @@ export default function SupportTicketsPage() {
             Manage and respond to user support requests
           </p>
         </div>
-        <Button className="gap-2">
-          <Plus className="h-4 w-4" />
-          Create Ticket
+        <Button variant="outline" onClick={fetchTickets} disabled={loading}>
+          <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+          Refresh
         </Button>
       </div>
 
       {/* Stats */}
       <div className="grid gap-4 md:grid-cols-5">
         {[
-          { label: "All", value: ticketCounts.all, color: "text-zinc-600" },
-          { label: "Open", value: ticketCounts.open, color: "text-blue-600" },
+          { label: "All", value: counts.total, color: "text-zinc-600" },
+          { label: "Open", value: counts.open, color: "text-blue-600" },
           {
             label: "In Progress",
-            value: ticketCounts.in_progress,
+            value: counts.inProgress,
             color: "text-yellow-600",
           },
           {
-            label: "Pending",
-            value: ticketCounts.pending,
+            label: "On Hold",
+            value: counts.onHold,
             color: "text-orange-600",
           },
           {
             label: "Resolved",
-            value: ticketCounts.resolved,
+            value: counts.resolved,
             color: "text-green-600",
           },
         ].map((stat) => (
@@ -277,30 +522,47 @@ export default function SupportTicketsPage() {
                 placeholder="Search tickets by ID, subject, or user..."
                 className="pl-9"
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  setPage(1);
+                }}
               />
             </div>
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => {
+                setStatusFilter(v);
+                setPage(1);
+              }}
+            >
               <SelectTrigger className="w-full sm:w-40">
                 <SelectValue placeholder="Status" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Status</SelectItem>
-                <SelectItem value="open">Open</SelectItem>
-                <SelectItem value="in_progress">In Progress</SelectItem>
-                <SelectItem value="pending">Pending</SelectItem>
-                <SelectItem value="resolved">Resolved</SelectItem>
+                <SelectItem value="OPEN">Open</SelectItem>
+                <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                <SelectItem value="ON_HOLD">On Hold</SelectItem>
+                <SelectItem value="RESOLVED">Resolved</SelectItem>
+                <SelectItem value="CLOSED">Closed</SelectItem>
               </SelectContent>
             </Select>
-            <Select value={priorityFilter} onValueChange={setPriorityFilter}>
+            <Select
+              value={priorityFilter}
+              onValueChange={(v) => {
+                setPriorityFilter(v);
+                setPage(1);
+              }}
+            >
               <SelectTrigger className="w-full sm:w-40">
                 <SelectValue placeholder="Priority" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Priority</SelectItem>
-                <SelectItem value="high">High</SelectItem>
-                <SelectItem value="medium">Medium</SelectItem>
-                <SelectItem value="low">Low</SelectItem>
+                <SelectItem value="URGENT">Urgent</SelectItem>
+                <SelectItem value="HIGH">High</SelectItem>
+                <SelectItem value="MEDIUM">Medium</SelectItem>
+                <SelectItem value="LOW">Low</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -310,199 +572,531 @@ export default function SupportTicketsPage() {
       {/* Tickets Table */}
       <Card>
         <CardContent className="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-24">Ticket ID</TableHead>
-                <TableHead>Subject</TableHead>
-                <TableHead>User</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Priority</TableHead>
-                <TableHead>Category</TableHead>
-                <TableHead>Updated</TableHead>
-                <TableHead className="w-12"></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredTickets.map((ticket) => (
-                <TableRow
-                  key={ticket.id}
-                  className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
-                  onClick={() => setSelectedTicket(ticket)}
-                >
-                  <TableCell className="font-mono text-sm">
-                    {ticket.id}
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      {getStatusIcon(ticket.status)}
-                      <span className="font-medium">{ticket.subject}</span>
-                      {ticket.messages > 0 && (
-                        <Badge variant="outline" className="text-xs gap-1">
-                          <MessageSquare className="h-3 w-3" />
-                          {ticket.messages}
-                        </Badge>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <Avatar className="h-6 w-6">
-                        <AvatarImage src={ticket.user.avatar} />
-                        <AvatarFallback className="text-xs">
-                          {ticket.user.name
-                            .split(" ")
-                            .map((n) => n[0])
-                            .join("")}
-                        </AvatarFallback>
-                      </Avatar>
-                      <span className="text-sm">{ticket.user.name}</span>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      className={getStatusColor(ticket.status)}
-                      variant="secondary"
-                    >
-                      {ticket.status.replace("_", " ")}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      className={getPriorityColor(ticket.priority)}
-                      variant="secondary"
-                    >
-                      {ticket.priority}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="capitalize text-sm text-zinc-600 dark:text-zinc-400">
-                    {ticket.category}
-                  </TableCell>
-                  <TableCell className="text-sm text-zinc-500">
-                    {formatDate(ticket.updatedAt)}
-                  </TableCell>
-                  <TableCell>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger
-                        asChild
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem>Assign to me</DropdownMenuItem>
-                        <DropdownMenuItem>Change status</DropdownMenuItem>
-                        <DropdownMenuItem>Change priority</DropdownMenuItem>
-                        <DropdownMenuItem className="text-red-600">
-                          Close ticket
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </TableCell>
+          {loading ? (
+            <div className="flex items-center justify-center h-64">
+              <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+            </div>
+          ) : tickets.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-64 text-zinc-500">
+              <MessageSquare className="h-12 w-12 mb-4" />
+              <p>No support tickets found</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-32">Ticket ID</TableHead>
+                  <TableHead>Subject</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Priority</TableHead>
+                  <TableHead>Issue Type</TableHead>
+                  <TableHead>Updated</TableHead>
+                  <TableHead className="w-12"></TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {tickets.map((ticket) => (
+                  <TableRow
+                    key={ticket.id}
+                    className="cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                    onClick={() => handleSelectTicket(ticket)}
+                  >
+                    <TableCell className="font-mono text-xs">
+                      {ticket.id.slice(-8).toUpperCase()}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        {getStatusIcon(ticket.status)}
+                        <span className="font-medium truncate max-w-[200px]">
+                          {ticket.title}
+                        </span>
+                        {ticket.responseCount > 0 && (
+                          <Badge variant="outline" className="text-xs gap-1">
+                            <MessageSquare className="h-3 w-3" />
+                            {ticket.responseCount}
+                          </Badge>
+                        )}
+                        {ticket.attachmentCount > 0 && (
+                          <Badge variant="outline" className="text-xs gap-1">
+                            <Paperclip className="h-3 w-3" />
+                            {ticket.attachmentCount}
+                          </Badge>
+                        )}
+                        {ticket.paymentId && (
+                          <Badge variant="outline" className="text-xs gap-1">
+                            <CreditCard className="h-3 w-3" />
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Avatar className="h-6 w-6">
+                          <AvatarImage src={ticket.user.image || ""} />
+                          <AvatarFallback className="text-xs">
+                            {ticket.user.name
+                              ?.split(" ")
+                              .map((n) => n[0])
+                              .join("") || "?"}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="text-sm">{ticket.user.name || "Unknown"}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        className={getStatusColor(ticket.status)}
+                        variant="secondary"
+                      >
+                        {ticket.status.replace("_", " ")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        className={getPriorityColor(ticket.priority)}
+                        variant="secondary"
+                      >
+                        {ticket.priority}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-zinc-600 dark:text-zinc-400">
+                      {ticket.issueType?.replace(/_/g, " ") || ticket.category || "-"}
+                    </TableCell>
+                    <TableCell className="text-sm text-zinc-500">
+                      {formatDate(ticket.updatedAt)}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          asChild
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={(e) =>
+                              handleQuickAction(ticket.id, "resolve", e)
+                            }
+                          >
+                            <CheckCircle2 className="h-4 w-4 mr-2" />
+                            Mark Resolved
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-red-600"
+                            onClick={(e) =>
+                              handleQuickAction(ticket.id, "close", e)
+                            }
+                          >
+                            <XCircle className="h-4 w-4 mr-2" />
+                            Close Ticket
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </CardContent>
       </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2">
+          <Button
+            variant="outline"
+            disabled={page <= 1}
+            onClick={() => setPage(page - 1)}
+          >
+            Previous
+          </Button>
+          <span className="flex items-center px-4 text-sm text-zinc-500">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            disabled={page >= totalPages}
+            onClick={() => setPage(page + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      )}
 
       {/* Ticket Detail Dialog */}
       <Dialog
         open={!!selectedTicket}
-        onOpenChange={() => setSelectedTicket(null)}
+        onOpenChange={() => {
+          setSelectedTicket(null);
+          setTicketDetail(null);
+          setReplyText("");
+        }}
       >
-        <DialogContent className="max-w-2xl">
-          {selectedTicket && (
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+          {loadingDetail ? (
+            <div className="flex items-center justify-center h-64">
+              <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+            </div>
+          ) : ticketDetail ? (
             <>
               <DialogHeader>
                 <div className="flex items-center justify-between">
                   <DialogTitle className="flex items-center gap-2">
-                    {getStatusIcon(selectedTicket.status)}
-                    {selectedTicket.subject}
+                    {getStatusIcon(ticketDetail.status)}
+                    <span className="truncate max-w-[400px]">{ticketDetail.title}</span>
                   </DialogTitle>
-                  <Badge
-                    className={getPriorityColor(selectedTicket.priority)}
-                    variant="secondary"
-                  >
-                    {selectedTicket.priority}
-                  </Badge>
-                </div>
-                <DialogDescription>
-                  {selectedTicket.id} • Created{" "}
-                  {formatDate(selectedTicket.createdAt)}
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4">
-                {/* User Info */}
-                <div className="flex items-center gap-3 p-3 rounded-lg bg-zinc-50 dark:bg-zinc-900">
-                  <Avatar>
-                    <AvatarImage src={selectedTicket.user.avatar} />
-                    <AvatarFallback>
-                      {selectedTicket.user.name
-                        .split(" ")
-                        .map((n) => n[0])
-                        .join("")}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <p className="font-medium">{selectedTicket.user.name}</p>
-                    <p className="text-sm text-zinc-500">
-                      {selectedTicket.user.email}
-                    </p>
+                  <div className="flex gap-2">
+                    <Badge
+                      className={getPriorityColor(ticketDetail.priority)}
+                      variant="secondary"
+                    >
+                      {ticketDetail.priority}
+                    </Badge>
+                    <Badge
+                      className={getStatusColor(ticketDetail.status)}
+                      variant="secondary"
+                    >
+                      {ticketDetail.status.replace("_", " ")}
+                    </Badge>
                   </div>
                 </div>
+                <DialogDescription>
+                  {ticketDetail.id.slice(-8).toUpperCase()} • Created{" "}
+                  {formatDate(ticketDetail.createdAt)}
+                  {ticketDetail.issueType && (
+                    <> • {ticketDetail.issueType.replace(/_/g, " ")}</>
+                  )}
+                </DialogDescription>
+              </DialogHeader>
 
-                {/* Description */}
-                <div>
-                  <Label className="text-sm font-medium">Description</Label>
-                  <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                    {selectedTicket.description}
-                  </p>
-                </div>
+              <div className="flex-1 -mx-6 px-6 overflow-y-auto max-h-[60vh]">
+                <div className="space-y-4 pb-4">
+                  {/* User Info */}
+                  <div className="flex items-center gap-3 p-3 rounded-lg bg-zinc-50 dark:bg-zinc-900">
+                    <Avatar>
+                      <AvatarImage src={ticketDetail.user.image || ""} />
+                      <AvatarFallback>
+                        {ticketDetail.user.name
+                          ?.split(" ")
+                          .map((n) => n[0])
+                          .join("") || "?"}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="font-medium">{ticketDetail.user.name || "Unknown"}</p>
+                      <p className="text-sm text-zinc-500">
+                        {ticketDetail.user.email}
+                        {ticketDetail.user.phone && ` • ${ticketDetail.user.phone}`}
+                      </p>
+                    </div>
+                  </div>
 
-                {/* Status Update */}
-                <div className="flex gap-2">
-                  <Select defaultValue={selectedTicket.status}>
-                    <SelectTrigger className="w-40">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="open">Open</SelectItem>
-                      <SelectItem value="in_progress">In Progress</SelectItem>
-                      <SelectItem value="pending">Pending</SelectItem>
-                      <SelectItem value="resolved">Resolved</SelectItem>
-                      <SelectItem value="closed">Closed</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Button variant="outline">Update Status</Button>
-                </div>
+                  {/* Linked Booking Context */}
+                  {ticketDetail.linkedConsultation && (
+                    <div className="p-3 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950">
+                      <div className="flex items-center gap-2 mb-2">
+                        <Calendar className="h-4 w-4 text-blue-600" />
+                        <span className="font-medium text-blue-900 dark:text-blue-100">
+                          Linked Booking
+                        </span>
+                      </div>
+                      <div className="text-sm space-y-1">
+                        <p>
+                          <strong>Plan:</strong>{" "}
+                          {ticketDetail.linkedConsultation.consultationPlan.title}
+                        </p>
+                        <p>
+                          <strong>Consultant:</strong>{" "}
+                          {ticketDetail.linkedConsultation.consultationPlan.consultantProfile.user.name}
+                        </p>
+                        <p>
+                          <strong>Status:</strong>{" "}
+                          {ticketDetail.linkedConsultation.requestStatus}
+                        </p>
+                        {ticketDetail.linkedConsultation.appointment && (
+                          <p>
+                            <strong>Scheduled:</strong>{" "}
+                            {new Date(
+                              ticketDetail.linkedConsultation.appointment.scheduledAt
+                            ).toLocaleString()}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  )}
 
-                {/* Reply */}
-                <div>
-                  <Label htmlFor="reply">Reply to User</Label>
-                  <Textarea
-                    id="reply"
-                    placeholder="Type your response..."
-                    className="mt-1"
-                    rows={4}
-                    value={replyText}
-                    onChange={(e) => setReplyText(e.target.value)}
-                  />
+                  {/* Linked Payment Context */}
+                  {ticketDetail.linkedPayment && (
+                    <div className="p-3 rounded-lg border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950">
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center gap-2">
+                          <DollarSign className="h-4 w-4 text-green-600" />
+                          <span className="font-medium text-green-900 dark:text-green-100">
+                            Linked Payment
+                          </span>
+                        </div>
+                        {ticketDetail.linkedPayment.paymentStatus === "SUCCEEDED" &&
+                          !ticketDetail.linkedRefund && (
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={handleInitiateRefund}
+                              disabled={initiatingRefund}
+                            >
+                              {initiatingRefund ? (
+                                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                              ) : (
+                                <DollarSign className="h-4 w-4 mr-2" />
+                              )}
+                              Initiate Refund
+                            </Button>
+                          )}
+                      </div>
+                      <div className="text-sm space-y-1">
+                        <p>
+                          <strong>Amount:</strong>{" "}
+                          {formatCurrency(
+                            ticketDetail.linkedPayment.amount,
+                            ticketDetail.linkedPayment.currency
+                          )}
+                        </p>
+                        <p>
+                          <strong>Status:</strong>{" "}
+                          <Badge
+                            variant="outline"
+                            className={
+                              ticketDetail.linkedPayment.paymentStatus === "SUCCEEDED"
+                                ? "text-green-600"
+                                : "text-yellow-600"
+                            }
+                          >
+                            {ticketDetail.linkedPayment.paymentStatus}
+                          </Badge>
+                        </p>
+                        <p>
+                          <strong>Gateway:</strong>{" "}
+                          {ticketDetail.linkedPayment.paymentGateway}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Linked Refund */}
+                  {ticketDetail.linkedRefund && (
+                    <div className="p-3 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950">
+                      <div className="flex items-center gap-2 mb-2">
+                        <DollarSign className="h-4 w-4 text-amber-600" />
+                        <span className="font-medium text-amber-900 dark:text-amber-100">
+                          Refund Initiated
+                        </span>
+                      </div>
+                      <div className="text-sm space-y-1">
+                        <p>
+                          <strong>Amount:</strong>{" "}
+                          {formatCurrency(
+                            ticketDetail.linkedRefund.amount,
+                            ticketDetail.linkedRefund.currency
+                          )}
+                        </p>
+                        <p>
+                          <strong>Status:</strong>{" "}
+                          <Badge
+                            variant="outline"
+                            className={
+                              ticketDetail.linkedRefund.status === "SUCCEEDED"
+                                ? "text-green-600"
+                                : "text-yellow-600"
+                            }
+                          >
+                            {ticketDetail.linkedRefund.status}
+                          </Badge>
+                        </p>
+                        {ticketDetail.linkedRefund.reason && (
+                          <p>
+                            <strong>Reason:</strong> {ticketDetail.linkedRefund.reason}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Description */}
+                  <div>
+                    <Label className="text-sm font-medium">Description</Label>
+                    <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400 whitespace-pre-wrap">
+                      {ticketDetail.description}
+                    </p>
+                  </div>
+
+                  {/* Attachments */}
+                  {ticketDetail.attachments && ticketDetail.attachments.length > 0 && (
+                    <div>
+                      <Label className="text-sm font-medium">Attachments</Label>
+                      <div className="mt-2 space-y-2">
+                        {ticketDetail.attachments.map((attachment) => (
+                          <a
+                            key={attachment.id}
+                            href={attachment.fileUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-2 p-2 border rounded hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                          >
+                            <FileText className="h-4 w-4 text-zinc-500" />
+                            <span className="flex-1 text-sm truncate">
+                              {attachment.originalName}
+                            </span>
+                            <span className="text-xs text-zinc-400">
+                              {formatFileSize(attachment.fileSize)}
+                            </span>
+                            <ExternalLink className="h-3 w-3 text-zinc-400" />
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <Separator />
+
+                  {/* Status Update */}
+                  <div className="flex gap-2">
+                    <Select
+                      value={ticketDetail.status}
+                      onValueChange={handleUpdateStatus}
+                      disabled={updatingStatus}
+                    >
+                      <SelectTrigger className="w-40">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="OPEN">Open</SelectItem>
+                        <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
+                        <SelectItem value="ON_HOLD">On Hold</SelectItem>
+                        <SelectItem value="RESOLVED">Resolved</SelectItem>
+                        <SelectItem value="CLOSED">Closed</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {updatingStatus && (
+                      <Loader2 className="h-4 w-4 animate-spin self-center" />
+                    )}
+                  </div>
+
+                  <Separator />
+
+                  {/* Response Thread */}
+                  {ticketDetail.responses && ticketDetail.responses.length > 0 && (
+                    <div>
+                      <Label className="text-sm font-medium mb-2 block">
+                        Conversation ({ticketDetail.responses.length})
+                      </Label>
+                      <div className="space-y-3 max-h-[200px] overflow-y-auto">
+                        {ticketDetail.responses.map((response) => (
+                          <div
+                            key={response.id}
+                            className={`p-3 rounded-lg ${
+                              response.user.role === "STAFF" ||
+                              response.user.role === "ADMIN"
+                                ? response.isInternal
+                                  ? "bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800"
+                                  : "bg-blue-50 dark:bg-blue-950"
+                                : "bg-zinc-100 dark:bg-zinc-800"
+                            }`}
+                          >
+                            <div className="flex items-center gap-2 mb-1">
+                              <Avatar className="h-5 w-5">
+                                <AvatarImage src={response.user.image || ""} />
+                                <AvatarFallback className="text-xs">
+                                  {response.user.name?.[0] || "?"}
+                                </AvatarFallback>
+                              </Avatar>
+                              <span className="text-sm font-medium">
+                                {response.user.name}
+                              </span>
+                              {response.user.role && (
+                                <Badge variant="outline" className="text-xs">
+                                  {response.user.role}
+                                </Badge>
+                              )}
+                              {response.isInternal && (
+                                <Badge
+                                  variant="outline"
+                                  className="text-xs text-amber-600"
+                                >
+                                  Internal
+                                </Badge>
+                              )}
+                              <span className="text-xs text-zinc-400 ml-auto">
+                                {formatDate(response.createdAt)}
+                              </span>
+                            </div>
+                            <p className="text-sm whitespace-pre-wrap">
+                              {response.message}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Reply Box */}
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <Label htmlFor="reply">Reply to User</Label>
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={isInternalNote}
+                          onChange={(e) => setIsInternalNote(e.target.checked)}
+                          className="rounded"
+                        />
+                        Internal note (not visible to user)
+                      </label>
+                    </div>
+                    <Textarea
+                      id="reply"
+                      placeholder={
+                        isInternalNote
+                          ? "Add an internal note..."
+                          : "Type your response to the user..."
+                      }
+                      rows={3}
+                      value={replyText}
+                      onChange={(e) => setReplyText(e.target.value)}
+                    />
+                  </div>
                 </div>
               </div>
-              <DialogFooter>
+
+              <DialogFooter className="mt-4">
                 <Button
                   variant="outline"
-                  onClick={() => setSelectedTicket(null)}
+                  onClick={() => {
+                    setSelectedTicket(null);
+                    setTicketDetail(null);
+                    setReplyText("");
+                  }}
                 >
-                  Cancel
+                  Close
                 </Button>
-                <Button>Send Reply</Button>
+                <Button
+                  onClick={handleSendReply}
+                  disabled={!replyText.trim() || sendingReply}
+                >
+                  {sendingReply ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  ) : (
+                    <Send className="h-4 w-4 mr-2" />
+                  )}
+                  {isInternalNote ? "Add Note" : "Send Reply"}
+                </Button>
               </DialogFooter>
             </>
-          )}
+          ) : null}
         </DialogContent>
       </Dialog>
     </div>

--- a/app/dashboard/staff/[staffId]/layout.tsx
+++ b/app/dashboard/staff/[staffId]/layout.tsx
@@ -17,6 +17,7 @@ import {
   ChevronRight,
   Wallet,
   Receipt,
+  Star,
 } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
@@ -32,6 +33,7 @@ import {
 const sidebarItems = [
   { name: "Home", icon: Home, path: "home" },
   { name: "Support Tickets", icon: Ticket, path: "tickets" },
+  { name: "User Feedback", icon: Star, path: "feedback" },
   { name: "Users", icon: Users, path: "users" },
   { name: "Content Moderation", icon: Shield, path: "moderation" },
   { name: "Appointments", icon: Calendar, path: "appointments" },

--- a/components/booking/CancellationReasonModal.tsx
+++ b/components/booking/CancellationReasonModal.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Loader2, AlertTriangle } from "lucide-react";
+
+// These match the CancellationReason enum in Prisma schema
+const CANCELLATION_REASONS = [
+  {
+    value: "SCHEDULE_CONFLICT",
+    label: "Schedule conflict",
+    description: "I have a scheduling conflict and can't make this time",
+  },
+  {
+    value: "FOUND_ALTERNATIVE",
+    label: "Found alternative",
+    description: "I've found another option that suits my needs better",
+  },
+  {
+    value: "FINANCIAL_REASONS",
+    label: "Financial reasons",
+    description: "I can no longer afford this booking",
+  },
+  {
+    value: "PERSONAL_EMERGENCY",
+    label: "Personal emergency",
+    description: "An unexpected personal situation has come up",
+  },
+  {
+    value: "NO_LONGER_NEEDED",
+    label: "No longer needed",
+    description: "I no longer need this consultation",
+  },
+  {
+    value: "CONSULTANT_ISSUE",
+    label: "Issue with consultant",
+    description: "I'm experiencing issues with the consultant",
+  },
+  {
+    value: "TECHNICAL_ISSUE",
+    label: "Technical issues",
+    description: "I'm having technical problems with the platform",
+  },
+  {
+    value: "OTHER",
+    label: "Other reason",
+    description: "Another reason not listed here",
+  },
+] as const;
+
+type CancellationReason = (typeof CANCELLATION_REASONS)[number]["value"];
+
+interface CancellationReasonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (reason: CancellationReason, notes?: string) => Promise<void>;
+  bookingType?: "consultation" | "subscription";
+  bookingTitle?: string;
+}
+
+export function CancellationReasonModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  bookingType = "consultation",
+  bookingTitle,
+}: CancellationReasonModalProps) {
+  const [selectedReason, setSelectedReason] =
+    useState<CancellationReason | null>(null);
+  const [notes, setNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    if (!selectedReason) {
+      setError("Please select a reason for cancellation");
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await onConfirm(selectedReason, notes || undefined);
+      // Reset state on success
+      setSelectedReason(null);
+      setNotes("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to cancel booking");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      setSelectedReason(null);
+      setNotes("");
+      setError(null);
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            Cancel {bookingType}
+          </DialogTitle>
+          <DialogDescription>
+            {bookingTitle ? (
+              <>Are you sure you want to cancel &quot;{bookingTitle}&quot;?</>
+            ) : (
+              <>Are you sure you want to cancel this {bookingType}?</>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Reason Selection */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              Please select a reason for cancellation
+            </Label>
+            <RadioGroup
+              value={selectedReason || ""}
+              onValueChange={(value) =>
+                setSelectedReason(value as CancellationReason)
+              }
+              className="space-y-2"
+            >
+              {CANCELLATION_REASONS.map((reason) => (
+                <div
+                  key={reason.value}
+                  className={`flex items-start space-x-3 rounded-lg border p-3 cursor-pointer transition-colors ${
+                    selectedReason === reason.value
+                      ? "border-primary bg-primary/5"
+                      : "border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800"
+                  }`}
+                  onClick={() => setSelectedReason(reason.value)}
+                >
+                  <RadioGroupItem value={reason.value} id={reason.value} />
+                  <div className="flex-1">
+                    <Label
+                      htmlFor={reason.value}
+                      className="font-medium cursor-pointer"
+                    >
+                      {reason.label}
+                    </Label>
+                    <p className="text-xs text-zinc-500">{reason.description}</p>
+                  </div>
+                </div>
+              ))}
+            </RadioGroup>
+          </div>
+
+          {/* Additional Notes */}
+          <div className="space-y-2">
+            <Label htmlFor="notes" className="text-sm font-medium">
+              Additional notes (optional)
+            </Label>
+            <Textarea
+              id="notes"
+              placeholder="Please provide any additional details about your cancellation..."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <p className="text-sm text-red-500 bg-red-50 dark:bg-red-950 p-2 rounded">
+              {error}
+            </p>
+          )}
+
+          {/* Refund Info */}
+          <div className="text-xs text-zinc-500 bg-zinc-50 dark:bg-zinc-900 p-3 rounded">
+            <p>
+              <strong>Note:</strong> Cancellation policy may apply. Refund
+              eligibility depends on the time until the scheduled appointment.
+              Please check our cancellation policy for more details.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={handleClose} disabled={isSubmitting}>
+            Keep Booking
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={!selectedReason || isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Cancelling...
+              </>
+            ) : (
+              "Confirm Cancellation"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { CANCELLATION_REASONS };
+export type { CancellationReason };

--- a/docs/api/cancellation-api-mobile.md
+++ b/docs/api/cancellation-api-mobile.md
@@ -1,0 +1,273 @@
+# Cancellation API - Mobile Integration Guide
+
+This document describes how to implement booking cancellation with structured reasons in the mobile app.
+
+## Overview
+
+When a user cancels a consultation or subscription, we now capture a structured cancellation reason for analytics and customer service purposes.
+
+---
+
+## CancellationReason Enum
+
+```typescript
+enum CancellationReason {
+  // User-initiated
+  SCHEDULE_CONFLICT        // User has a scheduling conflict
+  FOUND_ALTERNATIVE        // User found another option
+  FINANCIAL_REASONS        // User can no longer afford it
+  PERSONAL_EMERGENCY       // Unexpected personal situation
+  NO_LONGER_NEEDED         // User no longer needs the service
+
+  // Consultant-initiated
+  CONSULTANT_UNAVAILABLE   // Consultant can't make it
+  CONSULTANT_EMERGENCY     // Consultant has an emergency
+
+  // System-initiated
+  PAYMENT_FAILED           // Payment couldn't be processed
+  EXPIRED                  // Booking expired
+
+  // Issue-related
+  CONSULTANT_ISSUE         // Problem with the consultant
+  TECHNICAL_ISSUE          // Platform technical problems
+
+  // Other
+  OTHER                    // Other reason not listed
+}
+```
+
+---
+
+## API Endpoint
+
+### Cancel Appointment
+
+```http
+POST /api/appointments/{appointmentId}/cancel
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "reason": "SCHEDULE_CONFLICT",
+  "notes": "I have a work meeting at this time now"
+}
+```
+
+**Parameters:**
+- `reason` (optional): One of the `CancellationReason` enum values
+- `notes` (optional): Free-form text with additional details
+
+**Response (200 OK):**
+```json
+{
+  "success": true,
+  "cancellationReason": "SCHEDULE_CONFLICT",
+  "cancelledAt": "2025-12-31T10:00:00Z"
+}
+```
+
+**Backward Compatibility:** The `reason` and `notes` parameters are optional. Existing cancel flows without these fields will continue to work.
+
+---
+
+## UI Implementation
+
+### Recommended Flow
+
+1. User taps "Cancel Booking" button
+2. Show modal with reason selection (radio buttons)
+3. Include optional notes text field
+4. Confirm cancellation
+5. Call API with selected reason
+
+### Reason Display Labels
+
+| Enum Value | Display Label | Description for User |
+|------------|---------------|---------------------|
+| SCHEDULE_CONFLICT | Schedule conflict | I have a scheduling conflict |
+| FOUND_ALTERNATIVE | Found alternative | I've found another option |
+| FINANCIAL_REASONS | Financial reasons | I can no longer afford this |
+| PERSONAL_EMERGENCY | Personal emergency | An unexpected situation came up |
+| NO_LONGER_NEEDED | No longer needed | I don't need this anymore |
+| CONSULTANT_ISSUE | Issue with consultant | I'm having issues with the consultant |
+| TECHNICAL_ISSUE | Technical issues | I'm having technical problems |
+| OTHER | Other reason | Another reason not listed |
+
+### Example Flutter Implementation
+
+```dart
+import 'package:flutter/material.dart';
+
+enum CancellationReason {
+  scheduleConflict('SCHEDULE_CONFLICT', 'Schedule conflict'),
+  foundAlternative('FOUND_ALTERNATIVE', 'Found alternative'),
+  financialReasons('FINANCIAL_REASONS', 'Financial reasons'),
+  personalEmergency('PERSONAL_EMERGENCY', 'Personal emergency'),
+  noLongerNeeded('NO_LONGER_NEEDED', 'No longer needed'),
+  consultantIssue('CONSULTANT_ISSUE', 'Issue with consultant'),
+  technicalIssue('TECHNICAL_ISSUE', 'Technical issues'),
+  other('OTHER', 'Other reason');
+
+  final String apiValue;
+  final String displayLabel;
+
+  const CancellationReason(this.apiValue, this.displayLabel);
+}
+
+class CancellationReasonSheet extends StatefulWidget {
+  final Function(CancellationReason, String?) onConfirm;
+
+  const CancellationReasonSheet({required this.onConfirm});
+
+  @override
+  State<CancellationReasonSheet> createState() => _CancellationReasonSheetState();
+}
+
+class _CancellationReasonSheetState extends State<CancellationReasonSheet> {
+  CancellationReason? _selectedReason;
+  final _notesController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Why are you cancelling?', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          SizedBox(height: 16),
+          ...CancellationReason.values.map((reason) =>
+            RadioListTile<CancellationReason>(
+              title: Text(reason.displayLabel),
+              value: reason,
+              groupValue: _selectedReason,
+              onChanged: (value) => setState(() => _selectedReason = value),
+            )
+          ),
+          SizedBox(height: 16),
+          TextField(
+            controller: _notesController,
+            decoration: InputDecoration(
+              labelText: 'Additional notes (optional)',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+          ),
+          SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: Text('Keep Booking'),
+              ),
+              SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: _selectedReason == null
+                  ? null
+                  : () => widget.onConfirm(
+                      _selectedReason!,
+                      _notesController.text.isEmpty ? null : _notesController.text
+                    ),
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                child: Text('Confirm Cancellation'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+### API Client Method
+
+```dart
+class ApiClient {
+  Future<void> cancelAppointment(
+    String appointmentId, {
+    CancellationReason? reason,
+    String? notes,
+  }) async {
+    final response = await http.post(
+      Uri.parse('$baseUrl/api/appointments/$appointmentId/cancel'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({
+        if (reason != null) 'reason': reason.apiValue,
+        if (notes != null) 'notes': notes,
+      }),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to cancel appointment');
+    }
+  }
+}
+```
+
+---
+
+## Database Changes
+
+The cancellation is stored on the Consultation/Subscription model:
+
+```typescript
+model Consultation {
+  // ... existing fields ...
+
+  cancellationReason CancellationReason?  // Structured reason
+  cancellationNotes  String?               // Free-form notes
+  cancelledAt        DateTime?             // When cancelled
+  cancelledBy        String?               // User ID who cancelled
+}
+```
+
+This enables:
+1. **Analytics:** "Why do users cancel?" reports
+2. **Customer Service:** Staff can see cancellation reason in ticket context
+3. **Retention:** Identify patterns and improve service
+
+---
+
+## Error Handling
+
+| HTTP Status | Error | Description |
+|-------------|-------|-------------|
+| 401 | Unauthorized | User not logged in |
+| 400 | Invalid cancellation reason | Unknown reason value |
+| 404 | Appointment not found | Appointment ID doesn't exist |
+| 500 | Failed to cancel | Server error during cancellation |
+
+---
+
+## Testing
+
+Test with different cancellation reasons:
+
+```bash
+curl -X POST http://localhost:3000/api/appointments/abc123/cancel \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason": "SCHEDULE_CONFLICT", "notes": "Work meeting"}'
+```
+
+---
+
+## Analytics
+
+Admin can view cancellation analytics at:
+```
+GET /api/admin/analytics/cancellations?startDate=2025-01-01&endDate=2025-12-31
+```
+
+Returns aggregated data by reason, type, and time period.
+
+---
+
+## Related Documentation
+
+- [Support Tickets Mobile Guide](./support-tickets-mobile.md)
+- Web Issue #280: CancellationReason enum
+- Web Issue #281: Swiggy-style support integration

--- a/docs/api/support-tickets-mobile.md
+++ b/docs/api/support-tickets-mobile.md
@@ -1,0 +1,332 @@
+# Support Tickets API - Mobile Integration Guide
+
+This document describes how the mobile app should integrate with the shared support ticket system.
+
+## Architecture Overview
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Mobile App    │     │    Web App      │     │ Staff Dashboard │
+│   (Flutter)     │     │   (Next.js)     │     │   (Next.js)     │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │
+         └───────────────────────┴───────────────────────┘
+                                 │
+                    ┌────────────┴────────────┐
+                    │   Shared PostgreSQL DB   │
+                    │   (Supabase)            │
+                    └─────────────────────────┘
+```
+
+**Key Point:** Mobile and Web share the same database. Tickets created from mobile are immediately visible in the web staff dashboard.
+
+---
+
+## Database Models
+
+### SupportTicket
+
+```typescript
+model SupportTicket {
+  id          String              // UUID
+  title       String
+  description String
+  priority    SupportPriority     // LOW, MEDIUM, HIGH, URGENT
+  status      SupportTicketStatus // OPEN, IN_PROGRESS, ON_HOLD, RESOLVED, CLOSED
+  category    String?
+  issueType   SupportIssueType?   // See enum below
+
+  userId      String              // User who created the ticket
+
+  // Optional entity links (for Swiggy-style context)
+  consultationId String?
+  subscriptionId String?
+  paymentId      String?
+  refundId       String?
+
+  assignedToId String?            // Staff member assigned
+
+  createdAt DateTime
+  updatedAt DateTime
+}
+```
+
+### SupportIssueType Enum
+
+```typescript
+enum SupportIssueType {
+  // Booking Issues
+  CONSULTANT_NO_SHOW
+  SESSION_QUALITY_POOR
+  TECHNICAL_ISSUES
+  WRONG_CONSULTANT
+
+  // Payment Issues
+  PAYMENT_FAILED
+  CHARGED_TWICE
+  REFUND_REQUEST
+
+  // Cancellation
+  WANT_TO_CANCEL
+  CANCELLATION_ISSUE
+
+  // General
+  ACCOUNT_ISSUE
+  GENERAL_INQUIRY
+  OTHER
+}
+```
+
+### SupportTicketAttachment
+
+```typescript
+model SupportTicketAttachment {
+  id           String
+  fileName     String
+  originalName String
+  fileSize     Int
+  mimeType     String
+  fileUrl      String      // Supabase Storage URL
+  storagePath  String
+  ticketId     String
+  uploadedAt   DateTime
+}
+```
+
+---
+
+## API Endpoints
+
+### Create Support Ticket
+
+```http
+POST /api/user/support-tickets
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "title": "Session issue",
+  "description": "The consultant didn't join the scheduled call",
+  "priority": "HIGH",               // Optional: LOW, MEDIUM, HIGH, URGENT
+  "issueType": "CONSULTANT_NO_SHOW", // Optional: See enum above
+  "consultationId": "clx..."        // Optional: Link to booking for context
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "uuid-...",
+  "title": "Session issue",
+  "description": "The consultant didn't join the scheduled call",
+  "priority": "HIGH",
+  "status": "OPEN",
+  "issueType": "CONSULTANT_NO_SHOW",
+  "consultationId": "clx...",
+  "createdAt": "2025-12-31T10:00:00Z",
+  "updatedAt": "2025-12-31T10:00:00Z",
+  "responses": [],
+  "attachments": []
+}
+```
+
+### List User's Tickets
+
+```http
+GET /api/user/support-tickets
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid-...",
+    "title": "Session issue",
+    "description": "...",
+    "priority": "HIGH",
+    "status": "IN_PROGRESS",
+    "issueType": "CONSULTANT_NO_SHOW",
+    "responses": [
+      {
+        "id": "uuid-...",
+        "message": "We're looking into this for you.",
+        "createdAt": "2025-12-31T11:00:00Z",
+        "user": {
+          "name": "Support Team",
+          "role": "STAFF"
+        }
+      }
+    ],
+    "attachments": [...],
+    "createdAt": "2025-12-31T10:00:00Z",
+    "updatedAt": "2025-12-31T11:00:00Z"
+  }
+]
+```
+
+### Add Response to Ticket
+
+```http
+POST /api/user/support-tickets/{ticketId}/responses
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "message": "Thanks for looking into this. Here's more detail..."
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "id": "uuid-...",
+  "message": "Thanks for looking into this...",
+  "createdAt": "2025-12-31T12:00:00Z",
+  "user": {
+    "name": "John Doe",
+    "role": "CONSULTEE"
+  }
+}
+```
+
+### Upload Attachment
+
+```http
+POST /api/support-tickets/{ticketId}/attachments
+Authorization: Bearer <token>
+Content-Type: multipart/form-data
+
+file: <binary file data>
+```
+
+**Response (201 Created):**
+```json
+{
+  "attachment": {
+    "id": "uuid-...",
+    "fileName": "1735645200000_screenshot.png",
+    "originalName": "screenshot.png",
+    "fileSize": 102400,
+    "mimeType": "image/png",
+    "fileUrl": "https://xxx.supabase.co/storage/v1/object/public/..."
+  }
+}
+```
+
+**Limits:**
+- Max file size: 10MB
+- Max 5 attachments per ticket
+- Allowed types: PDF, Word docs, images (JPG, PNG, GIF, WebP), text files
+
+---
+
+## Status Flow
+
+```
+Mobile: Creates ticket (OPEN)
+    ↓
+Web Admin: Responds (status → IN_PROGRESS)
+    ↓
+Mobile: User sees response
+    ↓
+Web Admin: Resolves (status → RESOLVED)
+    ↓
+Mobile: User sees resolved status
+```
+
+---
+
+## Implementation Notes for Mobile
+
+### 1. Polling for Updates
+
+Since we don't have push notifications in scope, implement polling:
+
+```dart
+// Poll every 60 seconds for ticket updates
+Timer.periodic(Duration(seconds: 60), (timer) async {
+  final tickets = await apiClient.getUserTickets();
+  // Update local state and show notification badge if new responses
+});
+```
+
+### 2. Linking to Bookings
+
+When creating a ticket about a specific booking:
+
+```dart
+await apiClient.createSupportTicket(
+  title: "Issue with my consultation",
+  description: userDescription,
+  issueType: SupportIssueType.consultantNoShow,
+  consultationId: booking.consultationId, // Link to specific booking
+);
+```
+
+This allows staff to see the booking context when handling the ticket.
+
+### 3. Handling New Enum Values
+
+The mobile app should handle unknown enum values gracefully:
+
+```dart
+SupportIssueType parseIssueType(String? value) {
+  if (value == null) return null;
+  try {
+    return SupportIssueType.values.byName(value);
+  } catch (_) {
+    return SupportIssueType.other; // Fallback for unknown values
+  }
+}
+```
+
+### 4. Attachment Uploads
+
+Use the same Supabase bucket pattern as web:
+
+- Bucket: `support-attachments`
+- Path: `support-tickets/{ticketId}/{timestamp}_{filename}`
+
+```dart
+// Example using Supabase Dart client
+final fileBytes = await file.readAsBytes();
+final path = 'support-tickets/$ticketId/${DateTime.now().millisecondsSinceEpoch}_${file.name}';
+
+await supabase.storage
+  .from('support-attachments')
+  .uploadBinary(path, fileBytes);
+```
+
+---
+
+## Error Handling
+
+| HTTP Status | Error | Description |
+|------------|-------|-------------|
+| 401 | Unauthorized | User not logged in |
+| 400 | Invalid issue type | Unknown issueType value |
+| 400 | Invalid consultation ID | Linked consultation doesn't exist or doesn't belong to user |
+| 404 | Ticket not found | Ticket ID doesn't exist |
+| 500 | Server error | Something went wrong |
+
+---
+
+## Testing
+
+For local development, the API accepts tickets without real authentication when `NODE_ENV=development`.
+
+To test the full flow:
+1. Create a ticket from mobile
+2. Check the web staff dashboard - ticket should appear immediately
+3. Respond from staff dashboard
+4. Poll from mobile - response should appear
+
+---
+
+## Related Issues
+
+- familiarise_mobile#16: Customer Support MVP
+- familiarise_mobile#17: Mobile backend support tickets
+- familiarise_web#280: CancellationReason enum
+- familiarise_web#281: Swiggy-style support integration

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -378,6 +378,128 @@ const listAppointmentDocuments = async (
   }
 };
 
+// Support ticket attachment types
+export interface SupportAttachmentUploadOptions {
+  ticketId: string;
+  file: File;
+}
+
+/**
+ * Upload support ticket attachment to Supabase storage
+ */
+const uploadSupportTicketAttachment = async (
+  options: SupportAttachmentUploadOptions
+): Promise<DocumentUploadResult> => {
+  try {
+    const { ticketId, file } = options;
+
+    // Validate file
+    if (!file) {
+      return { success: false, error: "No file provided" };
+    }
+
+    // Check file size (max 10MB)
+    const maxSize = 10 * 1024 * 1024; // 10MB
+    if (file.size > maxSize) {
+      return { success: false, error: "File size exceeds 10MB limit" };
+    }
+
+    // Validate file type (common document types + images)
+    const allowedTypes = [
+      "application/pdf",
+      "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "image/jpeg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+      "text/plain",
+    ];
+
+    if (!allowedTypes.includes(file.type)) {
+      return { success: false, error: "File type not supported" };
+    }
+
+    // Ensure the support-attachments bucket exists
+    const bucketReady = await ensureBucketExists("support-attachments");
+    if (!bucketReady) {
+      return {
+        success: false,
+        error:
+          "Support attachments storage bucket not found. Please create a 'support-attachments' bucket in your Supabase dashboard with public access enabled.",
+      };
+    }
+
+    // Generate unique filename
+    const timestamp = Date.now();
+    const safeFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
+    const fileName = `${timestamp}_${safeFileName}`;
+
+    // Create folder structure: support-tickets/{ticketId}/
+    const folderPath = `support-tickets/${ticketId}`;
+    const storagePath = `${folderPath}/${fileName}`;
+
+    // Ensure folder structure exists
+    await ensureFolderExists("support-attachments", folderPath);
+
+    // Upload file to Supabase storage
+    const { data: _uploadData, error: uploadError } = await supabase.storage
+      .from("support-attachments")
+      .upload(storagePath, file, {
+        cacheControl: "3600",
+        upsert: false,
+      });
+
+    if (uploadError) {
+      console.error("Supabase upload error:", uploadError);
+      return { success: false, error: uploadError.message };
+    }
+
+    // Get public URL
+    const { data: urlData } = supabase.storage
+      .from("support-attachments")
+      .getPublicUrl(storagePath);
+
+    return {
+      success: true,
+      fileUrl: urlData.publicUrl,
+      storagePath,
+      fileName,
+      fileSize: file.size,
+      mimeType: file.type,
+    };
+  } catch (error) {
+    console.error("Error uploading support attachment:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Upload failed",
+    };
+  }
+};
+
+/**
+ * Delete support ticket attachment from Supabase storage
+ */
+const deleteSupportTicketAttachment = async (
+  storagePath: string
+): Promise<boolean> => {
+  try {
+    const { error } = await supabase.storage
+      .from("support-attachments")
+      .remove([storagePath]);
+
+    if (error) {
+      console.error("Error deleting support attachment:", error);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error("Error deleting support attachment:", error);
+    return false;
+  }
+};
+
 /**
  * Get manual bucket creation instructions
  */
@@ -406,6 +528,8 @@ export {
   uploadAppointmentDocument,
   deleteAppointmentDocument,
   listAppointmentDocuments,
+  uploadSupportTicketAttachment,
+  deleteSupportTicketAttachment,
   ensureBucketExists,
   ensureFolderExists,
   getManualBucketInstructions,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1315,6 +1315,11 @@ model DiscountCode {
   description   String
   discountType  DiscountType
   discountValue Float
+  isActive      Boolean      @default(true)
+  expiresAt     DateTime?
+  maxUses       Int?
+  currentUses   Int          @default(0)
+  maxDiscount   Float?
 
   Payment Payment[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,21 +93,37 @@ model SupportTicket {
   priority    SupportPriority     @default(MEDIUM)
   status      SupportTicketStatus @default(OPEN)
   category    String?
+  issueType   SupportIssueType?
 
   user   User   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId String
 
-  responses SupportResponse[]
+  responses   SupportResponse[]
+  attachments SupportTicketAttachment[]
+
+  // Entity links for Swiggy-style context (link ticket to booking/payment)
+  consultationId String?
+  subscriptionId String?
+  paymentId      String?
+  refundId       String? // If refund was initiated from this ticket
+
+  // Staff assignment
+  assignedToId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([userId])
+  @@index([status])
+  @@index([assignedToId])
+  @@index([consultationId])
+  @@index([paymentId])
 }
 
 model SupportResponse {
-  id      String @id @default(uuid())
-  message String @db.Text
+  id         String  @id @default(uuid())
+  message    String  @db.Text
+  isInternal Boolean @default(false) // Internal notes not visible to user
 
   supportTicket   SupportTicket @relation(fields: [supportTicketId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   supportTicketId String
@@ -119,6 +135,23 @@ model SupportResponse {
   updatedAt DateTime @updatedAt
 
   @@index([supportTicketId])
+}
+
+model SupportTicketAttachment {
+  id           String @id @default(uuid())
+  fileName     String
+  originalName String
+  fileSize     Int
+  mimeType     String
+  fileUrl      String
+  storagePath  String
+
+  ticket   SupportTicket @relation(fields: [ticketId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  ticketId String
+
+  uploadedAt DateTime @default(now())
+
+  @@index([ticketId])
 }
 
 enum FeedbackStatus {
@@ -142,6 +175,54 @@ enum SupportPriority {
   MEDIUM
   HIGH
   URGENT
+}
+
+// Cancellation reasons for Consultations and Subscriptions
+enum CancellationReason {
+  // User-initiated
+  SCHEDULE_CONFLICT
+  FOUND_ALTERNATIVE
+  FINANCIAL_REASONS
+  PERSONAL_EMERGENCY
+  NO_LONGER_NEEDED
+
+  // Consultant-initiated
+  CONSULTANT_UNAVAILABLE
+  CONSULTANT_EMERGENCY
+
+  // System-initiated
+  PAYMENT_FAILED
+  EXPIRED
+
+  // Issue-related
+  CONSULTANT_ISSUE
+  TECHNICAL_ISSUE
+
+  // Other
+  OTHER
+}
+
+// Issue types for support tickets (Swiggy-style categorization)
+enum SupportIssueType {
+  // Booking Issues
+  CONSULTANT_NO_SHOW
+  SESSION_QUALITY_POOR
+  TECHNICAL_ISSUES
+  WRONG_CONSULTANT
+
+  // Payment Issues
+  PAYMENT_FAILED
+  CHARGED_TWICE
+  REFUND_REQUEST
+
+  // Cancellation
+  WANT_TO_CANCEL
+  CANCELLATION_ISSUE
+
+  // General
+  ACCOUNT_ISSUE
+  GENERAL_INQUIRY
+  OTHER
 }
 
 model CookiePreference {
@@ -211,24 +292,24 @@ model VerificationToken {
 //////////////////////////////////////////////////// USER PROFILES and SLOTTING MECHANISM ////////////////////////////////////////////////////
 
 model ConsultantProfile {
-  id             String  @id @default(uuid())
-  description    String? @db.Text
-  experience     Float?
-  rating         Float   @default(0)
+  id          String  @id @default(uuid())
+  description String? @db.Text
+  experience  Float?
+  rating      Float   @default(0)
 
   // New fields for enhanced consultant profile
-  headline              String?       @db.VarChar(120) // Professional headline, max 120 chars
-  websiteUrl            String?
-  twitterUrl            String?
-  githubUrl             String?
-  videoIntroUrl         String?
-  languages             String[]      @default([])
-  toolsAndTechnologies  String[]      @default([])
-  mentoringStyle        String?       @db.Text
-  sessionTypes          SessionType[] @default([])
-  profileCompletionPercentage Int     @default(0)
-  isVerified            Boolean       @default(false)
-  totalMenteesHelped    Int           @default(0)
+  headline                    String?       @db.VarChar(120) // Professional headline, max 120 chars
+  websiteUrl                  String?
+  twitterUrl                  String?
+  githubUrl                   String?
+  videoIntroUrl               String?
+  languages                   String[]      @default([])
+  toolsAndTechnologies        String[]      @default([])
+  mentoringStyle              String?       @db.Text
+  sessionTypes                SessionType[] @default([])
+  profileCompletionPercentage Int           @default(0)
+  isVerified                  Boolean       @default(false)
+  totalMenteesHelped          Int           @default(0)
 
   // Deprecated fields - to be removed in Phase 6
   // @deprecated Use Certification and Education models instead
@@ -390,9 +471,9 @@ model StaffProfile {
   // New fields for enhanced staff profile
   employeeId   String?
   hireDate     DateTime?
-  reportsTo    String?   // Manager's user ID
+  reportsTo    String? // Manager's user ID
   skills       String[]  @default([])
-  workSchedule String?   // e.g., "9 AM - 5 PM", "Shift A", etc.
+  workSchedule String? // e.g., "9 AM - 5 PM", "Shift A", etc.
 
   user   User   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId String @unique
@@ -408,7 +489,7 @@ model StaffProfile {
 model AdminProfile {
   id              String     @id @default(uuid())
   adminLevel      AdminLevel
-  accessScope     Json?      // Granular permissions JSON
+  accessScope     Json? // Granular permissions JSON
   assignedRegions String[]   @default([]) // Geographic or domain regions
   notes           String?    @db.Text
 
@@ -561,6 +642,12 @@ model Consultation {
   feedbackFromConsultant String?
   rating                 Float?
 
+  // Cancellation tracking
+  cancellationReason CancellationReason?
+  cancellationNotes  String?             @db.Text
+  cancelledAt        DateTime?           @db.Timestamptz()
+  cancelledBy        String? // userId who cancelled
+
   appointment Appointment?
 
   createdAt DateTime @default(now()) @db.Timestamptz()
@@ -576,7 +663,7 @@ model SubscriptionPlan {
   priceCurrency          String           @default("INR")
   callsPerWeek           Int              @default(1)
   sessionDurationInHours Float            @default(1.0) // Duration of each session in hours
-  totalSessions          Int              @default(4)   // callsPerWeek × durationInMonths × 4
+  totalSessions          Int              @default(4) // callsPerWeek × durationInMonths × 4
   totalHours             Float            @default(4.0) // totalSessions × sessionDurationInHours
   emailSupport           PlanEmailSupport @default(GENERAL)
   language               String           @default("English")
@@ -610,6 +697,12 @@ model Subscription {
   feedbackFromConsultee  String?
   feedbackFromConsultant String?
   rating                 Float?
+
+  // Cancellation tracking
+  cancellationReason CancellationReason?
+  cancellationNotes  String?             @db.Text
+  cancelledAt        DateTime?           @db.Timestamptz()
+  cancelledBy        String? // userId who cancelled
 
   subscriptionPlan   SubscriptionPlan @relation(fields: [subscriptionPlanId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   subscriptionPlanId String
@@ -697,7 +790,7 @@ model ClassPlan {
   durationInMonths       Int              @default(1) // Duration in months
   meetingsPerWeek        Int              @default(1)
   sessionDurationInHours Float            @default(1.0) // Duration of each session in hours
-  totalSessions          Int              @default(4)   // meetingsPerWeek × durationInMonths × 4
+  totalSessions          Int              @default(4) // meetingsPerWeek × durationInMonths × 4
   totalHours             Float            @default(4.0) // totalSessions × sessionDurationInHours
   emailSupport           PlanEmailSupport @default(GENERAL)
   maxParticipants        Int              @default(1)
@@ -955,7 +1048,7 @@ model Payment {
   discountCode   DiscountCode? @relation(fields: [discountCodeId], references: [id], onUpdate: Cascade, onDelete: SetNull)
   discountCodeId String?
 
-  refunds  Refund[]  // Refunds associated with this payment
+  refunds  Refund[] // Refunds associated with this payment
   disputes Dispute[] // Disputes associated with this payment
 
   // Payout relations
@@ -965,9 +1058,9 @@ model Payment {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([userId, appointmentId]) // Allow multiple users to pay for same appointment (webinars/classes)
   @@index([expiresAt, paymentStatus])
   @@index([isMockPayment])
-  @@unique([userId, appointmentId]) // Allow multiple users to pay for same appointment (webinars/classes)
 }
 
 enum PaymentGateway {
@@ -986,13 +1079,13 @@ enum PaymentStatus {
 
 model Refund {
   id             String         @id @default(uuid())
-  amount         Int            // Amount refunded in smallest currency unit (e.g., cents for USD)
+  amount         Int // Amount refunded in smallest currency unit (e.g., cents for USD)
   currency       String
-  reason         String?        // Reason for refund
+  reason         String? // Reason for refund
   status         RefundStatus
   refundId       String         @unique // Gateway-specific refund ID (Stripe/Razorpay)
   paymentGateway PaymentGateway
-  metadata       Json?          // Additional gateway-specific metadata
+  metadata       Json? // Additional gateway-specific metadata
 
   payment   Payment @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   paymentId String
@@ -1006,23 +1099,23 @@ model Refund {
 }
 
 enum RefundStatus {
-  PENDING    // Refund initiated but not yet processed
-  SUCCEEDED  // Refund completed successfully
-  FAILED     // Refund failed
-  CANCELLED  // Refund cancelled
+  PENDING // Refund initiated but not yet processed
+  SUCCEEDED // Refund completed successfully
+  FAILED // Refund failed
+  CANCELLED // Refund cancelled
 }
 
 model Dispute {
-  id             String         @id @default(uuid())
-  amount         Int            // Disputed amount in smallest currency unit
-  currency       String
-  reason         String         // Dispute reason from gateway
-  status         DisputeStatus
-  disputeId      String         @unique // Gateway-specific dispute ID
-  paymentGateway PaymentGateway
-  evidence       Json?          // Evidence submitted to gateway
-  dueBy          DateTime?      // Deadline to respond to dispute
-  isChargeRefundable Boolean    @default(true)
+  id                 String         @id @default(uuid())
+  amount             Int // Disputed amount in smallest currency unit
+  currency           String
+  reason             String // Dispute reason from gateway
+  status             DisputeStatus
+  disputeId          String         @unique // Gateway-specific dispute ID
+  paymentGateway     PaymentGateway
+  evidence           Json? // Evidence submitted to gateway
+  dueBy              DateTime? // Deadline to respond to dispute
+  isChargeRefundable Boolean        @default(true)
 
   payment   Payment @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   paymentId String
@@ -1037,33 +1130,33 @@ model Dispute {
 }
 
 enum DisputeStatus {
-  WARNING_NEEDS_RESPONSE   // Early fraud warning, needs response
-  WARNING_UNDER_REVIEW     // Early fraud warning under review
-  WARNING_CLOSED           // Early fraud warning closed
-  NEEDS_RESPONSE           // Dispute filed, needs evidence
-  UNDER_REVIEW             // Evidence submitted, under review
-  CHARGE_REFUNDED          // Charge was refunded
-  WON                      // Dispute won
-  LOST                     // Dispute lost
+  WARNING_NEEDS_RESPONSE // Early fraud warning, needs response
+  WARNING_UNDER_REVIEW // Early fraud warning under review
+  WARNING_CLOSED // Early fraud warning closed
+  NEEDS_RESPONSE // Dispute filed, needs evidence
+  UNDER_REVIEW // Evidence submitted, under review
+  CHARGE_REFUNDED // Charge was refunded
+  WON // Dispute won
+  LOST // Dispute lost
 }
 
 ////////////////////////////////////////////// PAYOUT SYSTEM ////////////////////////////////////////////////////
 
 enum EarningStatus {
-  PENDING   // In hold period
-  HELD      // Extended hold (dispute)
-  READY     // Ready for payout
-  PAID      // Successfully paid
-  REFUNDED  // Refunded to consultee
+  PENDING // In hold period
+  HELD // Extended hold (dispute)
+  READY // Ready for payout
+  PAID // Successfully paid
+  REFUNDED // Refunded to consultee
 }
 
 enum PayoutStatus {
-  PENDING    // Awaiting approval
-  APPROVED   // Admin approved
+  PENDING // Awaiting approval
+  APPROVED // Admin approved
   PROCESSING // Being processed
-  COMPLETED  // Successfully sent
-  FAILED     // Provider rejected
-  CANCELLED  // Manually cancelled
+  COMPLETED // Successfully sent
+  FAILED // Provider rejected
+  CANCELLED // Manually cancelled
 }
 
 enum PayoutMethod {
@@ -1079,9 +1172,9 @@ enum PayoutAccountType {
 }
 
 model ConsultantEarnings {
-  id                  String        @id @default(cuid())
+  id                  String  @id @default(cuid())
   consultantProfileId String
-  paymentId           String        @unique
+  paymentId           String  @unique
   payoutId            String?
 
   // Revenue breakdown
@@ -1091,7 +1184,7 @@ model ConsultantEarnings {
 
   // Status tracking
   status    EarningStatus @default(PENDING)
-  holdUntil DateTime      // Release after hold period
+  holdUntil DateTime // Release after hold period
   paidAt    DateTime?
 
   createdAt DateTime @default(now())
@@ -1185,7 +1278,7 @@ model Invoice {
   paidAt        DateTime?
 
   // Tax breakdown
-  taxAmount Int?   // GST amount in paise
+  taxAmount Int? // GST amount in paise
   taxRate   Float? // 18% for services
   hsnCode   String? // SAC code (999293 for consulting)
 
@@ -1283,27 +1376,27 @@ enum Gender {
 
 enum CareerStage {
   STUDENT
-  EARLY_CAREER   // 0-3 years experience
-  MID_CAREER     // 3-10 years experience
-  SENIOR         // 10+ years experience
-  EXECUTIVE      // C-level or equivalent
+  EARLY_CAREER // 0-3 years experience
+  MID_CAREER // 3-10 years experience
+  SENIOR // 10+ years experience
+  EXECUTIVE // C-level or equivalent
 }
 
 enum AdminLevel {
-  SUPER_ADMIN    // Full system access
-  ADMIN          // High-level management
-  MODERATOR      // Day-to-day operations
+  SUPER_ADMIN // Full system access
+  ADMIN // High-level management
+  MODERATOR // Day-to-day operations
 }
 
 enum BudgetPreference {
-  BUDGET         // Looking for affordable options
-  MODERATE       // Mid-range pricing
-  PREMIUM        // Willing to pay for premium
-  FLEXIBLE       // No specific preference
+  BUDGET // Looking for affordable options
+  MODERATE // Mid-range pricing
+  PREMIUM // Willing to pay for premium
+  FLEXIBLE // No specific preference
 }
 
 enum SessionType {
-  ONE_ON_ONE     // 1:1 video/audio sessions
-  GROUP          // Group sessions
-  ASYNC_REVIEW   // Asynchronous document/code review
+  ONE_ON_ONE // 1:1 video/audio sessions
+  GROUP // Group sessions
+  ASYNC_REVIEW // Asynchronous document/code review
 }


### PR DESCRIPTION
## Summary

This PR implements a comprehensive Swiggy-style customer support and refund system that enables staff to handle tickets with full booking context. Key features:

- **Structured cancellation tracking** with `CancellationReason` enum for analytics
- **Support ticket enhancements** with entity links (booking, payment, refund)
- **Staff dashboard overhaul** - replaces mock data with real API integration
- **Direct refund initiation** from support ticket view
- **Mobile developer documentation** for shared database architecture

## Changes by Area

### Schema (Prisma)
- `CancellationReason` enum (SCHEDULE_CONFLICT, FINANCIAL_REASONS, etc.)
- `SupportIssueType` enum (CONSULTANT_NO_SHOW, REFUND_REQUEST, etc.)
- `SupportTicketAttachment` model for file uploads
- Entity linking: `consultationId`, `paymentId`, `refundId` on SupportTicket
- `isInternal` field on SupportResponse for staff-only notes
- Cancellation tracking on Consultation/Subscription models

### Staff APIs
| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/staff/support-tickets` | GET | List ALL tickets with filters |
| `/api/staff/support-tickets/[id]` | GET, PATCH | View/update any ticket |
| `/api/staff/support-tickets/[id]/responses` | POST | Staff respond to tickets |
| `/api/support-tickets/[id]/attachments` | POST, DELETE | Attachment management |

### Staff Dashboard UI
- Real API integration (no more mock data)
- Linked entity context panel (booking details, payment info)
- "Initiate Refund" button with two-phase refund flow
- Internal notes feature for staff-only communication
- Functional status dropdown

### User-Facing
- Enhanced cancel endpoint with `reason` and `notes` parameters
- `CancellationReasonModal` component for UI
- User ticket API accepts `issueType` and entity links

### Mobile Documentation
- `docs/api/support-tickets-mobile.md` - Full API guide
- `docs/api/cancellation-api-mobile.md` - Cancellation with Flutter examples

## Test Plan

- [x] Run `npx prisma migrate dev --name add_support_cancellation_fields` 
- [x] Create support ticket from user dashboard
- [x] View ticket in staff dashboard with linked booking
- [x] Staff responds to ticket (public + internal note)
- [x] Update ticket status from staff dashboard
- [ ] Cancel booking with structured reason
- [ ] Initiate refund from ticket view
- [ ] Check admin cancellation analytics

## Related Issues

Closes #280 (CancellationReason enum)
Closes #281 (Swiggy-style support integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)