### PR TITLE
feat(recordings): implement Stream video recording for webinars and classes

### DIFF
--- a/actions/stream/meetings/meeting.action.ts
+++ b/actions/stream/meetings/meeting.action.ts
@@ -12,8 +12,8 @@ const streamCallIdSchema = z.string().min(1, "Stream Call ID is required");
 
 const slotSchema = z.object({
   id: z.string().min(1),
-  startsAt: z.date(),
-  endsAt: z.date().nullable().optional(),
+  startsAt: z.coerce.date(),
+  endsAt: z.coerce.date().nullable().optional(),
   isTentative: z.boolean().optional(),
   appointmentId: z.string().nullable().optional(),
 });

--- a/app/api/consultants/[consultantId]/recordings/route.ts
+++ b/app/api/consultants/[consultantId]/recordings/route.ts
@@ -1,0 +1,157 @@
+/**
+ * Consultant Recordings API Route
+ * GET /api/consultants/[consultantId]/recordings
+ *
+ * Gets all recordings for a consultant's webinars and classes.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingService } from "@/lib/stream/recording-service";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
+
+type RouteParams = {
+  params: Promise<{
+    consultantId: string;
+  }>;
+};
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { consultantId } = await params;
+
+    // Verify the user is accessing their own recordings
+    if (
+      session.user.role !== "ADMIN" &&
+      session.user.role !== "STAFF" &&
+      session.user.consultantProfileId !== consultantId
+    ) {
+      return NextResponse.json(
+        { error: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Parse query params for filtering
+    const { searchParams } = new URL(req.url);
+    const type = searchParams.get("type"); // "webinar" or "class"
+    const status = searchParams.get("status"); // Recording status filter
+
+    // Get all recordings for consultant
+    const recordings = await RecordingService.getConsultantRecordings(consultantId);
+
+    // Filter by type if specified
+    let filteredRecordings = recordings;
+    if (type === "webinar") {
+      filteredRecordings = recordings.filter((r) => {
+        const rec = r as typeof r & {
+          meetingSession?: {
+            slotOfAppointment?: {
+              appointment?: {
+                webinar?: unknown;
+              };
+            };
+          };
+        };
+        return rec.meetingSession?.slotOfAppointment?.appointment?.webinar;
+      });
+    } else if (type === "class") {
+      filteredRecordings = recordings.filter((r) => {
+        const rec = r as typeof r & {
+          meetingSession?: {
+            slotOfAppointment?: {
+              appointment?: {
+                class?: unknown;
+              };
+            };
+          };
+        };
+        return rec.meetingSession?.slotOfAppointment?.appointment?.class;
+      });
+    }
+
+    // Filter by status if specified
+    if (status) {
+      filteredRecordings = filteredRecordings.filter(
+        (r) => r.status === status
+      );
+    }
+
+    // Map recordings to response format with best URLs
+    const formattedRecordings = filteredRecordings.map((recording) => {
+      const rec = recording as typeof recording & {
+        meetingSession?: {
+          slotOfAppointment?: {
+            appointment?: {
+              webinar?: {
+                webinarPlan?: {
+                  id?: string;
+                  title?: string;
+                };
+              };
+              class?: {
+                classPlan?: {
+                  id?: string;
+                  title?: string;
+                };
+              };
+            };
+          };
+        };
+      };
+
+      const appointment =
+        rec.meetingSession?.slotOfAppointment?.appointment;
+
+      let planType: "webinar" | "class" | null = null;
+      let planId: string | null = null;
+      let planTitle: string | null = null;
+
+      if (appointment?.webinar?.webinarPlan) {
+        planType = "webinar";
+        planId = appointment.webinar.webinarPlan.id ?? null;
+        planTitle = appointment.webinar.webinarPlan.title ?? null;
+      } else if (appointment?.class?.classPlan) {
+        planType = "class";
+        planId = appointment.class.classPlan.id ?? null;
+        planTitle = appointment.class.classPlan.title ?? null;
+      }
+
+      return {
+        id: recording.id,
+        title: recording.title,
+        durationInMinutes: recording.durationInMinutes,
+        recordedAt: recording.recordedAt,
+        status: recording.status,
+        storageType: recording.storageType,
+        playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+        thumbnailUrl: recording.thumbnailUrl,
+        resolution: recording.resolution,
+        streamUrlExpiresAt: recording.streamUrlExpiresAt,
+        transferredAt: recording.transferredAt,
+        planType,
+        planId,
+        planTitle,
+        createdAt: recording.createdAt,
+      };
+    });
+
+    return NextResponse.json({
+      recordings: formattedRecordings,
+      total: formattedRecordings.length,
+    });
+  } catch (error) {
+    console.error("Error getting consultant recordings:", error);
+    return NextResponse.json(
+      { error: "Failed to get recordings" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/consultees/[consulteeId]/recordings/route.ts
+++ b/app/api/consultees/[consulteeId]/recordings/route.ts
@@ -1,0 +1,259 @@
+/**
+ * Consultee Recordings API Route
+ * GET /api/consultees/[consulteeId]/recordings
+ *
+ * Gets all recordings the consultee has access to through their enrollments.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
+import prisma from "@/lib/prisma";
+
+type RouteParams = {
+  params: Promise<{
+    consulteeId: string;
+  }>;
+};
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { consulteeId } = await params;
+
+    // Verify the user is accessing their own recordings (or admin/staff)
+    if (
+      session.user.role !== "ADMIN" &&
+      session.user.role !== "STAFF" &&
+      session.user.consulteeProfileId !== consulteeId
+    ) {
+      return NextResponse.json(
+        { error: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Parse query params for filtering
+    const { searchParams } = new URL(req.url);
+    const type = searchParams.get("type"); // "webinar" or "class"
+
+    // Find all enrollments (paid appointments) for this consultee
+    const enrolledAppointments = await prisma.payment.findMany({
+      where: {
+        userId: session.user.id,
+        paymentStatus: "SUCCEEDED",
+        appointment: {
+          OR: [
+            { webinar: { isNot: null } },
+            { class: { isNot: null } },
+          ],
+        },
+      },
+      select: {
+        appointment: {
+          select: {
+            id: true,
+            webinarId: true,
+            classId: true,
+            webinar: {
+              select: {
+                id: true,
+                webinarPlanId: true,
+                webinarPlan: {
+                  select: {
+                    id: true,
+                    title: true,
+                    recordingEnabled: true,
+                  },
+                },
+              },
+            },
+            class: {
+              select: {
+                id: true,
+                classPlanId: true,
+                classPlan: {
+                  select: {
+                    id: true,
+                    title: true,
+                    recordingEnabled: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Get unique plan IDs where recording is enabled
+    const webinarPlanIds: string[] = [];
+    const classPlanIds: string[] = [];
+
+    for (const enrollment of enrolledAppointments) {
+      if (
+        enrollment.appointment?.webinar?.webinarPlan?.recordingEnabled &&
+        enrollment.appointment.webinar.webinarPlanId
+      ) {
+        if (!webinarPlanIds.includes(enrollment.appointment.webinar.webinarPlanId)) {
+          webinarPlanIds.push(enrollment.appointment.webinar.webinarPlanId);
+        }
+      }
+      if (
+        enrollment.appointment?.class?.classPlan?.recordingEnabled &&
+        enrollment.appointment.class.classPlanId
+      ) {
+        if (!classPlanIds.includes(enrollment.appointment.class.classPlanId)) {
+          classPlanIds.push(enrollment.appointment.class.classPlanId);
+        }
+      }
+    }
+
+    // Build query based on type filter
+    const whereConditions = [];
+
+    if (!type || type === "webinar") {
+      if (webinarPlanIds.length > 0) {
+        whereConditions.push({
+          meetingSession: {
+            slotOfAppointment: {
+              appointment: {
+                webinar: {
+                  webinarPlanId: {
+                    in: webinarPlanIds,
+                  },
+                },
+              },
+            },
+          },
+        });
+      }
+    }
+
+    if (!type || type === "class") {
+      if (classPlanIds.length > 0) {
+        whereConditions.push({
+          meetingSession: {
+            slotOfAppointment: {
+              appointment: {
+                class: {
+                  classPlanId: {
+                    in: classPlanIds,
+                  },
+                },
+              },
+            },
+          },
+        });
+      }
+    }
+
+    // If no valid enrollments found, return empty array
+    if (whereConditions.length === 0) {
+      return NextResponse.json({
+        recordings: [],
+        total: 0,
+      });
+    }
+
+    // Fetch recordings for enrolled plans
+    const recordings = await prisma.recording.findMany({
+      where: {
+        OR: whereConditions,
+        status: {
+          notIn: ["FAILED", "EXPIRED"],
+        },
+      },
+      include: {
+        meetingSession: {
+          include: {
+            slotOfAppointment: {
+              include: {
+                appointment: {
+                  include: {
+                    webinar: {
+                      include: {
+                        webinarPlan: {
+                          select: {
+                            id: true,
+                            title: true,
+                          },
+                        },
+                      },
+                    },
+                    class: {
+                      include: {
+                        classPlan: {
+                          select: {
+                            id: true,
+                            title: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        recordedAt: "desc",
+      },
+    });
+
+    // Format recordings for response
+    const formattedRecordings = recordings.map((recording) => {
+      const appointment =
+        recording.meetingSession?.slotOfAppointment?.appointment;
+
+      let planType: "webinar" | "class" | null = null;
+      let planId: string | null = null;
+      let planTitle: string | null = null;
+
+      if (appointment?.webinar?.webinarPlan) {
+        planType = "webinar";
+        planId = appointment.webinar.webinarPlan.id ?? null;
+        planTitle = appointment.webinar.webinarPlan.title ?? null;
+      } else if (appointment?.class?.classPlan) {
+        planType = "class";
+        planId = appointment.class.classPlan.id ?? null;
+        planTitle = appointment.class.classPlan.title ?? null;
+      }
+
+      return {
+        id: recording.id,
+        title: recording.title,
+        durationInMinutes: recording.durationInMinutes,
+        recordedAt: recording.recordedAt,
+        status: recording.status,
+        storageType: recording.storageType,
+        playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+        thumbnailUrl: recording.thumbnailUrl,
+        resolution: recording.resolution,
+        planType,
+        planId,
+        planTitle,
+        createdAt: recording.createdAt,
+      };
+    });
+
+    return NextResponse.json({
+      recordings: formattedRecordings,
+      total: formattedRecordings.length,
+    });
+  } catch (error) {
+    console.error("Error getting consultee recordings:", error);
+    return NextResponse.json(
+      { error: "Failed to get recordings" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/meetings/[streamCallId]/recording-info/route.ts
+++ b/app/api/meetings/[streamCallId]/recording-info/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Meeting Recording Info API Route
+ * GET /api/meetings/[streamCallId]/recording-info
+ *
+ * Gets recording information for a meeting session.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import prisma from "@/lib/prisma";
+
+type RouteParams = {
+  params: Promise<{
+    streamCallId: string;
+  }>;
+};
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { streamCallId } = await params;
+
+    // Find meeting session by streamCallId
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { streamCallId },
+      include: {
+        slotOfAppointment: {
+          include: {
+            appointment: {
+              include: {
+                webinar: {
+                  include: {
+                    webinarPlan: {
+                      select: {
+                        recordingEnabled: true,
+                      },
+                    },
+                  },
+                },
+                class: {
+                  include: {
+                    classPlan: {
+                      select: {
+                        recordingEnabled: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!meetingSession) {
+      return NextResponse.json(
+        { error: "Meeting session not found" },
+        { status: 404 }
+      );
+    }
+
+    // Determine if recording is enabled based on appointment type
+    let recordingEnabled = false;
+
+    const appointment = meetingSession.slotOfAppointment?.appointment;
+
+    if (appointment?.webinar?.webinarPlan) {
+      recordingEnabled = appointment.webinar.webinarPlan.recordingEnabled;
+    } else if (appointment?.class?.classPlan) {
+      recordingEnabled = appointment.class.classPlan.recordingEnabled;
+    }
+
+    return NextResponse.json({
+      meetingSessionId: meetingSession.id,
+      recordingEnabled,
+      isRecording: meetingSession.isRecording,
+      recordingStartedAt: meetingSession.recordingStartedAt,
+      recordingStartedBy: meetingSession.recordingStartedBy,
+    });
+  } catch (error) {
+    console.error("Error getting meeting recording info:", error);
+    return NextResponse.json(
+      { error: "Failed to get recording info" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/plans/classes/[classPlanId]/recordings/route.ts
+++ b/app/api/plans/classes/[classPlanId]/recordings/route.ts
@@ -1,8 +1,8 @@
 /**
- * Webinar Plan Recordings API Route
- * GET /api/plans/webinars/[id]/recordings
+ * Class Plan Recordings API Route
+ * GET /api/plans/classes/[classPlanId]/recordings
  *
- * Gets all recordings for a specific webinar plan.
+ * Gets all recordings for a specific class plan.
  * Access: Consultant owner or enrolled consultees.
  */
 
@@ -15,7 +15,7 @@ import prisma from "@/lib/prisma";
 
 type RouteParams = {
   params: Promise<{
-    id: string;
+    classPlanId: string;
   }>;
 };
 
@@ -27,11 +27,11 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id: webinarPlanId } = await params;
+    const { classPlanId } = await params;
 
