### PR TITLE
fix: booking improvements, performance fixes, contextual support tickets, and reschedule visibility

### DIFF
--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -2,6 +2,10 @@ import prisma from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import authOptions from "@/app/api/auth/[...nextauth]/options";
+import {
+  ReschedulePolicyError,
+  AppointmentNotFoundError,
+} from "@/utils/errors/RescheduleErrors";
 
 const MINIMUM_HOURS_BEFORE_RESCHEDULE = 24;
 
@@ -86,7 +90,7 @@ export async function POST(
         });
 
         if (!appointment) {
-          throw new Error("Appointment not found");
+          throw new AppointmentNotFoundError("appointment", appointmentId);
         }
 
         // Determine which slots will be affected
@@ -102,7 +106,7 @@ export async function POST(
             (s) => s.id === slotId,
           );
           if (!targetSlot) {
-            throw new Error("Specified slot not found in this appointment");
+            throw new AppointmentNotFoundError("slot", slotId);
           }
           slotsToReschedule = [targetSlot];
         }
@@ -116,9 +120,9 @@ export async function POST(
             (1000 * 60 * 60);
 
           if (hoursUntilSlot < MINIMUM_HOURS_BEFORE_RESCHEDULE) {
-            throw new Error(
-              `Cannot reschedule within ${MINIMUM_HOURS_BEFORE_RESCHEDULE} hours of the session. ` +
-                `The earliest session starts in ${Math.max(0, Math.floor(hoursUntilSlot))} hours.`,
+            throw new ReschedulePolicyError(
+              hoursUntilSlot,
+              MINIMUM_HOURS_BEFORE_RESCHEDULE,
             );
           }
         }
@@ -188,17 +192,13 @@ export async function POST(
   } catch (error) {
     console.error("Error requesting reschedule:", error);
 
-    // Return specific error messages for known error types
-    if (error instanceof Error) {
-      if (error.message.includes("Cannot reschedule within")) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
-      }
-      if (
-        error.message.includes("not found") ||
-        error.message.includes("Specified slot")
-      ) {
-        return NextResponse.json({ error: error.message }, { status: 404 });
-      }
+    // Type-safe error handling using custom error classes
+    if (error instanceof ReschedulePolicyError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    if (error instanceof AppointmentNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
     }
 
     return NextResponse.json(

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -12,24 +12,24 @@ const MINIMUM_HOURS_BEFORE_RESCHEDULE = 24;
 /**
  * POST /api/appointments/[appointmentId]/reschedule
  *
- * Reschedule an appointment or specific session within a subscription.
+ * Reschedule an appointment or specific session(s) within a subscription.
  *
  * Query Parameters:
  * - type: AppointmentType (CONSULTATION, SUBSCRIPTION, WEBINAR, CLASS)
  *
  * Body (optional):
- * - slotId: string - For SUBSCRIPTION type only. If provided, only this specific
- *                    session/slot will be marked as tentative. If not provided,
- *                    all slots in the subscription will be marked as tentative.
+ * - slotIds: string[] - For SUBSCRIPTION type only. If provided, only these specific
+ *                       slots will be marked as tentative. If not provided,
+ *                       all slots in the subscription will be marked as tentative.
  *
  * Behavior:
  * - For CONSULTATION: Marks all slots as tentative, reverts status to PENDING
- * - For SUBSCRIPTION with slotId: Marks only the specified slot as tentative (individual session reschedule)
- * - For SUBSCRIPTION without slotId: Marks ALL slots as tentative (entire subscription reschedule)
+ * - For SUBSCRIPTION with slotIds: Marks only specified slots as tentative (individual/multiple session reschedule)
+ * - For SUBSCRIPTION without slotIds: Marks ALL slots as tentative (entire subscription reschedule)
  * - For WEBINAR/CLASS: Marks all slots as tentative
  *
  * 24-Hour Restriction:
- * - Cannot reschedule if the earliest slot to be rescheduled is within 24 hours
+ * - Cannot reschedule if ANY slot to be rescheduled is within 24 hours
  */
 export async function POST(
   request: NextRequest,
@@ -45,13 +45,19 @@ export async function POST(
     const { searchParams } = new URL(request.url);
     const appointmentType = searchParams.get("type");
 
-    // Parse request body for optional slotId (used for individual session reschedule)
-    let slotId: string | undefined;
+    // Parse request body for optional slotIds (used for individual/multiple session reschedule)
+    let slotIds: string[] | undefined;
     try {
       const body = await request.json();
-      slotId = body?.slotId;
+      // Support both single slotId (legacy) and slotIds array
+      if (body?.slotIds && Array.isArray(body.slotIds)) {
+        slotIds = body.slotIds;
+      } else if (body?.slotId) {
+        // Legacy support: convert single slotId to array
+        slotIds = [body.slotId];
+      }
     } catch {
-      // No body or invalid JSON - that's fine, slotId is optional
+      // No body or invalid JSON - that's fine, slotIds is optional
     }
 
     // Start transaction
@@ -96,27 +102,31 @@ export async function POST(
         // Determine which slots will be affected
         let slotsToReschedule = appointment.slotsOfAppointment;
 
-        // For SUBSCRIPTION with slotId, only reschedule the specific slot
+        // For SUBSCRIPTION with slotIds, only reschedule the specific slots
         if (
           appointmentType === "SUBSCRIPTION" &&
-          slotId &&
+          slotIds &&
+          slotIds.length > 0 &&
           appointment.subscription
         ) {
-          const targetSlot = appointment.slotsOfAppointment.find(
-            (s) => s.id === slotId,
+          // Filter to only the requested slots
+          slotsToReschedule = appointment.slotsOfAppointment.filter((s) =>
+            slotIds.includes(s.id),
           );
-          if (!targetSlot) {
-            throw new AppointmentNotFoundError("slot", slotId);
+
+          // Validate all requested slots exist
+          if (slotsToReschedule.length !== slotIds.length) {
+            const foundIds = slotsToReschedule.map((s) => s.id);
+            const missingIds = slotIds.filter((id) => !foundIds.includes(id));
+            throw new AppointmentNotFoundError("slot", missingIds.join(", "));
           }
-          slotsToReschedule = [targetSlot];
         }
 
-        // 24-hour restriction check
+        // 24-hour restriction check - validate ALL selected slots
         const now = new Date();
-        const earliestSlot = slotsToReschedule[0];
-        if (earliestSlot) {
+        for (const slot of slotsToReschedule) {
           const hoursUntilSlot =
-            (new Date(earliestSlot.startsAt).getTime() - now.getTime()) /
+            (new Date(slot.startsAt).getTime() - now.getTime()) /
             (1000 * 60 * 60);
 
           if (hoursUntilSlot < MINIMUM_HOURS_BEFORE_RESCHEDULE) {
@@ -130,12 +140,16 @@ export async function POST(
         // Mark the appropriate slots as tentative
         if (
           appointmentType === "SUBSCRIPTION" &&
-          slotId &&
+          slotIds &&
+          slotIds.length > 0 &&
           appointment.subscription
         ) {
-          // Individual session reschedule - only mark the specific slot
-          await tx.slotOfAppointment.update({
-            where: { id: slotId },
+          // Individual/multiple session reschedule - only mark the specific slots
+          await tx.slotOfAppointment.updateMany({
+            where: {
+              id: { in: slotIds },
+              appointmentId, // Security: ensure slots belong to this appointment
+            },
             data: { isTentative: true },
           });
         } else {
@@ -169,18 +183,28 @@ export async function POST(
           });
         }
 
+        // Determine reschedule type for response
+        const getRescheduleType = () => {
+          if (appointmentType !== "SUBSCRIPTION" || !slotIds || slotIds.length === 0) {
+            return "entire_booking";
+          }
+          if (slotIds.length === 1) {
+            return "individual_session";
+          }
+          return "multiple_sessions";
+        };
+
+        const rescheduleType = getRescheduleType();
+
         // Return detailed response
         return {
           success: true,
-          rescheduleType:
-            appointmentType === "SUBSCRIPTION" && slotId
-              ? "individual_session"
-              : "entire_booking",
+          rescheduleType,
           slotsAffected: slotsToReschedule.length,
           message:
-            appointmentType === "SUBSCRIPTION" && slotId
-              ? "Session marked for rescheduling. Please select a new time."
-              : "All sessions marked for rescheduling. Please select new times.",
+            rescheduleType === "entire_booking"
+              ? "All sessions marked for rescheduling. Please select new times."
+              : `${slotsToReschedule.length} session(s) marked for rescheduling. Please select new time(s).`,
         };
       },
       {

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -3,6 +3,30 @@ import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import authOptions from "@/app/api/auth/[...nextauth]/options";
 
+const MINIMUM_HOURS_BEFORE_RESCHEDULE = 24;
+
+/**
+ * POST /api/appointments/[appointmentId]/reschedule
+ *
+ * Reschedule an appointment or specific session within a subscription.
+ *
+ * Query Parameters:
+ * - type: AppointmentType (CONSULTATION, SUBSCRIPTION, WEBINAR, CLASS)
+ *
+ * Body (optional):
+ * - slotId: string - For SUBSCRIPTION type only. If provided, only this specific
+ *                    session/slot will be marked as tentative. If not provided,
+ *                    all slots in the subscription will be marked as tentative.
+ *
+ * Behavior:
+ * - For CONSULTATION: Marks all slots as tentative, reverts status to PENDING
+ * - For SUBSCRIPTION with slotId: Marks only the specified slot as tentative (individual session reschedule)
+ * - For SUBSCRIPTION without slotId: Marks ALL slots as tentative (entire subscription reschedule)
+ * - For WEBINAR/CLASS: Marks all slots as tentative
+ *
+ * 24-Hour Restriction:
+ * - Cannot reschedule if the earliest slot to be rescheduled is within 24 hours
+ */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ appointmentId: string }> },
@@ -14,60 +38,169 @@ export async function POST(
     }
 
     const { appointmentId } = await params;
+    const { searchParams } = new URL(request.url);
+    const appointmentType = searchParams.get("type");
+
+    // Parse request body for optional slotId (used for individual session reschedule)
+    let slotId: string | undefined;
+    try {
+      const body = await request.json();
+      slotId = body?.slotId;
+    } catch {
+      // No body or invalid JSON - that's fine, slotId is optional
+    }
 
     // Start transaction
-    const result = await prisma.$transaction(async (tx) => {
-      // Get appointment details
-      const appointment = await tx.appointment.findUnique({
-        where: { id: appointmentId },
-        include: {
-          slotsOfAppointment: true,
-          consultation: true,
-          subscription: true,
-          webinar: true,
-          class: true,
-        },
-      });
-
-      if (!appointment) {
-        throw new Error("Appointment not found");
-      }
-
-      // Update all slots to tentative
-      await tx.slotOfAppointment.updateMany({
-        where: { appointmentId },
-        data: { isTentative: true },
-      });
-
-      // Update status based on appointment type
-      if (appointment.consultation) {
-        await tx.consultation.update({
-          where: { id: appointment.consultation.id },
-          data: { requestStatus: "PENDING" },
+    const result = await prisma.$transaction(
+      async (tx) => {
+        // Get appointment details with all related data
+        const appointment = await tx.appointment.findUnique({
+          where: { id: appointmentId },
+          include: {
+            slotsOfAppointment: {
+              orderBy: { startsAt: "asc" },
+            },
+            consultation: {
+              include: {
+                consultationPlan: {
+                  include: {
+                    consultantProfile: true,
+                  },
+                },
+                requestedBy: true,
+              },
+            },
+            subscription: {
+              include: {
+                subscriptionPlan: {
+                  include: {
+                    consultantProfile: true,
+                  },
+                },
+                requestedBy: true,
+              },
+            },
+            webinar: true,
+            class: true,
+          },
         });
-      } else if (appointment.subscription) {
-        await tx.subscription.update({
-          where: { id: appointment.subscription.id },
-          data: { requestStatus: "PENDING" },
-        });
-      } else if (appointment.webinar) {
-        await tx.webinar.update({
-          where: { id: appointment.webinar.id },
-          data: { status: "SCHEDULED" },
-        });
-      } else if (appointment.class) {
-        await tx.class.update({
-          where: { id: appointment.class.id },
-          data: { status: "SCHEDULED" },
-        });
-      }
 
-      return { success: true };
-    });
+        if (!appointment) {
+          throw new Error("Appointment not found");
+        }
+
+        // Determine which slots will be affected
+        let slotsToReschedule = appointment.slotsOfAppointment;
+
+        // For SUBSCRIPTION with slotId, only reschedule the specific slot
+        if (
+          appointmentType === "SUBSCRIPTION" &&
+          slotId &&
+          appointment.subscription
+        ) {
+          const targetSlot = appointment.slotsOfAppointment.find(
+            (s) => s.id === slotId,
+          );
+          if (!targetSlot) {
+            throw new Error("Specified slot not found in this appointment");
+          }
+          slotsToReschedule = [targetSlot];
+        }
+
+        // 24-hour restriction check
+        const now = new Date();
+        const earliestSlot = slotsToReschedule[0];
+        if (earliestSlot) {
+          const hoursUntilSlot =
+            (new Date(earliestSlot.startsAt).getTime() - now.getTime()) /
+            (1000 * 60 * 60);
+
+          if (hoursUntilSlot < MINIMUM_HOURS_BEFORE_RESCHEDULE) {
+            throw new Error(
+              `Cannot reschedule within ${MINIMUM_HOURS_BEFORE_RESCHEDULE} hours of the session. ` +
+                `The earliest session starts in ${Math.max(0, Math.floor(hoursUntilSlot))} hours.`,
+            );
+          }
+        }
+
+        // Mark the appropriate slots as tentative
+        if (
+          appointmentType === "SUBSCRIPTION" &&
+          slotId &&
+          appointment.subscription
+        ) {
+          // Individual session reschedule - only mark the specific slot
+          await tx.slotOfAppointment.update({
+            where: { id: slotId },
+            data: { isTentative: true },
+          });
+        } else {
+          // Entire appointment/subscription reschedule - mark all slots
+          await tx.slotOfAppointment.updateMany({
+            where: { appointmentId },
+            data: { isTentative: true },
+          });
+        }
+
+        // Update status based on appointment type
+        if (appointment.consultation) {
+          await tx.consultation.update({
+            where: { id: appointment.consultation.id },
+            data: { requestStatus: "PENDING" },
+          });
+        } else if (appointment.subscription) {
+          await tx.subscription.update({
+            where: { id: appointment.subscription.id },
+            data: { requestStatus: "PENDING" },
+          });
+        } else if (appointment.webinar) {
+          await tx.webinar.update({
+            where: { id: appointment.webinar.id },
+            data: { status: "SCHEDULED" },
+          });
+        } else if (appointment.class) {
+          await tx.class.update({
+            where: { id: appointment.class.id },
+            data: { status: "SCHEDULED" },
+          });
+        }
+
+        // Return detailed response
+        return {
+          success: true,
+          rescheduleType:
+            appointmentType === "SUBSCRIPTION" && slotId
+              ? "individual_session"
+              : "entire_booking",
+          slotsAffected: slotsToReschedule.length,
+          message:
+            appointmentType === "SUBSCRIPTION" && slotId
+              ? "Session marked for rescheduling. Please select a new time."
+              : "All sessions marked for rescheduling. Please select new times.",
+        };
+      },
+      {
+        timeout: 60000, // 60 second timeout for complex transactions
+      },
+    );
 
     return NextResponse.json(result);
   } catch (error) {
     console.error("Error requesting reschedule:", error);
+
+    // Return specific error messages for known error types
+    if (error instanceof Error) {
+      if (error.message.includes("Cannot reschedule within")) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      if (
+        error.message.includes("not found") ||
+        error.message.includes("Specified slot")
+      ) {
+        return NextResponse.json({ error: error.message }, { status: 404 });
+      }
+    }
+
     return NextResponse.json(
       { error: "Failed to request reschedule" },
       { status: 500 },

--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
 import { TWebinar, TClass } from "@/types/appointment";
 
 // Type for webinar events in planner with type discriminator
@@ -17,10 +18,82 @@ interface PlannerData {
   participantCounts: Record<string, number>;
 }
 
+/**
+ * Helper function to fetch participant counts directly via Prisma
+ * FIX #142: Uses batched queries instead of N+1 individual API calls
+ */
+async function getParticipantCounts(
+  webinarIds: string[],
+  classIds: string[],
+): Promise<Record<string, number>> {
+  const counts: Record<string, number> = {};
+
+  // Fetch webinar participant counts in a single query
+  if (webinarIds.length > 0) {
+    const webinarCounts = await prisma.webinar.findMany({
+      where: { id: { in: webinarIds } },
+      select: {
+        id: true,
+        appointment: {
+          select: {
+            slotsOfAppointment: {
+              select: { _count: { select: { user: true } } },
+              where: { isTentative: false },
+            },
+          },
+        },
+      },
+    });
+
+    for (const webinar of webinarCounts) {
+      counts[webinar.id] =
+        webinar.appointment?.slotsOfAppointment.reduce(
+          (total, slot) => total + slot._count.user,
+          0,
+        ) || 0;
+    }
+  }
+
+  // Fetch class participant counts in a single query
+  if (classIds.length > 0) {
+    const classCounts = await prisma.class.findMany({
+      where: { id: { in: classIds } },
+      select: {
+        id: true,
+        appointments: {
+          select: {
+            slotsOfAppointment: {
+              select: { _count: { select: { user: true } } },
+              where: { isTentative: false },
+            },
+          },
+        },
+      },
+    });
+
+    for (const classEvent of classCounts) {
+      counts[classEvent.id] = classEvent.appointments.reduce(
+        (total, appointment) =>
+          total +
+          appointment.slotsOfAppointment.reduce(
+            (slotTotal, slot) => slotTotal + slot._count.user,
+            0,
+          ),
+        0,
+      );
+    }
+  }
+
+  return counts;
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ consultantId: string }> },
 ) {
+  // Note: request parameter kept for Next.js API route signature compatibility
+  void request;
+
   try {
     const { consultantId } = await params;
 
@@ -36,6 +109,7 @@ export async function GET(
       : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
     // Fetch webinars and classes in parallel
+    // TODO: Consider refactoring to direct Prisma calls in future
     const [webinarsRes, classesRes] = await Promise.all([
       fetch(
         `${baseUrl}/api/events/webinars?consultantProfileId=${consultantId}`,
@@ -68,7 +142,7 @@ export async function GET(
       classesRes.json(),
     ]);
 
-    // Transform webinars to include type discriminator (same as PlannerService.fetchWebinars)
+    // Transform webinars to include type discriminator
     const webinars: WebinarEvent[] = (webinarsData.data || []).map(
       (webinar: TWebinar) => ({
         ...webinar,
@@ -76,7 +150,7 @@ export async function GET(
       }),
     );
 
-    // Transform classes to include type discriminator (same as PlannerService.fetchClasses)
+    // Transform classes to include type discriminator
     const classes: ClassEvent[] = (classesData.data || []).map(
       (classEvent: TClass) => ({
         ...classEvent,
@@ -84,55 +158,11 @@ export async function GET(
       }),
     );
 
-    // Fetch participant counts for all events in parallel
-    const participantCountPromises = [
-      ...webinars.map(async (webinar: WebinarEvent) => {
-        try {
-          const response = await fetch(
-            `${baseUrl}/api/participants/webinar/${webinar.id}`,
-          );
-          if (response.ok) {
-            const data = await response.json();
-            return {
-              eventId: webinar.id,
-              count: data.participants?.length || 0,
-            };
-          }
-        } catch (error) {
-          console.error(
-            `Failed to fetch participants for webinar ${webinar.id}:`,
-            error,
-          );
-        }
-        return { eventId: webinar.id, count: 0 };
-      }),
-      ...classes.map(async (classEvent: ClassEvent) => {
-        try {
-          const response = await fetch(
-            `${baseUrl}/api/participants/class/${classEvent.id}`,
-          );
-          if (response.ok) {
-            const data = await response.json();
-            return {
-              eventId: classEvent.id,
-              count: data.participants?.length || 0,
-            };
-          }
-        } catch (error) {
-          console.error(
-            `Failed to fetch participants for class ${classEvent.id}:`,
-            error,
-          );
-        }
-        return { eventId: classEvent.id, count: 0 };
-      }),
-    ];
+    // FIX #142: Fetch participant counts using direct Prisma query (not internal API)
+    const webinarIds = webinars.map((w) => w.id).filter(Boolean) as string[];
+    const classIds = classes.map((c) => c.id).filter(Boolean) as string[];
 
-    const participantCountResults = await Promise.all(participantCountPromises);
-    const participantCounts: Record<string, number> = {};
-    participantCountResults.forEach(({ eventId, count }) => {
-      participantCounts[eventId] = count;
-    });
+    const participantCounts = await getParticipantCounts(webinarIds, classIds);
 
     const plannerData: PlannerData = {
       webinars,

--- a/app/api/slots/appointments/[appointmentId]/route.ts
+++ b/app/api/slots/appointments/[appointmentId]/route.ts
@@ -10,9 +10,12 @@ interface UpdateSlotsRequest {
         slotStartTimeInUTC: string;
         slotEndTimeInUTC: string;
         type?: "WEEKLY" | "CUSTOM";
+        isTentative?: boolean;
       }>;
     };
   };
+  // Global isTentative flag - applies to all slots if individual slot doesn't specify
+  isTentative?: boolean;
 }
 
 interface UpdateAppointmentRequest {
@@ -320,6 +323,9 @@ export async function PATCH(
       );
     }
 
+    // Determine default isTentative value - global flag takes precedence
+    const defaultIsTentative = body.isTentative ?? false;
+
     const data: Prisma.AppointmentUpdateInput = {
       slotsOfAppointment: {
         deleteMany: {},
@@ -327,6 +333,7 @@ export async function PATCH(
           startsAt: new Date(slot.slotStartTimeInUTC),
           endsAt: new Date(slot.slotEndTimeInUTC),
           type: slot.type || "WEEKLY", // Default to WEEKLY if not specified
+          isTentative: slot.isTentative ?? defaultIsTentative, // Explicit tentative flag
         })),
       },
     };

--- a/app/api/user/support-tickets/route.ts
+++ b/app/api/user/support-tickets/route.ts
@@ -70,6 +70,7 @@ interface CreateTicketBody {
   consultationId?: string;
   subscriptionId?: string;
   paymentId?: string;
+  appointmentId?: string; // Can be used to auto-resolve to consultationId/subscriptionId
 }
 
 export async function POST(req: NextRequest) {
@@ -103,23 +104,58 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Resolve appointmentId to consultationId/subscriptionId if provided
+    let resolvedConsultationId = body.consultationId;
+    let resolvedSubscriptionId = body.subscriptionId;
+
+    if (body.appointmentId) {
+      const appointment = await prisma.appointment.findFirst({
+        where: {
+          id: body.appointmentId,
+          OR: [
+            { consultation: { requestedBy: { userId: session.user.id } } },
+            { subscription: { requestedBy: { userId: session.user.id } } },
+          ],
+        },
+        include: {
+          consultation: true,
+          subscription: true,
+        },
+      });
+
+      if (!appointment) {
+        return NextResponse.json(
+          { error: "Invalid appointment ID or unauthorized" },
+          { status: 400 }
+        );
+      }
+
+      // Resolve to actual consultation/subscription IDs
+      if (appointment.consultation) {
+        resolvedConsultationId = appointment.consultation.id;
+      } else if (appointment.subscription) {
+        resolvedSubscriptionId = appointment.subscription.id;
+      }
+    }
+
     // Validate entity links in parallel - ensure they belong to this user
+    // Skip validation for IDs resolved from appointmentId (already validated above)
     const validations = await Promise.all([
-      body.consultationId
+      resolvedConsultationId && !body.appointmentId
         ? prisma.consultation
             .findFirst({
               where: {
-                id: body.consultationId,
+                id: resolvedConsultationId,
                 requestedBy: { userId: session.user.id },
               },
             })
             .then((c) => ({ type: "consultation", valid: !!c }))
         : Promise.resolve({ type: "consultation", valid: true }),
-      body.subscriptionId
+      resolvedSubscriptionId && !body.appointmentId
         ? prisma.subscription
             .findFirst({
               where: {
-                id: body.subscriptionId,
+                id: resolvedSubscriptionId,
                 requestedBy: { userId: session.user.id },
               },
             })
@@ -152,8 +188,8 @@ export async function POST(req: NextRequest) {
         priority: body.priority || "MEDIUM",
         category: body.category,
         issueType: body.issueType,
-        consultationId: body.consultationId,
-        subscriptionId: body.subscriptionId,
+        consultationId: resolvedConsultationId,
+        subscriptionId: resolvedSubscriptionId,
         paymentId: body.paymentId,
         user: { connect: { id: session.user.id } },
       },

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
@@ -19,6 +19,7 @@ import {
   Event,
 } from "../types/event";
 import { EventCard } from "./EventCard";
+import { FormConfirmationDialog } from "./form-fields/FormConfirmationDialog";
 
 interface WebinarCarouselProps {
   events: WebinarEvent[];
@@ -142,6 +143,11 @@ export function EventCarousel({
   const [currentPage, setCurrentPage] = React.useState(1);
   const itemsPerPage = 8;
 
+  // Delete confirmation dialog state
+  const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
+  const [eventToDelete, setEventToDelete] = React.useState<Event | null>(null);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+
   // Calculate pagination
   const totalPages = Math.ceil(events.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
@@ -176,19 +182,31 @@ export function EventCarousel({
     }
   };
 
-  const handleDelete = async (event: Event) => {
-    const eventTitle = getEventTitle(event);
-    if (
-      window.confirm(
-        `Are you sure you want to delete "${eventTitle}"? This action cannot be undone.`,
-      )
-    ) {
-      try {
-        await onDelete(event.id ?? "");
-      } catch (error) {
-        console.error(`Error deleting ${eventType}:`, error);
-      }
+  // Open delete confirmation dialog
+  const handleDeleteClick = (event: Event) => {
+    setEventToDelete(event);
+    setShowDeleteDialog(true);
+  };
+
+  // Execute the delete operation
+  const handleDeleteConfirm = async () => {
+    if (!eventToDelete) return;
+
+    setIsDeleting(true);
+    try {
+      await onDelete(eventToDelete.id ?? "");
+      setShowDeleteDialog(false);
+      setEventToDelete(null);
+    } catch (error) {
+      console.error(`Error deleting ${eventType}:`, error);
+    } finally {
+      setIsDeleting(false);
     }
+  };
+
+  const handleDeleteCancel = () => {
+    setShowDeleteDialog(false);
+    setEventToDelete(null);
   };
 
   // Empty state
@@ -235,7 +253,7 @@ export function EventCarousel({
               eventType={eventType}
               participantCount={participantCounts[event.id ?? ""] ?? 0}
               onEdit={() => handleEdit(event)}
-              onDelete={() => handleDelete(event)}
+              onDelete={() => handleDeleteClick(event)}
             />
           </motion.div>
         ))}
@@ -267,6 +285,19 @@ export function EventCarousel({
           </Button>
         </div>
       )}
+
+      {/* Delete Confirmation Dialog */}
+      <FormConfirmationDialog
+        isOpen={showDeleteDialog}
+        onConfirm={handleDeleteConfirm}
+        onCancel={handleDeleteCancel}
+        title={`Delete ${eventType}?`}
+        description={`Are you sure you want to delete "${eventToDelete ? getEventTitle(eventToDelete) : ""}"? This action cannot be undone.`}
+        isLoading={isDeleting}
+        confirmText="Delete"
+        cancelText="Cancel"
+        variant="destructive"
+      />
     </div>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/table";
 import { toast } from "@/components/ui/use-toast";
 import { AppointmentsType, RequestStatus } from "@prisma/client";
+import { AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { RequestedSlotsDialog } from "./components/RequestedSlotsDialog";
@@ -49,13 +50,20 @@ import { countSundayWeeksInclusive } from "../shared/utils/calendarUtils";
 // interface ConsultantApiResponse { ... } // Removed
 // --- End API Response Type Definitions ---
 
+// Slot with tentative status for reschedule visibility
+interface RequestedSlot {
+  startsAt: string;
+  isTentative: boolean;
+}
+
 interface Request {
   id: string;
   type: AppointmentsType;
   title: string;
   requestedBy: RequestedBy;
   requestedAt: string;
-  requestedTimes?: string[];
+  requestedTimes?: string[]; // Kept for backward compatibility
+  requestedSlots?: RequestedSlot[]; // New: includes isTentative flag
   status: RequestStatus;
   requiredSlots: number;
   allocatedSlots?: string[];
@@ -66,6 +74,9 @@ interface Request {
   startDate?: Date;
   endDate?: Date;
   bookingSource?: "DIRECT_CHECKOUT" | "REQUEST_SUBMITTED"; // Booking source - direct checkout or request submitted
+  // Reschedule info
+  tentativeSlotCount?: number;
+  totalSlotCount?: number;
 }
 
 // interface SlotInterval { ... } // Removed - Now imported
@@ -176,25 +187,33 @@ export function RequestSlotAllocationTab({
         (type === "all" || type === "consultation")
       ) {
         processedRequests.push(
-          ...consultationsResult.data.map((consultation) => ({
-            id: consultation.id,
-            type: AppointmentsType.CONSULTATION,
-            title: consultation.consultationPlan?.title || "Untitled Plan",
-            requestedBy: consultation.requestedBy,
-            requestedAt: consultation.requestedAt,
-            requestedTimes:
-              consultation.appointment?.slotsOfAppointment?.map(
-                (slot) => slot.startsAt,
-              ) || [],
-            status: consultation.requestStatus,
-            requiredSlots: Math.ceil(
-              (consultation.consultationPlan?.durationInHours || 1) / 0.5,
-            ), // Convert hours to 30-min slots
-            durationInHours:
-              consultation.consultationPlan?.durationInHours || 1,
-            bookingSource: consultation.bookingSource, // Map bookingSource enum
-            // No scheduling period for consultations (one-time event)
-          })),
+          ...consultationsResult.data.map((consultation) => {
+            const slots = consultation.appointment?.slotsOfAppointment || [];
+            const tentativeCount = slots.filter((s) => s.isTentative).length;
+            const totalCount = slots.length;
+
+            return {
+              id: consultation.id,
+              type: AppointmentsType.CONSULTATION,
+              title: consultation.consultationPlan?.title || "Untitled Plan",
+              requestedBy: consultation.requestedBy,
+              requestedAt: consultation.requestedAt,
+              requestedTimes: slots.map((slot) => slot.startsAt),
+              requestedSlots: slots.map((slot) => ({
+                startsAt: slot.startsAt,
+                isTentative: slot.isTentative ?? false,
+              })),
+              status: consultation.requestStatus,
+              requiredSlots: Math.ceil(
+                (consultation.consultationPlan?.durationInHours || 1) / 0.5,
+              ), // Convert hours to 30-min slots
+              durationInHours:
+                consultation.consultationPlan?.durationInHours || 1,
+              bookingSource: consultation.bookingSource,
+              tentativeSlotCount: tentativeCount,
+              totalSlotCount: totalCount,
+            };
+          }),
         );
       }
 
@@ -210,17 +229,25 @@ export function RequestSlotAllocationTab({
               subscription.subscriptionPlan?.sessionDurationInHours || 1;
             const slotsPerSession = Math.ceil(sessionDuration / 0.5);
 
+            // Flatten all slots from all appointments
+            const allSlots =
+              subscription.appointments?.flatMap(
+                (appt) => appt.slotsOfAppointment || [],
+              ) || [];
+            const tentativeCount = allSlots.filter((s) => s.isTentative).length;
+            const totalCount = allSlots.length;
+
             return {
               id: subscription.id,
               type: AppointmentsType.SUBSCRIPTION,
               title: subscription.subscriptionPlan?.title || "Untitled Plan",
               requestedBy: subscription.requestedBy,
               requestedAt: subscription.requestedAt,
-              requestedTimes:
-                subscription.appointments?.flatMap(
-                  (appt) =>
-                    appt.slotsOfAppointment?.map((slot) => slot.startsAt) || [],
-                ) || [],
+              requestedTimes: allSlots.map((slot) => slot.startsAt),
+              requestedSlots: allSlots.map((slot) => ({
+                startsAt: slot.startsAt,
+                isTentative: slot.isTentative ?? false,
+              })),
               status: subscription.requestStatus,
               // FIXED: Use accurate week counting instead of hardcoded * 4
               requiredSlots: (() => {
@@ -256,6 +283,8 @@ export function RequestSlotAllocationTab({
                 ? new Date(subscription.schedulingPeriodEndsAt)
                 : undefined,
               bookingSource: subscription.bookingSource,
+              tentativeSlotCount: tentativeCount,
+              totalSlotCount: totalCount,
             };
           }),
         );
@@ -429,11 +458,70 @@ export function RequestSlotAllocationTab({
                   {new Date(request.requestedAt).toLocaleString()}
                 </TableCell>
                 <TableCell>
-                  {request.requestedTimes &&
-                  request.requestedTimes.length > 0 ? (
+                  {/* Reschedule indicator */}
+                  {request.tentativeSlotCount !== undefined &&
+                    request.tentativeSlotCount > 0 &&
+                    request.totalSlotCount !== undefined && (
+                      <div className="mb-2">
+                        {request.tentativeSlotCount === request.totalSlotCount ? (
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-blue-600 bg-blue-50 px-2 py-1 rounded-md">
+                            <RefreshCw className="h-3 w-3" />
+                            Full Reschedule ({request.totalSlotCount} session
+                            {request.totalSlotCount !== 1 ? "s" : ""} need new times)
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-amber-600 bg-amber-50 px-2 py-1 rounded-md">
+                            <AlertTriangle className="h-3 w-3" />
+                            Partial Reschedule ({request.tentativeSlotCount} of{" "}
+                            {request.totalSlotCount} session
+                            {request.tentativeSlotCount !== 1 ? "s" : ""} need new times)
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                  {request.requestedSlots && request.requestedSlots.length > 0 ? (
+                    <div className="space-y-1">
+                      {request.requestedSlots.slice(0, 5).map((slot, index) => {
+                        const date = new Date(slot.startsAt);
+                        const isValidDate = !isNaN(date.getTime());
+
+                        return (
+                          <div
+                            key={`${request.id}-slot-${index}`}
+                            className={`flex items-center gap-1.5 text-sm ${
+                              slot.isTentative
+                                ? "text-amber-600"
+                                : "text-muted-foreground"
+                            }`}
+                          >
+                            {slot.isTentative ? (
+                              <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+                            ) : (
+                              <CheckCircle2 className="h-3 w-3 flex-shrink-0 text-green-500" />
+                            )}
+                            <span>
+                              {isValidDate ? date.toLocaleString() : "Invalid date"}
+                            </span>
+                            {slot.isTentative && (
+                              <span className="text-xs text-amber-500">
+                                (needs rescheduling)
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })}
+                      {request.requestedSlots.length > 5 && (
+                        <div className="text-xs text-muted-foreground pl-5">
+                          ... and {request.requestedSlots.length - 5} more slot
+                          {request.requestedSlots.length - 5 !== 1 ? "s" : ""}
+                        </div>
+                      )}
+                    </div>
+                  ) : request.requestedTimes && request.requestedTimes.length > 0 ? (
+                    // Fallback to old format if requestedSlots not available
                     <div className="space-y-1">
                       {request.requestedTimes.slice(0, 5).map((time, index) => {
-                        // Validate and parse date string (Bug #5 fix)
                         const date = new Date(time);
                         const isValidDate = !isNaN(date.getTime());
 
@@ -442,9 +530,7 @@ export function RequestSlotAllocationTab({
                             key={`${request.id}-time-${index}`}
                             className="text-sm"
                           >
-                            {isValidDate
-                              ? date.toLocaleString()
-                              : "Invalid date"}
+                            {isValidDate ? date.toLocaleString() : "Invalid date"}
                           </div>
                         );
                       })}
@@ -620,6 +706,7 @@ export function RequestSlotAllocationTab({
             selectedRequestForDialog?.type || AppointmentsType.CONSULTATION
           }
           requestedSlots={selectedRequestForDialog?.requestedTimes || []}
+          requestedSlotsWithStatus={selectedRequestForDialog?.requestedSlots}
           schedulingPeriod={
             selectedRequestForDialog?.startDate &&
             selectedRequestForDialog?.endDate

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -466,15 +466,19 @@ export function RequestSlotAllocationTab({
                         {request.tentativeSlotCount === request.totalSlotCount ? (
                           <div className="flex items-center gap-1.5 text-xs font-medium text-blue-600 bg-blue-50 px-2 py-1 rounded-md">
                             <RefreshCw className="h-3 w-3" />
-                            Full Reschedule ({request.totalSlotCount} session
-                            {request.totalSlotCount !== 1 ? "s" : ""} need new times)
+                            Full Reschedule (all {request.totalSlotCount} session
+                            {request.totalSlotCount !== 1 ? "s" : ""})
+                          </div>
+                        ) : request.tentativeSlotCount === 1 ? (
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-amber-600 bg-amber-50 px-2 py-1 rounded-md">
+                            <AlertTriangle className="h-3 w-3" />
+                            Individual Session (1 of {request.totalSlotCount} needs new time)
                           </div>
                         ) : (
                           <div className="flex items-center gap-1.5 text-xs font-medium text-amber-600 bg-amber-50 px-2 py-1 rounded-md">
                             <AlertTriangle className="h-3 w-3" />
-                            Partial Reschedule ({request.tentativeSlotCount} of{" "}
-                            {request.totalSlotCount} session
-                            {request.tentativeSlotCount !== 1 ? "s" : ""} need new times)
+                            Multiple Sessions ({request.tentativeSlotCount} of{" "}
+                            {request.totalSlotCount} need new times)
                           </div>
                         )}
                       </div>

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
@@ -8,9 +8,16 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { AppointmentsType } from "@prisma/client";
+import { AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AllocationService } from "../../shared/utils/allocationService";
 import { TimeSlot } from "../../shared/utils/calendarUtils";
+
+// Slot with tentative status
+interface SlotWithStatus {
+  startsAt: string;
+  isTentative: boolean;
+}
 
 interface ValidationResult {
   conflicts: Array<{
@@ -36,6 +43,7 @@ interface RequestedSlotsDialogProps {
   requestId: string;
   requestType: AppointmentsType;
   requestedSlots: string[];
+  requestedSlotsWithStatus?: SlotWithStatus[]; // New: includes tentative info
   schedulingPeriod?: { startDate?: Date; endDate?: Date };
   onConfirm: (override: boolean) => Promise<void>;
   onCancel: () => void;
@@ -47,10 +55,16 @@ export function RequestedSlotsDialog({
   requestId,
   requestType,
   requestedSlots,
+  requestedSlotsWithStatus,
   schedulingPeriod,
   onConfirm,
   onCancel,
 }: RequestedSlotsDialogProps) {
+  // Calculate reschedule info from slots with status
+  const tentativeCount = requestedSlotsWithStatus?.filter((s) => s.isTentative).length ?? 0;
+  const totalCount = requestedSlotsWithStatus?.length ?? requestedSlots.length;
+  const hasReschedule = tentativeCount > 0;
+  const isFullReschedule = tentativeCount === totalCount && tentativeCount > 0;
   const [loading, setLoading] = useState(false);
   const [validationResult, setValidationResult] =
     useState<ValidationResult | null>(null);
@@ -426,6 +440,27 @@ export function RequestedSlotsDialog({
             Review requested slots before allocation
           </DialogDescription>
         </DialogHeader>
+
+        {/* Reschedule indicator */}
+        {hasReschedule && (
+          <div className="mb-4">
+            {isFullReschedule ? (
+              <div className="flex items-center gap-2 text-sm font-medium text-blue-600 bg-blue-50 px-3 py-2 rounded-md border border-blue-200">
+                <RefreshCw className="h-4 w-4" />
+                <span>
+                  Full Reschedule - All {totalCount} session{totalCount !== 1 ? "s" : ""} need new times
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 text-sm font-medium text-amber-600 bg-amber-50 px-3 py-2 rounded-md border border-amber-200">
+                <AlertTriangle className="h-4 w-4" />
+                <span>
+                  Partial Reschedule - {tentativeCount} of {totalCount} session{tentativeCount !== 1 ? "s" : ""} need new times
+                </span>
+              </div>
+            )}
+          </div>
+        )}
 
         {renderDialogContent()}
 

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/types.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/types.ts
@@ -28,6 +28,7 @@ export interface AppointmentSlot {
   id: string;
   startsAt: string;
   endsAt: string;
+  isTentative?: boolean; // Indicates if slot needs rescheduling
 }
 
 export interface AppointmentInfo {

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -265,7 +265,6 @@ export class AllocationAlgorithms {
             filteredSlots,
             requiredSlots,
             options.callsPerWeek || 1,
-            options.durationInMonths || 1,
             preferences,
             options,
           );
@@ -438,6 +437,7 @@ export class AllocationAlgorithms {
 
   /**
    * FIXED: Allocate consecutive slots for consultations
+   * FIX for #215: Only return valid consecutive blocks or empty array
    */
   private static allocateConsultationSlots(
     availableSlots: TimeSlot[],
@@ -450,18 +450,16 @@ export class AllocationAlgorithms {
       return sortedSlots.slice(0, 1);
     }
 
-    // FIXED: Find consecutive slots for multi-hour consultations
+    // Find consecutive slots for multi-hour consultations
     const sortedSlots = availableSlots.sort(
       (a, b) => a.startTime.getTime() - b.startTime.getTime(),
     );
 
-    let selectedSlots: TimeSlot[] = []; // to store best found slots if exact consecutive not found fo better error handling
-
-    // FIXED: Use Math.ceil(durationHours) to handle non-integer durations (e.g., 1.5 hours)
+    // FIX #215: Use Math.ceil(durationHours) to handle non-integer durations (e.g., 1.5 hours)
     const oneHourSlotsNeeded = Math.ceil(durationHours);
     for (let i = 0; i <= sortedSlots.length - oneHourSlotsNeeded; i++) {
-      const consecutiveSlots = [];
-      const consecutive1HourSlots = []; // for storing original 1-hour slots to validate consecutiveness
+      const consecutiveSlots: TimeSlot[] = [];
+      const consecutive1HourSlots: TimeSlot[] = [];
       let isConsecutive = true;
 
       // Check if we have enough consecutive 1-hour slots starting from this position
@@ -482,12 +480,12 @@ export class AllocationAlgorithms {
 
         consecutive1HourSlots.push(currentSlot);
 
-        // breaking of 1 hour slots into 2 >> 30 min slots in order to fulfill the required slot duration and validation
+        // Breaking of 1 hour slots into 2 >> 30 min slots in order to fulfill the required slot duration and validation
         // 1 hour slots are not supported in the current system
         const originalStartTime = new Date(currentSlot.startTime);
         const originalEndTime = new Date(currentSlot.endTime);
 
-        // breakpoint of 1 hour slot into 2 30-minute slots
+        // Breakpoint of 1 hour slot into 2 30-minute slots
         const midPointTime = new Date(originalStartTime.getTime() + 30 * 60000);
 
         // 1st 30 minute slot (e.g., 10:00 - 10:30)
@@ -504,20 +502,19 @@ export class AllocationAlgorithms {
           endTime: originalEndTime,
         };
 
-        // save both 30-minute slots
+        // Save both 30-minute slots
         consecutiveSlots.push(slotOne, slotTwo);
       }
 
-      if (consecutiveSlots.length >= selectedSlots.length) {
-        selectedSlots = consecutiveSlots;
-      }
-
+      // FIX #215: Only return when we have a VALID consecutive block of the required length
       if (isConsecutive && consecutiveSlots.length === requiredSlots) {
         return consecutiveSlots;
       }
     }
 
-    return selectedSlots; // No consecutive slots found
+    // FIX #215: Return empty array if no valid consecutive block found
+    // This makes the caller's responsibility simpler - only check if array is empty
+    return [];
   }
 
   /**
@@ -571,12 +568,12 @@ export class AllocationAlgorithms {
 
   /**
    * Allocate slots for recurring events (subscriptions/classes)
+   * Note: Duration is calculated from options.startDate/endDate via countSundayWeeksInclusive
    */
   private static allocateRecurringSlots(
     availableSlots: TimeSlot[],
     totalSlots: number,
     callsPerWeek: number,
-    durationInMonths: number,
     preferences: AutoAllocationPreferences,
     options: AllocationOptions,
   ): TimeSlot[] {

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/CancelConfirmationDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/CancelConfirmationDialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2, AlertTriangle } from "lucide-react";
+
+interface CancelConfirmationDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  consultant: string;
+  appointmentType: string;
+  isLoading?: boolean;
+}
+
+export function CancelConfirmationDialog({
+  isOpen,
+  onConfirm,
+  onCancel,
+  title,
+  consultant,
+  appointmentType,
+  isLoading = false,
+}: Readonly<CancelConfirmationDialogProps>) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-500" />
+            Cancel {appointmentType}?
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                Are you sure you want to cancel <strong>&quot;{title}&quot;</strong> with{" "}
+                <strong>{consultant}</strong>?
+              </p>
+              <p className="text-red-600 font-medium">
+                This action cannot be undone.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel} disabled={isLoading}>
+            Keep Appointment
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="bg-red-600 text-white hover:bg-red-700 focus:ring-red-600"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Cancelling...
+              </>
+            ) : (
+              "Yes, Cancel"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
@@ -21,7 +21,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { motion } from "framer-motion";
-import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange, AlertCircle, CheckSquare, Square, Check } from "lucide-react";
+import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange, AlertCircle, CheckSquare, Check } from "lucide-react";
 import React from "react";
 import { DocumentUpload } from "./DocumentUpload";
 import { cn } from "@/utils/tailwind";
@@ -498,7 +498,21 @@ export function EventCard({
                 </AccordionContent>
               </AccordionItem>
             </Accordion>
-          ) : type !== "Consultation" && type !== "Webinar" ? (
+          ) : type === "Consultation" && rawSlots.length > 0 ? (
+            <div className="bg-zinc-50 rounded-lg p-3 border border-zinc-100">
+              <div className="flex items-center gap-2 text-xs text-zinc-500 mb-1.5">
+                <Calendar className="h-3.5 w-3.5" />
+                <span>Scheduled Time</span>
+              </div>
+              <div className="text-sm text-zinc-700 font-medium">
+                {formatSlotDate(rawSlots[0].startsAt)}
+              </div>
+              <div className="text-sm text-zinc-500">
+                {formatSlotTime(rawSlots[0].startsAt)} -{" "}
+                {formatSlotTime(rawSlots[0].endsAt)}
+              </div>
+            </div>
+          ) : type !== "Webinar" ? (
             <div className="bg-zinc-50 rounded-lg p-3 border border-zinc-100">
               <div className="flex items-center gap-2 text-xs text-zinc-500 mb-1">
                 <Clock className="h-3.5 w-3.5" />
@@ -544,21 +558,18 @@ export function EventCard({
               Reschedule
             </Button>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleCancelClick}
-            disabled={isLoading || isInactiveStatus}
-            className={cn(
-              "flex-1 h-8 text-xs font-medium",
-              isInactiveStatus
-                ? "text-zinc-400 bg-zinc-50 border-zinc-200 cursor-not-allowed"
-                : "text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200 hover:border-red-300",
-            )}
-          >
-            <X className="h-3.5 w-3.5 mr-1.5" />
-            Cancel
-          </Button>
+          {!isInactiveStatus && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCancelClick}
+              disabled={isLoading}
+              className="flex-1 h-8 text-xs font-medium text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200 hover:border-red-300"
+            >
+              <X className="h-3.5 w-3.5 mr-1.5" />
+              Cancel
+            </Button>
+          )}
         </div>
 
         {/* Report Issue Button - Always visible for getting help with appointments */}

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
@@ -21,7 +21,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { motion } from "framer-motion";
-import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange } from "lucide-react";
+import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange, AlertCircle } from "lucide-react";
 import React from "react";
 import { DocumentUpload } from "./DocumentUpload";
 import { cn } from "@/utils/tailwind";
@@ -29,6 +29,8 @@ import { format } from "date-fns";
 import { useRouter } from "next/navigation";
 import { useStreamVideoClient } from "@stream-io/video-react-sdk";
 import { getOrCreateAppointmentMeeting } from "@/lib/meeting";
+import { ReportIssueDialog } from "./ReportIssueDialog";
+import type { AppointmentStatus } from "@/utils/supportTicketUrl";
 import type { TAppointment, TSlotOfAppointment } from "@/types/appointment";
 import type { SlotOfAppointment } from "@prisma/client";
 
@@ -119,6 +121,22 @@ export function EventCard({
   const [showRescheduleDialog, setShowRescheduleDialog] = React.useState(false);
   const [rescheduleType, setRescheduleType] = React.useState<"individual" | "entire">("entire");
   const [selectedSlotId, setSelectedSlotId] = React.useState<string | null>(null);
+
+  // Report Issue dialog state
+  const [showReportDialog, setShowReportDialog] = React.useState(false);
+
+  // Get appointment status and type for issue filtering
+  const appointmentStatus: AppointmentStatus =
+    status?.toLowerCase() === "completed" ? "COMPLETED" : "UPCOMING";
+  
+  const appointmentType: "CONSULTATION" | "SUBSCRIPTION" =
+    type === "Subscription" ? "SUBSCRIPTION" : "CONSULTATION";
+
+  // Get the first slot's scheduled time for context
+  const scheduledAt =
+    rawSlots && rawSlots.length > 0
+      ? new Date(rawSlots[0].startsAt).toISOString()
+      : undefined;
 
   const showSessionDetails =
     (type === "Subscription" || type === "Class") &&
@@ -541,6 +559,18 @@ export function EventCard({
           </Button>
         </div>
 
+        {/* Report Issue Button - Always visible for getting help with appointments */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowReportDialog(true)}
+          disabled={!appointmentId}
+          className="w-full mt-2 h-8 text-xs font-medium text-amber-600 hover:text-amber-700 hover:bg-amber-50 border-amber-200 hover:border-amber-300"
+        >
+          <AlertCircle className="h-3.5 w-3.5 mr-1.5" />
+          Report Issue
+        </Button>
+
         {/* Join Button - Always render for consistency */}
         <Button
           onClick={() => handleJoinSession()}
@@ -747,6 +777,22 @@ export function EventCard({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Report Issue Dialog for appointment-linked issues */}
+      {appointmentId && (
+        <ReportIssueDialog
+          open={showReportDialog}
+          onOpenChange={setShowReportDialog}
+          appointmentId={appointmentId}
+          appointmentType={appointmentType}
+          appointmentStatus={appointmentStatus}
+          consultantName={consultant}
+          scheduledAt={scheduledAt}
+          onSuccess={() => {
+            setShowReportDialog(false);
+          }}
+        />
+      )}
     </motion.div>
   );
 }

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
@@ -384,7 +384,8 @@ export function EventCard({
   const isInactiveStatus =
     status?.toLowerCase() === "cancelled" ||
     status?.toLowerCase() === "rejected" ||
-    status?.toLowerCase() === "completed";
+    status?.toLowerCase() === "completed" ||
+    status?.toLowerCase() === "expired";;
 
   const showDocumentUpload =
     (type === "Consultation" || type === "Subscription") && appointmentId;

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
@@ -21,7 +21,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { motion } from "framer-motion";
-import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange, AlertCircle } from "lucide-react";
+import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange, AlertCircle, CheckSquare, Square, Check } from "lucide-react";
 import React from "react";
 import { DocumentUpload } from "./DocumentUpload";
 import { cn } from "@/utils/tailwind";
@@ -30,6 +30,7 @@ import { useRouter } from "next/navigation";
 import { useStreamVideoClient } from "@stream-io/video-react-sdk";
 import { getOrCreateAppointmentMeeting } from "@/lib/meeting";
 import { ReportIssueDialog } from "./ReportIssueDialog";
+import { CancelConfirmationDialog } from "./CancelConfirmationDialog";
 import type { AppointmentStatus } from "@/utils/supportTicketUrl";
 import type { TAppointment, TSlotOfAppointment } from "@/types/appointment";
 import type { SlotOfAppointment } from "@prisma/client";
@@ -119,11 +120,14 @@ export function EventCard({
 
   // Reschedule dialog state
   const [showRescheduleDialog, setShowRescheduleDialog] = React.useState(false);
-  const [rescheduleType, setRescheduleType] = React.useState<"individual" | "entire">("entire");
-  const [selectedSlotId, setSelectedSlotId] = React.useState<string | null>(null);
+  const [rescheduleType, setRescheduleType] = React.useState<"individual" | "multiple" | "entire">("entire");
+  const [selectedSlotIds, setSelectedSlotIds] = React.useState<string[]>([]);
 
   // Report Issue dialog state
   const [showReportDialog, setShowReportDialog] = React.useState(false);
+
+  // Cancel confirmation dialog state
+  const [showCancelDialog, setShowCancelDialog] = React.useState(false);
 
   // Get appointment status and type for issue filtering
   const appointmentStatus: AppointmentStatus =
@@ -151,7 +155,7 @@ export function EventCard({
     if (isMultiSessionSubscription) {
       // Reset dialog state
       setRescheduleType("entire");
-      setSelectedSlotId(null);
+      setSelectedSlotIds([]);
       setShowRescheduleDialog(true);
     } else {
       // For consultations or single-session subscriptions, reschedule directly
@@ -160,7 +164,7 @@ export function EventCard({
   };
 
   // Execute the reschedule API call
-  const handleReschedule = async (slotId?: string) => {
+  const handleReschedule = async (slotIds?: string[]) => {
     if (!appointmentId) {
       toast({
         title: "Error",
@@ -182,8 +186,8 @@ export function EventCard({
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        // Include slotId in body for individual session reschedule
-        body: slotId ? JSON.stringify({ slotId }) : undefined,
+        // Include slotIds in body for individual/multiple session reschedule
+        body: slotIds && slotIds.length > 0 ? JSON.stringify({ slotIds }) : undefined,
       });
 
       const data = await response.json();
@@ -192,13 +196,13 @@ export function EventCard({
         throw new Error(data.error || "Failed to request reschedule");
       }
 
-      const isIndividualReschedule = data.rescheduleType === "individual_session";
+      const slotsAffected = data.slotsAffected ?? slotIds?.length ?? rawSlots.length;
 
       toast({
         title: "Reschedule initiated",
-        description: isIndividualReschedule
+        description: slotsAffected === 1
           ? `Your session has been marked for rescheduling. Please select a new time.`
-          : `All sessions have been marked for rescheduling. Please select new times.`,
+          : `${slotsAffected} sessions have been marked for rescheduling. Please select new times.`,
       });
 
       window.location.reload();
@@ -219,14 +223,15 @@ export function EventCard({
 
   // Handle dialog confirmation
   const handleRescheduleConfirm = () => {
-    if (rescheduleType === "individual" && selectedSlotId) {
-      handleReschedule(selectedSlotId);
+    if ((rescheduleType === "individual" || rescheduleType === "multiple") && selectedSlotIds.length > 0) {
+      handleReschedule(selectedSlotIds);
     } else {
       handleReschedule();
     }
   };
 
-  const handleCancel = async () => {
+  // Open cancel confirmation dialog
+  const handleCancelClick = () => {
     if (!appointmentId) {
       toast({
         title: "Error",
@@ -235,15 +240,11 @@ export function EventCard({
       });
       return;
     }
+    setShowCancelDialog(true);
+  };
 
-    if (
-      !window.confirm(
-        `Are you sure you want to cancel "${title}" with ${consultant}? This action cannot be undone.`,
-      )
-    ) {
-      return;
-    }
-
+  // Execute the cancel API call
+  const handleCancelConfirm = async () => {
     setIsLoading(true);
     try {
       const response = await fetch(
@@ -265,6 +266,7 @@ export function EventCard({
         description: `Your ${type.toLowerCase()} "${title}" has been cancelled successfully.`,
       });
 
+      setShowCancelDialog(false);
       window.location.reload();
     } catch (error) {
       console.error("Error cancelling appointment:", error);
@@ -545,7 +547,7 @@ export function EventCard({
           <Button
             variant="outline"
             size="sm"
-            onClick={handleCancel}
+            onClick={handleCancelClick}
             disabled={isLoading || isInactiveStatus}
             className={cn(
               "flex-1 h-8 text-xs font-medium",
@@ -634,9 +636,12 @@ export function EventCard({
             <RadioGroup
               value={rescheduleType}
               onValueChange={(value) => {
-                setRescheduleType(value as "individual" | "entire");
+                setRescheduleType(value as "individual" | "multiple" | "entire");
                 if (value === "entire") {
-                  setSelectedSlotId(null);
+                  setSelectedSlotIds([]);
+                } else if (value === "individual") {
+                  // Reset to single selection mode
+                  setSelectedSlotIds(selectedSlotIds.slice(0, 1));
                 }
               }}
               className="space-y-3"
@@ -656,6 +661,25 @@ export function EventCard({
                   </div>
                   <p className="text-xs text-zinc-500 mt-1">
                     Only the selected session will be rescheduled. Other sessions remain unchanged.
+                  </p>
+                </Label>
+              </div>
+
+              {/* Reschedule Multiple Sessions Option */}
+              <div className={cn(
+                "flex items-start space-x-3 p-3 rounded-lg border transition-colors",
+                rescheduleType === "multiple"
+                  ? "border-zinc-900 bg-zinc-50"
+                  : "border-zinc-200 hover:border-zinc-300"
+              )}>
+                <RadioGroupItem value="multiple" id="multiple" className="mt-1" />
+                <Label htmlFor="multiple" className="flex-1 cursor-pointer">
+                  <div className="flex items-center gap-2 font-medium text-zinc-900">
+                    <CheckSquare className="h-4 w-4" />
+                    Reschedule Multiple Sessions
+                  </div>
+                  <p className="text-xs text-zinc-500 mt-1">
+                    Select specific sessions to reschedule. Other sessions remain unchanged.
                   </p>
                 </Label>
               </div>
@@ -680,11 +704,13 @@ export function EventCard({
               </div>
             </RadioGroup>
 
-            {/* Session Selector - shown when "individual" is selected */}
-            {rescheduleType === "individual" && (
+            {/* Session Selector - shown when "individual" or "multiple" is selected */}
+            {(rescheduleType === "individual" || rescheduleType === "multiple") && (
               <div className="mt-4 space-y-2">
                 <Label className="text-sm font-medium text-zinc-700">
-                  Select the session to reschedule:
+                  {rescheduleType === "individual"
+                    ? "Select the session to reschedule:"
+                    : "Select sessions to reschedule:"}
                 </Label>
                 <div className="max-h-48 overflow-y-auto space-y-2 rounded-lg border border-zinc-200 p-2">
                   {rawSlots
@@ -693,15 +719,31 @@ export function EventCard({
                     .map((slot) => {
                       const startTime = new Date(slot.startsAt);
                       const endTime = new Date(slot.endsAt);
-                      const isSelected = selectedSlotId === slot.id;
+                      const isSelected = selectedSlotIds.includes(slot.id);
                       const hoursUntil = (startTime.getTime() - Date.now()) / (1000 * 60 * 60);
                       const isWithin24Hours = hoursUntil < 24;
+
+                      const handleSlotClick = () => {
+                        if (isWithin24Hours) return;
+
+                        if (rescheduleType === "individual") {
+                          // Single select mode - replace selection
+                          setSelectedSlotIds([slot.id]);
+                        } else {
+                          // Multi-select mode - toggle selection
+                          setSelectedSlotIds(prev =>
+                            prev.includes(slot.id)
+                              ? prev.filter(id => id !== slot.id)
+                              : [...prev, slot.id]
+                          );
+                        }
+                      };
 
                       return (
                         <button
                           key={slot.id}
                           type="button"
-                          onClick={() => !isWithin24Hours && setSelectedSlotId(slot.id)}
+                          onClick={handleSlotClick}
                           disabled={isWithin24Hours}
                           className={cn(
                             "w-full flex items-center justify-between p-2.5 rounded-md text-left transition-colors",
@@ -712,15 +754,30 @@ export function EventCard({
                                 : "bg-zinc-50 hover:bg-zinc-100 text-zinc-700"
                           )}
                         >
-                          <div>
-                            <div className="text-sm font-medium">
-                              {formatSlotDate(startTime)}
-                            </div>
-                            <div className={cn(
-                              "text-xs",
-                              isSelected ? "text-zinc-300" : "text-zinc-500"
-                            )}>
-                              {formatSlotTime(startTime)} - {formatSlotTime(endTime)}
+                          <div className="flex items-center gap-2">
+                            {/* Checkbox indicator for multi-select mode */}
+                            {rescheduleType === "multiple" && (
+                              <div className={cn(
+                                "w-4 h-4 rounded border flex items-center justify-center",
+                                isSelected
+                                  ? "bg-white border-white"
+                                  : isWithin24Hours
+                                    ? "border-zinc-300"
+                                    : "border-zinc-400"
+                              )}>
+                                {isSelected && <Check className="h-3 w-3 text-zinc-900" />}
+                              </div>
+                            )}
+                            <div>
+                              <div className="text-sm font-medium">
+                                {formatSlotDate(startTime)}
+                              </div>
+                              <div className={cn(
+                                "text-xs",
+                                isSelected ? "text-zinc-300" : "text-zinc-500"
+                              )}>
+                                {formatSlotTime(startTime)} - {formatSlotTime(endTime)}
+                              </div>
                             </div>
                           </div>
                           {isWithin24Hours && (
@@ -735,6 +792,11 @@ export function EventCard({
                 {rawSlots.filter((s) => !s.isTentative).length === 0 && (
                   <p className="text-sm text-zinc-500 text-center py-4">
                     No confirmed sessions available to reschedule.
+                  </p>
+                )}
+                {rescheduleType === "multiple" && selectedSlotIds.length > 0 && (
+                  <p className="text-sm text-zinc-600 font-medium">
+                    {selectedSlotIds.length} session{selectedSlotIds.length > 1 ? "s" : ""} selected
                   </p>
                 )}
               </div>
@@ -761,7 +823,7 @@ export function EventCard({
               onClick={handleRescheduleConfirm}
               disabled={
                 isLoading ||
-                (rescheduleType === "individual" && !selectedSlotId)
+                ((rescheduleType === "individual" || rescheduleType === "multiple") && selectedSlotIds.length === 0)
               }
               className="bg-zinc-900 hover:bg-zinc-800"
             >
@@ -793,6 +855,17 @@ export function EventCard({
           }}
         />
       )}
+
+      {/* Cancel Confirmation Dialog */}
+      <CancelConfirmationDialog
+        isOpen={showCancelDialog}
+        onConfirm={handleCancelConfirm}
+        onCancel={() => setShowCancelDialog(false)}
+        title={title}
+        consultant={consultant}
+        appointmentType={type}
+        isLoading={isLoading}
+      />
     </motion.div>
   );
 }

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
@@ -9,9 +9,19 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { motion } from "framer-motion";
-import { Clock, X, Video, Calendar, Loader2 } from "lucide-react";
+import { Clock, X, Video, Calendar, Loader2, CalendarClock, CalendarRange } from "lucide-react";
 import React from "react";
 import { DocumentUpload } from "./DocumentUpload";
 import { cn } from "@/utils/tailwind";
@@ -105,12 +115,34 @@ export function EventCard({
   const [isLoading, setIsLoading] = React.useState(false);
   const [isJoining, setIsJoining] = React.useState(false);
 
+  // Reschedule dialog state
+  const [showRescheduleDialog, setShowRescheduleDialog] = React.useState(false);
+  const [rescheduleType, setRescheduleType] = React.useState<"individual" | "entire">("entire");
+  const [selectedSlotId, setSelectedSlotId] = React.useState<string | null>(null);
+
   const showSessionDetails =
     (type === "Subscription" || type === "Class") &&
     actualSlots &&
     actualSlots.length > 1;
 
-  const handleReschedule = async () => {
+  // Check if this is a subscription with multiple sessions (for reschedule options)
+  const isMultiSessionSubscription = type === "Subscription" && rawSlots.length > 1;
+
+  // Handle reschedule button click - show dialog for subscriptions with multiple sessions
+  const handleRescheduleClick = () => {
+    if (isMultiSessionSubscription) {
+      // Reset dialog state
+      setRescheduleType("entire");
+      setSelectedSlotId(null);
+      setShowRescheduleDialog(true);
+    } else {
+      // For consultations or single-session subscriptions, reschedule directly
+      handleReschedule();
+    }
+  };
+
+  // Execute the reschedule API call
+  const handleReschedule = async (slotId?: string) => {
     if (!appointmentId) {
       toast({
         title: "Error",
@@ -121,14 +153,20 @@ export function EventCard({
     }
 
     setIsLoading(true);
+    setShowRescheduleDialog(false);
+
     try {
-      const response = await fetch(
-        `/api/appointments/${appointmentId}/reschedule`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+      // Build the URL with type parameter for subscriptions
+      const url = type === "Subscription"
+        ? `/api/appointments/${appointmentId}/reschedule?type=SUBSCRIPTION`
+        : `/api/appointments/${appointmentId}/reschedule`;
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // Include slotId in body for individual session reschedule
+        body: slotId ? JSON.stringify({ slotId }) : undefined,
+      });
 
       const data = await response.json();
 
@@ -136,9 +174,13 @@ export function EventCard({
         throw new Error(data.error || "Failed to request reschedule");
       }
 
+      const isIndividualReschedule = data.rescheduleType === "individual_session";
+
       toast({
-        title: "Reschedule request sent",
-        description: `Your reschedule request for ${title} has been sent to ${consultant}.`,
+        title: "Reschedule initiated",
+        description: isIndividualReschedule
+          ? `Your session has been marked for rescheduling. Please select a new time.`
+          : `All sessions have been marked for rescheduling. Please select new times.`,
       });
 
       window.location.reload();
@@ -154,6 +196,15 @@ export function EventCard({
       });
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  // Handle dialog confirmation
+  const handleRescheduleConfirm = () => {
+    if (rescheduleType === "individual" && selectedSlotId) {
+      handleReschedule(selectedSlotId);
+    } else {
+      handleReschedule();
     }
   };
 
@@ -309,11 +360,6 @@ export function EventCard({
     }
   };
 
-  const isConfirmed =
-    status?.toLowerCase() === "approved" ||
-    status?.toLowerCase() === "scheduled" ||
-    (!isTentative && actualSlots.length > 0);
-
   // Determine if actions should be disabled (negative/terminal statuses)
   const isInactiveStatus =
     status?.toLowerCase() === "cancelled" ||
@@ -465,7 +511,7 @@ export function EventCard({
             <Button
               variant="outline"
               size="sm"
-              onClick={handleReschedule}
+              onClick={handleRescheduleClick}
               disabled={isLoading || isInactiveStatus}
               className={cn(
                 "flex-1 h-8 text-xs font-medium border-zinc-200",
@@ -540,6 +586,167 @@ export function EventCard({
           </Button>
         )}
       </div>
+
+      {/* Reschedule Dialog for Subscriptions with Multiple Sessions */}
+      <Dialog open={showRescheduleDialog} onOpenChange={setShowRescheduleDialog}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Clock className="h-5 w-5 text-zinc-600" />
+              Reschedule Options
+            </DialogTitle>
+            <DialogDescription>
+              Choose how you&apos;d like to reschedule your subscription sessions.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="py-4 space-y-4">
+            <RadioGroup
+              value={rescheduleType}
+              onValueChange={(value) => {
+                setRescheduleType(value as "individual" | "entire");
+                if (value === "entire") {
+                  setSelectedSlotId(null);
+                }
+              }}
+              className="space-y-3"
+            >
+              {/* Reschedule One Session Option */}
+              <div className={cn(
+                "flex items-start space-x-3 p-3 rounded-lg border transition-colors",
+                rescheduleType === "individual"
+                  ? "border-zinc-900 bg-zinc-50"
+                  : "border-zinc-200 hover:border-zinc-300"
+              )}>
+                <RadioGroupItem value="individual" id="individual" className="mt-1" />
+                <Label htmlFor="individual" className="flex-1 cursor-pointer">
+                  <div className="flex items-center gap-2 font-medium text-zinc-900">
+                    <CalendarClock className="h-4 w-4" />
+                    Reschedule One Session
+                  </div>
+                  <p className="text-xs text-zinc-500 mt-1">
+                    Only the selected session will be rescheduled. Other sessions remain unchanged.
+                  </p>
+                </Label>
+              </div>
+
+              {/* Reschedule Entire Subscription Option */}
+              <div className={cn(
+                "flex items-start space-x-3 p-3 rounded-lg border transition-colors",
+                rescheduleType === "entire"
+                  ? "border-zinc-900 bg-zinc-50"
+                  : "border-zinc-200 hover:border-zinc-300"
+              )}>
+                <RadioGroupItem value="entire" id="entire" className="mt-1" />
+                <Label htmlFor="entire" className="flex-1 cursor-pointer">
+                  <div className="flex items-center gap-2 font-medium text-zinc-900">
+                    <CalendarRange className="h-4 w-4" />
+                    Reschedule Entire Subscription
+                  </div>
+                  <p className="text-xs text-zinc-500 mt-1">
+                    All {rawSlots.length} sessions will be released. You&apos;ll need to select new times for all sessions.
+                  </p>
+                </Label>
+              </div>
+            </RadioGroup>
+
+            {/* Session Selector - shown when "individual" is selected */}
+            {rescheduleType === "individual" && (
+              <div className="mt-4 space-y-2">
+                <Label className="text-sm font-medium text-zinc-700">
+                  Select the session to reschedule:
+                </Label>
+                <div className="max-h-48 overflow-y-auto space-y-2 rounded-lg border border-zinc-200 p-2">
+                  {rawSlots
+                    .filter((slot) => !slot.isTentative)
+                    .sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime())
+                    .map((slot) => {
+                      const startTime = new Date(slot.startsAt);
+                      const endTime = new Date(slot.endsAt);
+                      const isSelected = selectedSlotId === slot.id;
+                      const hoursUntil = (startTime.getTime() - Date.now()) / (1000 * 60 * 60);
+                      const isWithin24Hours = hoursUntil < 24;
+
+                      return (
+                        <button
+                          key={slot.id}
+                          type="button"
+                          onClick={() => !isWithin24Hours && setSelectedSlotId(slot.id)}
+                          disabled={isWithin24Hours}
+                          className={cn(
+                            "w-full flex items-center justify-between p-2.5 rounded-md text-left transition-colors",
+                            isSelected
+                              ? "bg-zinc-900 text-white"
+                              : isWithin24Hours
+                                ? "bg-zinc-100 text-zinc-400 cursor-not-allowed"
+                                : "bg-zinc-50 hover:bg-zinc-100 text-zinc-700"
+                          )}
+                        >
+                          <div>
+                            <div className="text-sm font-medium">
+                              {formatSlotDate(startTime)}
+                            </div>
+                            <div className={cn(
+                              "text-xs",
+                              isSelected ? "text-zinc-300" : "text-zinc-500"
+                            )}>
+                              {formatSlotTime(startTime)} - {formatSlotTime(endTime)}
+                            </div>
+                          </div>
+                          {isWithin24Hours && (
+                            <span className="text-xs bg-orange-100 text-orange-600 px-2 py-0.5 rounded">
+                              Within 24h
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                </div>
+                {rawSlots.filter((s) => !s.isTentative).length === 0 && (
+                  <p className="text-sm text-zinc-500 text-center py-4">
+                    No confirmed sessions available to reschedule.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Warning notice */}
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+              <p className="text-xs text-amber-800">
+                <strong>Note:</strong> Sessions cannot be rescheduled within 24 hours of the start time.
+                No refunds are provided for rescheduling.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="outline"
+              onClick={() => setShowRescheduleDialog(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRescheduleConfirm}
+              disabled={
+                isLoading ||
+                (rescheduleType === "individual" && !selectedSlotId)
+              }
+              className="bg-zinc-900 hover:bg-zinc-800"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Processing...
+                </>
+              ) : (
+                "Confirm Reschedule"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </motion.div>
   );
 }

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/Overview.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/Overview.tsx
@@ -78,7 +78,7 @@ function getValidAppointmentSlots(event: EventWithType): Array<{
 
 // Helper to check if a status is inactive (greyed out)
 function isInactiveStatus(status: string): boolean {
-  const inactive = ["cancelled", "rejected", "completed"];
+  const inactive = ["cancelled", "rejected", "completed", "expired"];
   return inactive.includes(status.toLowerCase());
 }
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
@@ -120,12 +120,8 @@ export function ReportIssueDialog({
         issueType,
       };
 
-      // Add appointment context based on type
-      if (appointmentType === "CONSULTATION") {
-        requestBody.consultationId = appointmentId;
-      } else if (appointmentType === "SUBSCRIPTION") {
-        requestBody.subscriptionId = appointmentId;
-      }
+      // Link to appointment - API will resolve to correct consultation/subscription
+      requestBody.appointmentId = appointmentId;
 
       const response = await fetch("/api/user/support-tickets", {
         method: "POST",

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
@@ -125,7 +125,7 @@ export function ReportIssueDialog({
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.message || "Failed to create support ticket");
+        throw new Error(errorData.error || errorData.message || "Failed to create support ticket");
       }
 
       toast({
@@ -206,11 +206,15 @@ export function ReportIssueDialog({
                 <SelectValue placeholder="Select issue type" />
               </SelectTrigger>
               <SelectContent>
-                {filteredIssueTypes.map((type) => (
-                  <SelectItem key={type} value={type}>
-                    {ISSUE_TYPE_LABELS[type]}
-                  </SelectItem>
-                ))}
+                {filteredIssueTypes.map((type) => {
+                  const label = ISSUE_TYPE_LABELS[type];
+                  if (!label) return null;
+                  return (
+                    <SelectItem key={type} value={type}>
+                      {label}
+                    </SelectItem>
+                  );
+                })}
               </SelectContent>
             </Select>
           </div>

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
@@ -33,6 +33,7 @@ import {
 import {
   getFilteredIssueTypes,
   ISSUE_TYPE_LABELS,
+  PRIORITY_OPTIONS,
   type AppointmentStatus,
 } from "@/utils/supportTicketUrl";
 import { format } from "date-fns";
@@ -47,13 +48,6 @@ interface ReportIssueDialogProps {
   scheduledAt?: string;
   onSuccess?: () => void;
 }
-
-const PRIORITY_OPTIONS: { value: SupportPriority; label: string; color: string }[] = [
-  { value: "LOW", label: "Low", color: "text-green-600" },
-  { value: "MEDIUM", label: "Medium", color: "text-amber-600" },
-  { value: "HIGH", label: "High", color: "text-orange-600" },
-  { value: "URGENT", label: "Urgent", color: "text-red-600" },
-];
 
 export function ReportIssueDialog({
   open,

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SupportPriority, SupportIssueType } from "@prisma/client";
+import { useToast } from "@/hooks/use-toast";
+import {
+  AlertCircle,
+  Calendar,
+  User,
+  Tag,
+  Loader2,
+  Send,
+} from "lucide-react";
+import {
+  getFilteredIssueTypes,
+  ISSUE_TYPE_LABELS,
+  type AppointmentStatus,
+} from "@/utils/supportTicketUrl";
+import { format } from "date-fns";
+
+interface ReportIssueDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  appointmentId: string;
+  appointmentType: "CONSULTATION" | "SUBSCRIPTION";
+  appointmentStatus: AppointmentStatus;
+  consultantName: string;
+  scheduledAt?: string;
+  onSuccess?: () => void;
+}
+
+const PRIORITY_OPTIONS: { value: SupportPriority; label: string; color: string }[] = [
+  { value: "LOW", label: "Low", color: "text-green-600" },
+  { value: "MEDIUM", label: "Medium", color: "text-amber-600" },
+  { value: "HIGH", label: "High", color: "text-orange-600" },
+  { value: "URGENT", label: "Urgent", color: "text-red-600" },
+];
+
+export function ReportIssueDialog({
+  open,
+  onOpenChange,
+  appointmentId,
+  appointmentType,
+  appointmentStatus,
+  consultantName,
+  scheduledAt,
+  onSuccess,
+}: ReportIssueDialogProps) {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  // Form state
+  const [issueType, setIssueType] = React.useState<SupportIssueType | undefined>();
+  const [title, setTitle] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const [priority, setPriority] = React.useState<SupportPriority>(SupportPriority.MEDIUM);
+
+  // Get filtered issue types based on appointment status
+  const filteredIssueTypes = React.useMemo(() => {
+    return getFilteredIssueTypes(appointmentStatus);
+  }, [appointmentStatus]);
+
+  // Format the scheduled date
+  const formattedDate = React.useMemo(() => {
+    if (!scheduledAt) return null;
+    try {
+      const date = new Date(scheduledAt);
+      return format(date, "EEE, MMM d, yyyy 'at' h:mm a");
+    } catch {
+      return scheduledAt;
+    }
+  }, [scheduledAt]);
+
+  // Reset form when dialog closes
+  React.useEffect(() => {
+    if (!open) {
+      setIssueType(undefined);
+      setTitle("");
+      setDescription("");
+      setPriority(SupportPriority.MEDIUM);
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!issueType || !title || !description) {
+      toast({
+        title: "Missing fields",
+        description: "Please fill in all required fields.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      // Build request body with context linking
+      const requestBody: Record<string, unknown> = {
+        title,
+        description,
+        priority,
+        issueType,
+      };
+
+      // Add appointment context based on type
+      if (appointmentType === "CONSULTATION") {
+        requestBody.consultationId = appointmentId;
+      } else if (appointmentType === "SUBSCRIPTION") {
+        requestBody.subscriptionId = appointmentId;
+      }
+
+      const response = await fetch("/api/user/support-tickets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "Failed to create support ticket");
+      }
+
+      toast({
+        title: "Issue reported",
+        description: "Your support ticket has been created and linked to this appointment.",
+      });
+
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (error) {
+      console.error("Failed to create support ticket:", error);
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to create support ticket. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const typeLabel = appointmentType === "CONSULTATION" ? "Consultation" : "Subscription";
+  const statusLabel = appointmentStatus === "COMPLETED" ? "Completed" : "Upcoming";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-amber-500" />
+            Report an Issue
+          </DialogTitle>
+          <DialogDescription>
+            Let us know what went wrong with your {typeLabel.toLowerCase()}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-4">
+          {/* Appointment Context Card */}
+          <div className="p-4 rounded-xl bg-gradient-to-r from-zinc-50 to-zinc-100 border border-zinc-200">
+            <div className="flex items-center gap-2 text-xs text-zinc-500 mb-3">
+              <Calendar className="h-3.5 w-3.5" />
+              <span>Linked to {typeLabel}</span>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <User className="h-4 w-4 text-zinc-400" />
+                <span className="font-medium text-zinc-800">{consultantName}</span>
+              </div>
+              {formattedDate && (
+                <div className="flex items-center gap-2 text-sm text-zinc-600">
+                  <Calendar className="h-4 w-4 text-zinc-400" />
+                  <span>{formattedDate}</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Tag className="h-4 w-4 text-zinc-400" />
+                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-zinc-200 text-zinc-700">
+                  {statusLabel}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Issue Type */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-zinc-700">
+              What&apos;s this about? <span className="text-red-500">*</span>
+            </Label>
+            <Select
+              value={issueType}
+              onValueChange={(value) => setIssueType(value as SupportIssueType)}
+            >
+              <SelectTrigger className="h-11">
+                <SelectValue placeholder="Select issue type" />
+              </SelectTrigger>
+              <SelectContent>
+                {filteredIssueTypes.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {ISSUE_TYPE_LABELS[type]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Subject */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-zinc-700">
+              Subject <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Brief summary of your issue"
+              className="h-11"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-zinc-700">
+              Description <span className="text-red-500">*</span>
+            </Label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Please describe your issue in detail..."
+              className="min-h-[120px] resize-none"
+            />
+          </div>
+
+          {/* Priority */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-zinc-700">Priority</Label>
+            <Select
+              value={priority}
+              onValueChange={(value) => setPriority(value as SupportPriority)}
+            >
+              <SelectTrigger className="h-11">
+                <SelectValue placeholder="Select priority" />
+              </SelectTrigger>
+              <SelectContent>
+                {PRIORITY_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    <span className={option.color}>{option.label}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isLoading || !issueType || !title || !description}
+            className="bg-amber-600 hover:bg-amber-700 text-white"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Submitting...
+              </>
+            ) : (
+              <>
+                <Send className="h-4 w-4 mr-2" />
+                Submit Report
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/ReportIssueDialog.tsx
@@ -165,7 +165,7 @@ export function ReportIssueDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto scrollbar-hide">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertCircle className="h-5 w-5 text-amber-500" />

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/AppointmentContextCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/AppointmentContextCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React from "react";
+import { Calendar, User, Clock, Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface AppointmentContextData {
+  appointmentId: string;
+  appointmentType: "CONSULTATION" | "SUBSCRIPTION";
+  appointmentStatus: "COMPLETED" | "UPCOMING";
+  consultantName?: string;
+  scheduledAt?: string;
+}
+
+interface AppointmentContextCardProps {
+  context: AppointmentContextData;
+  onClear?: () => void;
+  className?: string;
+}
+
+/**
+ * Displays linked appointment context when creating a support ticket
+ * from an appointment card
+ */
+export function AppointmentContextCard({
+  context,
+  onClear,
+  className,
+}: AppointmentContextCardProps) {
+  const { appointmentType, appointmentStatus, consultantName, scheduledAt } = context;
+
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return null;
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  const typeLabel = appointmentType === "CONSULTATION" ? "Consultation" : "Subscription";
+  const statusLabel = appointmentStatus === "COMPLETED" ? "Completed" : "Upcoming";
+  const statusColor =
+    appointmentStatus === "COMPLETED"
+      ? "bg-green-50 text-green-700 border-green-200"
+      : "bg-blue-50 text-blue-700 border-blue-200";
+
+  return (
+    <div
+      className={cn(
+        "p-4 rounded-xl bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-200",
+        "dark:from-amber-900/20 dark:to-orange-900/20 dark:border-amber-800",
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <div className="p-1.5 rounded-md bg-amber-100 dark:bg-amber-800/50">
+            <Link2 className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+          </div>
+          <span className="text-xs font-medium text-amber-700 dark:text-amber-300">
+            Linked to {typeLabel}
+          </span>
+        </div>
+        {onClear && (
+          <button
+            onClick={onClear}
+            className="text-xs text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 underline"
+          >
+            Clear link
+          </button>
+        )}
+      </div>
+
+      {/* Context Details */}
+      <div className="space-y-2">
+        {consultantName && (
+          <div className="flex items-center gap-2 text-sm">
+            <User className="h-4 w-4 text-zinc-400" />
+            <span className="font-medium text-zinc-800 dark:text-zinc-200">
+              {consultantName}
+            </span>
+          </div>
+        )}
+
+        {scheduledAt && (
+          <div className="flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+            <Calendar className="h-4 w-4 text-zinc-400" />
+            <span>{formatDate(scheduledAt)}</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-zinc-400" />
+          <span
+            className={cn(
+              "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border",
+              statusColor
+            )}
+          >
+            {statusLabel}
+          </span>
+        </div>
+      </div>
+
+      {/* Helper Text */}
+      <p className="mt-3 text-xs text-amber-700/80 dark:text-amber-400/80">
+        Your support ticket will be linked to this {typeLabel.toLowerCase()} for faster resolution.
+      </p>
+    </div>
+  );
+}

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
@@ -34,18 +34,15 @@ import {
   Sparkles,
   Link2,
 } from "lucide-react";
-import { ISSUE_TYPE_LABELS, ISSUE_TYPE_CATEGORIES } from "@/utils/supportTicketUrl";
+import {
+  ISSUE_TYPE_LABELS,
+  ISSUE_TYPE_CATEGORIES,
+  PRIORITY_OPTIONS,
+} from "@/utils/supportTicketUrl";
 
 interface FeedbackSupportTabProps {
   consulteeId: string;
 }
-
-const PRIORITY_OPTIONS: { value: SupportPriority; label: string; color: string }[] = [
-  { value: "LOW", label: "Low", color: "text-green-600" },
-  { value: "MEDIUM", label: "Medium", color: "text-amber-600" },
-  { value: "HIGH", label: "High", color: "text-orange-600" },
-  { value: "URGENT", label: "Urgent", color: "text-red-600" },
-];
 
 export default function FeedbackSupportTab({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
@@ -32,27 +32,13 @@ import {
   Loader2,
   ChevronRight,
   Sparkles,
+  Link2,
 } from "lucide-react";
+import { ISSUE_TYPE_LABELS, ISSUE_TYPE_CATEGORIES } from "@/utils/supportTicketUrl";
 
 interface FeedbackSupportTabProps {
   consulteeId: string;
 }
-
-// Human-readable labels for issue types
-const ISSUE_TYPE_OPTIONS: { value: SupportIssueType; label: string; description: string }[] = [
-  { value: "CONSULTANT_NO_SHOW", label: "Consultant didn't show up", description: "Expert was absent from scheduled session" },
-  { value: "SESSION_QUALITY_POOR", label: "Poor session quality", description: "Unsatisfied with consultation quality" },
-  { value: "TECHNICAL_ISSUES", label: "Technical problems", description: "Audio, video, or connection issues" },
-  { value: "WRONG_CONSULTANT", label: "Wrong consultant assigned", description: "Matched with incorrect expert" },
-  { value: "PAYMENT_FAILED", label: "Payment failed", description: "Issue completing payment" },
-  { value: "CHARGED_TWICE", label: "Charged twice", description: "Duplicate charge on payment" },
-  { value: "REFUND_REQUEST", label: "Refund request", description: "Request money back for a booking" },
-  { value: "WANT_TO_CANCEL", label: "Want to cancel booking", description: "Need to cancel an upcoming session" },
-  { value: "CANCELLATION_ISSUE", label: "Cancellation problem", description: "Issue with cancellation process" },
-  { value: "ACCOUNT_ISSUE", label: "Account issue", description: "Profile, login, or settings problem" },
-  { value: "GENERAL_INQUIRY", label: "General inquiry", description: "Questions about the platform" },
-  { value: "OTHER", label: "Other", description: "Something else not listed" },
-];
 
 const PRIORITY_OPTIONS: { value: SupportPriority; label: string; color: string }[] = [
   { value: "LOW", label: "Low", color: "text-green-600" },
@@ -132,8 +118,7 @@ export default function FeedbackSupportTab({
 
   const formatIssueType = (issueType: SupportIssueType | null) => {
     if (!issueType) return null;
-    const option = ISSUE_TYPE_OPTIONS.find(o => o.value === issueType);
-    return option?.label || issueType.replace(/_/g, " ");
+    return ISSUE_TYPE_LABELS[issueType] || issueType.replace(/_/g, " ");
   };
 
   return (
@@ -337,37 +322,18 @@ export default function FeedbackSupportTab({
                       <SelectValue placeholder="Select issue type" />
                     </SelectTrigger>
                     <SelectContent>
-                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide">Booking Issues</div>
-                      {ISSUE_TYPE_OPTIONS.slice(0, 4).map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          <div className="flex flex-col">
-                            <span>{option.label}</span>
+                      {Object.entries(ISSUE_TYPE_CATEGORIES).map(([category, types], idx) => (
+                        <React.Fragment key={category}>
+                          {idx > 0 && <div className="my-1" />}
+                          <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                            {category}
                           </div>
-                        </SelectItem>
-                      ))}
-                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide mt-2">Payment Issues</div>
-                      {ISSUE_TYPE_OPTIONS.slice(4, 7).map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          <div className="flex flex-col">
-                            <span>{option.label}</span>
-                          </div>
-                        </SelectItem>
-                      ))}
-                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide mt-2">Cancellation</div>
-                      {ISSUE_TYPE_OPTIONS.slice(7, 9).map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          <div className="flex flex-col">
-                            <span>{option.label}</span>
-                          </div>
-                        </SelectItem>
-                      ))}
-                      <div className="py-1 px-2 text-xs font-medium text-zinc-500 uppercase tracking-wide mt-2">General</div>
-                      {ISSUE_TYPE_OPTIONS.slice(9).map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
-                          <div className="flex flex-col">
-                            <span>{option.label}</span>
-                          </div>
-                        </SelectItem>
+                          {types.map((issueType) => (
+                            <SelectItem key={issueType} value={issueType}>
+                              <span>{ISSUE_TYPE_LABELS[issueType]}</span>
+                            </SelectItem>
+                          ))}
+                        </React.Fragment>
                       ))}
                     </SelectContent>
                   </Select>
@@ -461,11 +427,22 @@ export default function FeedbackSupportTab({
                     <div className="flex justify-between items-start gap-4 mb-2">
                       <div className="flex-1 min-w-0">
                         <h4 className="font-medium text-zinc-900 dark:text-white truncate">{ticket.title}</h4>
-                        {ticket.issueType && (
-                          <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                            {formatIssueType(ticket.issueType)}
-                          </span>
-                        )}
+                        <div className="flex items-center gap-2 flex-wrap">
+                          {ticket.issueType && (
+                            <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                              {formatIssueType(ticket.issueType)}
+                            </span>
+                          )}
+                          {/* Context indicator for linked tickets */}
+                          {(ticket.consultationId || ticket.subscriptionId || ticket.paymentId) && (
+                            <span className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400">
+                              <Link2 className="h-3 w-3" />
+                              {ticket.paymentId && !ticket.consultationId && !ticket.subscriptionId
+                                ? "Linked to payment"
+                                : "Linked to appointment"}
+                            </span>
+                          )}
+                        </div>
                       </div>
                       <div className="flex gap-2 shrink-0">
                         <Badge variant="outline" className={`${getPriorityColor(ticket.priority as SupportPriority)} text-xs`}>

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/useFeedbackSupport.ts
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/useFeedbackSupport.ts
@@ -37,7 +37,7 @@ interface EnrichedSupportTicketResponse extends PrismaSupportResponse {
   } | null;
 }
 
-interface SupportTicketWithResponses extends SupportTicket {
+export interface SupportTicketWithResponses extends SupportTicket {
   responses: EnrichedSupportTicketResponse[];
 }
 
@@ -83,13 +83,14 @@ export function useFeedbackSupport() {
       }
       const data = await response.json();
       setFeedbacks(data);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to load feedbacks:", error);
       toast({
         title: "Error",
         description:
-          error.message ||
-          "Unable to load your feedback history. Please try refreshing the page.",
+          error instanceof Error
+            ? error.message
+            : "Unable to load your feedback history. Please try refreshing the page.",
         variant: "destructive",
       });
     } finally {
@@ -109,13 +110,14 @@ export function useFeedbackSupport() {
       }
       const data = await response.json();
       setTickets(data);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to load support tickets:", error);
       toast({
         title: "Error",
         description:
-          error.message ||
-          "Unable to load your support tickets. Please try refreshing the page.",
+          error instanceof Error
+            ? error.message
+            : "Unable to load your support tickets. Please try refreshing the page.",
         variant: "destructive",
       });
     } finally {
@@ -149,13 +151,14 @@ export function useFeedbackSupport() {
 
       setFeedbackForm({ title: "", description: "" });
       loadFeedbacks();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to submit feedback:", error);
       toast({
         title: "Error",
         description:
-          error.message ||
-          "Unable to submit your feedback. Please check your input and try again.",
+          error instanceof Error
+            ? error.message
+            : "Unable to submit your feedback. Please check your input and try again.",
         variant: "destructive",
       });
     } finally {
@@ -166,6 +169,7 @@ export function useFeedbackSupport() {
   const handleTicketSubmit = async () => {
     try {
       setIsLoading(true);
+
       const response = await fetch("/api/user/support-tickets", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -190,14 +194,16 @@ export function useFeedbackSupport() {
         priority: SupportPriority.MEDIUM,
         issueType: undefined,
       });
+
       loadTickets();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to create support ticket:", error);
       toast({
         title: "Error",
         description:
-          error.message ||
-          "Unable to create your support ticket. Please check your input and try again.",
+          error instanceof Error
+            ? error.message
+            : "Unable to create your support ticket. Please check your input and try again.",
         variant: "destructive",
       });
     } finally {
@@ -229,13 +235,14 @@ export function useFeedbackSupport() {
 
       setResponseForm({ message: "" });
       loadTickets(); // Reload tickets to show the new response
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to submit response:", error);
       toast({
         title: "Error",
         description:
-          error.message ||
-          "Unable to submit your response. Please check your message and try again.",
+          error instanceof Error
+            ? error.message
+            : "Unable to submit your response. Please check your message and try again.",
         variant: "destructive",
       });
     } finally {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -204,16 +204,28 @@ enum CancellationReason {
 
 // Issue types for support tickets (Swiggy-style categorization)
 enum SupportIssueType {
-  // Booking Issues
+  // Session Issues
   CONSULTANT_NO_SHOW
+  CONSULTANT_LATE
+  SESSION_ENDED_EARLY
   SESSION_QUALITY_POOR
+  COMMUNICATION_ISSUE
   TECHNICAL_ISSUES
   WRONG_CONSULTANT
+
+  // Access & Scheduling
+  ACCESS_ISSUE
+  TIMEZONE_CONFUSION
+  RESCHEDULING_HELP
 
   // Payment Issues
   PAYMENT_FAILED
   CHARGED_TWICE
   REFUND_REQUEST
+  BILLING_QUESTION
+
+  // Documents
+  DOCUMENT_ISSUE
 
   // Cancellation
   WANT_TO_CANCEL

--- a/utils/errors/RescheduleErrors.ts
+++ b/utils/errors/RescheduleErrors.ts
@@ -1,0 +1,49 @@
+/**
+ * Custom error classes for reschedule operations
+ *
+ * Benefits over string matching:
+ * - Type-safe error handling with instanceof
+ * - No brittleness from message text changes
+ * - Structured error data for clients
+ */
+
+/**
+ * Thrown when a reschedule is attempted within the restricted time window
+ */
+export class ReschedulePolicyError extends Error {
+  constructor(
+    public readonly hoursUntilSlot: number,
+    public readonly minimumHoursRequired: number,
+  ) {
+    super(
+      `Cannot reschedule within ${minimumHoursRequired} hours of the session. ` +
+        `The earliest session starts in ${Math.max(0, Math.floor(hoursUntilSlot))} hours.`,
+    );
+    this.name = "ReschedulePolicyError";
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ReschedulePolicyError);
+    }
+  }
+}
+
+/**
+ * Thrown when an appointment or slot is not found
+ */
+export class AppointmentNotFoundError extends Error {
+  constructor(
+    public readonly resourceType: "appointment" | "slot",
+    public readonly resourceId: string,
+  ) {
+    const message =
+      resourceType === "appointment"
+        ? "Appointment not found"
+        : "Specified slot not found in this appointment";
+    super(message);
+    this.name = "AppointmentNotFoundError";
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AppointmentNotFoundError);
+    }
+  }
+}

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -89,11 +89,41 @@ export class SlotAllocationService {
 
         const { consultant, config, consulteeUserId } = eventData;
 
-        // Calculate required slots
-        const requiredSlots = SlotCalculationService.calculateRequiredSlots(
-          eventType,
-          config,
+        // CRITICAL FIX: Check for existing appointments to detect reschedule scenario
+        // If tentative slots exist, this is a reschedule and we should preserve the original slot count
+        const relationField = this.getEventRelationField(eventType);
+        const existingAppointments = await (tx as any).appointment.findMany({
+          where: { [`${relationField}Id`]: eventId },
+          include: { slotsOfAppointment: true },
+        });
+
+        // Count existing slots by tentative status
+        const existingNonTentativeSlotCount = existingAppointments.reduce(
+          (count: number, app: any) =>
+            count + app.slotsOfAppointment.filter((s: any) => !s.isTentative).length,
+          0,
         );
+        const tentativeSlotCount = existingAppointments.reduce(
+          (count: number, app: any) =>
+            count + app.slotsOfAppointment.filter((s: any) => s.isTentative).length,
+          0,
+        );
+        const isReschedule = tentativeSlotCount > 0;
+
+        // Calculate required slots - preserve count during reschedule
+        let requiredSlots: number;
+        if (isReschedule) {
+          // RESCHEDULE: Preserve the original total slot count
+          // This prevents slot count from changing when rescheduling
+          requiredSlots = existingNonTentativeSlotCount + tentativeSlotCount;
+        } else {
+          // INITIAL ALLOCATION: Calculate from config
+          requiredSlots = SlotCalculationService.calculateRequiredSlots(
+            eventType,
+            config,
+          );
+        }
+
         const slotsPerCall = SlotCalculationService.getSlotsPerCall(
           config.sessionDurationInHours || config.durationInHours || 1,
         );
@@ -143,8 +173,9 @@ export class SlotAllocationService {
         }
 
         // CRITICAL FIX: Delete existing appointments before creating new ones
-        // This prevents duplicate appointments when auto-allocating on reschedule
-        await this.deleteExistingAppointments(tx, eventType, eventId);
+        // For reschedules: only delete appointments with tentative slots (preserve confirmed ones)
+        // For initial allocation: delete all (shouldn't be any, but safety measure)
+        await this.deleteExistingAppointments(tx, eventType, eventId, isReschedule);
 
         // Create appointments
         const appointments = await this.createAppointments(
@@ -828,16 +859,32 @@ export class SlotAllocationService {
 
   /**
    * Delete existing appointments for an event
+   *
+   * @param onlyTentative - If true, only delete appointments that have at least one tentative slot.
+   *                        This is used for partial reschedules where we want to preserve
+   *                        confirmed appointments and only replace the rescheduled ones.
    */
   private static async deleteExistingAppointments(
     tx: PrismaTransaction,
     eventType: EventType,
     eventId: string,
+    onlyTentative: boolean = false,
   ): Promise<void> {
     const relationField = this.getEventRelationField(eventType);
 
+    // Build where clause - optionally filter to only appointments with tentative slots
+    const whereClause: any = { [`${relationField}Id`]: eventId };
+
+    if (onlyTentative) {
+      // Only delete appointments that have at least one tentative slot
+      // This preserves confirmed appointments during partial reschedules
+      whereClause.slotsOfAppointment = {
+        some: { isTentative: true },
+      };
+    }
+
     const existing = await (tx as any).appointment.findMany({
-      where: { [`${relationField}Id`]: eventId },
+      where: whereClause,
     });
 
     await Promise.all(

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -142,6 +142,10 @@ export class SlotAllocationService {
           }
         }
 
+        // CRITICAL FIX: Delete existing appointments before creating new ones
+        // This prevents duplicate appointments when auto-allocating on reschedule
+        await this.deleteExistingAppointments(tx, eventType, eventId);
+
         // Create appointments
         const appointments = await this.createAppointments(
           tx,
@@ -376,6 +380,16 @@ export class SlotAllocationService {
           requestedSlots[0],
           config,
         );
+
+        // CRITICAL FIX: Clear isTentative flag on all slots after approval
+        // This ensures slots are no longer marked as pending reschedule
+        const appointmentIds = existingAppointments.map((app: any) => app.id);
+        await tx.slotOfAppointment.updateMany({
+          where: {
+            appointmentId: { in: appointmentIds },
+          },
+          data: { isTentative: false },
+        });
 
         return {
           success: true,

--- a/utils/supportTicketUrl.ts
+++ b/utils/supportTicketUrl.ts
@@ -1,4 +1,4 @@
-import { SupportIssueType } from "@prisma/client";
+import { SupportIssueType, SupportPriority } from "@prisma/client";
 
 /**
  * Support ticket URL utility for contextual ticket creation
@@ -8,18 +8,38 @@ import { SupportIssueType } from "@prisma/client";
 export type AppointmentStatus = "COMPLETED" | "UPCOMING";
 
 /**
+ * Priority options for support tickets
+ */
+export const PRIORITY_OPTIONS: {
+  value: SupportPriority;
+  label: string;
+  color: string;
+}[] = [
+  { value: "LOW", label: "Low", color: "text-green-600" },
+  { value: "MEDIUM", label: "Medium", color: "text-amber-600" },
+  { value: "HIGH", label: "High", color: "text-orange-600" },
+  { value: "URGENT", label: "Urgent", color: "text-red-600" },
+];
+
+/**
  * Issue types filtered by context
  * Based on GitHub Issue #298 requirements
  */
 export const CONTEXTUAL_ISSUE_TYPES = {
   COMPLETED: [
     SupportIssueType.CONSULTANT_NO_SHOW,
+    SupportIssueType.CONSULTANT_LATE,
+    SupportIssueType.SESSION_ENDED_EARLY,
     SupportIssueType.SESSION_QUALITY_POOR,
+    SupportIssueType.COMMUNICATION_ISSUE,
     SupportIssueType.TECHNICAL_ISSUES,
     SupportIssueType.OTHER,
   ],
   UPCOMING: [
     SupportIssueType.WANT_TO_CANCEL,
+    SupportIssueType.RESCHEDULING_HELP,
+    SupportIssueType.ACCESS_ISSUE,
+    SupportIssueType.TIMEZONE_CONFUSION,
     SupportIssueType.TECHNICAL_ISSUES,
     SupportIssueType.OTHER,
   ],
@@ -27,6 +47,7 @@ export const CONTEXTUAL_ISSUE_TYPES = {
     SupportIssueType.CHARGED_TWICE,
     SupportIssueType.REFUND_REQUEST,
     SupportIssueType.PAYMENT_FAILED,
+    SupportIssueType.BILLING_QUESTION,
     SupportIssueType.OTHER,
   ],
 } as const;
@@ -109,16 +130,28 @@ export function getFilteredIssueTypes(
  * Human-readable labels for issue types
  */
 export const ISSUE_TYPE_LABELS: Record<SupportIssueType, string> = {
-  // Booking Issues
+  // Session Issues
   [SupportIssueType.CONSULTANT_NO_SHOW]: "Consultant didn't show up",
+  [SupportIssueType.CONSULTANT_LATE]: "Consultant was late",
+  [SupportIssueType.SESSION_ENDED_EARLY]: "Session ended earlier than expected",
   [SupportIssueType.SESSION_QUALITY_POOR]: "Poor session quality",
+  [SupportIssueType.COMMUNICATION_ISSUE]: "Audio/video problems during call",
   [SupportIssueType.TECHNICAL_ISSUES]: "Technical issues",
   [SupportIssueType.WRONG_CONSULTANT]: "Wrong consultant assigned",
+
+  // Access & Scheduling
+  [SupportIssueType.ACCESS_ISSUE]: "Cannot join or access session",
+  [SupportIssueType.TIMEZONE_CONFUSION]: "Wrong time zone displayed",
+  [SupportIssueType.RESCHEDULING_HELP]: "Need help rescheduling",
 
   // Payment Issues
   [SupportIssueType.PAYMENT_FAILED]: "Payment failed",
   [SupportIssueType.CHARGED_TWICE]: "Charged twice",
   [SupportIssueType.REFUND_REQUEST]: "Refund request",
+  [SupportIssueType.BILLING_QUESTION]: "Invoice or receipt inquiry",
+
+  // Documents
+  [SupportIssueType.DOCUMENT_ISSUE]: "Materials not received or incorrect",
 
   // Cancellation
   [SupportIssueType.WANT_TO_CANCEL]: "Want to cancel booking",
@@ -134,17 +167,27 @@ export const ISSUE_TYPE_LABELS: Record<SupportIssueType, string> = {
  * Issue type categories for grouped display
  */
 export const ISSUE_TYPE_CATEGORIES = {
-  "Booking Issues": [
+  "Session Issues": [
     SupportIssueType.CONSULTANT_NO_SHOW,
+    SupportIssueType.CONSULTANT_LATE,
+    SupportIssueType.SESSION_ENDED_EARLY,
     SupportIssueType.SESSION_QUALITY_POOR,
+    SupportIssueType.COMMUNICATION_ISSUE,
     SupportIssueType.TECHNICAL_ISSUES,
     SupportIssueType.WRONG_CONSULTANT,
+  ],
+  "Access & Scheduling": [
+    SupportIssueType.ACCESS_ISSUE,
+    SupportIssueType.TIMEZONE_CONFUSION,
+    SupportIssueType.RESCHEDULING_HELP,
   ],
   "Payment Issues": [
     SupportIssueType.PAYMENT_FAILED,
     SupportIssueType.CHARGED_TWICE,
     SupportIssueType.REFUND_REQUEST,
+    SupportIssueType.BILLING_QUESTION,
   ],
+  Documents: [SupportIssueType.DOCUMENT_ISSUE],
   Cancellation: [
     SupportIssueType.WANT_TO_CANCEL,
     SupportIssueType.CANCELLATION_ISSUE,

--- a/utils/supportTicketUrl.ts
+++ b/utils/supportTicketUrl.ts
@@ -1,0 +1,178 @@
+import { SupportIssueType } from "@prisma/client";
+
+/**
+ * Support ticket URL utility for contextual ticket creation
+ * Generates URLs with pre-filled context from appointments/payments
+ */
+
+export type AppointmentStatus = "COMPLETED" | "UPCOMING";
+
+/**
+ * Issue types filtered by context
+ * Based on GitHub Issue #298 requirements
+ */
+export const CONTEXTUAL_ISSUE_TYPES = {
+  COMPLETED: [
+    SupportIssueType.CONSULTANT_NO_SHOW,
+    SupportIssueType.SESSION_QUALITY_POOR,
+    SupportIssueType.TECHNICAL_ISSUES,
+    SupportIssueType.OTHER,
+  ],
+  UPCOMING: [
+    SupportIssueType.WANT_TO_CANCEL,
+    SupportIssueType.TECHNICAL_ISSUES,
+    SupportIssueType.OTHER,
+  ],
+  PAYMENT: [
+    SupportIssueType.CHARGED_TWICE,
+    SupportIssueType.REFUND_REQUEST,
+    SupportIssueType.PAYMENT_FAILED,
+    SupportIssueType.OTHER,
+  ],
+} as const;
+
+/**
+ * All available issue types for generic support
+ */
+export const ALL_ISSUE_TYPES = Object.values(SupportIssueType);
+
+export interface AppointmentContext {
+  appointmentId: string;
+  appointmentType: "CONSULTATION" | "SUBSCRIPTION";
+  status: AppointmentStatus;
+  consultantName?: string;
+  scheduledAt?: string;
+}
+
+export interface PaymentContext {
+  paymentId: string;
+}
+
+export type SupportContext =
+  | { type: "appointment"; context: AppointmentContext }
+  | { type: "payment"; context: PaymentContext };
+
+/**
+ * Generate URL for contextual support ticket creation
+ * @param consulteeId - The consultee's profile ID
+ * @param context - Appointment or payment context
+ * @returns URL string with query parameters
+ */
+export function generateSupportTicketUrl(
+  consulteeId: string,
+  context: SupportContext
+): string {
+  const params = new URLSearchParams();
+  params.set("tab", "support");
+
+  if (context.type === "appointment") {
+    const { appointmentId, appointmentType, status, consultantName, scheduledAt } =
+      context.context;
+    params.set("appointmentId", appointmentId);
+    params.set("appointmentType", appointmentType);
+    params.set("appointmentStatus", status);
+    if (consultantName) params.set("consultantName", consultantName);
+    if (scheduledAt) params.set("scheduledAt", scheduledAt);
+  } else if (context.type === "payment") {
+    params.set("paymentId", context.context.paymentId);
+  }
+
+  return `/dashboard/consultee/${consulteeId}/feedback?${params.toString()}`;
+}
+
+/**
+ * Get filtered issue types based on context
+ * @param appointmentStatus - COMPLETED or UPCOMING
+ * @param isPayment - Whether this is a payment-related issue
+ * @returns Array of applicable SupportIssueType values
+ */
+export function getFilteredIssueTypes(
+  appointmentStatus?: AppointmentStatus,
+  isPayment?: boolean
+): SupportIssueType[] {
+  if (isPayment) {
+    return [...CONTEXTUAL_ISSUE_TYPES.PAYMENT];
+  }
+
+  if (appointmentStatus === "COMPLETED") {
+    return [...CONTEXTUAL_ISSUE_TYPES.COMPLETED];
+  }
+
+  if (appointmentStatus === "UPCOMING") {
+    return [...CONTEXTUAL_ISSUE_TYPES.UPCOMING];
+  }
+
+  return ALL_ISSUE_TYPES;
+}
+
+/**
+ * Human-readable labels for issue types
+ */
+export const ISSUE_TYPE_LABELS: Record<SupportIssueType, string> = {
+  // Booking Issues
+  [SupportIssueType.CONSULTANT_NO_SHOW]: "Consultant didn't show up",
+  [SupportIssueType.SESSION_QUALITY_POOR]: "Poor session quality",
+  [SupportIssueType.TECHNICAL_ISSUES]: "Technical issues",
+  [SupportIssueType.WRONG_CONSULTANT]: "Wrong consultant assigned",
+
+  // Payment Issues
+  [SupportIssueType.PAYMENT_FAILED]: "Payment failed",
+  [SupportIssueType.CHARGED_TWICE]: "Charged twice",
+  [SupportIssueType.REFUND_REQUEST]: "Refund request",
+
+  // Cancellation
+  [SupportIssueType.WANT_TO_CANCEL]: "Want to cancel booking",
+  [SupportIssueType.CANCELLATION_ISSUE]: "Issue with cancellation",
+
+  // General
+  [SupportIssueType.ACCOUNT_ISSUE]: "Account issue",
+  [SupportIssueType.GENERAL_INQUIRY]: "General inquiry",
+  [SupportIssueType.OTHER]: "Other",
+};
+
+/**
+ * Issue type categories for grouped display
+ */
+export const ISSUE_TYPE_CATEGORIES = {
+  "Booking Issues": [
+    SupportIssueType.CONSULTANT_NO_SHOW,
+    SupportIssueType.SESSION_QUALITY_POOR,
+    SupportIssueType.TECHNICAL_ISSUES,
+    SupportIssueType.WRONG_CONSULTANT,
+  ],
+  "Payment Issues": [
+    SupportIssueType.PAYMENT_FAILED,
+    SupportIssueType.CHARGED_TWICE,
+    SupportIssueType.REFUND_REQUEST,
+  ],
+  Cancellation: [
+    SupportIssueType.WANT_TO_CANCEL,
+    SupportIssueType.CANCELLATION_ISSUE,
+  ],
+  General: [
+    SupportIssueType.ACCOUNT_ISSUE,
+    SupportIssueType.GENERAL_INQUIRY,
+    SupportIssueType.OTHER,
+  ],
+} as const;
+
+/**
+ * Get grouped issue types for dropdown display
+ * Filters by context if provided
+ */
+export function getGroupedIssueTypes(
+  appointmentStatus?: AppointmentStatus,
+  isPayment?: boolean
+): Record<string, SupportIssueType[]> {
+  const allowedTypes = getFilteredIssueTypes(appointmentStatus, isPayment);
+  const result: Record<string, SupportIssueType[]> = {};
+
+  for (const [category, types] of Object.entries(ISSUE_TYPE_CATEGORIES)) {
+    const filteredTypes = types.filter((t) => allowedTypes.includes(t));
+    if (filteredTypes.length > 0) {
+      result[category] = filteredTypes;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **CRITICAL: Session Duplication Fix**: Fixed bug where reschedule could cause session count to jump (e.g., 8 → 20) due to missing cleanup
- **CRITICAL: Slot Count Preservation Fix**: Fixed bug where reschedule recalculated slots from plan config instead of preserving existing count
- **CRITICAL: Partial Reschedule Fix**: Fixed bug where partial reschedule deleted ALL appointments instead of only tentative ones
- **CRITICAL: Expired Subscription Fix**: Disabled reschedule/cancel buttons for EXPIRED subscriptions
- **Reschedule API enhancements** (#278, #279): Added support for individual session, **multi-session**, and entire subscription rescheduling with 24-hour restriction
- **Multi-slot Reschedule UI**: Consultees can now select multiple specific sessions to reschedule (not just 1 or all)
- **Cancellation Confirmation Dialogs**: Replaced `window.confirm()` with styled AlertDialog components for better UX
- **Support Ticket Bug Fix**: Fixed appointment linking by resolving `appointmentId` to correct entity IDs
- **Reschedule Visibility**: Enhanced consultant dashboard to show which slots need rescheduling with improved messaging
- **Slot algorithm fix** (#215): Fixed fallback logic that was returning non-consecutive slots
- **Performance fix** (#142): Replaced N+1 participant count queries with direct Prisma batch query
- **Contextual Report Issue** (#298): Added "Report Issue" button on appointment cards with modal dialog
- **UI Bug Fixes**: Hide cancel button for inactive appointments, add consultation time display
- **Support Ticket Enhancements**: Added 8 new issue types for better customer satisfaction

## Changes

### CRITICAL: Session Duplication Bug Fix
**Files:** `utils/slotAllocation/SlotAllocationService.ts`

**Problem:** When a subscription was rescheduled and then re-allocated, the session count would jump (e.g., from 8 to 20 sessions) because old appointments weren't being cleaned up.

**Root Cause:** `autoAllocate()` was creating new appointments without first deleting existing ones, causing cumulative session counts.

**Fixes Applied:**
1. Added `deleteExistingAppointments()` call in `autoAllocate()` before creating new appointments
2. Added code to clear `isTentative: false` on all slots after approval in `useRequestedSlots()`
3. Added explicit `isTentative` field support in PATCH `/api/slots/appointments` endpoint

### CRITICAL: Slot Count Recalculation Bug Fix (NEW)
**Files:** `utils/slotAllocation/SlotAllocationService.ts`

**Problem:** When rescheduling (partial or full), the system recalculated `requiredSlots` from the subscription plan configuration instead of preserving the existing slot count. This caused slot count changes (e.g., 6 slots → 8 slots).

**Root Cause:** `autoAllocate()` always called `SlotCalculationService.calculateRequiredSlots()` without checking if this was a reschedule scenario.

**Fix:** Added logic to detect reschedules by checking for tentative slots. If tentative slots exist, preserve the original total slot count instead of recalculating from plan config.

### CRITICAL: Partial Reschedule Deletion Bug Fix (NEW)
**Files:** `utils/slotAllocation/SlotAllocationService.ts`

**Problem:** When a user rescheduled 1 of 8 sessions, the system deleted ALL 8 appointments and recreated them, instead of only replacing the tentative one.

**Root Cause:** `deleteExistingAppointments()` had no filtering - it deleted ALL appointments for the event regardless of tentative status.

**Fix:** 
1. Added `onlyTentative` parameter to `deleteExistingAppointments()`
2. When `true`, only deletes appointments that have at least one tentative slot
3. `autoAllocate()` now passes `isReschedule` flag to control deletion scope

### CRITICAL: EXPIRED Subscription Reschedule Fix
**Files:** `EventCard.tsx`, `Overview.tsx`

**Problem:** EXPIRED subscriptions still showed enabled Reschedule/Cancel buttons, allowing users to trigger the reschedule flow on expired subscriptions.

**Fix:** Added `"expired"` to the `isInactiveStatus` check to disable/hide these buttons for expired subscriptions.

### NEW: Hide Cancel Button for Inactive Appointments
**File:** `app/dashboard/consultee/.../appointments/EventCard.tsx`

Previously, the Cancel button was shown but disabled for cancelled/rejected/completed appointments. Now it's completely hidden for better UX.

### NEW: Consultation Time Display
**File:** `app/dashboard/consultee/.../appointments/EventCard.tsx`

Consultations now show their scheduled date and time (previously only showed for classes/subscriptions).

### NEW: 8 Additional Support Ticket Issue Types
**Files:** `prisma/schema.prisma`, `utils/supportTicketUrl.ts`

Added new issue types for better customer support coverage:

| Category | New Issue Types |
|----------|-----------------|
| **Session Issues** | Consultant was late, Session ended early, Audio/video problems |
| **Access & Scheduling** | Cannot access session, Wrong timezone, Need rescheduling help |
| **Billing** | Invoice/receipt inquiry |
| **Documents** | Materials not received |

### NEW: Constants Refactor
**Files:** `utils/supportTicketUrl.ts`, `ReportIssueDialog.tsx`, `FeedbackSupportTab.tsx`

- Moved `PRIORITY_OPTIONS` to centralized constants file
- Updated all UI files to import from single source of truth

### NEW: Multi-Slot Reschedule (`app/dashboard/consultee/.../EventCard.tsx`)
Consultees can now select multiple specific sessions to reschedule instead of just "one" or "all".

**UI Options:**
- ○ Reschedule One Session (select below)
- ○ Reschedule Multiple Sessions (select below) ← **NEW**
- ○ Reschedule Entire Subscription (all X sessions)

**Features:**
- Checkbox multi-select UI when "Multiple Sessions" selected
- Shows count: "X sessions selected"
- 24-hour restriction applies to ALL selected slots
- State changed from `selectedSlotId: string | null` to `selectedSlotIds: string[]`

### NEW: Reschedule API Multi-Slot Support (`app/api/appointments/[appointmentId]/reschedule/route.ts`)
- Now accepts `slotIds[]` array (with backward compatibility for single `slotId`)
- Validates all requested slots exist in the appointment
- Validates 24-hour restriction on ALL selected slots (not just earliest)
- Returns `rescheduleType`: `individual_session`, `multiple_sessions`, or `entire_booking`

### NEW: Cancellation Confirmation Dialogs
Replaced browser's `window.confirm()` with styled AlertDialog components for consistent UX.

**Consultee Dashboard** (`app/dashboard/consultee/.../appointments/`):
- Created `CancelConfirmationDialog.tsx` component
- Shows appointment title and consultant name
- Loading state during API call
- Destructive styling with "Yes, Cancel" button

**Consultant Dashboard** (`app/dashboard/consultant/.../planner/components/EventCarousel.tsx`):
- Integrated existing `FormConfirmationDialog` component
- Shows event title in confirmation
- Loading state during deletion

### NEW: Support Ticket Bug Fix (`app/api/user/support-tickets/route.ts`)
**Problem:** "Report Issue" from appointments failed because frontend passed `Appointment.id` but API expected `Consultation.id`/`Subscription.id`.

**Solution:**
- API now accepts `appointmentId` parameter
- Looks up appointment and resolves to correct `consultationId`/`subscriptionId`
- Frontend (`ReportIssueDialog.tsx`) now sends `appointmentId` instead of incorrectly mapping

### Reschedule Visibility Improvements (`app/dashboard/consultant/.../requests/`)
Improved messaging to distinguish between reschedule types:
- **Full Reschedule (all 5 sessions)** - Blue indicator
- **Individual Session (1 of 5 needs new time)** - Amber indicator ← **NEW**
- **Multiple Sessions (3 of 5 need new times)** - Amber indicator ← **NEW**

### Contextual Report Issue (`app/dashboard/consultee/.../appointments/`)
- Added `ReportIssueDialog.tsx` - Modal dialog for creating appointment-linked support tickets
- Added "Report Issue" button on `EventCard.tsx` that opens the dialog
- Issue types filtered based on appointment status (COMPLETED vs UPCOMING)
- Tickets automatically linked to the appointment

### Support Tab Separation (`app/dashboard/consultee/.../feedback/`)
- Added `AppointmentContextCard.tsx` - Displays linked appointment context
- Modified `FeedbackSupportTab.tsx` - Form creates generic tickets only, list shows ALL tickets
- Added `utils/supportTicketUrl.ts` - Issue type filtering and labels utility

### Reschedule API (`app/api/appointments/[appointmentId]/reschedule/route.ts`)
- Added `type` query parameter support (SUBSCRIPTION, CONSULTATION, etc.)
- Added optional `slotIds[]` body parameter for individual/multiple session reschedule
- Added 24-hour restriction check for ALL selected slots
- Returns detailed response with `rescheduleType` and `slotsAffected`

### Slot Algorithm Fix (`app/dashboard/consultant/.../allocationAlgorithms.ts`)
- Fixed `allocateConsultationSlots` to return empty array instead of potentially non-consecutive slots
- Removed unused `durationInMonths` parameter from `allocateRecurringSlots`

### Performance Fix (`app/api/dashboard/consultant/[consultantId]/planner/route.ts`)
- Replaced N+1 internal API calls with direct Prisma batch query
- Added `getParticipantCounts` helper function using efficient `findMany` with `_count`

## Test Plan

### Critical Bug Fixes
- [x] Verify EXPIRED subscriptions have disabled/hidden Reschedule and Cancel buttons
- [x] Test reschedule flow doesn't cause session count duplication
- [x] Verify auto-allocation deletes old appointments before creating new ones
- [x] Verify `isTentative` flag is cleared after consultant approval
- [ ] Test slot count is preserved during reschedule (6 slots stays 6 slots)
- [ ] Test partial reschedule only deletes appointments with tentative slots

### New UI Fixes
- [x] Verify Cancel button is hidden (not visible) for cancelled/rejected/completed appointments
- [x] Verify consultation cards show scheduled date and time
- [x] Verify new support ticket issue types appear in dropdowns based on context

### Multi-Slot Reschedule
- [x] Test "Reschedule Multiple Sessions" option appears for subscriptions
- [x] Verify checkbox UI appears when "Multiple Sessions" selected
- [x] Verify selected count shows ("2 sessions selected")
- [x] Test 24-hour validation applies to ALL selected slots
- [x] Verify API accepts array of slot IDs
- [ ] Verify only selected slots marked as tentative

### Cancellation Dialogs
- [x] Verify styled AlertDialog appears instead of browser confirm (consultee)
- [x] Verify loading state during cancellation API call
- [x] Verify "Keep Appointment" cancels the action
- [x] Verify consultant delete uses FormConfirmationDialog

### Support Ticket Bug Fix
- [x] Test "Report Issue" from appointment card successfully creates ticket
- [x] Verify ticket is linked to correct consultation/subscription
- [x] Verify error no longer occurs

### Reschedule Visibility
- [x] Verify "Individual Session (1 of 5)" displays for single slot reschedule
- [x] Verify "Multiple Sessions (3 of 5)" displays for multi-slot reschedule
- [x] Verify "Full Reschedule (all 5)" displays when all slots tentative
- [ ] Confirm slot status icons show ✓ for confirmed and ⚠️ for tentative

### Other Features
- [x] Test "Report Issue" button opens modal dialog
- [ ] Verify issue types filtered by appointment status
- [x] Verify Support tab form creates generic tickets
- [ ] Verify 24-hour restriction blocks reschedule attempts
- [ ] Verify slot algorithm returns empty array when no consecutive slots found
- [ ] Verify planner loads participant counts correctly

## Related Issues

Closes #278, #279, #215, #142, #298

## Related GitHub Issues Created

- #300 - Notification system design (future enhancement)
- #301 - Reschedule UX improvements (future enhancement)
- #302 - Automatic status transition job (APPROVED → COMPLETED)
- #303 - Payment-Earning sync job
- #304 - Lost dispute handler job
- #305 - Refund-earning cascade job
- #306 - Tentative slot cleanup job
- #307 - Stale PENDING cleanup job
- #308 - Seed data consistency fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)