### PR TITLE
fix(payments): auto-create ConsulteeProfile for consultants at checkout UI fix

### DIFF
--- a/app/explore/experts/[consultantId]/components/ConsultationPricingToggle.tsx
+++ b/app/explore/experts/[consultantId]/components/ConsultationPricingToggle.tsx
@@ -198,19 +198,20 @@ export default function ConsultationPricingToggle({
 
   if (
     session?.user?.role &&
-    ["consultant", "staff"].includes(session.user.role.toLowerCase())
+    ["staff"].includes(session.user.role.toLowerCase())
   ) {
     return (
       <div className="w-full p-8 text-center space-y-3">
         <h3 className="text-2xl font-medium tracking-tight text-zinc-300">
-          Consultee Access Required
+          Staff Access Restricted
         </h3>
         <p className="text-zinc-500">
-          To book consultations, please sign in with a consultee account.
+          Staff accounts cannot book consultations. Please use a consultee account.
         </p>
       </div>
     );
   }
+
 
   return (
     <Tabs

--- a/app/explore/experts/[consultantId]/components/SubscriptionPricingToggle.tsx
+++ b/app/explore/experts/[consultantId]/components/SubscriptionPricingToggle.tsx
@@ -143,15 +143,15 @@ export default function SubscriptionPricingToggle({
 
   if (
     session?.user?.role &&
-    ["consultant", "staff"].includes(session.user.role.toLowerCase())
+    ["staff"].includes(session.user.role.toLowerCase())
   ) {
     return (
       <div className="w-full p-8 text-center space-y-3">
         <h3 className="text-2xl font-medium tracking-tight text-zinc-300">
-          Consultee Access Required
+          Staff Access Restricted
         </h3>
         <p className="text-zinc-500">
-          To subscribe to services, please sign in with a consultee account.
+          Staff accounts cannot subscribe to services. Please use a consultee account.
         </p>
       </div>
     );

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -175,8 +175,17 @@ export async function calculateAmountAndValidate(
       },
     });
 
-    if (!user?.consulteeProfile) {
-      throw new Error("User profile not found");
+    // Auto-create ConsulteeProfile if missing (handles edge cases like admin-created users,
+    // legacy data, or OAuth sign-up failures where profile wasn't created)
+    let consulteeProfileId = user?.consulteeProfile?.id;
+    if (!consulteeProfileId) {
+      if (!user) {
+        throw new Error("User not found");
+      }
+      const newProfile = await tx.consulteeProfile.create({
+        data: { userId: userId },
+      });
+      consulteeProfileId = newProfile.id;
     }
 
     // Get plan and validate availability without creating records
@@ -198,7 +207,7 @@ export async function calculateAmountAndValidate(
         await validateSlotAvailability(
           tx,
           validatedData,
-          user.consulteeProfile.id,
+          consulteeProfileId,
           plan.consultantProfile.user.id, // FIX: Pass consultant user ID to filter by consultant
         );
         amount = plan.price;
@@ -221,7 +230,7 @@ export async function calculateAmountAndValidate(
         await validateSlotAvailability(
           tx,
           validatedData,
-          user.consulteeProfile.id,
+          consulteeProfileId,
           plan.consultantProfile.user.id, // FIX: Pass consultant user ID to filter by consultant
         );
         amount = plan.price;
@@ -362,7 +371,7 @@ export async function calculateAmountAndValidate(
       amount,
       currency,
       discountCodeId,
-      consulteeProfileId: user.consulteeProfile.id,
+      consulteeProfileId,
     };
   });
 }
@@ -789,8 +798,17 @@ async function revalidateInsideLock(
       include: { consulteeProfile: true },
     });
 
-    if (!user?.consulteeProfile) {
-      throw new Error("User profile not found");
+    // Auto-create ConsulteeProfile if missing (handles edge cases like admin-created users,
+    // legacy data, or OAuth sign-up failures where profile wasn't created)
+    let consulteeProfileId = user?.consulteeProfile?.id;
+    if (!consulteeProfileId) {
+      if (!user) {
+        throw new Error("User not found");
+      }
+      const newProfile = await tx.consulteeProfile.create({
+        data: { userId: userId },
+      });
+      consulteeProfileId = newProfile.id;
     }
 
     // BUG-E: Re-validate plan still exists (could be deleted between initial validation and lock)
@@ -811,7 +829,7 @@ async function revalidateInsideLock(
           await validateSlotAvailability(
             tx,
             data,
-            user.consulteeProfile.id,
+            consulteeProfileId,
             consultationPlan.consultantProfile.user.id,
           );
         }
@@ -830,7 +848,7 @@ async function revalidateInsideLock(
           await validateSlotAvailability(
             tx,
             data,
-            user.consulteeProfile.id,
+            consulteeProfileId,
             subscriptionPlan.consultantProfile.user.id,
           );
         }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -449,11 +449,15 @@ async function createAppointmentFromWebhook(
     notes,
   } = metadata;
 
-  if (!payment.user.consulteeProfile) {
-    throw new Error("User profile not found for payment");
+  // Auto-create ConsulteeProfile if missing (handles edge cases like admin-created users,
+  // legacy data, or OAuth sign-up failures where profile wasn't created)
+  let consulteeProfileId = payment.user.consulteeProfile?.id;
+  if (!consulteeProfileId) {
+    const newProfile = await tx.consulteeProfile.create({
+      data: { userId: payment.user.id },
+    });
+    consulteeProfileId = newProfile.id;
   }
-
-  const consulteeProfileId = payment.user.consulteeProfile.id;
   const userId = payment.user.id;
 
   let appointment;


### PR DESCRIPTION
## Summary

This PR extends PR #353 by adding the required **frontend changes** to allow consultants to book other consultants' services.

## Problem

Previously, consultants attempting to book another consultant's consultation or subscription would see a "Consultee Access Required" message, blocking them from the booking UI entirely.

## Changes

### Modified Files

| File | Change |
|------|--------|
| [ConsultationPricingToggle.tsx](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Familarise%20new%20January%2017th%202026/familiarise_web/app/explore/experts/%5BconsultantId%5D/components/ConsultationPricingToggle.tsx:0:0-0:0) | Removed `consultant` from role check |
| [SubscriptionPricingToggle.tsx](cci:7://file:///c:/Users/shubh/OneDrive/Desktop/Practitionist%20Intern/Familarise%20new%20January%2017th%202026/familiarise_web/app/explore/experts/%5BconsultantId%5D/components/SubscriptionPricingToggle.tsx:0:0-0:0) | Removed `consultant` from role check |

### Before

```tsx
["consultant", "staff"].includes(session.user.role.toLowerCase())
```

### After

```tsx
["staff"].includes(session.user.role.toLowerCase())
```

### Result
- ✅ Consultants can now book consultations and subscriptions from other consultants
- ⛔ Staff accounts remain restricted (intentional)