-    // Get the webinar plan to check ownership and recording settings
-    const webinarPlan = await prisma.webinarPlan.findUnique({
-      where: { id: webinarPlanId },
+    // Get the class plan to check ownership and recording settings
+    const classPlan = await prisma.classPlan.findUnique({
+      where: { id: classPlanId },
       select: {
         id: true,
         title: true,
@@ -40,9 +40,9 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       },
     });
 
-    if (!webinarPlan) {
+    if (!classPlan) {
       return NextResponse.json(
-        { error: "Webinar plan not found" },
+        { error: "Class plan not found" },
         { status: 404 }
       );
     }
@@ -53,16 +53,16 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     if (session.user.role === "CONSULTANT") {
       // Consultant must own the plan
       hasAccess =
-        webinarPlan.consultantProfileId === session.user.consultantProfileId;
+        classPlan.consultantProfileId === session.user.consultantProfileId;
     } else if (session.user.role === "CONSULTEE") {
-      // Consultee must have purchased a webinar from this plan
+      // Consultee must have purchased a class from this plan
       const enrollment = await prisma.payment.findFirst({
         where: {
           userId: session.user.id,
           paymentStatus: "SUCCEEDED",
           appointment: {
-            webinar: {
-              webinarPlanId,
+            class: {
+              classPlanId,
             },
           },
         },
@@ -79,9 +79,9 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Get recordings for this webinar plan
-    const recordings = await RecordingService.getWebinarPlanRecordings(
-      webinarPlanId
+    // Get recordings for this class plan
+    const recordings = await RecordingService.getClassPlanRecordings(
+      classPlanId
     );
 
     // Map recordings to response format
@@ -102,14 +102,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     }));
 
     return NextResponse.json({
-      planId: webinarPlanId,
-      planTitle: webinarPlan.title,
-      recordingEnabled: webinarPlan.recordingEnabled,
+      planId: classPlanId,
+      planTitle: classPlan.title,
+      recordingEnabled: classPlan.recordingEnabled,
       recordings: formattedRecordings,
       total: formattedRecordings.length,
     });
   } catch (error) {
-    console.error("Error getting webinar plan recordings:", error);
+    console.error("Error getting class plan recordings:", error);
     return NextResponse.json(
       { error: "Failed to get recordings" },
       { status: 500 }

--- a/app/api/plans/classes/[id]/recordings/route.ts
+++ b/app/api/plans/classes/[id]/recordings/route.ts
@@ -1,0 +1,118 @@
+/**
+ * Class Plan Recordings API Route
+ * GET /api/plans/classes/[id]/recordings
+ *
+ * Gets all recordings for a specific class plan.
+ * Access: Consultant owner or enrolled consultees.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingService } from "@/lib/stream/recording-service";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
+import prisma from "@/lib/prisma";
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: classPlanId } = await params;
+
+    // Get the class plan to check ownership and recording settings
+    const classPlan = await prisma.classPlan.findUnique({
+      where: { id: classPlanId },
+      select: {
+        id: true,
+        title: true,
+        consultantProfileId: true,
+        recordingEnabled: true,
+      },
+    });
+
+    if (!classPlan) {
+      return NextResponse.json(
+        { error: "Class plan not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check access permissions
+    let hasAccess = false;
+
+    if (session.user.role === "CONSULTANT") {
+      // Consultant must own the plan
+      hasAccess =
+        classPlan.consultantProfileId === session.user.consultantProfileId;
+    } else if (session.user.role === "CONSULTEE") {
+      // Consultee must have purchased a class from this plan
+      const enrollment = await prisma.payment.findFirst({
+        where: {
+          userId: session.user.id,
+          paymentStatus: "SUCCEEDED",
+          appointment: {
+            class: {
+              classPlanId,
+            },
+          },
+        },
+      });
+      hasAccess = !!enrollment;
+    } else if (session.user.role === "ADMIN" || session.user.role === "STAFF") {
+      hasAccess = true;
+    }
+
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: "Access denied to these recordings" },
+        { status: 403 }
+      );
+    }
+
+    // Get recordings for this class plan
+    const recordings = await RecordingService.getClassPlanRecordings(
+      classPlanId
+    );
+
+    // Map recordings to response format
+    const formattedRecordings = recordings.map((recording) => ({
+      id: recording.id,
+      title: recording.title,
+      durationInMinutes: recording.durationInMinutes,
+      recordedAt: recording.recordedAt,
+      status: recording.status,
+      storageType: recording.storageType,
+      playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+      thumbnailUrl: recording.thumbnailUrl,
+      resolution: recording.resolution,
+      previewClipUrl: recording.previewClipUrl,
+      previewClipDuration: recording.previewClipDuration,
+      streamUrlExpiresAt: recording.streamUrlExpiresAt,
+      createdAt: recording.createdAt,
+    }));
+
+    return NextResponse.json({
+      planId: classPlanId,
+      planTitle: classPlan.title,
+      recordingEnabled: classPlan.recordingEnabled,
+      recordings: formattedRecordings,
+      total: formattedRecordings.length,
+    });
+  } catch (error) {
+    console.error("Error getting class plan recordings:", error);
+    return NextResponse.json(
+      { error: "Failed to get recordings" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/plans/webinars/[id]/recordings/route.ts
+++ b/app/api/plans/webinars/[id]/recordings/route.ts
@@ -1,0 +1,118 @@
+/**
+ * Webinar Plan Recordings API Route
+ * GET /api/plans/webinars/[id]/recordings
+ *
+ * Gets all recordings for a specific webinar plan.
+ * Access: Consultant owner or enrolled consultees.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingService } from "@/lib/stream/recording-service";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
+import prisma from "@/lib/prisma";
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: webinarPlanId } = await params;
+
+    // Get the webinar plan to check ownership and recording settings
+    const webinarPlan = await prisma.webinarPlan.findUnique({
+      where: { id: webinarPlanId },
+      select: {
+        id: true,
+        title: true,
+        consultantProfileId: true,
+        recordingEnabled: true,
+      },
+    });
+
+    if (!webinarPlan) {
+      return NextResponse.json(
+        { error: "Webinar plan not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check access permissions
+    let hasAccess = false;
+
+    if (session.user.role === "CONSULTANT") {
+      // Consultant must own the plan
+      hasAccess =
+        webinarPlan.consultantProfileId === session.user.consultantProfileId;
+    } else if (session.user.role === "CONSULTEE") {
+      // Consultee must have purchased a webinar from this plan
+      const enrollment = await prisma.payment.findFirst({
+        where: {
+          userId: session.user.id,
+          paymentStatus: "SUCCEEDED",
+          appointment: {
+            webinar: {
+              webinarPlanId,
+            },
+          },
+        },
+      });
+      hasAccess = !!enrollment;
+    } else if (session.user.role === "ADMIN" || session.user.role === "STAFF") {
+      hasAccess = true;
+    }
+
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: "Access denied to these recordings" },
+        { status: 403 }
+      );
+    }
+
+    // Get recordings for this webinar plan
+    const recordings = await RecordingService.getWebinarPlanRecordings(
+      webinarPlanId
+    );
+
+    // Map recordings to response format
+    const formattedRecordings = recordings.map((recording) => ({
+      id: recording.id,
+      title: recording.title,
+      durationInMinutes: recording.durationInMinutes,
+      recordedAt: recording.recordedAt,
+      status: recording.status,
+      storageType: recording.storageType,
+      playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+      thumbnailUrl: recording.thumbnailUrl,
+      resolution: recording.resolution,
+      previewClipUrl: recording.previewClipUrl,
+      previewClipDuration: recording.previewClipDuration,
+      streamUrlExpiresAt: recording.streamUrlExpiresAt,
+      createdAt: recording.createdAt,
+    }));
+
+    return NextResponse.json({
+      planId: webinarPlanId,
+      planTitle: webinarPlan.title,
+      recordingEnabled: webinarPlan.recordingEnabled,
+      recordings: formattedRecordings,
+      total: formattedRecordings.length,
+    });
+  } catch (error) {
+    console.error("Error getting webinar plan recordings:", error);
+    return NextResponse.json(
+      { error: "Failed to get recordings" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/plans/webinars/[webinarPlanId]/recordings/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/recordings/route.ts
@@ -1,8 +1,8 @@
 /**
- * Class Plan Recordings API Route
- * GET /api/plans/classes/[id]/recordings
+ * Webinar Plan Recordings API Route
+ * GET /api/plans/webinars/[webinarPlanId]/recordings
  *
- * Gets all recordings for a specific class plan.
+ * Gets all recordings for a specific webinar plan.
  * Access: Consultant owner or enrolled consultees.
  */
 
@@ -15,7 +15,7 @@ import prisma from "@/lib/prisma";
 
 type RouteParams = {
   params: Promise<{
-    id: string;
+    webinarPlanId: string;
   }>;
 };
 
@@ -27,11 +27,11 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id: classPlanId } = await params;
+    const { webinarPlanId } = await params;
 
-    // Get the class plan to check ownership and recording settings
-    const classPlan = await prisma.classPlan.findUnique({
-      where: { id: classPlanId },
+    // Get the webinar plan to check ownership and recording settings
+    const webinarPlan = await prisma.webinarPlan.findUnique({
+      where: { id: webinarPlanId },
       select: {
         id: true,
         title: true,
@@ -40,9 +40,9 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       },
     });
 
-    if (!classPlan) {
+    if (!webinarPlan) {
       return NextResponse.json(
-        { error: "Class plan not found" },
+        { error: "Webinar plan not found" },
         { status: 404 }
       );
     }
@@ -53,16 +53,16 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     if (session.user.role === "CONSULTANT") {
       // Consultant must own the plan
       hasAccess =
-        classPlan.consultantProfileId === session.user.consultantProfileId;
+        webinarPlan.consultantProfileId === session.user.consultantProfileId;
     } else if (session.user.role === "CONSULTEE") {
-      // Consultee must have purchased a class from this plan
+      // Consultee must have purchased a webinar from this plan
       const enrollment = await prisma.payment.findFirst({
         where: {
           userId: session.user.id,
           paymentStatus: "SUCCEEDED",
           appointment: {
-            class: {
-              classPlanId,
+            webinar: {
+              webinarPlanId,
             },
           },
         },
@@ -79,9 +79,9 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Get recordings for this class plan
-    const recordings = await RecordingService.getClassPlanRecordings(
-      classPlanId
+    // Get recordings for this webinar plan
+    const recordings = await RecordingService.getWebinarPlanRecordings(
+      webinarPlanId
     );
 
     // Map recordings to response format
@@ -102,14 +102,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     }));
 
     return NextResponse.json({
-      planId: classPlanId,
-      planTitle: classPlan.title,
-      recordingEnabled: classPlan.recordingEnabled,
+      planId: webinarPlanId,
+      planTitle: webinarPlan.title,
+      recordingEnabled: webinarPlan.recordingEnabled,
       recordings: formattedRecordings,
       total: formattedRecordings.length,
     });
   } catch (error) {
-    console.error("Error getting class plan recordings:", error);
+    console.error("Error getting webinar plan recordings:", error);
     return NextResponse.json(
       { error: "Failed to get recordings" },
       { status: 500 }

--- a/app/api/recordings/[recordingId]/route.ts
+++ b/app/api/recordings/[recordingId]/route.ts
@@ -1,0 +1,138 @@
+/**
+ * Recording Details API Route
+ * GET /api/recordings/[recordingId]
+ *
+ * Gets details for a specific recording. Access control based on user role.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingService } from "@/lib/stream/recording-service";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
+import prisma from "@/lib/prisma";
+
+type RouteParams = {
+  params: Promise<{
+    recordingId: string;
+  }>;
+};
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { recordingId } = await params;
+
+    // Get recording with related data
+    const recording = await RecordingService.getRecordingById(recordingId);
+
+    if (!recording) {
+      return NextResponse.json(
+        { error: "Recording not found" },
+        { status: 404 }
+      );
+    }
+
+    // Type assertion for the recording with includes
+    const recordingWithSession = recording as typeof recording & {
+      meetingSession: {
+        slotOfAppointment: {
+          appointmentId: string;
+          appointment: {
+            webinar?: {
+              webinarPlan: {
+                consultantProfileId: string | null;
+              };
+            } | null;
+            class?: {
+              classPlan: {
+                consultantProfileId: string | null;
+              };
+            } | null;
+          } | null;
+        };
+      };
+    };
+
+    // Check access permissions
+    const appointment =
+      recordingWithSession.meetingSession?.slotOfAppointment?.appointment;
+
+    let hasAccess = false;
+
+    if (session.user.role === "CONSULTANT") {
+      // Consultant can access their own recordings
+      const consultantProfileId = session.user.consultantProfileId;
+
+      if (appointment?.webinar?.webinarPlan) {
+        hasAccess =
+          appointment.webinar.webinarPlan.consultantProfileId ===
+          consultantProfileId;
+      } else if (appointment?.class?.classPlan) {
+        hasAccess =
+          appointment.class.classPlan.consultantProfileId ===
+          consultantProfileId;
+      }
+    } else if (session.user.role === "CONSULTEE") {
+      // Consultee can access recordings for sessions they participated in
+      // Check if user is enrolled in the webinar/class
+      // Get the appointment ID from the recording chain to check payments
+      const appointmentId =
+        recordingWithSession.meetingSession?.slotOfAppointment?.appointmentId;
+
+      if (appointmentId && (appointment?.webinar || appointment?.class)) {
+        // Check if user has paid for this appointment (webinar or class)
+        const payment = await prisma.payment.findFirst({
+          where: {
+            userId: session.user.id,
+            appointmentId,
+            paymentStatus: "SUCCEEDED",
+          },
+        });
+        hasAccess = !!payment;
+      }
+    } else if (session.user.role === "ADMIN" || session.user.role === "STAFF") {
+      // Admin and staff can access all recordings
+      hasAccess = true;
+    }
+
+    if (!hasAccess) {
+      return NextResponse.json(
+        { error: "Access denied to this recording" },
+        { status: 403 }
+      );
+    }
+
+    // Get the best available URL
+    const playbackUrl = RecordingTransferService.getBestRecordingUrl(recording);
+
+    return NextResponse.json({
+      recording: {
+        id: recording.id,
+        title: recording.title,
+        durationInMinutes: recording.durationInMinutes,
+        recordedAt: recording.recordedAt,
+        status: recording.status,
+        storageType: recording.storageType,
+        playbackUrl,
+        thumbnailUrl: recording.thumbnailUrl,
+        resolution: recording.resolution,
+        previewClipUrl: recording.previewClipUrl,
+        previewClipDuration: recording.previewClipDuration,
+        streamUrlExpiresAt: recording.streamUrlExpiresAt,
+        createdAt: recording.createdAt,
+      },
+    });
+  } catch (error) {
+    console.error("Error getting recording:", error);
+    return NextResponse.json(
+      { error: "Failed to get recording" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/recordings/[recordingId]/transfer/route.ts
+++ b/app/api/recordings/[recordingId]/transfer/route.ts
@@ -1,0 +1,159 @@
+/**
+ * Recording Transfer API Route
+ * POST /api/recordings/[recordingId]/transfer
+ *
+ * Manually triggers transfer of a recording from Stream S3 to Supabase.
+ * Only consultants who own the recording can trigger transfer.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
+import prisma from "@/lib/prisma";
+
+type RouteParams = {
+  params: Promise<{
+    recordingId: string;
+  }>;
+};
+
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Only consultants can trigger transfers
+    if (session.user.role !== "CONSULTANT") {
+      return NextResponse.json(
+        { error: "Only consultants can transfer recordings" },
+        { status: 403 }
+      );
+    }
+
+    const { recordingId } = await params;
+
+    // Get recording with ownership info
+    const recording = await prisma.recording.findUnique({
+      where: { id: recordingId },
+      include: {
+        meetingSession: {
+          include: {
+            slotOfAppointment: {
+              include: {
+                appointment: {
+                  include: {
+                    webinar: {
+                      include: {
+                        webinarPlan: {
+                          select: {
+                            consultantProfileId: true,
+                          },
+                        },
+                      },
+                    },
+                    class: {
+                      include: {
+                        classPlan: {
+                          select: {
+                            consultantProfileId: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!recording) {
+      return NextResponse.json(
+        { error: "Recording not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify ownership
+    const appointment =
+      recording.meetingSession?.slotOfAppointment?.appointment;
+    let isOwner = false;
+
+    if (appointment?.webinar?.webinarPlan) {
+      isOwner =
+        appointment.webinar.webinarPlan.consultantProfileId ===
+        session.user.consultantProfileId;
+    } else if (appointment?.class?.classPlan) {
+      isOwner =
+        appointment.class.classPlan.consultantProfileId ===
+        session.user.consultantProfileId;
+    }
+
+    if (!isOwner) {
+      return NextResponse.json(
+        { error: "Not authorized to transfer this recording" },
+        { status: 403 }
+      );
+    }
+
+    // Check if recording is already transferred
+    if (recording.storageType === "SUPABASE") {
+      return NextResponse.json(
+        { error: "Recording is already transferred to permanent storage" },
+        { status: 400 }
+      );
+    }
+
+    // Check if recording is in a transferable state
+    if (recording.status !== "READY") {
+      return NextResponse.json(
+        {
+          error: `Recording cannot be transferred in ${recording.status} state`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Start transfer
+    const result = await RecordingTransferService.transferRecordingToSupabase(
+      recordingId
+    );
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error || "Transfer failed" },
+        { status: 500 }
+      );
+    }
+
+    // Get updated recording
+    const updatedRecording = await prisma.recording.findUnique({
+      where: { id: recordingId },
+      select: {
+        id: true,
+        status: true,
+        storageType: true,
+        supabaseUrl: true,
+        transferredAt: true,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Recording transferred successfully",
+      recording: updatedRecording,
+    });
+  } catch (error) {
+    console.error("Error transferring recording:", error);
+    return NextResponse.json(
+      { error: "Failed to transfer recording" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/recordings/start/route.ts
+++ b/app/api/recordings/start/route.ts
@@ -1,0 +1,164 @@
+/**
+ * Start Recording API Route
+ * POST /api/recordings/start
+ *
+ * Starts recording for a video call. Only consultants can start recordings.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingService } from "@/lib/stream/recording-service";
+import prisma from "@/lib/prisma";
+
+const startRecordingSchema = z.object({
+  streamCallId: z.string().min(1, "Stream call ID is required"),
+  meetingSessionId: z.string().min(1, "Meeting session ID is required"),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Only consultants can start recordings
+    if (session.user.role !== "CONSULTANT") {
+      return NextResponse.json(
+        { error: "Only consultants can start recordings" },
+        { status: 403 }
+      );
+    }
+
+    // Parse and validate request body
+    const body = await req.json();
+    const { streamCallId, meetingSessionId } = startRecordingSchema.parse(body);
+
+    // Verify the meeting session exists and belongs to consultant's appointment
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { id: meetingSessionId },
+      include: {
+        slotOfAppointment: {
+          include: {
+            appointment: {
+              include: {
+                webinar: {
+                  include: {
+                    webinarPlan: {
+                      select: {
+                        consultantProfileId: true,
+                        recordingEnabled: true,
+                      },
+                    },
+                  },
+                },
+                class: {
+                  include: {
+                    classPlan: {
+                      select: {
+                        consultantProfileId: true,
+                        recordingEnabled: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!meetingSession) {
+      return NextResponse.json(
+        { error: "Meeting session not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify the consultant owns this appointment
+    const appointment = meetingSession.slotOfAppointment.appointment;
+    let isOwner = false;
+    let recordingEnabled = false;
+
+    if (appointment?.webinar?.webinarPlan) {
+      isOwner =
+        appointment.webinar.webinarPlan.consultantProfileId ===
+        session.user.consultantProfileId;
+      recordingEnabled = appointment.webinar.webinarPlan.recordingEnabled;
+    } else if (appointment?.class?.classPlan) {
+      isOwner =
+        appointment.class.classPlan.consultantProfileId ===
+        session.user.consultantProfileId;
+      recordingEnabled = appointment.class.classPlan.recordingEnabled;
+    }
+
+    if (!isOwner) {
+      return NextResponse.json(
+        { error: "Not authorized to record this session" },
+        { status: 403 }
+      );
+    }
+
+    // Check if recording is enabled for this plan
+    if (!recordingEnabled) {
+      return NextResponse.json(
+        { error: "Recording is not enabled for this plan" },
+        { status: 400 }
+      );
+    }
+
+    // Check if already recording
+    if (meetingSession.isRecording) {
+      return NextResponse.json(
+        { error: "Recording is already in progress" },
+        { status: 400 }
+      );
+    }
+
+    // Start recording via Stream API
+    const result = await RecordingService.startRecording(
+      streamCallId,
+      session.user.id
+    );
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error || "Failed to start recording" },
+        { status: 500 }
+      );
+    }
+
+    // Update meeting session (webhook will also update, but we update immediately for UI)
+    await prisma.meetingSession.update({
+      where: { id: meetingSessionId },
+      data: {
+        isRecording: true,
+        recordingStartedAt: new Date(),
+        recordingStartedBy: session.user.id,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Recording started",
+    });
+  } catch (error) {
+    console.error("Error starting recording:", error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Failed to start recording" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/recordings/stop/route.ts
+++ b/app/api/recordings/stop/route.ts
@@ -1,0 +1,146 @@
+/**
+ * Stop Recording API Route
+ * POST /api/recordings/stop
+ *
+ * Stops recording for a video call. Only consultants can stop recordings.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+import authOptions from "@/app/api/auth/[...nextauth]/options";
+import { RecordingService } from "@/lib/stream/recording-service";
+import prisma from "@/lib/prisma";
+
+const stopRecordingSchema = z.object({
+  streamCallId: z.string().min(1, "Stream call ID is required"),
+  meetingSessionId: z.string().min(1, "Meeting session ID is required"),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    // Check authentication
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Only consultants can stop recordings
+    if (session.user.role !== "CONSULTANT") {
+      return NextResponse.json(
+        { error: "Only consultants can stop recordings" },
+        { status: 403 }
+      );
+    }
+
+    // Parse and validate request body
+    const body = await req.json();
+    const { streamCallId, meetingSessionId } = stopRecordingSchema.parse(body);
+
+    // Verify the meeting session exists
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { id: meetingSessionId },
+      include: {
+        slotOfAppointment: {
+          include: {
+            appointment: {
+              include: {
+                webinar: {
+                  include: {
+                    webinarPlan: {
+                      select: {
+                        consultantProfileId: true,
+                      },
+                    },
+                  },
+                },
+                class: {
+                  include: {
+                    classPlan: {
+                      select: {
+                        consultantProfileId: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!meetingSession) {
+      return NextResponse.json(
+        { error: "Meeting session not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify the consultant owns this appointment
+    const appointment = meetingSession.slotOfAppointment.appointment;
+    let isOwner = false;
+
+    if (appointment?.webinar?.webinarPlan) {
+      isOwner =
+        appointment.webinar.webinarPlan.consultantProfileId ===
+        session.user.consultantProfileId;
+    } else if (appointment?.class?.classPlan) {
+      isOwner =
+        appointment.class.classPlan.consultantProfileId ===
+        session.user.consultantProfileId;
+    }
+
+    if (!isOwner) {
+      return NextResponse.json(
+        { error: "Not authorized to stop this recording" },
+        { status: 403 }
+      );
+    }
+
+    // Check if recording is active
+    if (!meetingSession.isRecording) {
+      return NextResponse.json(
+        { error: "No recording in progress" },
+        { status: 400 }
+      );
+    }
+
+    // Stop recording via Stream API
+    const result = await RecordingService.stopRecording(streamCallId);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error || "Failed to stop recording" },
+        { status: 500 }
+      );
+    }
+
+    // Update meeting session (webhook will also update, but we update immediately for UI)
+    await prisma.meetingSession.update({
+      where: { id: meetingSessionId },
+      data: {
+        isRecording: false,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Recording stopped",
+    });
+  } catch (error) {
+    console.error("Error stopping recording:", error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Failed to stop recording" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/webhooks/stream/route.ts
+++ b/app/api/webhooks/stream/route.ts
@@ -1,0 +1,237 @@
+/**
+ * Stream Video Webhook Handler
+ * Handles recording lifecycle events from Stream
+ *
+ * Events handled:
+ * - call.recording_started
+ * - call.recording_stopped
+ * - call.recording_ready
+ * - call.recording_failed
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { z } from "zod";
+import {
+  handleRecordingStarted,
+  handleRecordingStopped,
+  handleRecordingReady,
+  handleRecordingFailed,
+  StreamRecordingStartedEvent,
+  StreamRecordingStoppedEvent,
+  StreamRecordingReadyEvent,
+  StreamRecordingFailedEvent,
+} from "@/lib/stream/recording-handlers";
+import { logWebhookEvent, markWebhookEventProcessed } from "../utils";
+
+// Stream webhook event types we handle
+const HANDLED_EVENT_TYPES = [
+  "call.recording_started",
+  "call.recording_stopped",
+  "call.recording_ready",
+  "call.recording_failed",
+] as const;
+
+type HandledEventType = (typeof HANDLED_EVENT_TYPES)[number];
+
+// Base event schema
+const streamBaseEventSchema = z.object({
+  type: z.string(),
+  call_cid: z.string(),
+  created_at: z.string(),
+});
+
+// Recording ready event schema
+const streamRecordingReadySchema = streamBaseEventSchema.extend({
+  type: z.literal("call.recording_ready"),
+  call_recording: z.object({
+    filename: z.string(),
+    url: z.string(),
+    start_time: z.string(),
+    end_time: z.string(),
+  }),
+});
+
+// Recording failed event schema
+const streamRecordingFailedSchema = streamBaseEventSchema.extend({
+  type: z.literal("call.recording_failed"),
+  error: z
+    .object({
+      message: z.string().optional(),
+      code: z.string().optional(),
+    })
+    .optional(),
+});
+
+// Recording started/stopped schema
+const streamRecordingStateSchema = streamBaseEventSchema.extend({
+  user: z
+    .object({
+      id: z.string(),
+      name: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Verify Stream webhook signature using HMAC SHA256
+ */
+async function verifyStreamSignature(
+  req: NextRequest,
+  body: string,
+  secret: string
+): Promise<boolean> {
+  const signature = req.headers.get("x-signature");
+
+  if (!signature) {
+    console.warn("No x-signature header found in Stream webhook request");
+    return false;
+  }
+
+  try {
+    // Stream uses HMAC SHA256 for signature verification
+    const expectedSignature = crypto
+      .createHmac("sha256", secret)
+      .update(body)
+      .digest("hex");
+
+    // Constant-time comparison to prevent timing attacks
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature)
+    );
+  } catch (error) {
+    console.error("Error verifying Stream webhook signature:", error);
+    return false;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.STREAM_WEBHOOK_SECRET;
+
+  // Validate webhook secret is configured
+  if (!secret) {
+    console.error("STREAM_WEBHOOK_SECRET not configured");
+    return NextResponse.json(
+      { error: "Webhook secret not configured" },
+      { status: 500 }
+    );
+  }
+
+  // Read request body
+  const body = await req.text();
+
+  // Verify signature
+  const isValid = await verifyStreamSignature(req, body, secret);
+
+  if (!isValid) {
+    console.warn("Invalid Stream webhook signature");
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  try {
+    const event = JSON.parse(body);
+
+    // Parse base event to get type
+    const baseEvent = streamBaseEventSchema.parse(event);
+    const eventType = baseEvent.type;
+
+    // Check if this is an event type we handle
+    if (!HANDLED_EVENT_TYPES.includes(eventType as HandledEventType)) {
+      console.log(`Unhandled Stream event type: ${eventType}`);
+      return NextResponse.json({ status: "ok", handled: false });
+    }
+
+    // Generate unique event ID for idempotency
+    const eventId = `stream_${eventType}_${baseEvent.call_cid}_${baseEvent.created_at}`;
+
+    // Log webhook event (idempotency check)
+    const { isNew } = await logWebhookEvent(
+      "stream",
+      eventId,
+      eventType,
+      event,
+      req.headers.get("x-signature") || undefined
+    );
+
+    if (!isNew) {
+      console.log(`Duplicate Stream webhook event ${eventId}, returning OK`);
+      return NextResponse.json({ status: "ok", duplicate: true });
+    }
+
+    console.log(`Processing Stream webhook: ${eventType}`, {
+      call_cid: baseEvent.call_cid,
+      created_at: baseEvent.created_at,
+    });
+
+    let processingError: string | undefined;
+
+    try {
+      switch (eventType) {
+        case "call.recording_started": {
+          const startedEvent = streamRecordingStateSchema.parse(event);
+          await handleRecordingStarted(startedEvent as StreamRecordingStartedEvent);
+          break;
+        }
+
+        case "call.recording_stopped": {
+          const stoppedEvent = streamRecordingStateSchema.parse(event);
+          await handleRecordingStopped(stoppedEvent as StreamRecordingStoppedEvent);
+          break;
+        }
+
+        case "call.recording_ready": {
+          const readyEvent = streamRecordingReadySchema.parse(event);
+          await handleRecordingReady(readyEvent as StreamRecordingReadyEvent);
+          break;
+        }
+
+        case "call.recording_failed": {
+          const failedEvent = streamRecordingFailedSchema.parse(event);
+          await handleRecordingFailed(failedEvent as StreamRecordingFailedEvent);
+          break;
+        }
+
+        default:
+          console.log(`Unhandled Stream event type: ${eventType}`);
+      }
+    } catch (handlerError) {
+      processingError =
+        handlerError instanceof Error
+          ? handlerError.message
+          : String(handlerError);
+      console.error(`Error processing ${eventType}:`, handlerError);
+      throw handlerError;
+    } finally {
+      // Mark event as processed
+      await markWebhookEventProcessed(eventId, processingError);
+    }
+
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    console.error("Stream webhook error:", error);
+
+    // Return 200 to prevent retries for parsing errors
+    // Stream will retry on 5xx errors
+    if (error instanceof z.ZodError) {
+      console.error("Stream webhook validation error:", error.errors);
+      return NextResponse.json(
+        { error: "Invalid event format", details: error.errors },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: "Webhook handler failed" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * HEAD handler for webhook verification
+ * Some webhook providers send a HEAD request to verify the endpoint
+ */
+export async function HEAD() {
+  return new NextResponse(null, { status: 200 });
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
@@ -119,6 +119,7 @@ export function EventPlannerForClass({
           learningOutcomes: initialData.classPlan.learningOutcomes,
           topics: initialData.classPlan.topics ?? [],
           certificateProvided: initialData.classPlan.certificateProvided,
+          recordingEnabled: initialData.classPlan.recordingEnabled ?? false,
           meetingsPerWeek: initialData.classPlan.meetingsPerWeek,
           emailSupport: initialData.classPlan.emailSupport,
           consultantProfileId: initialData.classPlan.consultantProfileId,
@@ -139,6 +140,7 @@ export function EventPlannerForClass({
           learningOutcomes: [],
           topics: [],
           certificateProvided: false,
+          recordingEnabled: false,
           meetingsPerWeek: 2,
           emailSupport: "GENERAL" as const,
           classContents: [],
@@ -163,6 +165,7 @@ export function EventPlannerForClass({
         learningOutcomes: initialData.classPlan.learningOutcomes,
         topics: initialData.classPlan.topics ?? [],
         certificateProvided: initialData.classPlan.certificateProvided,
+        recordingEnabled: initialData.classPlan.recordingEnabled ?? false,
         meetingsPerWeek: initialData.classPlan.meetingsPerWeek,
         emailSupport: initialData.classPlan.emailSupport,
         consultantProfileId: initialData.classPlan.consultantProfileId,
@@ -259,6 +262,7 @@ export function EventPlannerForClass({
           consultantProfileId: consultantId,
           consultantProfile: null,
           certificateProvided: formData.certificateProvided ?? false,
+          recordingEnabled: formData.recordingEnabled ?? false,
           sessionDurationInHours:
             initialData?.classPlan?.sessionDurationInHours ?? 1,
           meetingsPerWeek: formData.meetingsPerWeek,
@@ -589,6 +593,29 @@ export function EventPlannerForClass({
                         </FormLabel>
                         <FormDescription>
                           Provide students with a certificate upon completion
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="recordingEnabled"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 mt-4">
+                      <div className="space-y-0.5">
+                        <FormLabel className="text-base">
+                          Enable Recording
+                        </FormLabel>
+                        <FormDescription>
+                          Allow recording of class sessions for students to watch later
                         </FormDescription>
                       </div>
                       <FormControl>

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
@@ -67,6 +67,7 @@ const WebinarFormSchema = z.object({
   topics: z.array(z.string()).min(1, "At least one topic is required"),
   consultantProfileId: z.string().optional(),
   certificateProvided: z.boolean(),
+  recordingEnabled: z.boolean(),
   durationInHours: z.number().min(0.5, "Duration must be at least 30 minutes"),
   scheduledAt: z.string().min(1, "Start time is required"),
 });
@@ -168,6 +169,8 @@ export function EventPlannerForWebinar({
       learningOutcomes: initialData?.webinarPlan?.learningOutcomes ?? [],
       certificateProvided:
         initialData?.webinarPlan?.certificateProvided ?? false,
+      recordingEnabled:
+        initialData?.webinarPlan?.recordingEnabled ?? false,
       topics: initialData?.webinarPlan?.topics ?? [],
       scheduledAt: getInitialScheduledAt(),
       consultantProfileId: consultantId,
@@ -191,6 +194,8 @@ export function EventPlannerForWebinar({
         learningOutcomes: initialData.webinarPlan.learningOutcomes ?? [],
         certificateProvided:
           initialData.webinarPlan.certificateProvided ?? false,
+        recordingEnabled:
+          initialData.webinarPlan.recordingEnabled ?? false,
         topics: initialData.webinarPlan.topics ?? [],
         scheduledAt: getInitialScheduledAt(),
         consultantProfileId: consultantId,
@@ -270,6 +275,7 @@ export function EventPlannerForWebinar({
           price: formData.price,
           priceCurrency: formData.priceCurrency ?? "INR",
           certificateProvided: formData.certificateProvided ?? false,
+          recordingEnabled: formData.recordingEnabled ?? false,
           durationInHours: formData.durationInHours,
           maxParticipants: formData.maxParticipants,
           language: formData.language ?? "English",
@@ -515,6 +521,29 @@ export function EventPlannerForWebinar({
                         </FormLabel>
                         <FormDescription>
                           Provide attendees with a certificate after the webinar
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="recordingEnabled"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 mt-4">
+                      <div className="space-y-0.5">
+                        <FormLabel className="text-base">
+                          Enable Recording
+                        </FormLabel>
+                        <FormDescription>
+                          Allow recording of this webinar for attendees to watch later
                         </FormDescription>
                       </div>
                       <FormControl>

--- a/app/dashboard/consultant/[consultantId]/(features)/recordings/components/RecordingCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/recordings/components/RecordingCard.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState } from "react";
+import { formatDistanceToNow, format } from "date-fns";
+import {
+  Play,
+  Clock,
+  Calendar,
+  HardDrive,
+  Cloud,
+  AlertCircle,
+  Loader2,
+  Download,
+  ExternalLink,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/utils/tailwind";
+
+export interface RecordingData {
+  id: string;
+  title: string;
+  durationInMinutes: number;
+  recordedAt: string;
+  status: string;
+  storageType: string;
+  playbackUrl: string | null;
+  thumbnailUrl: string | null;
+  resolution: string | null;
+  streamUrlExpiresAt: string | null;
+  transferredAt: string | null;
+  planType: "webinar" | "class" | null;
+  planId: string | null;
+  planTitle: string | null;
+  createdAt: string;
+}
+
+interface RecordingCardProps {
+  recording: RecordingData;
+  onTransfer?: (recordingId: string) => Promise<void>;
+}
+
+export function RecordingCard({ recording, onTransfer }: RecordingCardProps) {
+  const { toast } = useToast();
+  const [isTransferring, setIsTransferring] = useState(false);
+
+  const formatDuration = (minutes: number) => {
+    const hrs = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hrs > 0) {
+      return `${hrs}h ${mins}m`;
+    }
+    return `${mins}m`;
+  };
+
+  const getStatusBadge = () => {
+    switch (recording.status) {
+      case "AVAILABLE":
+        return (
+          <Badge className="bg-green-500/10 text-green-600 border-green-500/20">
+            <Cloud className="w-3 h-3 mr-1" />
+            Permanent
+          </Badge>
+        );
+      case "READY":
+        return (
+          <Badge className="bg-blue-500/10 text-blue-600 border-blue-500/20">
+            <HardDrive className="w-3 h-3 mr-1" />
+            Stream Storage
+          </Badge>
+        );
+      case "TRANSFERRING":
+        return (
+          <Badge className="bg-yellow-500/10 text-yellow-600 border-yellow-500/20">
+            <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+            Transferring
+          </Badge>
+        );
+      case "FAILED":
+        return (
+          <Badge variant="destructive">
+            <AlertCircle className="w-3 h-3 mr-1" />
+            Failed
+          </Badge>
+        );
+      case "EXPIRED":
+        return (
+          <Badge variant="secondary">
+            <AlertCircle className="w-3 h-3 mr-1" />
+            Expired
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{recording.status}</Badge>;
+    }
+  };
+
+  const handleTransfer = async () => {
+    if (!onTransfer) return;
+
+    setIsTransferring(true);
+    try {
+      await onTransfer(recording.id);
+      toast({
+        title: "Transfer Started",
+        description: "Recording is being transferred to permanent storage.",
+      });
+    } catch (error) {
+      toast({
+        title: "Transfer Failed",
+        description:
+          error instanceof Error ? error.message : "Failed to transfer recording",
+        variant: "destructive",
+      });
+    } finally {
+      setIsTransferring(false);
+    }
+  };
+
+  const canTransfer =
+    recording.status === "READY" && recording.storageType === "STREAM_S3";
+
+  const isExpiringSoon =
+    recording.streamUrlExpiresAt &&
+    new Date(recording.streamUrlExpiresAt).getTime() - Date.now() <
+      3 * 24 * 60 * 60 * 1000; // 3 days
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-lg truncate">{recording.title}</CardTitle>
+            {recording.planTitle && (
+              <p className="text-sm text-muted-foreground mt-1">
+                {recording.planType === "webinar" ? "Webinar" : "Class"}:{" "}
+                {recording.planTitle}
+              </p>
+            )}
+          </div>
+          {getStatusBadge()}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Thumbnail or placeholder */}
+        <div className="relative aspect-video bg-muted rounded-lg overflow-hidden">
+          {recording.thumbnailUrl ? (
+            <img
+              src={recording.thumbnailUrl}
+              alt={recording.title}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-zinc-800 to-zinc-900">
+              <Play className="w-12 h-12 text-zinc-600" />
+            </div>
+          )}
+          {/* Duration overlay */}
+          <div className="absolute bottom-2 right-2 px-2 py-1 bg-black/80 rounded text-xs text-white font-medium">
+            {formatDuration(recording.durationInMinutes)}
+          </div>
+        </div>
+
+        {/* Metadata */}
+        <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground">
+          <div className="flex items-center gap-1">
+            <Calendar className="w-4 h-4" />
+            <span>{format(new Date(recording.recordedAt), "MMM d, yyyy")}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock className="w-4 h-4" />
+            <span>{format(new Date(recording.recordedAt), "h:mm a")}</span>
+          </div>
+          {recording.resolution && (
+            <span className="text-xs bg-muted px-2 py-0.5 rounded">
+              {recording.resolution}
+            </span>
+          )}
+        </div>
+
+        {/* Expiration warning */}
+        {isExpiringSoon && recording.status === "READY" && (
+          <div className="flex items-center gap-2 p-2 bg-yellow-500/10 border border-yellow-500/20 rounded-lg text-sm text-yellow-600">
+            <AlertCircle className="w-4 h-4 flex-shrink-0" />
+            <span>
+              Expires{" "}
+              {formatDistanceToNow(new Date(recording.streamUrlExpiresAt!), {
+                addSuffix: true,
+              })}
+            </span>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          {recording.playbackUrl && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="default"
+                    className="flex-1"
+                    onClick={() => window.open(recording.playbackUrl!, "_blank")}
+                  >
+                    <Play className="w-4 h-4 mr-2" />
+                    Watch
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Open recording in new tab</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+
+          {canTransfer && onTransfer && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    onClick={handleTransfer}
+                    disabled={isTransferring}
+                    className={cn(isExpiringSoon && "border-yellow-500/50")}
+                  >
+                    {isTransferring ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Download className="w-4 h-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Transfer to permanent storage</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+
+          {recording.status === "AVAILABLE" && recording.playbackUrl && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => {
+                      navigator.clipboard.writeText(recording.playbackUrl!);
+                      toast({
+                        title: "Copied",
+                        description: "Recording URL copied to clipboard",
+                      });
+                    }}
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Copy URL</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RecordingCard;

--- a/app/dashboard/consultant/[consultantId]/(features)/recordings/components/RecordingsList.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/recordings/components/RecordingsList.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2, Video, AlertCircle } from "lucide-react";
+import { RecordingCard, RecordingData } from "./RecordingCard";
+import { useToast } from "@/hooks/use-toast";
+
+interface RecordingsListProps {
+  consultantId: string;
+  type?: "webinar" | "class" | null;
+}
+
+export function RecordingsList({ consultantId, type }: RecordingsListProps) {
+  const { toast } = useToast();
+  const [recordings, setRecordings] = useState<RecordingData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRecordings = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams();
+      if (type) {
+        params.set("type", type);
+      }
+
+      const response = await fetch(
+        `/api/consultants/${consultantId}/recordings?${params.toString()}`
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch recordings");
+      }
+
+      const data = await response.json();
+      setRecordings(data.recordings);
+    } catch (err) {
+      console.error("Error fetching recordings:", err);
+      setError(err instanceof Error ? err.message : "Failed to load recordings");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRecordings();
+  }, [consultantId, type]);
+
+  const handleTransfer = async (recordingId: string) => {
+    const response = await fetch(`/api/recordings/${recordingId}/transfer`, {
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      const data = await response.json();
+      throw new Error(data.error || "Transfer failed");
+    }
+
+    // Refresh recordings list after successful transfer
+    await fetchRecordings();
+
+    toast({
+      title: "Success",
+      description: "Recording transferred to permanent storage.",
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <AlertCircle className="w-12 h-12 text-muted-foreground mb-4" />
+        <p className="text-lg font-medium">Failed to load recordings</p>
+        <p className="text-sm text-muted-foreground mt-1">{error}</p>
+        <button
+          onClick={fetchRecordings}
+          className="mt-4 text-sm text-primary hover:underline"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (recordings.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Video className="w-12 h-12 text-muted-foreground mb-4" />
+        <p className="text-lg font-medium">No recordings yet</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          {type === "webinar"
+            ? "Webinar recordings will appear here after you record a session."
+            : type === "class"
+              ? "Class recordings will appear here after you record a session."
+              : "Your recorded sessions will appear here."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {recordings.map((recording) => (
+        <RecordingCard
+          key={recording.id}
+          recording={recording}
+          onTransfer={handleTransfer}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default RecordingsList;

--- a/app/dashboard/consultant/[consultantId]/(features)/recordings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/recordings/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { use, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Video, Play, GraduationCap } from "lucide-react";
+import { RecordingsList } from "./components/RecordingsList";
+
+interface RecordingsPageProps {
+  params: Promise<{
+    consultantId: string;
+  }>;
+}
+
+export default function RecordingsPage({ params }: RecordingsPageProps) {
+  const { consultantId } = use(params);
+  const [activeTab, setActiveTab] = useState<"all" | "webinar" | "class">("all");
+
+  return (
+    <div className="container py-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="p-2 bg-primary/10 rounded-lg">
+          <Video className="w-6 h-6 text-primary" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">Recordings</h1>
+          <p className="text-muted-foreground">
+            Manage your webinar and class recordings
+          </p>
+        </div>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as "all" | "webinar" | "class")}
+        className="space-y-6"
+      >
+        <TabsList className="grid w-full max-w-[400px] grid-cols-3">
+          <TabsTrigger value="all" className="flex items-center gap-2">
+            <Video className="w-4 h-4" />
+            <span>All</span>
+          </TabsTrigger>
+          <TabsTrigger value="webinar" className="flex items-center gap-2">
+            <Play className="w-4 h-4" />
+            <span>Webinars</span>
+          </TabsTrigger>
+          <TabsTrigger value="class" className="flex items-center gap-2">
+            <GraduationCap className="w-4 h-4" />
+            <span>Classes</span>
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="all" className="mt-6">
+          <RecordingsList consultantId={consultantId} />
+        </TabsContent>
+
+        <TabsContent value="webinar" className="mt-6">
+          <RecordingsList consultantId={consultantId} type="webinar" />
+        </TabsContent>
+
+        <TabsContent value="class" className="mt-6">
+          <RecordingsList consultantId={consultantId} type="class" />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/layout.tsx
+++ b/app/dashboard/consultant/[consultantId]/layout.tsx
@@ -24,6 +24,7 @@ const NAV_ITEMS: NavItem[] = [
   { name: "Event Planner", path: "planner" },
   { name: "Requests", path: "requests" },
   { name: "Documents", path: "documents" },
+  { name: "Recordings", "path": "recordings" },
   { name: "Help", path: "help" },
 ];
 
@@ -232,9 +233,9 @@ function ErrorDisplay({ message }: { message: string }) {
               onClick={
                 config.secondaryAction.href === "#"
                   ? (e) => {
-                      e.preventDefault();
-                      window.location.reload();
-                    }
+                    e.preventDefault();
+                    window.location.reload();
+                  }
                   : undefined
               }
               className="w-full px-6 py-2.5 bg-zinc-100 text-zinc-700 rounded-lg font-medium hover:bg-zinc-200 transition-colors"

--- a/app/dashboard/consultee/[consulteeId]/(features)/recordings/components/ConsulteeRecordingCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/recordings/components/ConsulteeRecordingCard.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { format } from "date-fns";
+import { Play, Clock, Calendar } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+export interface ConsulteeRecordingData {
+  id: string;
+  title: string;
+  durationInMinutes: number;
+  recordedAt: string;
+  status: string;
+  storageType: string;
+  playbackUrl: string | null;
+  thumbnailUrl: string | null;
+  resolution: string | null;
+  planType: "webinar" | "class" | null;
+  planId: string | null;
+  planTitle: string | null;
+  createdAt: string;
+}
+
+interface ConsulteeRecordingCardProps {
+  recording: ConsulteeRecordingData;
+}
+
+export function ConsulteeRecordingCard({ recording }: ConsulteeRecordingCardProps) {
+  const formatDuration = (minutes: number) => {
+    const hrs = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hrs > 0) {
+      return `${hrs}h ${mins}m`;
+    }
+    return `${mins}m`;
+  };
+
+  return (
+    <Card className="overflow-hidden hover:shadow-lg transition-shadow">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-lg truncate">{recording.title}</CardTitle>
+            {recording.planTitle && (
+              <p className="text-sm text-muted-foreground mt-1">
+                {recording.planType === "webinar" ? "Webinar" : "Class"}:{" "}
+                {recording.planTitle}
+              </p>
+            )}
+          </div>
+          <Badge variant="secondary">
+            {recording.planType === "webinar" ? "Webinar" : "Class"}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Thumbnail or placeholder */}
+        <div className="relative aspect-video bg-muted rounded-lg overflow-hidden group">
+          {recording.thumbnailUrl ? (
+            <img
+              src={recording.thumbnailUrl}
+              alt={recording.title}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-zinc-800 to-zinc-900">
+              <Play className="w-12 h-12 text-zinc-600 group-hover:text-zinc-400 transition-colors" />
+            </div>
+          )}
+          {/* Duration overlay */}
+          <div className="absolute bottom-2 right-2 px-2 py-1 bg-black/80 rounded text-xs text-white font-medium">
+            {formatDuration(recording.durationInMinutes)}
+          </div>
+          {/* Play overlay on hover */}
+          {recording.playbackUrl && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
+              <div className="w-16 h-16 rounded-full bg-white/20 flex items-center justify-center">
+                <Play className="w-8 h-8 text-white fill-white" />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Metadata */}
+        <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground">
+          <div className="flex items-center gap-1">
+            <Calendar className="w-4 h-4" />
+            <span>{format(new Date(recording.recordedAt), "MMM d, yyyy")}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock className="w-4 h-4" />
+            <span>{format(new Date(recording.recordedAt), "h:mm a")}</span>
+          </div>
+          {recording.resolution && (
+            <span className="text-xs bg-muted px-2 py-0.5 rounded">
+              {recording.resolution}
+            </span>
+          )}
+        </div>
+
+        {/* Watch button */}
+        {recording.playbackUrl && (
+          <Button
+            className="w-full"
+            onClick={() => window.open(recording.playbackUrl!, "_blank")}
+          >
+            <Play className="w-4 h-4 mr-2" />
+            Watch Recording
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ConsulteeRecordingCard;

--- a/app/dashboard/consultee/[consulteeId]/(features)/recordings/components/ConsulteeRecordingsList.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/recordings/components/ConsulteeRecordingsList.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2, Video, AlertCircle } from "lucide-react";
+import {
+  ConsulteeRecordingCard,
+  ConsulteeRecordingData,
+} from "./ConsulteeRecordingCard";
+
+interface ConsulteeRecordingsListProps {
+  consulteeId: string;
+  type?: "webinar" | "class" | null;
+}
+
+export function ConsulteeRecordingsList({
+  consulteeId,
+  type,
+}: ConsulteeRecordingsListProps) {
+  const [recordings, setRecordings] = useState<ConsulteeRecordingData[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRecordings = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const params = new URLSearchParams();
+      if (type) {
+        params.set("type", type);
+      }
+
+      const response = await fetch(
+        `/api/consultees/${consulteeId}/recordings?${params.toString()}`
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch recordings");
+      }
+
+      const data = await response.json();
+      setRecordings(data.recordings);
+    } catch (err) {
+      console.error("Error fetching recordings:", err);
+      setError(err instanceof Error ? err.message : "Failed to load recordings");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRecordings();
+  }, [consulteeId, type]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <AlertCircle className="w-12 h-12 text-muted-foreground mb-4" />
+        <p className="text-lg font-medium">Failed to load recordings</p>
+        <p className="text-sm text-muted-foreground mt-1">{error}</p>
+        <button
+          onClick={fetchRecordings}
+          className="mt-4 text-sm text-primary hover:underline"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (recordings.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Video className="w-12 h-12 text-muted-foreground mb-4" />
+        <p className="text-lg font-medium">No recordings available</p>
+        <p className="text-sm text-muted-foreground mt-1 max-w-md">
+          {type === "webinar"
+            ? "Recordings from your enrolled webinars will appear here."
+            : type === "class"
+              ? "Recordings from your enrolled classes will appear here."
+              : "Recordings from your enrolled webinars and classes will appear here after the consultant records a session."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {recordings.map((recording) => (
+        <ConsulteeRecordingCard key={recording.id} recording={recording} />
+      ))}
+    </div>
+  );
+}
+
+export default ConsulteeRecordingsList;

--- a/app/dashboard/consultee/[consulteeId]/(features)/recordings/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/recordings/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { use, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Video, Play, GraduationCap } from "lucide-react";
+import { ConsulteeRecordingsList } from "./components/ConsulteeRecordingsList";
+
+interface RecordingsPageProps {
+  params: Promise<{
+    consulteeId: string;
+  }>;
+}
+
+export default function ConsulteeRecordingsPage({ params }: RecordingsPageProps) {
+  const { consulteeId } = use(params);
+  const [activeTab, setActiveTab] = useState<"all" | "webinar" | "class">("all");
+
+  return (
+    <div className="container py-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="p-2 bg-primary/10 rounded-lg">
+          <Video className="w-6 h-6 text-primary" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">My Recordings</h1>
+          <p className="text-muted-foreground">
+            Watch recordings from your enrolled webinars and classes
+          </p>
+        </div>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as "all" | "webinar" | "class")}
+        className="space-y-6"
+      >
+        <TabsList className="grid w-full max-w-[400px] grid-cols-3">
+          <TabsTrigger value="all" className="flex items-center gap-2">
+            <Video className="w-4 h-4" />
+            <span>All</span>
+          </TabsTrigger>
+          <TabsTrigger value="webinar" className="flex items-center gap-2">
+            <Play className="w-4 h-4" />
+            <span>Webinars</span>
+          </TabsTrigger>
+          <TabsTrigger value="class" className="flex items-center gap-2">
+            <GraduationCap className="w-4 h-4" />
+            <span>Classes</span>
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="all" className="mt-6">
+          <ConsulteeRecordingsList consulteeId={consulteeId} />
+        </TabsContent>
+
+        <TabsContent value="webinar" className="mt-6">
+          <ConsulteeRecordingsList consulteeId={consulteeId} type="webinar" />
+        </TabsContent>
+
+        <TabsContent value="class" className="mt-6">
+          <ConsulteeRecordingsList consulteeId={consulteeId} type="class" />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/app/meetings/[id]/components/MeetingRoom.tsx
+++ b/app/meetings/[id]/components/MeetingRoom.tsx
@@ -24,6 +24,8 @@ import {
 import Loader from "./Loader";
 import EndCallButton from "./EndCallButton";
 import CallEnded from "./CallEnded";
+import RecordingControls from "./RecordingControls";
+import { useMeetingRecording } from "../hooks/useMeetingRecording";
 import { cn } from "@/utils/tailwind";
 import { StreamVideoErrorBoundary } from "@/components/stream/StreamErrorBoundary";
 
@@ -60,6 +62,9 @@ const MeetingRoom = () => {
   const call = useCall();
   const { useCallCallingState, useCallEndedAt, useParticipantCount } =
     useCallStateHooks();
+
+  // Get recording info for this meeting
+  const { meetingSessionId, recordingEnabled } = useMeetingRecording(call?.id);
 
   const callingState = useCallCallingState();
   const callEndedAt = useCallEndedAt();
@@ -298,6 +303,17 @@ const MeetingRoom = () => {
                   </span>
                 )}
               </button>
+
+              {/* Recording Controls */}
+              {meetingSessionId && (
+                <>
+                  <div className="w-px h-8 bg-zinc-700 mx-1" />
+                  <RecordingControls
+                    meetingSessionId={meetingSessionId}
+                    recordingEnabled={recordingEnabled}
+                  />
+                </>
+              )}
 
               {/* Divider */}
               {!isPersonalRoom && <div className="w-px h-8 bg-zinc-700 mx-1" />}

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useCall, useCallStateHooks } from "@stream-io/video-react-sdk";
+import { useSession } from "next-auth/react";
+import { Circle, Square, Loader2 } from "lucide-react";
+import { cn } from "@/utils/tailwind";
+import { useToast } from "@/hooks/use-toast";
+
+interface RecordingControlsProps {
+  meetingSessionId: string;
+  recordingEnabled: boolean;
+}
+
+const RecordingControls = ({
+  meetingSessionId,
+  recordingEnabled,
+}: RecordingControlsProps) => {
+  const call = useCall();
+  const { data: session } = useSession();
+  const { toast } = useToast();
+  const [isRecording, setIsRecording] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+
+  const { useLocalParticipant } = useCallStateHooks();
+  const localParticipant = useLocalParticipant();
+
+  // Check if user is the call owner (consultant)
+  const isCallOwner =
+    localParticipant &&
+    call?.state.createdBy &&
+    localParticipant.userId === call.state.createdBy.id;
+
+  // Subscribe to call recording state changes
+  useEffect(() => {
+    if (!call) return;
+
+    // Get initial recording state from call
+    const checkRecordingState = () => {
+      const callState = call.state;
+      const recording = callState.recording;
+      setIsRecording(!!recording);
+    };
+
+    checkRecordingState();
+
+    // Listen for recording state changes
+    const unsubscribe = call.on("call.recording_started", () => {
+      setIsRecording(true);
+      setIsLoading(false);
+      toast({
+        title: "Recording Started",
+        description: "The session is now being recorded.",
+      });
+    });
+
+    const unsubscribeStopped = call.on("call.recording_stopped", () => {
+      setIsRecording(false);
+      setIsLoading(false);
+      setRecordingDuration(0);
+      toast({
+        title: "Recording Stopped",
+        description: "The recording has been saved.",
+      });
+    });
+
+    const unsubscribeFailed = call.on("call.recording_failed", () => {
+      setIsRecording(false);
+      setIsLoading(false);
+      toast({
+        title: "Recording Failed",
+        description: "There was an error with the recording.",
+        variant: "destructive",
+      });
+    });
+
+    return () => {
+      unsubscribe();
+      unsubscribeStopped();
+      unsubscribeFailed();
+    };
+  }, [call, toast]);
+
+  // Recording duration timer
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+
+    if (isRecording) {
+      interval = setInterval(() => {
+        setRecordingDuration((prev) => prev + 1);
+      }, 1000);
+    }
+
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [isRecording]);
+
+  // Format duration as MM:SS or HH:MM:SS
+  const formatDuration = (seconds: number) => {
+    const hrs = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hrs > 0) {
+      return `${hrs.toString().padStart(2, "0")}:${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+    }
+    return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const handleStartRecording = async () => {
+    if (!call || isLoading) return;
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/recordings/start", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          streamCallId: call.id,
+          meetingSessionId,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to start recording");
+      }
+
+      // The recording state will be updated via call events
+    } catch (error) {
+      console.error("Error starting recording:", error);
+      setIsLoading(false);
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error ? error.message : "Failed to start recording",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleStopRecording = async () => {
+    if (!call || isLoading) return;
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/recordings/stop", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          streamCallId: call.id,
+          meetingSessionId,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to stop recording");
+      }
+
+      // The recording state will be updated via call events
+    } catch (error) {
+      console.error("Error stopping recording:", error);
+      setIsLoading(false);
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error ? error.message : "Failed to stop recording",
+        variant: "destructive",
+      });
+    }
+  };
+
+  // Don't render if recording is not enabled for this session
+  if (!recordingEnabled) {
+    return null;
+  }
+
+  // Only show controls to call owner (consultant)
+  // But show recording indicator to everyone
+  if (!isCallOwner) {
+    // Recording indicator for non-owners when recording is active
+    if (isRecording) {
+      return (
+        <div className="flex items-center gap-2 px-3 py-2 bg-red-500/20 rounded-lg border border-red-500/30">
+          <Circle className="w-3 h-3 fill-red-500 text-red-500 animate-pulse" />
+          <span className="text-sm font-medium text-red-400">
+            Recording {formatDuration(recordingDuration)}
+          </span>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Recording indicator when active */}
+      {isRecording && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-red-500/20 rounded-lg border border-red-500/30 mr-1">
+          <Circle className="w-3 h-3 fill-red-500 text-red-500 animate-pulse" />
+          <span className="text-sm font-medium text-red-400">
+            {formatDuration(recordingDuration)}
+          </span>
+        </div>
+      )}
+
+      {/* Recording control button */}
+      <button
+        onClick={isRecording ? handleStopRecording : handleStartRecording}
+        disabled={isLoading}
+        className={cn(
+          "p-3 rounded-xl transition-all duration-200 flex items-center gap-2",
+          isRecording
+            ? "bg-red-500 hover:bg-red-600 text-white"
+            : "bg-zinc-800 hover:bg-zinc-700 text-white",
+          isLoading && "opacity-50 cursor-not-allowed"
+        )}
+        title={isRecording ? "Stop Recording" : "Start Recording"}
+      >
+        {isLoading ? (
+          <Loader2 className="w-5 h-5 animate-spin" />
+        ) : isRecording ? (
+          <Square className="w-5 h-5 fill-current" />
+        ) : (
+          <Circle className="w-5 h-5 fill-red-500 text-red-500" />
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default RecordingControls;

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { useCall, useCallStateHooks } from "@stream-io/video-react-sdk";
-import { useSession } from "next-auth/react";
 import { Circle, Square, Loader2 } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 import { useToast } from "@/hooks/use-toast";
@@ -17,7 +16,6 @@ const RecordingControls = ({
   recordingEnabled,
 }: RecordingControlsProps) => {
   const call = useCall();
-  const { data: session } = useSession();
   const { toast } = useToast();
   const [isRecording, setIsRecording] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -84,7 +82,7 @@ const RecordingControls = ({
 
   // Recording duration timer
   useEffect(() => {
-    let interval: NodeJS.Timeout;
+    let interval: ReturnType<typeof setInterval> | undefined;
 
     if (isRecording) {
       interval = setInterval(() => {

--- a/app/meetings/[id]/hooks/useMeetingRecording.ts
+++ b/app/meetings/[id]/hooks/useMeetingRecording.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface MeetingRecordingData {
+  meetingSessionId: string | null;
+  recordingEnabled: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Hook to fetch meeting session data for recording controls
+ * @param streamCallId The Stream call ID
+ */
+export function useMeetingRecording(
+  streamCallId: string | undefined
+): MeetingRecordingData {
+  const [data, setData] = useState<MeetingRecordingData>({
+    meetingSessionId: null,
+    recordingEnabled: false,
+    isLoading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!streamCallId) {
+      setData((prev) => ({ ...prev, isLoading: false }));
+      return;
+    }
+
+    const fetchMeetingSession = async () => {
+      try {
+        const response = await fetch(
+          `/api/meetings/${encodeURIComponent(streamCallId)}/recording-info`
+        );
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            // Meeting session not found - recording not available
+            setData({
+              meetingSessionId: null,
+              recordingEnabled: false,
+              isLoading: false,
+              error: null,
+            });
+            return;
+          }
+          throw new Error("Failed to fetch meeting recording info");
+        }
+
+        const result = await response.json();
+
+        setData({
+          meetingSessionId: result.meetingSessionId,
+          recordingEnabled: result.recordingEnabled,
+          isLoading: false,
+          error: null,
+        });
+      } catch (error) {
+        console.error("Error fetching meeting recording info:", error);
+        setData({
+          meetingSessionId: null,
+          recordingEnabled: false,
+          isLoading: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to fetch recording info",
+        });
+      }
+    };
+
+    fetchMeetingSession();
+  }, [streamCallId]);
+
+  return data;
+}
+
+export default useMeetingRecording;

--- a/components/dashboard/DashboardSidebar.tsx
+++ b/components/dashboard/DashboardSidebar.tsx
@@ -35,6 +35,7 @@ import {
   Loader,
   ClipboardCheck,
   RotateCcw,
+  Video,
 } from "lucide-react";
 import { ReactNode } from "react";
 
@@ -59,6 +60,7 @@ const iconMap: Record<string, typeof Home> = {
   messages: MessageSquare,
   feedback: Ticket,
   policy: Shield,
+  recordings: Video,
   // Payout related icons
   wallet: Wallet,
   "payouts/pending": ClipboardCheck,

--- a/lib/stream/recording-handlers.ts
+++ b/lib/stream/recording-handlers.ts
@@ -151,7 +151,7 @@ export async function handleRecordingStopped(
 export async function handleRecordingReady(
   event: StreamRecordingReadyEvent
 ): Promise<void> {
-  const { call_cid, call_recording, created_at } = event;
+  const { call_cid, call_recording, created_at: _created_at } = event;
 
   const streamCallId = call_cid.split(":")[1] || call_cid;
   const { filename, url, start_time, end_time } = call_recording;

--- a/lib/stream/recording-handlers.ts
+++ b/lib/stream/recording-handlers.ts
@@ -1,0 +1,358 @@
+/**
+ * Stream Recording Event Handlers
+ * Handles webhook events for recording lifecycle
+ */
+
+import prisma from "@/lib/prisma";
+import { RecordingStatus } from "@prisma/client";
+import { streamLogger } from "@/lib/stream-logger";
+
+// Types for Stream webhook payloads
+export interface StreamRecordingStartedEvent {
+  call_cid: string;
+  type: "call.recording_started";
+  user?: {
+    id: string;
+    name?: string;
+  };
+  created_at: string;
+}
+
+export interface StreamRecordingStoppedEvent {
+  call_cid: string;
+  type: "call.recording_stopped";
+  created_at: string;
+}
+
+export interface StreamRecordingReadyEvent {
+  call_cid: string;
+  type: "call.recording_ready";
+  call_recording: {
+    filename: string;
+    url: string;
+    start_time: string;
+    end_time: string;
+  };
+  created_at: string;
+}
+
+export interface StreamRecordingFailedEvent {
+  call_cid: string;
+  type: "call.recording_failed";
+  error?: {
+    message?: string;
+    code?: string;
+  };
+  created_at: string;
+}
+
+/**
+ * Handle call.recording_started event
+ * Updates MeetingSession to mark recording as active
+ */
+export async function handleRecordingStarted(
+  event: StreamRecordingStartedEvent
+): Promise<void> {
+  const { call_cid, user, created_at } = event;
+
+  // Extract call ID from call_cid (format: "default:callId")
+  const streamCallId = call_cid.split(":")[1] || call_cid;
+
+  streamLogger.info("Recording started", {
+    streamCallId,
+    userId: user?.id,
+    startedAt: created_at,
+  });
+
+  try {
+    // Find meeting session by streamCallId
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { streamCallId },
+    });
+
+    if (!meetingSession) {
+      streamLogger.warn("Meeting session not found for recording started event", {
+        streamCallId,
+      });
+      return;
+    }
+
+    // Update meeting session to mark recording as active
+    await prisma.meetingSession.update({
+      where: { id: meetingSession.id },
+      data: {
+        isRecording: true,
+        recordingStartedAt: new Date(created_at),
+        recordingStartedBy: user?.id || null,
+      },
+    });
+
+    streamLogger.info("Meeting session updated - recording started", {
+      sessionId: meetingSession.id,
+      streamCallId,
+    });
+  } catch (error) {
+    streamLogger.error("Failed to handle recording started event", error, {
+      streamCallId,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Handle call.recording_stopped event
+ * Updates MeetingSession to mark recording as stopped
+ */
+export async function handleRecordingStopped(
+  event: StreamRecordingStoppedEvent
+): Promise<void> {
+  const { call_cid } = event;
+
+  const streamCallId = call_cid.split(":")[1] || call_cid;
+
+  streamLogger.info("Recording stopped", { streamCallId });
+
+  try {
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { streamCallId },
+    });
+
+    if (!meetingSession) {
+      streamLogger.warn("Meeting session not found for recording stopped event", {
+        streamCallId,
+      });
+      return;
+    }
+
+    // Update meeting session to mark recording as stopped
+    await prisma.meetingSession.update({
+      where: { id: meetingSession.id },
+      data: {
+        isRecording: false,
+      },
+    });
+
+    streamLogger.info("Meeting session updated - recording stopped", {
+      sessionId: meetingSession.id,
+      streamCallId,
+    });
+  } catch (error) {
+    streamLogger.error("Failed to handle recording stopped event", error, {
+      streamCallId,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Handle call.recording_ready event
+ * Creates a Recording record in the database
+ */
+export async function handleRecordingReady(
+  event: StreamRecordingReadyEvent
+): Promise<void> {
+  const { call_cid, call_recording, created_at } = event;
+
+  const streamCallId = call_cid.split(":")[1] || call_cid;
+  const { filename, url, start_time, end_time } = call_recording;
+
+  streamLogger.info("Recording ready", {
+    streamCallId,
+    filename,
+    url: url.substring(0, 50) + "...",
+  });
+
+  try {
+    // Find meeting session by streamCallId
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { streamCallId },
+      include: {
+        slotOfAppointment: {
+          include: {
+            appointment: {
+              include: {
+                consultation: {
+                  include: {
+                    consultationPlan: true,
+                  },
+                },
+                subscription: {
+                  include: {
+                    subscriptionPlan: true,
+                  },
+                },
+                webinar: {
+                  include: {
+                    webinarPlan: true,
+                  },
+                },
+                class: {
+                  include: {
+                    classPlan: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!meetingSession) {
+      streamLogger.warn("Meeting session not found for recording ready event", {
+        streamCallId,
+      });
+      return;
+    }
+
+    // Calculate duration in minutes
+    const startDate = new Date(start_time);
+    const endDate = new Date(end_time);
+    const durationInMinutes = Math.round(
+      (endDate.getTime() - startDate.getTime()) / (1000 * 60)
+    );
+
+    // Generate title from appointment info
+    const appointment = meetingSession.slotOfAppointment.appointment;
+    let title = "Recording";
+
+    if (appointment?.webinar?.webinarPlan?.title) {
+      title = `Webinar: ${appointment.webinar.webinarPlan.title}`;
+    } else if (appointment?.class?.classPlan?.title) {
+      title = `Class: ${appointment.class.classPlan.title}`;
+    } else if (appointment?.consultation?.consultationPlan?.title) {
+      title = `Consultation: ${appointment.consultation.consultationPlan.title}`;
+    } else if (appointment?.subscription?.subscriptionPlan?.title) {
+      title = `Subscription: ${appointment.subscription.subscriptionPlan.title}`;
+    }
+
+    // Add date to title
+    const dateStr = startDate.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+    title = `${title} - ${dateStr}`;
+
+    // Calculate Stream URL expiration (2 weeks from now)
+    const streamUrlExpiresAt = new Date();
+    streamUrlExpiresAt.setDate(streamUrlExpiresAt.getDate() + 14);
+
+    // Check if recording already exists (idempotency)
+    const existingRecording = await prisma.recording.findFirst({
+      where: {
+        meetingSessionId: meetingSession.id,
+        streamRecordingId: filename,
+      },
+    });
+
+    if (existingRecording) {
+      streamLogger.info("Recording already exists, skipping creation", {
+        recordingId: existingRecording.id,
+        streamRecordingId: filename,
+      });
+      return;
+    }
+
+    // Create recording record
+    const recording = await prisma.recording.create({
+      data: {
+        title,
+        recordingUrl: url,
+        durationInMinutes,
+        recordedAt: startDate,
+        streamRecordingId: filename,
+        streamCallId,
+        storageType: "STREAM_S3",
+        status: "READY",
+        streamUrlExpiresAt,
+        meetingSessionId: meetingSession.id,
+      },
+    });
+
+    // Also update the meeting session to stop recording state if still active
+    if (meetingSession.isRecording) {
+      await prisma.meetingSession.update({
+        where: { id: meetingSession.id },
+        data: { isRecording: false },
+      });
+    }
+
+    streamLogger.info("Recording created successfully", {
+      recordingId: recording.id,
+      sessionId: meetingSession.id,
+      title,
+      durationInMinutes,
+    });
+  } catch (error) {
+    streamLogger.error("Failed to handle recording ready event", error, {
+      streamCallId,
+      filename,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Handle call.recording_failed event
+ * Logs the error and optionally notifies the consultant
+ */
+export async function handleRecordingFailed(
+  event: StreamRecordingFailedEvent
+): Promise<void> {
+  const { call_cid, error: eventError } = event;
+
+  const streamCallId = call_cid.split(":")[1] || call_cid;
+
+  streamLogger.error("Recording failed", new Error(eventError?.message || "Unknown error"), {
+    streamCallId,
+    errorCode: eventError?.code,
+    errorMessage: eventError?.message,
+  });
+
+  try {
+    const meetingSession = await prisma.meetingSession.findUnique({
+      where: { streamCallId },
+    });
+
+    if (!meetingSession) {
+      streamLogger.warn("Meeting session not found for recording failed event", {
+        streamCallId,
+      });
+      return;
+    }
+
+    // Update meeting session to stop recording state
+    await prisma.meetingSession.update({
+      where: { id: meetingSession.id },
+      data: {
+        isRecording: false,
+      },
+    });
+
+    // Create a failed recording record for tracking
+    await prisma.recording.create({
+      data: {
+        title: "Recording Failed",
+        recordingUrl: "",
+        durationInMinutes: 0,
+        recordedAt: new Date(),
+        streamCallId,
+        status: "FAILED" as RecordingStatus,
+        meetingSessionId: meetingSession.id,
+      },
+    });
+
+    // TODO: Send notification to consultant about failed recording
+
+    streamLogger.info("Meeting session updated - recording failed", {
+      sessionId: meetingSession.id,
+      streamCallId,
+    });
+  } catch (error) {
+    streamLogger.error("Failed to handle recording failed event", error, {
+      streamCallId,
+    });
+    throw error;
+  }
+}

--- a/lib/stream/recording-service.ts
+++ b/lib/stream/recording-service.ts
@@ -1,0 +1,584 @@
+/**
+ * Stream Recording Service
+ * Provides methods to manage video call recordings
+ */
+
+import { getStreamVideoClient } from "@/lib/stream-client";
+import prisma from "@/lib/prisma";
+import { Recording, RecordingStatus, MeetingSession } from "@prisma/client";
+import { streamLogger } from "@/lib/stream-logger";
+
+// Types for Stream Recording API responses
+export interface StreamRecording {
+  filename: string;
+  url: string;
+  start_time: Date;
+  end_time: Date;
+}
+
+export interface RecordingWithSession extends Recording {
+  meetingSession: MeetingSession & {
+    slotOfAppointment: {
+      appointment: {
+        appointmentType: string;
+        webinar?: {
+          webinarPlan: {
+            title: string;
+            consultantProfileId: string | null;
+          };
+        } | null;
+        class?: {
+          classPlan: {
+            title: string;
+            consultantProfileId: string | null;
+          };
+        } | null;
+      } | null;
+    };
+  };
+}
+
+/**
+ * Recording Service class for managing video call recordings
+ */
+export class RecordingService {
+  /**
+   * Start recording for a call
+   * @param streamCallId The Stream call ID
+   * @param userId The user ID who started the recording
+   */
+  static async startRecording(
+    streamCallId: string,
+    userId: string
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const client = getStreamVideoClient();
+
+      // Get call type from call ID (format: "callType:callId" or just "callId")
+      const callType = "default";
+      const callId = streamCallId.includes(":")
+        ? streamCallId.split(":")[1]
+        : streamCallId;
+
+      // Get the call and start recording
+      const call = client.video.call(callType, callId);
+      await call.startRecording();
+
+      streamLogger.info("Recording started via API", {
+        streamCallId: callId,
+        userId,
+      });
+
+      return { success: true };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to start recording";
+      streamLogger.error("Failed to start recording", error, {
+        streamCallId,
+        userId,
+      });
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  /**
+   * Stop recording for a call
+   * @param streamCallId The Stream call ID
+   */
+  static async stopRecording(
+    streamCallId: string
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const client = getStreamVideoClient();
+
+      const callType = "default";
+      const callId = streamCallId.includes(":")
+        ? streamCallId.split(":")[1]
+        : streamCallId;
+
+      const call = client.video.call(callType, callId);
+      await call.stopRecording();
+
+      streamLogger.info("Recording stopped via API", {
+        streamCallId: callId,
+      });
+
+      return { success: true };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to stop recording";
+      streamLogger.error("Failed to stop recording", error, {
+        streamCallId,
+      });
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  /**
+   * Get recordings for a specific call from Stream
+   * @param streamCallId The Stream call ID
+   */
+  static async getCallRecordingsFromStream(
+    streamCallId: string
+  ): Promise<StreamRecording[]> {
+    try {
+      const client = getStreamVideoClient();
+
+      const callType = "default";
+      const callId = streamCallId.includes(":")
+        ? streamCallId.split(":")[1]
+        : streamCallId;
+
+      const call = client.video.call(callType, callId);
+      const response = await call.listRecordings();
+
+      return response.recordings.map((r) => ({
+        filename: r.filename,
+        url: r.url,
+        start_time: r.start_time,
+        end_time: r.end_time,
+      }));
+    } catch (error) {
+      streamLogger.error("Failed to get call recordings from Stream", error, {
+        streamCallId,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Get recordings for a meeting session from database
+   * @param meetingSessionId The meeting session ID
+   */
+  static async getSessionRecordings(
+    meetingSessionId: string
+  ): Promise<Recording[]> {
+    try {
+      const recordings = await prisma.recording.findMany({
+        where: {
+          meetingSessionId,
+          status: {
+            notIn: ["FAILED", "EXPIRED"],
+          },
+        },
+        orderBy: {
+          recordedAt: "desc",
+        },
+      });
+
+      return recordings;
+    } catch (error) {
+      streamLogger.error("Failed to get session recordings", error, {
+        meetingSessionId,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Get all recordings for a webinar plan
+   * @param webinarPlanId The webinar plan ID
+   */
+  static async getWebinarPlanRecordings(
+    webinarPlanId: string
+  ): Promise<Recording[]> {
+    try {
+      const recordings = await prisma.recording.findMany({
+        where: {
+          meetingSession: {
+            slotOfAppointment: {
+              appointment: {
+                webinar: {
+                  webinarPlanId,
+                },
+              },
+            },
+          },
+          status: {
+            notIn: ["FAILED", "EXPIRED"],
+          },
+        },
+        include: {
+          meetingSession: {
+            include: {
+              slotOfAppointment: {
+                include: {
+                  appointment: {
+                    include: {
+                      webinar: {
+                        include: {
+                          webinarPlan: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          recordedAt: "desc",
+        },
+      });
+
+      return recordings;
+    } catch (error) {
+      streamLogger.error("Failed to get webinar plan recordings", error, {
+        webinarPlanId,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Get all recordings for a class plan
+   * @param classPlanId The class plan ID
+   */
+  static async getClassPlanRecordings(
+    classPlanId: string
+  ): Promise<Recording[]> {
+    try {
+      const recordings = await prisma.recording.findMany({
+        where: {
+          meetingSession: {
+            slotOfAppointment: {
+              appointment: {
+                class: {
+                  classPlanId,
+                },
+              },
+            },
+          },
+          status: {
+            notIn: ["FAILED", "EXPIRED"],
+          },
+        },
+        include: {
+          meetingSession: {
+            include: {
+              slotOfAppointment: {
+                include: {
+                  appointment: {
+                    include: {
+                      class: {
+                        include: {
+                          classPlan: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          recordedAt: "desc",
+        },
+      });
+
+      return recordings;
+    } catch (error) {
+      streamLogger.error("Failed to get class plan recordings", error, {
+        classPlanId,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Get all recordings for a consultant
+   * @param consultantProfileId The consultant profile ID
+   */
+  static async getConsultantRecordings(
+    consultantProfileId: string
+  ): Promise<Recording[]> {
+    try {
+      const recordings = await prisma.recording.findMany({
+        where: {
+          OR: [
+            {
+              meetingSession: {
+                slotOfAppointment: {
+                  appointment: {
+                    webinar: {
+                      webinarPlan: {
+                        consultantProfileId,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            {
+              meetingSession: {
+                slotOfAppointment: {
+                  appointment: {
+                    class: {
+                      classPlan: {
+                        consultantProfileId,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          status: {
+            notIn: ["FAILED", "EXPIRED"],
+          },
+        },
+        include: {
+          meetingSession: {
+            include: {
+              slotOfAppointment: {
+                include: {
+                  appointment: {
+                    include: {
+                      webinar: {
+                        include: {
+                          webinarPlan: {
+                            select: {
+                              id: true,
+                              title: true,
+                            },
+                          },
+                        },
+                      },
+                      class: {
+                        include: {
+                          classPlan: {
+                            select: {
+                              id: true,
+                              title: true,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: {
+          recordedAt: "desc",
+        },
+      });
+
+      return recordings;
+    } catch (error) {
+      streamLogger.error("Failed to get consultant recordings", error, {
+        consultantProfileId,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Get a single recording by ID
+   * @param recordingId The recording ID
+   */
+  static async getRecordingById(
+    recordingId: string
+  ): Promise<Recording | null> {
+    try {
+      const recording = await prisma.recording.findUnique({
+        where: { id: recordingId },
+        include: {
+          meetingSession: {
+            include: {
+              slotOfAppointment: {
+                include: {
+                  appointment: {
+                    include: {
+                      webinar: {
+                        include: {
+                          webinarPlan: true,
+                        },
+                      },
+                      class: {
+                        include: {
+                          classPlan: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      return recording;
+    } catch (error) {
+      streamLogger.error("Failed to get recording by ID", error, {
+        recordingId,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Update recording status
+   * @param recordingId The recording ID
+   * @param status The new status
+   * @param additionalData Additional fields to update
+   */
+  static async updateRecordingStatus(
+    recordingId: string,
+    status: RecordingStatus,
+    additionalData?: Partial<Recording>
+  ): Promise<Recording | null> {
+    try {
+      const recording = await prisma.recording.update({
+        where: { id: recordingId },
+        data: {
+          status,
+          ...additionalData,
+        },
+      });
+
+      streamLogger.info("Recording status updated", {
+        recordingId,
+        status,
+      });
+
+      return recording;
+    } catch (error) {
+      streamLogger.error("Failed to update recording status", error, {
+        recordingId,
+        status,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Check if recording is enabled for an appointment type
+   * @param appointmentId The appointment ID
+   */
+  static async isRecordingEnabledForAppointment(
+    appointmentId: string
+  ): Promise<boolean> {
+    try {
+      const appointment = await prisma.appointment.findUnique({
+        where: { id: appointmentId },
+        include: {
+          webinar: {
+            include: {
+              webinarPlan: {
+                select: {
+                  recordingEnabled: true,
+                },
+              },
+            },
+          },
+          class: {
+            include: {
+              classPlan: {
+                select: {
+                  recordingEnabled: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!appointment) {
+        return false;
+      }
+
+      // Check webinar recording setting
+      if (appointment.webinar?.webinarPlan?.recordingEnabled) {
+        return true;
+      }
+
+      // Check class recording setting
+      if (appointment.class?.classPlan?.recordingEnabled) {
+        return true;
+      }
+
+      // Consultations and subscriptions don't have recording enabled by default
+      return false;
+    } catch (error) {
+      streamLogger.error("Failed to check recording enabled", error, {
+        appointmentId,
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Get recordings that are expiring soon (for transfer to Supabase)
+   * @param daysBeforeExpiry Number of days before expiry to consider
+   */
+  static async getExpiringRecordings(
+    daysBeforeExpiry: number = 3
+  ): Promise<Recording[]> {
+    const expiryThreshold = new Date();
+    expiryThreshold.setDate(expiryThreshold.getDate() + daysBeforeExpiry);
+
+    try {
+      const recordings = await prisma.recording.findMany({
+        where: {
+          storageType: "STREAM_S3",
+          status: "READY",
+          streamUrlExpiresAt: {
+            lte: expiryThreshold,
+          },
+        },
+        orderBy: {
+          streamUrlExpiresAt: "asc",
+        },
+      });
+
+      return recordings;
+    } catch (error) {
+      streamLogger.error("Failed to get expiring recordings", error, {
+        daysBeforeExpiry,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Get the current recording state for a meeting session
+   * @param meetingSessionId The meeting session ID
+   */
+  static async getRecordingState(
+    meetingSessionId: string
+  ): Promise<{ isRecording: boolean; startedAt: Date | null; startedBy: string | null }> {
+    try {
+      const session = await prisma.meetingSession.findUnique({
+        where: { id: meetingSessionId },
+        select: {
+          isRecording: true,
+          recordingStartedAt: true,
+          recordingStartedBy: true,
+        },
+      });
+
+      if (!session) {
+        return { isRecording: false, startedAt: null, startedBy: null };
+      }
+
+      return {
+        isRecording: session.isRecording,
+        startedAt: session.recordingStartedAt,
+        startedBy: session.recordingStartedBy,
+      };
+    } catch (error) {
+      streamLogger.error("Failed to get recording state", error, {
+        meetingSessionId,
+      });
+      return { isRecording: false, startedAt: null, startedBy: null };
+    }
+  }
+}
+
+export default RecordingService;

--- a/lib/stream/recording-transfer-service.ts
+++ b/lib/stream/recording-transfer-service.ts
@@ -1,0 +1,388 @@
+/**
+ * Recording Transfer Service
+ * Handles transferring recordings from Stream S3 to Supabase for permanent storage
+ */
+
+import prisma from "@/lib/prisma";
+import { Recording, RecordingStatus } from "@prisma/client";
+import { streamLogger } from "@/lib/stream-logger";
+import supabase, { ensureBucketExists } from "@/lib/supabase";
+
+// Recordings bucket name
+const RECORDINGS_BUCKET = "recordings";
+
+// Allowed video MIME types
+const ALLOWED_VIDEO_TYPES = [
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "video/x-msvideo",
+  "application/octet-stream", // Stream may return this
+];
+
+/**
+ * Recording Transfer Service for moving recordings to permanent storage
+ */
+export class RecordingTransferService {
+  /**
+   * Queue a recording for transfer to Supabase
+   * @param recordingId The recording ID to queue
+   */
+  static async queueRecordingTransfer(recordingId: string): Promise<boolean> {
+    try {
+      // Update status to TRANSFERRING
+      await prisma.recording.update({
+        where: { id: recordingId },
+        data: {
+          status: "TRANSFERRING" as RecordingStatus,
+        },
+      });
+
+      streamLogger.info("Recording queued for transfer", { recordingId });
+      return true;
+    } catch (error) {
+      streamLogger.error("Failed to queue recording for transfer", error, {
+        recordingId,
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Transfer a recording from Stream S3 to Supabase
+   * @param recordingId The recording ID to transfer
+   */
+  static async transferRecordingToSupabase(
+    recordingId: string
+  ): Promise<{ success: boolean; error?: string }> {
+    let recording: Recording | null = null;
+
+    try {
+      // Get the recording
+      recording = await prisma.recording.findUnique({
+        where: { id: recordingId },
+      });
+
+      if (!recording) {
+        return { success: false, error: "Recording not found" };
+      }
+
+      if (!recording.recordingUrl) {
+        return { success: false, error: "Recording URL not available" };
+      }
+
+      // Update status to TRANSFERRING
+      await prisma.recording.update({
+        where: { id: recordingId },
+        data: { status: "TRANSFERRING" as RecordingStatus },
+      });
+
+      // Ensure the recordings bucket exists
+      const bucketReady = await ensureBucketExists(RECORDINGS_BUCKET);
+      if (!bucketReady) {
+        await prisma.recording.update({
+          where: { id: recordingId },
+          data: { status: "READY" as RecordingStatus },
+        });
+        return {
+          success: false,
+          error: `Recordings bucket not found. Please create a '${RECORDINGS_BUCKET}' bucket in Supabase.`,
+        };
+      }
+
+      // Download the recording from Stream S3
+      streamLogger.info("Downloading recording from Stream", {
+        recordingId,
+        url: recording.recordingUrl.substring(0, 50) + "...",
+      });
+
+      const response = await fetch(recording.recordingUrl);
+
+      if (!response.ok) {
+        await prisma.recording.update({
+          where: { id: recordingId },
+          data: { status: "FAILED" as RecordingStatus },
+        });
+        return {
+          success: false,
+          error: `Failed to download recording: ${response.status} ${response.statusText}`,
+        };
+      }
+
+      // Get file data
+      const contentType = response.headers.get("content-type") || "video/mp4";
+      const contentLength = response.headers.get("content-length");
+      const fileSize = contentLength ? BigInt(contentLength) : null;
+
+      // Validate content type
+      if (!ALLOWED_VIDEO_TYPES.includes(contentType)) {
+        streamLogger.warn("Unexpected content type for recording", {
+          recordingId,
+          contentType,
+        });
+      }
+
+      // Create file path: recordings/{year}/{month}/{recordingId}/{filename}
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = (now.getMonth() + 1).toString().padStart(2, "0");
+      const filename =
+        recording.streamRecordingId || `${recordingId}.mp4`;
+      const storagePath = `recordings/${year}/${month}/${recordingId}/${filename}`;
+
+      // Upload to Supabase
+      streamLogger.info("Uploading recording to Supabase", {
+        recordingId,
+        storagePath,
+      });
+
+      const fileBuffer = await response.arrayBuffer();
+
+      const { error: uploadError } = await supabase.storage
+        .from(RECORDINGS_BUCKET)
+        .upload(storagePath, fileBuffer, {
+          contentType,
+          cacheControl: "31536000", // 1 year cache
+          upsert: true,
+        });
+
+      if (uploadError) {
+        await prisma.recording.update({
+          where: { id: recordingId },
+          data: { status: "FAILED" as RecordingStatus },
+        });
+        streamLogger.error("Failed to upload to Supabase", uploadError, {
+          recordingId,
+          storagePath,
+        });
+        return { success: false, error: uploadError.message };
+      }
+
+      // Get public URL
+      const { data: urlData } = supabase.storage
+        .from(RECORDINGS_BUCKET)
+        .getPublicUrl(storagePath);
+
+      // Update recording with Supabase details
+      await prisma.recording.update({
+        where: { id: recordingId },
+        data: {
+          supabaseUrl: urlData.publicUrl,
+          supabasePath: storagePath,
+          storageType: "SUPABASE",
+          status: "AVAILABLE" as RecordingStatus,
+          transferredAt: new Date(),
+          fileSize: fileSize,
+        },
+      });
+
+      streamLogger.info("Recording transferred successfully", {
+        recordingId,
+        storagePath,
+        supabaseUrl: urlData.publicUrl,
+      });
+
+      return { success: true };
+    } catch (error) {
+      // Revert status on error
+      if (recording) {
+        await prisma.recording.update({
+          where: { id: recordingId },
+          data: { status: "FAILED" as RecordingStatus },
+        });
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error during transfer";
+      streamLogger.error("Failed to transfer recording", error, {
+        recordingId,
+      });
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  /**
+   * Process all recordings that are expiring soon
+   * This should be run as a cron job
+   * @param daysBeforeExpiry Days before expiry to start transferring
+   * @param batchSize Maximum number of recordings to process in one batch
+   */
+  static async processExpiringRecordings(
+    daysBeforeExpiry: number = 3,
+    batchSize: number = 10
+  ): Promise<{
+    processed: number;
+    succeeded: number;
+    failed: number;
+    errors: string[];
+  }> {
+    const expiryThreshold = new Date();
+    expiryThreshold.setDate(expiryThreshold.getDate() + daysBeforeExpiry);
+
+    const results = {
+      processed: 0,
+      succeeded: 0,
+      failed: 0,
+      errors: [] as string[],
+    };
+
+    try {
+      // Get recordings that are expiring soon and still on Stream S3
+      const expiringRecordings = await prisma.recording.findMany({
+        where: {
+          storageType: "STREAM_S3",
+          status: "READY",
+          streamUrlExpiresAt: {
+            lte: expiryThreshold,
+          },
+        },
+        take: batchSize,
+        orderBy: {
+          streamUrlExpiresAt: "asc",
+        },
+      });
+
+      streamLogger.info("Processing expiring recordings", {
+        count: expiringRecordings.length,
+        daysBeforeExpiry,
+      });
+
+      for (const recording of expiringRecordings) {
+        results.processed++;
+
+        const result = await this.transferRecordingToSupabase(recording.id);
+
+        if (result.success) {
+          results.succeeded++;
+        } else {
+          results.failed++;
+          results.errors.push(
+            `Recording ${recording.id}: ${result.error || "Unknown error"}`
+          );
+        }
+      }
+
+      streamLogger.info("Finished processing expiring recordings", results);
+
+      return results;
+    } catch (error) {
+      streamLogger.error("Failed to process expiring recordings", error);
+      return results;
+    }
+  }
+
+  /**
+   * Mark expired Stream S3 recordings
+   * This should be run as a cron job to mark recordings whose URLs have expired
+   */
+  static async markExpiredRecordings(): Promise<number> {
+    try {
+      const now = new Date();
+
+      const result = await prisma.recording.updateMany({
+        where: {
+          storageType: "STREAM_S3",
+          status: "READY",
+          streamUrlExpiresAt: {
+            lt: now,
+          },
+        },
+        data: {
+          status: "EXPIRED" as RecordingStatus,
+        },
+      });
+
+      if (result.count > 0) {
+        streamLogger.warn("Marked recordings as expired", {
+          count: result.count,
+        });
+      }
+
+      return result.count;
+    } catch (error) {
+      streamLogger.error("Failed to mark expired recordings", error);
+      return 0;
+    }
+  }
+
+  /**
+   * Delete a recording from Supabase storage
+   * @param recordingId The recording ID to delete
+   */
+  static async deleteRecordingFromSupabase(
+    recordingId: string
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const recording = await prisma.recording.findUnique({
+        where: { id: recordingId },
+      });
+
+      if (!recording) {
+        return { success: false, error: "Recording not found" };
+      }
+
+      if (!recording.supabasePath) {
+        return { success: false, error: "Recording not stored in Supabase" };
+      }
+
+      // Delete from Supabase
+      const { error: deleteError } = await supabase.storage
+        .from(RECORDINGS_BUCKET)
+        .remove([recording.supabasePath]);
+
+      if (deleteError) {
+        streamLogger.error("Failed to delete from Supabase", deleteError, {
+          recordingId,
+          path: recording.supabasePath,
+        });
+        return { success: false, error: deleteError.message };
+      }
+
+      // Update recording record
+      await prisma.recording.update({
+        where: { id: recordingId },
+        data: {
+          supabaseUrl: null,
+          supabasePath: null,
+          storageType: "STREAM_S3",
+          status: recording.streamUrlExpiresAt && recording.streamUrlExpiresAt < new Date()
+            ? "EXPIRED"
+            : "READY",
+        },
+      });
+
+      streamLogger.info("Recording deleted from Supabase", {
+        recordingId,
+        path: recording.supabasePath,
+      });
+
+      return { success: true };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error during deletion";
+      streamLogger.error("Failed to delete recording from Supabase", error, {
+        recordingId,
+      });
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  /**
+   * Get the best available URL for a recording
+   * Returns Supabase URL if available, otherwise Stream URL
+   * @param recording The recording object
+   */
+  static getBestRecordingUrl(recording: Recording): string | null {
+    if (recording.status === "AVAILABLE" && recording.supabaseUrl) {
+      return recording.supabaseUrl;
+    }
+
+    if (recording.status === "READY" && recording.recordingUrl) {
+      return recording.recordingUrl;
+    }
+
+    return null;
+  }
+}
+
+export default RecordingTransferService;

--- a/lib/stream/recording-transfer-service.ts
+++ b/lib/stream/recording-transfer-service.ts
@@ -11,6 +11,10 @@ import supabase, { ensureBucketExists } from "@/lib/supabase";
 // Recordings bucket name
 const RECORDINGS_BUCKET = "recordings";
 
+// Maximum file size for direct transfer (500MB)
+// Files larger than this should use resumable uploads (future enhancement)
+const MAX_TRANSFER_SIZE = 500 * 1024 * 1024; // 500MB
+
 // Allowed video MIME types
 const ALLOWED_VIDEO_TYPES = [
   "video/mp4",
@@ -113,6 +117,24 @@ export class RecordingTransferService {
       const contentType = response.headers.get("content-type") || "video/mp4";
       const contentLength = response.headers.get("content-length");
       const fileSize = contentLength ? BigInt(contentLength) : null;
+      const fileSizeNumber = contentLength ? parseInt(contentLength, 10) : null;
+
+      // Check file size before attempting transfer to prevent OOM
+      if (fileSizeNumber && fileSizeNumber > MAX_TRANSFER_SIZE) {
+        await prisma.recording.update({
+          where: { id: recordingId },
+          data: { status: "READY" as RecordingStatus }, // Revert to READY
+        });
+        streamLogger.warn("Recording too large for direct transfer", {
+          recordingId,
+          fileSize: fileSizeNumber,
+          maxSize: MAX_TRANSFER_SIZE,
+        });
+        return {
+          success: false,
+          error: `Recording is too large for direct transfer (${Math.round(fileSizeNumber / 1024 / 1024)}MB). Maximum size is 500MB. Large recordings will need to be transferred manually or via a background job.`,
+        };
+      }
 
       // Validate content type
       if (!ALLOWED_VIDEO_TYPES.includes(contentType)) {
@@ -136,11 +158,13 @@ export class RecordingTransferService {
         storagePath,
       });
 
-      const fileBuffer = await response.arrayBuffer();
+      // Use blob() instead of arrayBuffer() for more efficient memory handling
+      // Blob is more memory-efficient in most JS runtimes for large files
+      const fileBlob = await response.blob();
 
       const { error: uploadError } = await supabase.storage
         .from(RECORDINGS_BUCKET)
-        .upload(storagePath, fileBuffer, {
+        .upload(storagePath, fileBlob, {
           contentType,
           cacheControl: "31536000", // 1 year cache
           upsert: true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -766,6 +766,7 @@ model WebinarPlan {
   price               Int
   priceCurrency       String   @default("INR")
   certificateProvided Boolean  @default(false)
+  recordingEnabled    Boolean  @default(false) // Allow consultant to record sessions
   durationInHours     Float    @default(1) // Duration in hours
   maxParticipants     Int      @default(100)
   language            String?  @default("English")
@@ -817,6 +818,7 @@ model ClassPlan {
   price                  Int
   priceCurrency          String           @default("INR")
   certificateProvided    Boolean          @default(false)
+  recordingEnabled       Boolean          @default(false) // Allow consultant to record sessions
   durationInMonths       Int              @default(1) // Duration in months
   meetingsPerWeek        Int              @default(1)
   sessionDurationInHours Float            @default(1.0) // Duration of each session in hours
@@ -1085,6 +1087,11 @@ model MeetingSession {
   passcode     String?
   hostKeys     String[]
 
+  // Recording state
+  isRecording        Boolean   @default(false)
+  recordingStartedAt DateTime?
+  recordingStartedBy String? // userId who started recording
+
   recordings Recording[]
 
   slotOfAppointment   SlotOfAppointment @relation(fields: [slotOfAppointmentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
@@ -1092,15 +1099,60 @@ model MeetingSession {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([isRecording])
 }
 
-// New model for storing recording details
+// Recording storage types
+enum RecordingStorageType {
+  STREAM_S3 // Default: expires in 2 weeks
+  SUPABASE // Permanent storage
+}
+
+// Recording status lifecycle
+enum RecordingStatus {
+  RECORDING // Currently being recorded
+  PROCESSING // Stream is processing the recording
+  READY // Available on Stream S3
+  TRANSFERRING // Being transferred to Supabase
+  AVAILABLE // Available on Supabase (permanent)
+  FAILED // Recording failed
+  EXPIRED // Stream S3 URL expired
+}
+
+// Model for storing recording details with dual storage support
 model Recording {
   id                String   @id @default(cuid())
   title             String
   recordingUrl      String
   durationInMinutes Int
   recordedAt        DateTime
+
+  // Stream-specific identifiers
+  streamRecordingId String? @unique
+  streamCallId      String?
+
+  // Storage configuration
+  storageType RecordingStorageType @default(STREAM_S3)
+  status      RecordingStatus      @default(READY)
+
+  // Supabase permanent storage
+  supabaseUrl  String?
+  supabasePath String?
+
+  // Media metadata
+  thumbnailUrl String?
+  fileSize     BigInt? // File size in bytes
+  codec        String? // e.g., "h264", "vp9"
+  resolution   String? // e.g., "1920x1080", "1280x720"
+
+  // Preview clip (for explore pages)
+  previewClipUrl      String?
+  previewClipDuration Int? // Duration in seconds
+
+  // Expiration tracking
+  streamUrlExpiresAt DateTime? // When Stream S3 URL expires
+  transferredAt      DateTime? // When transferred to Supabase
 
   meetingSession   MeetingSession @relation(fields: [meetingSessionId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   meetingSessionId String
@@ -1109,6 +1161,10 @@ model Recording {
   updatedAt DateTime @updatedAt
 
   @@index([meetingSessionId])
+  @@index([streamRecordingId])
+  @@index([status])
+  @@index([storageType])
+  @@index([streamUrlExpiresAt])
 }
 
 enum Platform {

--- a/schemas/plans.ts
+++ b/schemas/plans.ts
@@ -368,6 +368,7 @@ export const createUniqueTitleValidator = (
 // Webinar specific schema
 export const WebinarPlanSchema = BaseEventPlanSchema.extend({
   certificateProvided: z.boolean().default(false),
+  recordingEnabled: z.boolean().default(false),
   durationInHours: z
     .number()
     .min(0.5, "Duration must be at least 30 minutes")
@@ -450,6 +451,7 @@ export const ClassPlanSchema = BaseEventPlanSchema.extend({
   planType: z.literal("class"),
   durationInMonths: z.number().min(1, "Duration must be at least 1 month"),
   certificateProvided: z.boolean().default(false),
+  recordingEnabled: z.boolean().default(false),
   meetingsPerWeek: z.number().min(0, "Meetings per week must be non-negative"),
   emailSupport: z.enum(["GENERAL", "PRIORITY", "DEDICATED"]).default("GENERAL"),
   classContents: z


### PR DESCRIPTION
## What This PR Does

This PR adds the ability to **record video calls** during Webinar and Class sessions. Consultants can start/stop recordings during a live session, and both consultants and consultees can watch the recordings later from their dashboards.

---

## Why We Need This

Currently, when a consultant hosts a webinar or class, there's no way to save the session. Consultees who miss a session or want to rewatch it have no options. This feature solves that by:

1. Letting consultants record their sessions
2. Storing recordings so they don't expire
3. Giving consultees access to recordings they've paid for

---

## How Stream Recording Works (Background)

We use **Stream Video** for our video calls. Stream has a built-in recording feature:

1. When you call `call.startRecording()`, Stream starts recording on their servers
2. When you call `call.stopRecording()`, Stream stops and processes the video
3. Stream stores the recording in their S3 bucket for **~2 weeks**, then it expires
4. Stream notifies us about recording events via **webhooks**

The problem: Stream's recordings expire. We need to transfer them to our own storage (Supabase) for permanent access.

---

## Database Schema Changes Explained

### New Enums

```prisma
enum RecordingStorageType {
  STREAM_S3      // Recording is still on Stream's servers (temporary)
  SUPABASE       // Recording has been transferred to our storage (permanent)
}

enum RecordingStatus {
  RECORDING      // Currently being recorded
  PROCESSING     // Stream is processing the video after recording stopped
  READY          // Ready to watch (still on Stream S3)
  TRANSFERRING   // Being transferred to Supabase
  AVAILABLE      // Transferred to Supabase, permanently available
  FAILED         // Something went wrong
  EXPIRED        // Stream URL expired before we could transfer
}
```

### Recording Model

This stores information about each recording:

```prisma
model Recording {
  id                String    // Unique identifier
  
  // Basic info
  title             String    // e.g., "Webinar Recording - Jan 15, 2026"
  recordingUrl      String    // Stream's URL to the video
  durationInMinutes Int       // How long the recording is
  recordedAt        DateTime  // When it was recorded
  
  // Stream-specific
  streamRecordingId String?   // Stream's internal ID for this recording
  streamCallId      String?   // Which call this recording belongs to
  
  // Storage tracking
  storageType       RecordingStorageType  // Where is it stored?
  status            RecordingStatus       // What state is it in?
  supabaseUrl       String?               // URL after transfer to Supabase
  supabasePath      String?               // File path in Supabase bucket
  
  // Expiration tracking
  streamUrlExpiresAt DateTime?  // When Stream's URL will expire
  transferredAt      DateTime?  // When we transferred to Supabase
  
  // Link to the meeting session
  meetingSession    MeetingSession @relation(...)
  meetingSessionId  String
}
```

### MeetingSession Changes

We added fields to track if a session is currently being recorded:

```prisma
model MeetingSession {
  // ... existing fields ...
  
  isRecording         Boolean    @default(false)  // Is recording active right now?
  recordingStartedAt  DateTime?  // When did recording start?
  recordingStartedBy  String?    // Which user started it?
  
  recordings          Recording[]  // All recordings for this session
}
```

### Plan Changes

We added a toggle so consultants can enable/disable recording for their plans:

```prisma
model WebinarPlan {
  // ... existing fields ...
  recordingEnabled    Boolean     @default(false)
}

model ClassPlan {
  // ... existing fields ...
  recordingEnabled    Boolean     @default(false)
}
```

---

## How The Code Works Together

### Step 1: Consultant Enables Recording for a Plan

In the event planner (`EventPlannerForWebinar.tsx` / `EventPlannerForClass.tsx`), there's now a toggle switch. When enabled, it saves `recordingEnabled: true` to the WebinarPlan/ClassPlan in the database.

### Step 2: During a Live Meeting

When a consultant joins a meeting, `RecordingControls.tsx` appears if:
- The user is a consultant
- The plan has `recordingEnabled: true`

The component shows a red "Record" button. When clicked, it calls `POST /api/recordings/start`.

### Step 3: Start Recording API (`/api/recordings/start/route.ts`)

This endpoint:
1. Verifies the user is a consultant
2. Verifies they own this appointment
3. Checks that `recordingEnabled` is true for the plan
4. Calls `RecordingService.startRecording()` which tells Stream to start recording
5. Updates the MeetingSession with `isRecording: true`

### Step 4: Stream Sends Webhooks

Stream notifies us about recording events by sending HTTP POST requests to `/api/webhooks/stream`. We handle 4 events:

| Event | What It Means | What We Do |
|-------|---------------|------------|
| `call.recording_started` | Recording has begun | Set `isRecording: true` on MeetingSession |
| `call.recording_stopped` | Recording stopped, processing begins | Set `isRecording: false` |
| `call.recording_ready` | Video is processed and ready | Create `Recording` entry in database |
| `call.recording_failed` | Something went wrong | Log the error |

### Step 5: Webhook Security

We verify that webhooks actually come from Stream using HMAC SHA256:

```typescript
const expectedSignature = crypto
  .createHmac("sha256", process.env.STREAM_WEBHOOK_SECRET)
  .update(rawBody)
  .digest("hex");

if (expectedSignature !== actualSignature) {
  return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
}
```

### Step 6: Viewing Recordings

**Consultant Dashboard** (`/dashboard/consultant/[id]/recordings`):
- Fetches recordings via `GET /api/consultants/[id]/recordings`
- Shows all recordings from their webinars and classes
- Can filter by type (webinar/class)
- Can trigger transfer to Supabase

**Consultee Dashboard** (`/dashboard/consultee/[id]/recordings`):
- Fetches recordings via `GET /api/consultees/[id]/recordings`
- **Only shows recordings for plans they've paid for**
- The API checks the `Payment` table to verify the user paid for the appointment

### Step 7: Transferring to Supabase (Optional)

Since Stream recordings expire in ~2 weeks, we can transfer them to Supabase for permanent storage. The transfer process:

1. Download the video from Stream's URL
2. Upload to Supabase storage bucket
3. Update the Recording entry with `storageType: SUPABASE` and the new URL

---

## File-by-File Guide

### Prisma Schema
| File | What Changed |
|------|--------------|
| `prisma/schema.prisma` | Added enums, Recording model, MeetingSession fields, Plan fields |

### Services (Business Logic)
| File | Purpose |
|------|---------|
| `lib/stream/recording-service.ts` | Start/stop recording via Stream API, query recordings from database |
| `lib/stream/recording-transfer-service.ts` | Download from Stream, upload to Supabase |
| `lib/stream/recording-handlers.ts` | Functions that run when webhooks arrive |

### API Routes
| File | Method | Purpose |
|------|--------|---------|
| `app/api/webhooks/stream/route.ts` | POST | Receives webhooks from Stream |
| `app/api/recordings/start/route.ts` | POST | Consultant starts recording |
| `app/api/recordings/stop/route.ts` | POST | Consultant stops recording |
| `app/api/recordings/[recordingId]/route.ts` | GET | Get single recording details |
| `app/api/recordings/[recordingId]/transfer/route.ts` | POST | Transfer to Supabase |
| `app/api/consultants/[consultantId]/recordings/route.ts` | GET | List all consultant's recordings |
| `app/api/consultees/[consulteeId]/recordings/route.ts` | GET | List consultee's accessible recordings |
| `app/api/meetings/[streamCallId]/recording-info/route.ts` | GET | Is this meeting being recorded? |

### Frontend Components
| File | Purpose |
|------|---------|
| `app/meetings/[id]/components/RecordingControls.tsx` | The Record button in the meeting room |
| `app/meetings/[id]/hooks/useMeetingRecording.ts` | Hook to fetch if recording is enabled/active |
| `app/meetings/[id]/components/MeetingRoom.tsx` | Modified to include RecordingControls |
| `app/dashboard/consultant/.../recordings/page.tsx` | Consultant's recordings list page |
| `app/dashboard/consultant/.../recordings/components/RecordingCard.tsx` | Card UI for each recording |
| `app/dashboard/consultant/.../recordings/components/RecordingsList.tsx` | Grid of recording cards |
| `app/dashboard/consultee/.../recordings/page.tsx` | Consultee's recordings list page |
| `app/dashboard/consultee/.../recordings/components/ConsulteeRecordingCard.tsx` | Card UI for consultee |
| `app/dashboard/consultee/.../recordings/components/ConsulteeRecordingsList.tsx` | Grid for consultee |
| `EventPlannerForWebinar.tsx` | Added recordingEnabled toggle |
| `EventPlannerForClass.tsx` | Added recordingEnabled toggle |
| `schemas/plans.ts` | Added recordingEnabled to Zod schemas |

---

## The Data Flow Visualized

```
┌─────────────────────────────────────────────────────────────────────┐
│                         SETUP PHASE                                  │
├─────────────────────────────────────────────────────────────────────┤
│  Consultant creates WebinarPlan with recordingEnabled: true         │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│                       LIVE MEETING                                   │
├─────────────────────────────────────────────────────────────────────┤
│  1. Consultant joins meeting                                         │
│  2. RecordingControls component appears (because recordingEnabled)   │
│  3. Consultant clicks "Start Recording"                              │
│  4. Frontend calls POST /api/recordings/start                        │
│  5. Backend calls Stream API: call.startRecording()                  │
│  6. Backend updates MeetingSession.isRecording = true                │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│                     STREAM WEBHOOKS                                  │
├─────────────────────────────────────────────────────────────────────┤
│  Stream sends POST to /api/webhooks/stream:                          │
│    • call.recording_started  → We update isRecording = true          │
│    • call.recording_stopped  → We update isRecording = false         │
│    • call.recording_ready    → We CREATE Recording in database       │
│    • call.recording_failed   → We log the error                      │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│                    VIEWING RECORDINGS                                │
├─────────────────────────────────────────────────────────────────────┤
│  Consultant: GET /api/consultants/[id]/recordings                    │
│    → Returns all recordings from their plans                         │
│                                                                      │
│  Consultee: GET /api/consultees/[id]/recordings                      │
│    → Returns only recordings for plans they PAID for                 │
│    → Checks Payment table for paymentStatus: "SUCCEEDED"             │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│                 OPTIONAL: TRANSFER TO SUPABASE                       │
├─────────────────────────────────────────────────────────────────────┤
│  POST /api/recordings/[id]/transfer                                  │
│    1. Download video from Stream URL                                 │
│    2. Upload to Supabase storage                                     │
│    3. Update Recording: storageType = SUPABASE, status = AVAILABLE   │
│                                                                      │
│  Why? Stream URLs expire in ~2 weeks. Supabase is permanent.         │
└─────────────────────────────────────────────────────────────────────┘
```

---

## How to Test

1. **Setup**: Add `STREAM_WEBHOOK_SECRET` to your `.env` file (get from Stream dashboard)

2. **Enable recording on a plan**:
   - Go to consultant dashboard → Planner
   - Create or edit a webinar plan
   - Toggle "Enable Recording" ON
   - Save the plan

3. **Start a meeting and record**:
   - Create a webinar appointment from that plan
   - Join the meeting as the consultant
   - You should see a red "Record" button in the meeting controls
   - Click to start recording (button turns into a stop button)
   - A red dot indicator appears showing recording is active
   - Click again to stop recording

4. **Check recordings appeared**:
   - Go to consultant dashboard → Recordings tab
   - You should see your new recording in the list
   - Click to play it

5. **Test consultee access**:
   - As a consultee, purchase the webinar
   - Go to consultee dashboard → Recordings
   - You should see the recording (because you paid)

---

## Environment Variables

```env
STREAM_WEBHOOK_SECRET=your_webhook_secret_from_stream_dashboard
```

Get this from: Stream Dashboard → Your App → Webhooks → Signing Secret

---

## What's NOT in This PR (Future Work)

- [ ] Recording previews on public explore pages
- [ ] Migration script for legacy `Class.recordingUrls` field  
- [ ] Automatic transfer of expiring recordings (cron job)
- [ ] Custom video player component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #356