### PR TITLE
fix(bookings): prevent past slot booking and resolve checkout warnings

### DIFF
--- a/app/api/slots/availability/[consultantId]/route.ts
+++ b/app/api/slots/availability/[consultantId]/route.ts
@@ -6,6 +6,7 @@ import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
 
 // Assuming TSlotTiming is defined in a types file
 import { TSlotTiming } from "@/types/slots";
+import { MINIMUM_BOOKING_LEAD_TIME_MS } from "@/lib/payments/constants";
 
 export async function GET(
   req: NextRequest,
@@ -59,6 +60,7 @@ export async function GET(
 
     slots = filterSlots(slots, userDayStart, userDayEnd);
     slots = await removeBookedSlots(slots);
+    slots = filterExpiredSlots(slots);
 
     const totalSlots = slots.length;
     const paginatedSlots = slots.slice((page - 1) * limit, page * limit);
@@ -182,6 +184,19 @@ async function removeBookedSlots(slots: TSlotTiming[]): Promise<TSlotTiming[]> {
   return slots.filter(
     (slot) => !bookedSlotTimes.includes(slot.slotStartTimeInUTC),
   );
+}
+
+/**
+ * Filters out slots that have already passed or are within the minimum booking lead time.
+ * Users cannot book slots that start within MINIMUM_BOOKING_LEAD_TIME_MINUTES of now.
+ */
+function filterExpiredSlots(slots: TSlotTiming[]): TSlotTiming[] {
+  const minimumBookingTime = new Date(Date.now() + MINIMUM_BOOKING_LEAD_TIME_MS);
+
+  return slots.filter((slot) => {
+    const slotStart = parseISO(slot.slotStartTimeInUTC);
+    return slotStart >= minimumBookingTime;
+  });
 }
 
 function getDayOfWeek(date: Date): DayOfWeek {

--- a/lib/payments/constants.ts
+++ b/lib/payments/constants.ts
@@ -7,3 +7,9 @@ export const APPROVAL_PAYMENT_EXPIRATION_MS = 48 * 60 * 60 * 1000;
 
 /** Time in hours before an approval payment link expires */
 export const APPROVAL_PAYMENT_EXPIRATION_HOURS = 48;
+
+/** Minimum booking lead time in milliseconds (15 minutes) */
+export const MINIMUM_BOOKING_LEAD_TIME_MS = 15 * 60 * 1000;
+
+/** Minimum booking lead time in minutes */
+export const MINIMUM_BOOKING_LEAD_TIME_MINUTES = 15;

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -21,10 +21,7 @@ import {
   unlockEventCheckout,
   ApprovalLock,
 } from "@/utils/appointmentlock";
-import {
-  MINIMUM_BOOKING_LEAD_TIME_MS,
-  MINIMUM_BOOKING_LEAD_TIME_MINUTES,
-} from "@/lib/payments/constants";
+import { validateSlotTiming } from "@/lib/payments/utils/slot-validation";
 import {
   countUniqueParticipants,
   isUserEnrolled,
@@ -394,18 +391,9 @@ export async function validateSlotAvailability(
   const slotEnd = new Date(data.slotEndTimeInUTC);
 
   // 0. Validate slot is not in the past or too soon (minimum lead time check)
-  const now = new Date();
-  const minimumBookingTime = new Date(now.getTime() + MINIMUM_BOOKING_LEAD_TIME_MS);
-
-  if (slotStart < now) {
-    throw new Error("This time slot has already passed");
-  }
-
-  if (slotStart < minimumBookingTime) {
-    const minutesUntilSlot = Math.ceil((slotStart.getTime() - now.getTime()) / (60 * 1000));
-    throw new Error(
-      `This time slot starts too soon (in ${minutesUntilSlot} minute${minutesUntilSlot === 1 ? "" : "s"}). Bookings must be made at least ${MINIMUM_BOOKING_LEAD_TIME_MINUTES} minutes in advance.`
-    );
+  const timingError = validateSlotTiming(slotStart);
+  if (timingError) {
+    throw new Error(timingError);
   }
 
   // 1. Check for confirmed overlapping appointments FOR THIS CONSULTANT ONLY

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -22,6 +22,10 @@ import {
   ApprovalLock,
 } from "@/utils/appointmentlock";
 import {
+  MINIMUM_BOOKING_LEAD_TIME_MS,
+  MINIMUM_BOOKING_LEAD_TIME_MINUTES,
+} from "@/lib/payments/constants";
+import {
   countUniqueParticipants,
   isUserEnrolled,
 } from "@/lib/payments/utils/participants";
@@ -388,6 +392,21 @@ export async function validateSlotAvailability(
 
   const slotStart = new Date(data.slotStartTimeInUTC);
   const slotEnd = new Date(data.slotEndTimeInUTC);
+
+  // 0. Validate slot is not in the past or too soon (minimum lead time check)
+  const now = new Date();
+  const minimumBookingTime = new Date(now.getTime() + MINIMUM_BOOKING_LEAD_TIME_MS);
+
+  if (slotStart < now) {
+    throw new Error("This time slot has already passed");
+  }
+
+  if (slotStart < minimumBookingTime) {
+    const minutesUntilSlot = Math.ceil((slotStart.getTime() - now.getTime()) / (60 * 1000));
+    throw new Error(
+      `This time slot starts too soon (in ${minutesUntilSlot} minute${minutesUntilSlot === 1 ? "" : "s"}). Bookings must be made at least ${MINIMUM_BOOKING_LEAD_TIME_MINUTES} minutes in advance.`
+    );
+  }
 
   // 1. Check for confirmed overlapping appointments FOR THIS CONSULTANT ONLY
   // FIX: Previously checked ALL consultants globally, now filters by specific consultant

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -980,7 +980,7 @@ export async function handleSubscriptionCheckout(
   tx: Prisma.TransactionClient,
   data: CheckoutInput,
   consulteeProfileId: string,
-  skipPayment: boolean,
+  _skipPayment: boolean,
 ): Promise<SubscriptionCheckoutResult> {
   const plan = await tx.subscriptionPlan.findUnique({
     where: { id: data.planId },

--- a/lib/payments/utils/slot-validation.ts
+++ b/lib/payments/utils/slot-validation.ts
@@ -1,0 +1,27 @@
+import {
+  MINIMUM_BOOKING_LEAD_TIME_MS,
+  MINIMUM_BOOKING_LEAD_TIME_MINUTES,
+} from "@/lib/payments/constants";
+
+/**
+ * Validates slot timing - returns error message if invalid, null if valid
+ */
+export function validateSlotTiming(slotStart: Date): string | null {
+  const now = new Date();
+
+  if (slotStart < now) {
+    return "This time slot has already passed";
+  }
+
+  const minimumBookingTime = new Date(
+    now.getTime() + MINIMUM_BOOKING_LEAD_TIME_MS
+  );
+  if (slotStart < minimumBookingTime) {
+    const minutesUntilSlot = Math.ceil(
+      (slotStart.getTime() - now.getTime()) / (60 * 1000)
+    );
+    return `This time slot starts too soon (in ${minutesUntilSlot} minute${minutesUntilSlot === 1 ? "" : "s"}). Bookings must be made at least ${MINIMUM_BOOKING_LEAD_TIME_MINUTES} minutes in advance.`;
+  }
+
+  return null;
+}

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import { AppointmentsType, PaymentGateway } from "@prisma/client";
+import {
+  MINIMUM_BOOKING_LEAD_TIME_MS,
+  MINIMUM_BOOKING_LEAD_TIME_MINUTES,
+} from "@/lib/payments/constants";
 
 // Base schemas for individual components
 export const appointmentTypeSchema = z.enum([
@@ -171,6 +175,28 @@ export const checkoutSchema = z
           code: z.ZodIssueCode.custom,
           message: "Start time must be before end time",
           path: ["slotEndTimeInUTC"],
+        });
+      }
+    }
+
+    // Validate slot is not in the past or within minimum booking lead time
+    if (data.slotStartTimeInUTC) {
+      const slotStart = new Date(data.slotStartTimeInUTC);
+      const now = new Date();
+      const minimumBookingTime = new Date(now.getTime() + MINIMUM_BOOKING_LEAD_TIME_MS);
+
+      if (slotStart < now) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "This time slot has already passed",
+          path: ["slotStartTimeInUTC"],
+        });
+      } else if (slotStart < minimumBookingTime) {
+        const minutesUntilSlot = Math.ceil((slotStart.getTime() - now.getTime()) / (60 * 1000));
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `This time slot starts too soon (in ${minutesUntilSlot} minute${minutesUntilSlot === 1 ? "" : "s"}). Bookings must be made at least ${MINIMUM_BOOKING_LEAD_TIME_MINUTES} minutes in advance.`,
+          path: ["slotStartTimeInUTC"],
         });
       }
     }

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 import { AppointmentsType, PaymentGateway } from "@prisma/client";
-import {
-  MINIMUM_BOOKING_LEAD_TIME_MS,
-  MINIMUM_BOOKING_LEAD_TIME_MINUTES,
-} from "@/lib/payments/constants";
+import { validateSlotTiming } from "@/lib/payments/utils/slot-validation";
 
 // Base schemas for individual components
 export const appointmentTypeSchema = z.enum([
@@ -182,20 +179,11 @@ export const checkoutSchema = z
     // Validate slot is not in the past or within minimum booking lead time
     if (data.slotStartTimeInUTC) {
       const slotStart = new Date(data.slotStartTimeInUTC);
-      const now = new Date();
-      const minimumBookingTime = new Date(now.getTime() + MINIMUM_BOOKING_LEAD_TIME_MS);
-
-      if (slotStart < now) {
+      const timingError = validateSlotTiming(slotStart);
+      if (timingError) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: "This time slot has already passed",
-          path: ["slotStartTimeInUTC"],
-        });
-      } else if (slotStart < minimumBookingTime) {
-        const minutesUntilSlot = Math.ceil((slotStart.getTime() - now.getTime()) / (60 * 1000));
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `This time slot starts too soon (in ${minutesUntilSlot} minute${minutesUntilSlot === 1 ? "" : "s"}). Bookings must be made at least ${MINIMUM_BOOKING_LEAD_TIME_MINUTES} minutes in advance.`,
+          message: timingError,
           path: ["slotStartTimeInUTC"],
         });
       }


### PR DESCRIPTION
## Summary

Closes #343

### 1. Prevent booking past or imminent consultation slots

Added validation in `validateSlotAvailability()` to reject consultation slots that:
- Have already passed (start time is in the past)
- Start within the next 15 minutes (imminent slots)

This prevents users from completing checkout for impossible appointment times, avoiding invalid transactions and potential refund requests.

### 2. Resolve unused `skipPayment` parameter warning

Prefixed the `skipPayment` parameter with underscore in `handleSubscriptionCheckout()`. This parameter exists for API consistency with other checkout handlers but is intentionally unused because subscription checkout has a different flow—slots are allocated later by the consultant via the Requests tab, not during checkout.

### 3. Extract slot timing validation to shared utility

Moved duplicate slot timing validation logic to `lib/payments/utils/slot-validation.ts`. Both the Zod schema (`schemas/checkout.ts`) and backend validation (`lib/payments/operations/checkout.ts`) now use the shared `validateSlotTiming()` function, ensuring consistent error messages and easier maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)