### PR TITLE
fix(classes): Fixes Issues from #369 issues for Class Scheduling

### DIFF
--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -54,7 +54,7 @@ async function getParticipantCounts(
     }
   }
 
-  // Fetch class participant counts in a single query
+  // Fetch class participant counts - count UNIQUE users across all sessions
   if (classIds.length > 0) {
     const classCounts = await prisma.class.findMany({
       where: { id: { in: classIds } },
@@ -63,7 +63,11 @@ async function getParticipantCounts(
         appointments: {
           select: {
             slotsOfAppointment: {
-              select: { _count: { select: { user: true } } },
+              select: {
+                user: {
+                  select: { id: true },
+                },
+              },
               where: { isTentative: false },
             },
           },
@@ -72,15 +76,19 @@ async function getParticipantCounts(
     });
 
     for (const classEvent of classCounts) {
-      counts[classEvent.id] = classEvent.appointments.reduce(
-        (total, appointment) =>
-          total +
-          appointment.slotsOfAppointment.reduce(
-            (slotTotal, slot) => slotTotal + slot._count.user,
-            0,
-          ),
-        0,
-      );
+      // Use a Set to count unique users across ALL appointments/sessions
+      const uniqueUserIds = new Set<string>();
+
+      for (const appointment of classEvent.appointments) {
+        for (const slot of appointment.slotsOfAppointment) {
+          // slot.user is an array of users connected to this slot
+          for (const user of slot.user) {
+            uniqueUserIds.add(user.id);
+          }
+        }
+      }
+
+      counts[classEvent.id] = uniqueUserIds.size;
     }
   }
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -1236,6 +1236,7 @@ export async function handleClassCheckout(
     // Get timing from the first existing slot or use appointment times
     const existingSlot = appointment.slotsOfAppointment[0];
 
+    // Step 1: Create the slot without user connection
     const slot = await tx.slotOfAppointment.create({
       data: {
         appointmentId: appointment.id,
@@ -1248,11 +1249,19 @@ export async function handleClassCheckout(
           appointment.slotsOfAppointment[0]?.endsAt ||
           new Date(),
         isTentative: !skipPayment,
+      },
+    });
+
+    // Step 2: Connect user to slot in a separate update (fixes FK constraint issue)
+    await tx.slotOfAppointment.update({
+      where: { id: slot.id },
+      data: {
         user: {
           connect: { id: userId },
         },
       },
     });
+
     createdSlots.push(slot);
   }
 
@@ -1440,7 +1449,7 @@ export async function handleCheckout(
         }
 
         return { appointmentId: createdAppointment?.id };
-      });
+      }, { timeout: 25000 });
 
       const logMessage = isMockPayment
         ? `🎭 Mock payment + tentative appointment created: ${paymentResponse.id}`


### PR DESCRIPTION

Fixes #369

## Issues Fixed

### 1. Transaction Timeout (P2028) - Class Creation & Enrollment **Problem:** Creating classes with 8+ sessions or enrolling in multi-session classes exceeded the default 5-second Prisma transaction timeout.

**Error:** Transaction API error: The timeout for this transaction was 5000 ms

**Fix:** Added { timeout: 25000 } to transactions in:
- app/api/events/classes/crud-with-plan/route.ts
- lib/payments/operations/checkout.ts

**Expectation:** Classes with up to ~40 sessions can now be created/enrolled without timeout errors.

### 2. Foreign Key Constraint Violation (P2003) - Class Enrollment **Problem:** Enrolling in a class failed with FK violation on _SlotOfAppointmentToUser_A_fkey join table.

**Cause:** Prisma implicit many-to-many relations fail when creating a record and connecting a relation in same create() operation within a transaction.

**Fix:** Split slot creation into two operations in handleClassCheckout:
1. Create SlotOfAppointment without user connection
2. Update slot to connect user via separate update() call

**File:** lib/payments/operations/checkout.ts

**Expectation:** Class enrollment now succeeds without FK constraint errors.

### 3. Incorrect Participant Count - Consultant Dashboard **Problem:** Dashboard showed 10 participants for a class when only 1 user was enrolled (in a 10-session class).

**Cause:** getParticipantCounts() was summing total slots across all appointments instead of counting unique users.

**Fix:** Changed counting logic to use Set<string> for user ID deduplication.

**File:** app/api/dashboard/consultant/[consultantId]/planner/route.ts

**Expectation:** Participant count correctly shows unique enrolled users.