### PR TITLE
fix(db): add connection pool settings to prevent exhaustion

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,12 @@
 # Connection string for Supabase database via connection pooling with Supavisor
+# Uses port 6543 (pooler) - limited connections, causes "MaxClientsInSessionMode" errors
+# Format: postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
 DATABASE_URL=""
-# Direct connection to Supabase database (used for migrations)
+
+# REQUIRED: Direct connection to Supabase database (bypasses PgBouncer pooler)
+# Uses port 5432 (direct) - required for Prisma to avoid connection pool exhaustion
+# Format: postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres
+# NOTE: Must use port 5432 (NOT 6543) to bypass the connection pooler
 DIRECT_URL=""
 
 # Facebook OAuth credentials for authentication

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -5,8 +5,21 @@ const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
+// IMPORTANT: Use DIRECT_URL (port 5432) to bypass PgBouncer pooler
+// Using DATABASE_URL (port 6543) with Supabase causes "MaxClientsInSessionMode" errors
+// because PgBouncer's session mode has very limited connections (3-10)
+const connectionString = process.env.DIRECT_URL || process.env.DATABASE_URL;
+
+if (!process.env.DIRECT_URL && process.env.NODE_ENV === "development") {
+  console.warn(
+    "⚠️  DIRECT_URL not set - using DATABASE_URL which may cause connection pool exhaustion.\n" +
+    "   Set DIRECT_URL in your .env file with port 5432 (not 6543) to fix this."
+  );
+}
+
 const adapter = new PrismaPg({
-  connectionString: process.env.DIRECT_URL || process.env.DATABASE_URL,
+  connectionString,
+  max: 20, // Maximum connections in the pool (prevents pool exhaustion)
 });
 
 const prisma =


### PR DESCRIPTION
## Summary

- Adds explicit `max: 20` pool setting to `PrismaPg` adapter to prevent connection pool exhaustion
- Adds development warning when `DIRECT_URL` is not set, guiding developers to fix their environment
- Documents the critical difference between port 5432 (direct) and 6543 (pooler) for Supabase connections

## Problem

The `GET /api/user/consultants/[id]` endpoint was returning 500 errors with:
```
MaxClientsInSessionMode: max clients reached - in Session mode max clients are limited to pool_size
```

This occurs when `DIRECT_URL` is not set and Prisma falls back to `DATABASE_URL`, which uses Supabase's PgBouncer pooler (port 6543) with very limited connections (3-10).

## Solution

1. **Explicit pool settings** - Added `max: 20` to `PrismaPg` adapter configuration
2. **Developer warning** - Console warning in development when `DIRECT_URL` is missing
3. **Documentation** - Comments explaining why `DIRECT_URL` with port 5432 is required

## For Developers

Ensure your `.env` has `DIRECT_URL` set with **port 5432** (not 6543):
```
DIRECT_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres"
```

## Test plan

- [ ] Verify `DIRECT_URL` is set in local `.env` with port 5432
- [ ] Restart dev server with `npm run dev`
- [ ] Hit `GET /api/user/consultants/[id]` endpoint
- [ ] Confirm no `MaxClientsInSessionMode` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)