### PR TITLE
fix(consultant-settings-tab): accept null values in API schema and fix UI…

### DIFF
--- a/app/api/user/consultants/[id]/route.ts
+++ b/app/api/user/consultants/[id]/route.ts
@@ -56,16 +56,16 @@ const updateConsultantSchema = z
     tagIds: z.array(uuidSchema),
     slotsOfAvailabilityWeekly: z.array(weeklySlotSchema).optional(),
     slotsOfAvailabilityCustom: z.array(customSlotSchema).optional(),
-    // New fields
-    headline: z.string().max(120).optional(),
-    websiteUrl: z.string().url().optional().or(z.literal("")),
-    twitterUrl: z.string().url().optional().or(z.literal("")),
-    githubUrl: z.string().url().optional().or(z.literal("")),
-    videoIntroUrl: z.string().url().optional().or(z.literal("")),
-    languages: z.array(z.string()).optional(),
-    toolsAndTechnologies: z.array(z.string()).optional(),
-    mentoringStyle: z.string().optional(),
-    sessionTypes: z.array(z.nativeEnum(SessionType)).optional(),
+    // New fields - accept null values from frontend for optional fields
+    headline: z.string().max(120).nullable().optional(),
+    websiteUrl: z.string().url().nullable().optional().or(z.literal("")),
+    twitterUrl: z.string().url().nullable().optional().or(z.literal("")),
+    githubUrl: z.string().url().nullable().optional().or(z.literal("")),
+    videoIntroUrl: z.string().url().nullable().optional().or(z.literal("")),
+    languages: z.array(z.string()).nullable().optional(),
+    toolsAndTechnologies: z.array(z.string()).nullable().optional(),
+    mentoringStyle: z.string().nullable().optional(),
+    sessionTypes: z.array(z.nativeEnum(SessionType)).nullable().optional(),
   })
   .refine(
     (data) => {

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
@@ -567,7 +567,7 @@ export function SettingsTab({ consultant }: Readonly<SettingsTabProps>) {
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-white p-6 rounded-lg space-y-8"
+      className="bg-white p-6 rounded-lg shadow space-y-8"
       role="form"
       aria-label="Settings form"
     >

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
@@ -567,7 +567,7 @@ export function SettingsTab({ consultant }: Readonly<SettingsTabProps>) {
   return (
     <form
       onSubmit={handleSubmit}
-      className="bg-white p-6 rounded-lg shadow space-y-8"
+      className="bg-white p-6 rounded-lg space-y-8"
       role="form"
       aria-label="Settings form"
     >
@@ -790,8 +790,8 @@ export function SettingsTab({ consultant }: Readonly<SettingsTabProps>) {
                           sessionTypes: checked
                             ? [...(prev.sessionTypes || []), type]
                             : (prev.sessionTypes || []).filter(
-                                (t) => t !== type,
-                              ),
+                              (t) => t !== type,
+                            ),
                         }));
                       }}
                     />

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -109,7 +109,7 @@ export function DashboardShell({
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={{ duration: 0.2, ease: "easeOut" }}
-              className="flex-1 flex flex-col min-h-0 p-6 lg:p-8"
+              className="p-6 lg:p-8"
             >
               {children}
             </motion.div>

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -44,7 +44,7 @@ export function DashboardShell({
 
   return (
     <MobileSidebarContext.Provider value={contextValue}>
-      <div className={cn("flex h-screen bg-zinc-100", className)}>
+      <div className={cn("flex min-h-screen bg-zinc-100", className)}>
         {/* Desktop Sidebar */}
         <aside className="fixed left-0 top-0 z-40 hidden h-screen w-64 lg:block">
           {sidebar}
@@ -88,7 +88,7 @@ export function DashboardShell({
         </AnimatePresence>
 
         {/* Main Content */}
-        <main className="flex-1 lg:ml-64 flex flex-col h-screen overflow-y-auto bg-white">
+        <main className="flex-1 lg:ml-64 min-h-screen bg-zinc-100">
           {/* Mobile Header Bar */}
           <div className="sticky top-0 z-30 flex items-center gap-3 px-4 py-3 bg-white border-b border-zinc-200 lg:hidden">
             <Button
@@ -109,7 +109,7 @@ export function DashboardShell({
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={{ duration: 0.2, ease: "easeOut" }}
-              className="p-6 lg:p-8"
+              className="min-h-0 p-6 lg:p-8 bg-zinc-100"
             >
               {children}
             </motion.div>


### PR DESCRIPTION
## Summary

This PR fixes two issues in the consultant dashboard:
1. **API Validation Error** - Settings update failing with "Validation failed" error
2. **UI Layout Issues** - Double scrollbars and white space on dashboard pages

## Problems Fixed

### 1. Consultant Settings API - Null Value Validation Error

**Issue:** When saving consultant settings, users received 400 error:
- `Expected string, received null` for optional fields

**Cause:** Zod schema expected strings, but frontend sends `null` for empty fields.

### 2. Dashboard UI - Double Scrollbar & White Space

**Issue:** 
- Two scrollbars visible (sidebar edge + content area)
- Large empty space below content on shorter pages

**Cause:** Nested scroll containers and flex stretching.

## Changes Made

### API Schema ([app/api/user/consultants/[id]/route.ts](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Familarise%20new%20January%2017th%202026/familiarise_web/app/api/user/consultants/%5Bid%5D/route.ts:0:0-0:0))
Added `.nullable()` to optional fields:
- `headline`, `websiteUrl`, `twitterUrl`, `githubUrl`, `videoIntroUrl`
- `languages`, `toolsAndTechnologies`, `mentoringStyle`, `sessionTypes`

### Dashboard Layout ([components/dashboard/DashboardShell.tsx](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Familarise%20new%20January%2017th%202026/familiarise_web/components/dashboard/DashboardShell.tsx:0:0-0:0))
| Element | Before | After |
|---------|--------|-------|
| Outer div | `h-screen overflow-hidden` | `min-h-screen` |
| Main | `flex-1 flex flex-col overflow-y-auto` | `flex-1 min-h-screen` |
| motion.div | `flex-1 flex flex-col min-h-0` | `min-h-0 bg-zinc-100` |

## Expected Results

✅ Settings "Save Changes" works without validation errors  
✅ No white space below content on any dashboard page  
✅ Single scrollbar (browser's native) across all pages  
✅ Consistent scrolling behavior on all dashboard tabs

## Testing

- [x] Go to Settings → Leave optional fields empty → Save → Should succeed
- [x] Check Settings page → No white space below form
- [x] Check Appointments, Home pages → Consistent layout
- [x] Scroll on any page → Only one scrollbar visible