### PR TITLE
fix: eliminate internal API chaining in dashboard routes

### DIFF
--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -1,23 +1,63 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { TWebinar, TClass } from "@/types/appointment";
+import { Prisma } from "@prisma/client";
 import { transformNestedPlanTopics } from "@/lib/topics";
 
-// Type for webinar events in planner with type discriminator
-type WebinarEvent = TWebinar & {
-  type: "webinar";
-};
+// =============================================================================
+// Prisma Query Types - Derived from actual query shape for type safety
+// =============================================================================
 
-// Type for class events in planner with type discriminator
-type ClassEvent = TClass & {
-  type: "class";
-};
+const webinarInclude = {
+  webinarPlan: {
+    include: {
+      consultantProfile: true,
+      topics: true,
+    },
+  },
+  appointment: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+      },
+    },
+  },
+  waitlist: true,
+} satisfies Prisma.WebinarInclude;
+
+const classInclude = {
+  classPlan: {
+    include: {
+      consultantProfile: true,
+      topics: true,
+      classContents: {
+        orderBy: {
+          order: "asc" as const,
+        },
+      },
+    },
+  },
+  appointments: true,
+} satisfies Prisma.ClassInclude;
+
+// Derive types from the include objects
+type PlannerWebinar = Prisma.WebinarGetPayload<{ include: typeof webinarInclude }>;
+type PlannerClass = Prisma.ClassGetPayload<{ include: typeof classInclude }>;
+
+// Response types with discriminators
+type WebinarEvent = PlannerWebinar & { type: "webinar" };
+type ClassEvent = PlannerClass & { type: "class" };
 
 interface PlannerData {
   webinars: WebinarEvent[];
   classes: ClassEvent[];
   participantCounts: Record<string, number>;
 }
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
 
 /**
  * Helper function to fetch participant counts directly via Prisma
@@ -96,6 +136,10 @@ async function getParticipantCounts(
   return counts;
 }
 
+// =============================================================================
+// Route Handler
+// =============================================================================
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ consultantId: string }> },
@@ -122,24 +166,7 @@ export async function GET(
             consultantProfileId: consultantId,
           },
         },
-        include: {
-          webinarPlan: {
-            include: {
-              consultantProfile: true,
-              topics: true,
-            },
-          },
-          appointment: {
-            include: {
-              slotsOfAppointment: {
-                include: {
-                  user: true,
-                },
-              },
-            },
-          },
-          waitlist: true,
-        },
+        include: webinarInclude,
       }),
       prisma.class.findMany({
         where: {
@@ -147,20 +174,7 @@ export async function GET(
             consultantProfileId: consultantId,
           },
         },
-        include: {
-          classPlan: {
-            include: {
-              consultantProfile: true,
-              topics: true,
-              classContents: {
-                orderBy: {
-                  order: "asc",
-                },
-              },
-            },
-          },
-          appointments: true,
-        },
+        include: classInclude,
       }),
     ]);
 
@@ -172,23 +186,20 @@ export async function GET(
       transformNestedPlanTopics(c, "classPlan"),
     );
 
-    // Transform webinars to include type discriminator
-    // Cast to unknown first to avoid type mismatch with TWebinar (which expects more fields)
+    // Transform to include type discriminator
     const webinars: WebinarEvent[] = transformedWebinars.map((webinar) => ({
-      ...(webinar as unknown as TWebinar),
+      ...webinar,
       type: "webinar" as const,
     }));
 
-    // Transform classes to include type discriminator
-    // Cast to unknown first to avoid type mismatch with TClass (which expects more fields)
     const classes: ClassEvent[] = transformedClasses.map((classEvent) => ({
-      ...(classEvent as unknown as TClass),
+      ...classEvent,
       type: "class" as const,
     }));
 
     // FIX #142: Fetch participant counts using direct Prisma query (not internal API)
-    const webinarIds = webinars.map((w) => w.id).filter(Boolean) as string[];
-    const classIds = classes.map((c) => c.id).filter(Boolean) as string[];
+    const webinarIds = webinars.map((w) => w.id);
+    const classIds = classes.map((c) => c.id);
 
     const participantCounts = await getParticipantCounts(webinarIds, classIds);
 

--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { TWebinar, TClass } from "@/types/appointment";
+import { transformNestedPlanTopics } from "@/lib/topics";
 
 // Type for webinar events in planner with type discriminator
 type WebinarEvent = TWebinar & {
@@ -112,59 +113,78 @@ export async function GET(
       );
     }
 
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-
-    // Fetch webinars and classes in parallel
-    // TODO: Consider refactoring to direct Prisma calls in future
-    const [webinarsRes, classesRes] = await Promise.all([
-      fetch(
-        `${baseUrl}/api/events/webinars?consultantProfileId=${consultantId}`,
-      ),
-      fetch(
-        `${baseUrl}/api/events/classes?consultantProfileId=${consultantId}`,
-      ),
+    // PERFORMANCE FIX #364: Use direct Prisma queries instead of internal HTTP fetches
+    // This eliminates network overhead and reduces response time significantly
+    const [webinarsRaw, classesRaw] = await Promise.all([
+      prisma.webinar.findMany({
+        where: {
+          webinarPlan: {
+            consultantProfileId: consultantId,
+          },
+        },
+        include: {
+          webinarPlan: {
+            include: {
+              consultantProfile: true,
+              topics: true,
+            },
+          },
+          appointment: {
+            include: {
+              slotsOfAppointment: {
+                include: {
+                  user: true,
+                },
+              },
+            },
+          },
+          waitlist: true,
+        },
+      }),
+      prisma.class.findMany({
+        where: {
+          classPlan: {
+            consultantProfileId: consultantId,
+          },
+        },
+        include: {
+          classPlan: {
+            include: {
+              consultantProfile: true,
+              topics: true,
+              classContents: {
+                orderBy: {
+                  order: "asc",
+                },
+              },
+            },
+          },
+          appointments: true,
+        },
+      }),
     ]);
 
-    // Check for errors in responses
-    if (!webinarsRes.ok) {
-      console.error("Failed to fetch webinars:", webinarsRes.statusText);
-      return NextResponse.json(
-        { error: "Failed to fetch webinars" },
-        { status: webinarsRes.status },
-      );
-    }
-
-    if (!classesRes.ok) {
-      console.error("Failed to fetch classes:", classesRes.statusText);
-      return NextResponse.json(
-        { error: "Failed to fetch classes" },
-        { status: classesRes.status },
-      );
-    }
-
-    // Parse responses
-    const [webinarsData, classesData] = await Promise.all([
-      webinarsRes.json(),
-      classesRes.json(),
-    ]);
+    // Transform topics from objects to strings in nested plans (matching original API behavior)
+    const transformedWebinars = webinarsRaw.map((w) =>
+      transformNestedPlanTopics(w, "webinarPlan"),
+    );
+    const transformedClasses = classesRaw.map((c) =>
+      transformNestedPlanTopics(c, "classPlan"),
+    );
 
     // Transform webinars to include type discriminator
-    const webinars: WebinarEvent[] = (webinarsData.data || []).map(
-      (webinar: TWebinar) => ({
-        ...webinar,
-        type: "webinar" as const,
-      }),
-    );
+    // Cast to unknown first to avoid type mismatch with TWebinar (which expects more fields)
+    const webinars: WebinarEvent[] = transformedWebinars.map((webinar) => ({
+      ...(webinar as unknown as TWebinar),
+      type: "webinar" as const,
+    }));
 
     // Transform classes to include type discriminator
-    const classes: ClassEvent[] = (classesData.data || []).map(
-      (classEvent: TClass) => ({
-        ...classEvent,
-        type: "class" as const,
-      }),
-    );
+    // Cast to unknown first to avoid type mismatch with TClass (which expects more fields)
+    const classes: ClassEvent[] = transformedClasses.map((classEvent) => ({
+      ...(classEvent as unknown as TClass),
+      type: "class" as const,
+    }));
 
     // FIX #142: Fetch participant counts using direct Prisma query (not internal API)
     const webinarIds = webinars.map((w) => w.id).filter(Boolean) as string[];

--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -42,7 +42,9 @@ const classInclude = {
 } satisfies Prisma.ClassInclude;
 
 // Derive types from the include objects
-type PlannerWebinar = Prisma.WebinarGetPayload<{ include: typeof webinarInclude }>;
+type PlannerWebinar = Prisma.WebinarGetPayload<{
+  include: typeof webinarInclude;
+}>;
 type PlannerClass = Prisma.ClassGetPayload<{ include: typeof classInclude }>;
 
 // Response types with discriminators

--- a/app/api/dashboard/consultant/[consultantId]/requests/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/requests/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
 import {
   TAppointment,
   TConsultation,
@@ -54,8 +55,12 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ consultantId: string }> },
 ) {
+  // Note: request parameter kept for Next.js API route signature compatibility
+  void request;
+
   try {
     const { consultantId } = await params;
+    const consultantProfileId = consultantId;
 
     if (!consultantId) {
       return NextResponse.json(
@@ -64,81 +69,298 @@ export async function GET(
       );
     }
 
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-
-    // Fetch all requests data in parallel
+    // PERFORMANCE FIX #364: Use direct Prisma queries instead of internal HTTP fetches
+    // This eliminates network overhead and reduces response time significantly
     const [
-      consultationsRes,
-      subscriptionsRes,
-      weeklyAvailabilityRes,
-      customAvailabilityRes,
-      appointmentsRes,
-      consultantRes,
+      consultations,
+      subscriptions,
+      weeklyAvailability,
+      customAvailability,
+      appointmentsRaw,
+      consultant,
     ] = await Promise.all([
-      fetch(
-        `${baseUrl}/api/events/consultations?consultantProfileId=${consultantId}&status=PENDING`,
-      ),
-      fetch(
-        `${baseUrl}/api/events/subscriptions?consultantProfileId=${consultantId}&status=PENDING`,
-      ),
-      fetch(
-        `${baseUrl}/api/slots/availability/weekly?consultantProfileId=${consultantId}`,
-      ),
-      fetch(
-        `${baseUrl}/api/slots/availability/custom?consultantProfileId=${consultantId}`,
-      ),
-      fetch(
-        `${baseUrl}/api/slots/appointments?consultantProfileId=${consultantId}&consultationStatus=APPROVED&subscriptionStatus=APPROVED&webinarStatus=APPROVED&classStatus=APPROVED`,
-      ),
-      fetch(`${baseUrl}/api/user/consultants/${consultantId}`),
+      // Fetch pending consultations
+      prisma.consultation.findMany({
+        where: {
+          consultationPlan: {
+            consultantProfile: {
+              id: consultantProfileId,
+            },
+          },
+          requestStatus: "PENDING",
+        },
+        include: {
+          consultationPlan: {
+            include: {
+              consultantProfile: {
+                include: {
+                  user: true,
+                },
+              },
+            },
+          },
+          requestedBy: {
+            include: {
+              user: true,
+            },
+          },
+          appointment: {
+            include: {
+              slotsOfAppointment: {
+                include: {
+                  user: true,
+                },
+                orderBy: {
+                  startsAt: "asc",
+                },
+              },
+              payment: true,
+            },
+          },
+        },
+        orderBy: {
+          requestedAt: "desc",
+        },
+      }),
+      // Fetch pending subscriptions
+      prisma.subscription.findMany({
+        where: {
+          subscriptionPlan: {
+            consultantProfileId,
+          },
+          requestStatus: "PENDING",
+        },
+        include: {
+          subscriptionPlan: {
+            include: {
+              consultantProfile: {
+                include: {
+                  user: true,
+                  domain: true,
+                  subDomains: true,
+                  tags: true,
+                },
+              },
+            },
+          },
+          requestedBy: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  image: true,
+                },
+              },
+            },
+          },
+          appointments: {
+            include: {
+              slotsOfAppointment: {
+                include: {
+                  user: true,
+                },
+              },
+              payment: true,
+            },
+          },
+        },
+        orderBy: {
+          requestedAt: "desc",
+        },
+      }),
+      // Fetch weekly availability slots
+      prisma.slotOfAvailabilityWeekly.findMany({
+        where: {
+          consultantProfileId,
+        },
+        orderBy: [
+          { dayOfWeekForStartsAt: "asc" },
+          { availabilityStartsAt: "asc" },
+        ],
+        include: {
+          consultantProfile: {
+            select: {
+              id: true,
+              user: {
+                select: {
+                  name: true,
+                  email: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      // Fetch custom availability slots
+      prisma.slotOfAvailabilityCustom.findMany({
+        where: {
+          consultantProfileId,
+        },
+        orderBy: {
+          availabilityStartsAt: "asc",
+        },
+        include: {
+          consultantProfile: {
+            select: {
+              id: true,
+              user: {
+                select: {
+                  name: true,
+                  email: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      // Fetch approved appointments for consultations, subscriptions, webinars, and classes
+      prisma.appointment.findMany({
+        where: {
+          OR: [
+            {
+              consultation: {
+                consultationPlan: { consultantProfileId },
+                requestStatus: "APPROVED",
+              },
+            },
+            {
+              subscription: {
+                subscriptionPlan: { consultantProfileId },
+                requestStatus: "APPROVED",
+              },
+            },
+            {
+              webinar: {
+                webinarPlan: { consultantProfileId },
+                status: "SCHEDULED",
+              },
+            },
+            {
+              class: {
+                classPlan: { consultantProfileId },
+                status: "SCHEDULED",
+              },
+            },
+          ],
+        },
+        include: {
+          slotsOfAppointment: {
+            include: {
+              user: true,
+            },
+          },
+          consultation: {
+            include: {
+              consultationPlan: {
+                include: {
+                  consultantProfile: {
+                    include: {
+                      user: true,
+                    },
+                  },
+                },
+              },
+              requestedBy: {
+                include: {
+                  user: true,
+                },
+              },
+            },
+          },
+          subscription: {
+            select: {
+              id: true,
+              subscriptionPlan: {
+                include: {
+                  consultantProfile: {
+                    include: {
+                      user: true,
+                    },
+                  },
+                },
+              },
+              requestedBy: {
+                include: {
+                  user: true,
+                },
+              },
+              schedulingPeriodStartsAt: true,
+              schedulingPeriodEndsAt: true,
+              requestStatus: true,
+            },
+          },
+          webinar: {
+            include: {
+              webinarPlan: {
+                include: {
+                  consultantProfile: {
+                    include: {
+                      user: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+          class: {
+            include: {
+              classPlan: {
+                include: {
+                  consultantProfile: {
+                    include: {
+                      user: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+      // Fetch consultant profile
+      prisma.consultantProfile.findUnique({
+        where: { id: consultantId },
+        include: {
+          user: true,
+          domain: true,
+          subDomains: true,
+          tags: true,
+          slotsOfAvailabilityWeekly: true,
+          slotsOfAvailabilityCustom: true,
+          consultationPlans: true,
+          subscriptionPlans: true,
+          webinarPlans: true,
+          classPlans: true,
+          workExperiences: true,
+          certifications: true,
+          education: true,
+        },
+      }),
     ]);
 
-    // Check for errors in any of the responses
-    const responses = [
-      { name: "consultations", response: consultationsRes },
-      { name: "subscriptions", response: subscriptionsRes },
-      { name: "weeklyAvailability", response: weeklyAvailabilityRes },
-      { name: "customAvailability", response: customAvailabilityRes },
-      { name: "appointments", response: appointmentsRes },
-      { name: "consultant", response: consultantRes },
-    ];
+    // Sort appointments by slot start time (matching original API behavior)
+    const sortedAppointments = appointmentsRaw.sort((a, b) => {
+      const aTime = a.slotsOfAppointment?.[0]?.startsAt;
+      const bTime = b.slotsOfAppointment?.[0]?.startsAt;
 
-    for (const { name, response } of responses) {
-      if (!response.ok) {
-        console.error(`Failed to fetch ${name}:`, response.statusText);
-        return NextResponse.json(
-          { error: `Failed to fetch ${name} data` },
-          { status: response.status },
-        );
-      }
-    }
+      if (!aTime && !bTime) return 0;
+      if (!aTime) return 1;
+      if (!bTime) return -1;
 
-    // Parse all responses with proper typing
-    const [
-      consultationsData,
-      subscriptionsData,
-      weeklyAvailabilityData,
-      customAvailabilityData,
-      appointmentsData,
-      consultantData,
-    ] = await Promise.all([
-      consultationsRes.json() as Promise<{ data: TConsultation[] }>,
-      subscriptionsRes.json() as Promise<{ data: TSubscription[] }>,
-      weeklyAvailabilityRes.json() as Promise<{ data: TWeeklyAvailability[] }>,
-      customAvailabilityRes.json() as Promise<{ data: TCustomAvailability[] }>,
-      appointmentsRes.json() as Promise<{ data: TAppointment[] }>,
-      consultantRes.json() as Promise<{ data: TConsultantProfile }>,
-    ]);
+      return new Date(aTime).getTime() - new Date(bTime).getTime();
+    });
 
     const requestsData: RequestsData = {
-      consultations: consultationsData.data || [],
-      subscriptions: subscriptionsData.data || [],
-      weeklyAvailability: weeklyAvailabilityData.data || [],
-      customAvailability: customAvailabilityData.data || [],
-      appointments: appointmentsData.data || [],
-      consultant: consultantData.data || null,
+      consultations: (consultations || []) as unknown as TConsultation[],
+      subscriptions: (subscriptions || []) as unknown as TSubscription[],
+      weeklyAvailability: (weeklyAvailability ||
+        []) as unknown as TWeeklyAvailability[],
+      customAvailability: (customAvailability ||
+        []) as unknown as TCustomAvailability[],
+      appointments: (sortedAppointments || []) as unknown as TAppointment[],
+      consultant: (consultant || null) as unknown as TConsultantProfile | null,
     };
 
     return NextResponse.json({

--- a/app/api/dashboard/consultant/[consultantId]/requests/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/requests/route.ts
@@ -1,55 +1,229 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import {
-  TAppointment,
-  TConsultation,
-  TSubscription,
-} from "@/types/appointment";
-import { TConsultantProfile } from "@/types/consultant";
 import { Prisma } from "@prisma/client";
 
-// Type for weekly availability slots
-type TWeeklyAvailability = Prisma.SlotOfAvailabilityWeeklyGetPayload<{
-  include: {
-    consultantProfile: {
-      select: {
-        id: true;
-        user: {
-          select: {
-            name: true;
-            email: true;
-          };
-        };
-      };
-    };
-  };
+// =============================================================================
+// Prisma Query Types - Derived from actual query shape for type safety
+// =============================================================================
+
+const consultationInclude = {
+  consultationPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: true,
+        },
+      },
+    },
+  },
+  requestedBy: {
+    include: {
+      user: true,
+    },
+  },
+  appointment: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+        orderBy: {
+          startsAt: "asc" as const,
+        },
+      },
+      payment: true,
+    },
+  },
+} satisfies Prisma.ConsultationInclude;
+
+const subscriptionInclude = {
+  subscriptionPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: true,
+          domain: true,
+          subDomains: true,
+          tags: true,
+        },
+      },
+    },
+  },
+  requestedBy: {
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+  },
+  appointments: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+      },
+      payment: true,
+    },
+  },
+} satisfies Prisma.SubscriptionInclude;
+
+const weeklyAvailabilityInclude = {
+  consultantProfile: {
+    select: {
+      id: true,
+      user: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.SlotOfAvailabilityWeeklyInclude;
+
+const customAvailabilityInclude = {
+  consultantProfile: {
+    select: {
+      id: true,
+      user: {
+        select: {
+          name: true,
+          email: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.SlotOfAvailabilityCustomInclude;
+
+const appointmentInclude = {
+  slotsOfAppointment: {
+    include: {
+      user: true,
+    },
+  },
+  consultation: {
+    include: {
+      consultationPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+      requestedBy: {
+        include: {
+          user: true,
+        },
+      },
+    },
+  },
+  subscription: {
+    select: {
+      id: true,
+      subscriptionPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+      requestedBy: {
+        include: {
+          user: true,
+        },
+      },
+      schedulingPeriodStartsAt: true,
+      schedulingPeriodEndsAt: true,
+      requestStatus: true,
+    },
+  },
+  webinar: {
+    include: {
+      webinarPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  class: {
+    include: {
+      classPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.AppointmentInclude;
+
+const consultantInclude = {
+  user: true,
+  domain: true,
+  subDomains: true,
+  tags: true,
+  slotsOfAvailabilityWeekly: true,
+  slotsOfAvailabilityCustom: true,
+  consultationPlans: true,
+  subscriptionPlans: true,
+  webinarPlans: true,
+  classPlans: true,
+  workExperiences: true,
+  certifications: true,
+  education: true,
+} satisfies Prisma.ConsultantProfileInclude;
+
+// Derive types from the include objects
+type RequestsConsultation = Prisma.ConsultationGetPayload<{
+  include: typeof consultationInclude;
+}>;
+type RequestsSubscription = Prisma.SubscriptionGetPayload<{
+  include: typeof subscriptionInclude;
+}>;
+type RequestsWeeklyAvailability = Prisma.SlotOfAvailabilityWeeklyGetPayload<{
+  include: typeof weeklyAvailabilityInclude;
+}>;
+type RequestsCustomAvailability = Prisma.SlotOfAvailabilityCustomGetPayload<{
+  include: typeof customAvailabilityInclude;
+}>;
+type RequestsAppointment = Prisma.AppointmentGetPayload<{
+  include: typeof appointmentInclude;
+}>;
+type RequestsConsultant = Prisma.ConsultantProfileGetPayload<{
+  include: typeof consultantInclude;
 }>;
 
-// Type for custom availability slots
-type TCustomAvailability = Prisma.SlotOfAvailabilityCustomGetPayload<{
-  include: {
-    consultantProfile: {
-      select: {
-        id: true;
-        user: {
-          select: {
-            name: true;
-            email: true;
-          };
-        };
-      };
-    };
-  };
-}>;
-
+// Response data interface
 interface RequestsData {
-  consultations: TConsultation[];
-  subscriptions: TSubscription[];
-  weeklyAvailability: TWeeklyAvailability[];
-  customAvailability: TCustomAvailability[];
-  appointments: TAppointment[];
-  consultant: TConsultantProfile | null;
+  consultations: RequestsConsultation[];
+  subscriptions: RequestsSubscription[];
+  weeklyAvailability: RequestsWeeklyAvailability[];
+  customAvailability: RequestsCustomAvailability[];
+  appointments: RequestsAppointment[];
+  consultant: RequestsConsultant | null;
 }
+
+// =============================================================================
+// Route Handler
+// =============================================================================
 
 export async function GET(
   request: Request,
@@ -89,35 +263,7 @@ export async function GET(
           },
           requestStatus: "PENDING",
         },
-        include: {
-          consultationPlan: {
-            include: {
-              consultantProfile: {
-                include: {
-                  user: true,
-                },
-              },
-            },
-          },
-          requestedBy: {
-            include: {
-              user: true,
-            },
-          },
-          appointment: {
-            include: {
-              slotsOfAppointment: {
-                include: {
-                  user: true,
-                },
-                orderBy: {
-                  startsAt: "asc",
-                },
-              },
-              payment: true,
-            },
-          },
-        },
+        include: consultationInclude,
         orderBy: {
           requestedAt: "desc",
         },
@@ -130,42 +276,7 @@ export async function GET(
           },
           requestStatus: "PENDING",
         },
-        include: {
-          subscriptionPlan: {
-            include: {
-              consultantProfile: {
-                include: {
-                  user: true,
-                  domain: true,
-                  subDomains: true,
-                  tags: true,
-                },
-              },
-            },
-          },
-          requestedBy: {
-            include: {
-              user: {
-                select: {
-                  id: true,
-                  name: true,
-                  email: true,
-                  image: true,
-                },
-              },
-            },
-          },
-          appointments: {
-            include: {
-              slotsOfAppointment: {
-                include: {
-                  user: true,
-                },
-              },
-              payment: true,
-            },
-          },
-        },
+        include: subscriptionInclude,
         orderBy: {
           requestedAt: "desc",
         },
@@ -179,19 +290,7 @@ export async function GET(
           { dayOfWeekForStartsAt: "asc" },
           { availabilityStartsAt: "asc" },
         ],
-        include: {
-          consultantProfile: {
-            select: {
-              id: true,
-              user: {
-                select: {
-                  name: true,
-                  email: true,
-                },
-              },
-            },
-          },
-        },
+        include: weeklyAvailabilityInclude,
       }),
       // Fetch custom availability slots
       prisma.slotOfAvailabilityCustom.findMany({
@@ -201,19 +300,7 @@ export async function GET(
         orderBy: {
           availabilityStartsAt: "asc",
         },
-        include: {
-          consultantProfile: {
-            select: {
-              id: true,
-              user: {
-                select: {
-                  name: true,
-                  email: true,
-                },
-              },
-            },
-          },
-        },
+        include: customAvailabilityInclude,
       }),
       // Fetch approved appointments for consultations, subscriptions, webinars, and classes
       prisma.appointment.findMany({
@@ -245,98 +332,12 @@ export async function GET(
             },
           ],
         },
-        include: {
-          slotsOfAppointment: {
-            include: {
-              user: true,
-            },
-          },
-          consultation: {
-            include: {
-              consultationPlan: {
-                include: {
-                  consultantProfile: {
-                    include: {
-                      user: true,
-                    },
-                  },
-                },
-              },
-              requestedBy: {
-                include: {
-                  user: true,
-                },
-              },
-            },
-          },
-          subscription: {
-            select: {
-              id: true,
-              subscriptionPlan: {
-                include: {
-                  consultantProfile: {
-                    include: {
-                      user: true,
-                    },
-                  },
-                },
-              },
-              requestedBy: {
-                include: {
-                  user: true,
-                },
-              },
-              schedulingPeriodStartsAt: true,
-              schedulingPeriodEndsAt: true,
-              requestStatus: true,
-            },
-          },
-          webinar: {
-            include: {
-              webinarPlan: {
-                include: {
-                  consultantProfile: {
-                    include: {
-                      user: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
-          class: {
-            include: {
-              classPlan: {
-                include: {
-                  consultantProfile: {
-                    include: {
-                      user: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
+        include: appointmentInclude,
       }),
       // Fetch consultant profile
       prisma.consultantProfile.findUnique({
         where: { id: consultantId },
-        include: {
-          user: true,
-          domain: true,
-          subDomains: true,
-          tags: true,
-          slotsOfAvailabilityWeekly: true,
-          slotsOfAvailabilityCustom: true,
-          consultationPlans: true,
-          subscriptionPlans: true,
-          webinarPlans: true,
-          classPlans: true,
-          workExperiences: true,
-          certifications: true,
-          education: true,
-        },
+        include: consultantInclude,
       }),
     ]);
 
@@ -353,14 +354,12 @@ export async function GET(
     });
 
     const requestsData: RequestsData = {
-      consultations: (consultations || []) as unknown as TConsultation[],
-      subscriptions: (subscriptions || []) as unknown as TSubscription[],
-      weeklyAvailability: (weeklyAvailability ||
-        []) as unknown as TWeeklyAvailability[],
-      customAvailability: (customAvailability ||
-        []) as unknown as TCustomAvailability[],
-      appointments: (sortedAppointments || []) as unknown as TAppointment[],
-      consultant: (consultant || null) as unknown as TConsultantProfile | null,
+      consultations: consultations || [],
+      subscriptions: subscriptions || [],
+      weeklyAvailability: weeklyAvailability || [],
+      customAvailability: customAvailability || [],
+      appointments: sortedAppointments || [],
+      consultant: consultant || null,
     };
 
     return NextResponse.json({

--- a/app/api/dashboard/consultant/[consultantId]/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/route.ts
@@ -1,10 +1,188 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import {
-  TAppointment,
-  TConsultation,
-  TSubscription,
-} from "@/types/appointment";
+import { Prisma } from "@prisma/client";
+
+// =============================================================================
+// Prisma Query Types - Derived from actual query shape for type safety
+// =============================================================================
+
+const appointmentInclude = {
+  slotsOfAppointment: {
+    include: {
+      user: true,
+    },
+  },
+  consultation: {
+    include: {
+      consultationPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+      requestedBy: {
+        include: {
+          user: true,
+        },
+      },
+    },
+  },
+  subscription: {
+    select: {
+      id: true,
+      subscriptionPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+      requestedBy: {
+        include: {
+          user: true,
+        },
+      },
+      schedulingPeriodStartsAt: true,
+      schedulingPeriodEndsAt: true,
+      requestStatus: true,
+    },
+  },
+  webinar: {
+    include: {
+      webinarPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  class: {
+    include: {
+      classPlan: {
+        include: {
+          consultantProfile: {
+            include: {
+              user: true,
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.AppointmentInclude;
+
+const consultationInclude = {
+  consultationPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: true,
+        },
+      },
+    },
+  },
+  requestedBy: {
+    include: {
+      user: true,
+    },
+  },
+  appointment: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+        orderBy: {
+          startsAt: "asc" as const,
+        },
+      },
+      payment: true,
+    },
+  },
+} satisfies Prisma.ConsultationInclude;
+
+const subscriptionInclude = {
+  subscriptionPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: true,
+          domain: true,
+          subDomains: true,
+          tags: true,
+        },
+      },
+    },
+  },
+  requestedBy: {
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+  },
+  appointments: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+      },
+      payment: true,
+    },
+  },
+} satisfies Prisma.SubscriptionInclude;
+
+// Derive types from the include objects
+type DashboardAppointment = Prisma.AppointmentGetPayload<{ include: typeof appointmentInclude }>;
+type DashboardConsultation = Prisma.ConsultationGetPayload<{ include: typeof consultationInclude }>;
+type DashboardSubscription = Prisma.SubscriptionGetPayload<{ include: typeof subscriptionInclude }>;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function formatDate(dateString?: string | Date | null): string {
+  if (!dateString) return "Date not set";
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return "Invalid date";
+
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(dateString?: string | Date | null): string {
+  if (!dateString) return "Time not set";
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return "Invalid time";
+
+  return date.toLocaleString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+// =============================================================================
+// Route Handler
+// =============================================================================
 
 export async function GET(
   request: NextRequest,
@@ -58,79 +236,7 @@ export async function GET(
               },
             ],
           },
-          include: {
-            slotsOfAppointment: {
-              include: {
-                user: true,
-              },
-            },
-            consultation: {
-              include: {
-                consultationPlan: {
-                  include: {
-                    consultantProfile: {
-                      include: {
-                        user: true,
-                      },
-                    },
-                  },
-                },
-                requestedBy: {
-                  include: {
-                    user: true,
-                  },
-                },
-              },
-            },
-            subscription: {
-              select: {
-                id: true,
-                subscriptionPlan: {
-                  include: {
-                    consultantProfile: {
-                      include: {
-                        user: true,
-                      },
-                    },
-                  },
-                },
-                requestedBy: {
-                  include: {
-                    user: true,
-                  },
-                },
-                schedulingPeriodStartsAt: true,
-                schedulingPeriodEndsAt: true,
-                requestStatus: true,
-              },
-            },
-            webinar: {
-              include: {
-                webinarPlan: {
-                  include: {
-                    consultantProfile: {
-                      include: {
-                        user: true,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            class: {
-              include: {
-                classPlan: {
-                  include: {
-                    consultantProfile: {
-                      include: {
-                        user: true,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
+          include: appointmentInclude,
         }),
         // Fetch pending consultations
         prisma.consultation.findMany({
@@ -142,35 +248,7 @@ export async function GET(
             },
             requestStatus: "PENDING",
           },
-          include: {
-            consultationPlan: {
-              include: {
-                consultantProfile: {
-                  include: {
-                    user: true,
-                  },
-                },
-              },
-            },
-            requestedBy: {
-              include: {
-                user: true,
-              },
-            },
-            appointment: {
-              include: {
-                slotsOfAppointment: {
-                  include: {
-                    user: true,
-                  },
-                  orderBy: {
-                    startsAt: "asc",
-                  },
-                },
-                payment: true,
-              },
-            },
-          },
+          include: consultationInclude,
           orderBy: {
             requestedAt: "desc",
           },
@@ -183,42 +261,7 @@ export async function GET(
             },
             requestStatus: "PENDING",
           },
-          include: {
-            subscriptionPlan: {
-              include: {
-                consultantProfile: {
-                  include: {
-                    user: true,
-                    domain: true,
-                    subDomains: true,
-                    tags: true,
-                  },
-                },
-              },
-            },
-            requestedBy: {
-              include: {
-                user: {
-                  select: {
-                    id: true,
-                    name: true,
-                    email: true,
-                    image: true,
-                  },
-                },
-              },
-            },
-            appointments: {
-              include: {
-                slotsOfAppointment: {
-                  include: {
-                    user: true,
-                  },
-                },
-                payment: true,
-              },
-            },
-          },
+          include: subscriptionInclude,
           orderBy: {
             requestedAt: "desc",
           },
@@ -237,112 +280,111 @@ export async function GET(
       return new Date(aTime).getTime() - new Date(bTime).getTime();
     });
 
-    // Cast to match expected types
-    const appointmentsData = sortedAppointments as unknown as TAppointment[];
-    const consultationsData = pendingConsultations as unknown as TConsultation[];
-    const subscriptionsData = pendingSubscriptions as unknown as TSubscription[];
-
     // Transform appointments (same logic as fetchHelpers.ts)
-    const transformedAppointments = appointmentsData.map((appointment) => ({
-      id: appointment.id,
-      appointmentType: appointment.appointmentType,
-      slotsOfAppointment: appointment.slotsOfAppointment.map((slot) => ({
-        id: slot.id,
-        slotStartTimeInUTC: new Date(slot.startsAt),
-        slotEndTimeInUTC: slot.endsAt ? new Date(slot.endsAt) : null,
-        isTentative: slot.isTentative,
-        user: Array.isArray(slot.user)
-          ? slot.user.map((u) => ({
-              id: u.id,
-              name: u.name,
-              email: u.email,
-              image: u.image,
-              phone: u.phone || null,
-              address: u.address || null,
-              password: u.password || null,
-              passwordResetToken: u.passwordResetToken || null,
-              passwordResetExpires: u.passwordResetExpires || null,
-              onlineStatus: u.onlineStatus,
-              currentTimezone: u.timezone || null,
-              onboardingCompleted: u.onboardingCompleted,
-              role: u.role,
-              consultantProfileId: u.consultantProfileId,
-              consulteeProfileId: u.consulteeProfileId,
-              staffProfileId: u.staffProfileId,
-            }))
-          : [],
-      })),
-      consultation: appointment.consultation
-        ? {
-            id: appointment.consultation.id,
-            consultationPlan: {
-              ...appointment.consultation.consultationPlan,
-              consultantProfile: appointment.consultation.consultationPlan
-                .consultantProfile as any,
-            },
-            requestStatus: appointment.consultation.requestStatus,
-            requestedBy: {
-              id: appointment.consultation.requestedBy?.id ?? "",
-              user: {
-                name: appointment.consultation.requestedBy?.user?.name ?? null,
-                image:
-                  appointment.consultation.requestedBy?.user?.image ?? null,
+    const transformedAppointments = sortedAppointments.map(
+      (appointment: DashboardAppointment) => ({
+        id: appointment.id,
+        appointmentType: appointment.appointmentType,
+        slotsOfAppointment: appointment.slotsOfAppointment.map((slot) => ({
+          id: slot.id,
+          slotStartTimeInUTC: new Date(slot.startsAt),
+          slotEndTimeInUTC: slot.endsAt ? new Date(slot.endsAt) : null,
+          isTentative: slot.isTentative,
+          user: Array.isArray(slot.user)
+            ? slot.user.map((u) => ({
+                id: u.id,
+                name: u.name,
+                email: u.email,
+                image: u.image,
+                phone: u.phone || null,
+                address: u.address || null,
+                password: u.password || null,
+                passwordResetToken: u.passwordResetToken || null,
+                passwordResetExpires: u.passwordResetExpires || null,
+                onlineStatus: u.onlineStatus,
+                currentTimezone: u.timezone || null,
+                onboardingCompleted: u.onboardingCompleted,
+                role: u.role,
+                consultantProfileId: u.consultantProfileId,
+                consulteeProfileId: u.consulteeProfileId,
+                staffProfileId: u.staffProfileId,
+              }))
+            : [],
+        })),
+        consultation: appointment.consultation
+          ? {
+              id: appointment.consultation.id,
+              consultationPlan: {
+                ...appointment.consultation.consultationPlan,
+                consultantProfile:
+                  appointment.consultation.consultationPlan.consultantProfile,
               },
-            },
-          }
-        : undefined,
-      subscription: appointment.subscription
-        ? {
-            id: appointment.subscription.id,
-            subscriptionPlan: {
-              ...appointment.subscription.subscriptionPlan,
-              consultantProfile: appointment.subscription.subscriptionPlan
-                .consultantProfile as any,
-            },
-            requestStatus: appointment.subscription.requestStatus,
-            requestedBy: {
-              id: appointment.subscription.requestedBy?.id ?? "",
-              user: {
-                name: appointment.subscription.requestedBy?.user?.name ?? null,
-                image:
-                  appointment.subscription.requestedBy?.user?.image ?? null,
+              requestStatus: appointment.consultation.requestStatus,
+              requestedBy: {
+                id: appointment.consultation.requestedBy?.id ?? "",
+                user: {
+                  name:
+                    appointment.consultation.requestedBy?.user?.name ?? null,
+                  image:
+                    appointment.consultation.requestedBy?.user?.image ?? null,
+                },
               },
-            },
-            startDate: new Date(
-              appointment.subscription.schedulingPeriodStartsAt,
-            ).toISOString(),
-            endDate: new Date(
-              appointment.subscription.schedulingPeriodEndsAt,
-            ).toISOString(),
-          }
-        : undefined,
-      webinar: appointment.webinar
-        ? {
-            id: appointment.webinar.id,
-            webinarPlan: {
-              ...appointment.webinar.webinarPlan,
-              consultantProfile: appointment.webinar.webinarPlan
-                .consultantProfile as any,
-            },
-            status: appointment.webinar.status,
-          }
-        : undefined,
-      class: appointment.class
-        ? {
-            id: appointment.class.id,
-            classPlan: {
-              ...appointment.class.classPlan,
-              consultantProfile: appointment.class.classPlan
-                .consultantProfile as any,
-            },
-            status: appointment.class.status,
-          }
-        : undefined,
-    }));
+            }
+          : undefined,
+        subscription: appointment.subscription
+          ? {
+              id: appointment.subscription.id,
+              subscriptionPlan: {
+                ...appointment.subscription.subscriptionPlan,
+                consultantProfile:
+                  appointment.subscription.subscriptionPlan.consultantProfile,
+              },
+              requestStatus: appointment.subscription.requestStatus,
+              requestedBy: {
+                id: appointment.subscription.requestedBy?.id ?? "",
+                user: {
+                  name:
+                    appointment.subscription.requestedBy?.user?.name ?? null,
+                  image:
+                    appointment.subscription.requestedBy?.user?.image ?? null,
+                },
+              },
+              startDate: new Date(
+                appointment.subscription.schedulingPeriodStartsAt,
+              ).toISOString(),
+              endDate: new Date(
+                appointment.subscription.schedulingPeriodEndsAt,
+              ).toISOString(),
+            }
+          : undefined,
+        webinar: appointment.webinar
+          ? {
+              id: appointment.webinar.id,
+              webinarPlan: {
+                ...appointment.webinar.webinarPlan,
+                consultantProfile:
+                  appointment.webinar.webinarPlan.consultantProfile,
+              },
+              status: appointment.webinar.status,
+            }
+          : undefined,
+        class: appointment.class
+          ? {
+              id: appointment.class.id,
+              classPlan: {
+                ...appointment.class.classPlan,
+                consultantProfile:
+                  appointment.class.classPlan.consultantProfile,
+              },
+              status: appointment.class.status,
+            }
+          : undefined,
+      }),
+    );
 
     // Transform approvals (same logic as fetchHelpers.ts)
-    const consultationApprovals = consultationsData.map(
-      (consultation: TConsultation) => ({
+    const consultationApprovals = pendingConsultations.map(
+      (consultation: DashboardConsultation) => ({
         id: consultation.id,
         type: "Consultation",
         name: consultation.requestedBy?.user?.name ?? "Unknown",
@@ -350,8 +392,8 @@ export async function GET(
       }),
     );
 
-    const subscriptionApprovals = subscriptionsData.map(
-      (subscription: TSubscription) => ({
+    const subscriptionApprovals = pendingSubscriptions.map(
+      (subscription: DashboardSubscription) => ({
         id: subscription.id,
         type: "Subscription",
         name: subscription.requestedBy?.user?.name ?? "Unknown",
@@ -378,7 +420,7 @@ export async function GET(
     }));
 
     // Activities are empty for now (as in original)
-    const activities: any[] = [];
+    const activities: unknown[] = [];
 
     // Return consolidated response
     return NextResponse.json({
@@ -400,28 +442,4 @@ export async function GET(
       { status: 500 },
     );
   }
-}
-
-function formatDate(dateString?: string | Date | null): string {
-  if (!dateString) return "Date not set";
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) return "Invalid date";
-
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function formatTime(dateString?: string | Date | null): string {
-  if (!dateString) return "Time not set";
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) return "Invalid time";
-
-  return date.toLocaleString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
 }

--- a/app/api/dashboard/consultant/[consultantId]/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/route.ts
@@ -1,172 +1,347 @@
 import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
 import {
   TAppointment,
   TConsultation,
   TSubscription,
 } from "@/types/appointment";
-import { ApiResponse } from "@/app/dashboard/consultant/[consultantId]/types";
-
-// Helper to get the base URL, preferring VERCEL_URL if available
-const getBaseUrl = () => {
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-};
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ consultantId: string }> },
 ) {
+  // Note: request parameter kept for Next.js API route signature compatibility
+  void request;
+
   try {
     const resolvedParams = await params;
-    const { consultantId } = resolvedParams;
-    const baseUrl = getBaseUrl();
+    const { consultantId: consultantProfileId } = resolvedParams;
 
-    // Fetch all dashboard data in parallel
-    const [appointmentsRes, consultationsRes, subscriptionsRes] =
+    if (!consultantProfileId) {
+      return NextResponse.json(
+        { error: "Consultant ID is required" },
+        { status: 400 },
+      );
+    }
+
+    // PERFORMANCE FIX #364: Use direct Prisma queries instead of internal HTTP fetches
+    // This eliminates network overhead and reduces response time significantly
+    const [appointmentsRaw, pendingConsultations, pendingSubscriptions] =
       await Promise.all([
-        fetch(
-          `${baseUrl}/api/slots/appointments?consultantProfileId=${consultantId}&consultationStatus=APPROVED&subscriptionStatus=APPROVED&webinarStatus=APPROVED&classStatus=APPROVED`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
-        fetch(
-          `${baseUrl}/api/events/consultations?consultantProfileId=${consultantId}&status=PENDING`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
-        fetch(
-          `${baseUrl}/api/events/subscriptions?consultantProfileId=${consultantId}&status=PENDING`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
+        // Fetch approved appointments for consultations, subscriptions, webinars, and classes
+        prisma.appointment.findMany({
+          where: {
+            OR: [
+              {
+                consultation: {
+                  consultationPlan: { consultantProfileId },
+                  requestStatus: "APPROVED",
+                },
+              },
+              {
+                subscription: {
+                  subscriptionPlan: { consultantProfileId },
+                  requestStatus: "APPROVED",
+                },
+              },
+              {
+                webinar: {
+                  webinarPlan: { consultantProfileId },
+                  status: "SCHEDULED",
+                },
+              },
+              {
+                class: {
+                  classPlan: { consultantProfileId },
+                  status: "SCHEDULED",
+                },
+              },
+            ],
+          },
+          include: {
+            slotsOfAppointment: {
+              include: {
+                user: true,
+              },
+            },
+            consultation: {
+              include: {
+                consultationPlan: {
+                  include: {
+                    consultantProfile: {
+                      include: {
+                        user: true,
+                      },
+                    },
+                  },
+                },
+                requestedBy: {
+                  include: {
+                    user: true,
+                  },
+                },
+              },
+            },
+            subscription: {
+              select: {
+                id: true,
+                subscriptionPlan: {
+                  include: {
+                    consultantProfile: {
+                      include: {
+                        user: true,
+                      },
+                    },
+                  },
+                },
+                requestedBy: {
+                  include: {
+                    user: true,
+                  },
+                },
+                schedulingPeriodStartsAt: true,
+                schedulingPeriodEndsAt: true,
+                requestStatus: true,
+              },
+            },
+            webinar: {
+              include: {
+                webinarPlan: {
+                  include: {
+                    consultantProfile: {
+                      include: {
+                        user: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            class: {
+              include: {
+                classPlan: {
+                  include: {
+                    consultantProfile: {
+                      include: {
+                        user: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+        // Fetch pending consultations
+        prisma.consultation.findMany({
+          where: {
+            consultationPlan: {
+              consultantProfile: {
+                id: consultantProfileId,
+              },
+            },
+            requestStatus: "PENDING",
+          },
+          include: {
+            consultationPlan: {
+              include: {
+                consultantProfile: {
+                  include: {
+                    user: true,
+                  },
+                },
+              },
+            },
+            requestedBy: {
+              include: {
+                user: true,
+              },
+            },
+            appointment: {
+              include: {
+                slotsOfAppointment: {
+                  include: {
+                    user: true,
+                  },
+                  orderBy: {
+                    startsAt: "asc",
+                  },
+                },
+                payment: true,
+              },
+            },
+          },
+          orderBy: {
+            requestedAt: "desc",
+          },
+        }),
+        // Fetch pending subscriptions
+        prisma.subscription.findMany({
+          where: {
+            subscriptionPlan: {
+              consultantProfileId,
+            },
+            requestStatus: "PENDING",
+          },
+          include: {
+            subscriptionPlan: {
+              include: {
+                consultantProfile: {
+                  include: {
+                    user: true,
+                    domain: true,
+                    subDomains: true,
+                    tags: true,
+                  },
+                },
+              },
+            },
+            requestedBy: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                    image: true,
+                  },
+                },
+              },
+            },
+            appointments: {
+              include: {
+                slotsOfAppointment: {
+                  include: {
+                    user: true,
+                  },
+                },
+                payment: true,
+              },
+            },
+          },
+          orderBy: {
+            requestedAt: "desc",
+          },
+        }),
       ]);
 
-    // Check for errors
-    if (!appointmentsRes.ok) {
-      throw new Error(
-        `Failed to fetch appointments: ${appointmentsRes.statusText}`,
-      );
-    }
-    if (!consultationsRes.ok) {
-      throw new Error(
-        `Failed to fetch consultations: ${consultationsRes.statusText}`,
-      );
-    }
-    if (!subscriptionsRes.ok) {
-      throw new Error(
-        `Failed to fetch subscriptions: ${subscriptionsRes.statusText}`,
-      );
-    }
+    // Sort appointments by slot start time (matching original API behavior)
+    const sortedAppointments = appointmentsRaw.sort((a, b) => {
+      const aTime = a.slotsOfAppointment?.[0]?.startsAt;
+      const bTime = b.slotsOfAppointment?.[0]?.startsAt;
 
-    // Parse responses
-    const appointmentsData: ApiResponse<TAppointment[]> =
-      await appointmentsRes.json();
-    const consultationsData: ApiResponse<TConsultation[]> =
-      await consultationsRes.json();
-    const subscriptionsData: ApiResponse<TSubscription[]> =
-      await subscriptionsRes.json();
+      if (!aTime && !bTime) return 0;
+      if (!aTime) return 1;
+      if (!bTime) return -1;
+
+      return new Date(aTime).getTime() - new Date(bTime).getTime();
+    });
+
+    // Cast to match expected types
+    const appointmentsData = sortedAppointments as unknown as TAppointment[];
+    const consultationsData = pendingConsultations as unknown as TConsultation[];
+    const subscriptionsData = pendingSubscriptions as unknown as TSubscription[];
 
     // Transform appointments (same logic as fetchHelpers.ts)
-    const transformedAppointments = appointmentsData.data.map(
-      (appointment) => ({
-        id: appointment.id,
-        appointmentType: appointment.appointmentType,
-        slotsOfAppointment: appointment.slotsOfAppointment.map((slot) => ({
-          id: slot.id,
-          slotStartTimeInUTC: new Date(slot.startsAt),
-          slotEndTimeInUTC: slot.endsAt ? new Date(slot.endsAt) : null,
-          isTentative: slot.isTentative,
-          user: Array.isArray(slot.user)
-            ? slot.user.map((u) => ({
-                id: u.id,
-                name: u.name,
-                email: u.email,
-                image: u.image,
-                phone: u.phone || null,
-                address: u.address || null,
-                password: u.password || null,
-                passwordResetToken: u.passwordResetToken || null,
-                passwordResetExpires: u.passwordResetExpires || null,
-                onlineStatus: u.onlineStatus,
-                currentTimezone: u.timezone || null,
-                onboardingCompleted: u.onboardingCompleted,
-                role: u.role,
-                consultantProfileId: u.consultantProfileId,
-                consulteeProfileId: u.consulteeProfileId,
-                staffProfileId: u.staffProfileId,
-              }))
-            : [],
-        })),
-        consultation: appointment.consultation
-          ? {
-              id: appointment.consultation.id,
-              consultationPlan: {
-                ...appointment.consultation.consultationPlan,
-                consultantProfile: appointment.consultation.consultationPlan
-                  .consultantProfile as any,
+    const transformedAppointments = appointmentsData.map((appointment) => ({
+      id: appointment.id,
+      appointmentType: appointment.appointmentType,
+      slotsOfAppointment: appointment.slotsOfAppointment.map((slot) => ({
+        id: slot.id,
+        slotStartTimeInUTC: new Date(slot.startsAt),
+        slotEndTimeInUTC: slot.endsAt ? new Date(slot.endsAt) : null,
+        isTentative: slot.isTentative,
+        user: Array.isArray(slot.user)
+          ? slot.user.map((u) => ({
+              id: u.id,
+              name: u.name,
+              email: u.email,
+              image: u.image,
+              phone: u.phone || null,
+              address: u.address || null,
+              password: u.password || null,
+              passwordResetToken: u.passwordResetToken || null,
+              passwordResetExpires: u.passwordResetExpires || null,
+              onlineStatus: u.onlineStatus,
+              currentTimezone: u.timezone || null,
+              onboardingCompleted: u.onboardingCompleted,
+              role: u.role,
+              consultantProfileId: u.consultantProfileId,
+              consulteeProfileId: u.consulteeProfileId,
+              staffProfileId: u.staffProfileId,
+            }))
+          : [],
+      })),
+      consultation: appointment.consultation
+        ? {
+            id: appointment.consultation.id,
+            consultationPlan: {
+              ...appointment.consultation.consultationPlan,
+              consultantProfile: appointment.consultation.consultationPlan
+                .consultantProfile as any,
+            },
+            requestStatus: appointment.consultation.requestStatus,
+            requestedBy: {
+              id: appointment.consultation.requestedBy?.id ?? "",
+              user: {
+                name: appointment.consultation.requestedBy?.user?.name ?? null,
+                image:
+                  appointment.consultation.requestedBy?.user?.image ?? null,
               },
-              requestStatus: appointment.consultation.requestStatus,
-              requestedBy: {
-                id: appointment.consultation.requestedBy?.id ?? "",
-                user: {
-                  name:
-                    appointment.consultation.requestedBy?.user?.name ?? null,
-                  image:
-                    appointment.consultation.requestedBy?.user?.image ?? null,
-                },
+            },
+          }
+        : undefined,
+      subscription: appointment.subscription
+        ? {
+            id: appointment.subscription.id,
+            subscriptionPlan: {
+              ...appointment.subscription.subscriptionPlan,
+              consultantProfile: appointment.subscription.subscriptionPlan
+                .consultantProfile as any,
+            },
+            requestStatus: appointment.subscription.requestStatus,
+            requestedBy: {
+              id: appointment.subscription.requestedBy?.id ?? "",
+              user: {
+                name: appointment.subscription.requestedBy?.user?.name ?? null,
+                image:
+                  appointment.subscription.requestedBy?.user?.image ?? null,
               },
-            }
-          : undefined,
-        subscription: appointment.subscription
-          ? {
-              id: appointment.subscription.id,
-              subscriptionPlan: {
-                ...appointment.subscription.subscriptionPlan,
-                consultantProfile: appointment.subscription.subscriptionPlan
-                  .consultantProfile as any,
-              },
-              requestStatus: appointment.subscription.requestStatus,
-              requestedBy: {
-                id: appointment.subscription.requestedBy?.id ?? "",
-                user: {
-                  name:
-                    appointment.subscription.requestedBy?.user?.name ?? null,
-                  image:
-                    appointment.subscription.requestedBy?.user?.image ?? null,
-                },
-              },
-              startDate: new Date(
-                appointment.subscription.schedulingPeriodStartsAt,
-              ).toISOString(),
-              endDate: new Date(
-                appointment.subscription.schedulingPeriodEndsAt,
-              ).toISOString(),
-            }
-          : undefined,
-        webinar: appointment.webinar
-          ? {
-              id: appointment.webinar.id,
-              webinarPlan: {
-                ...appointment.webinar.webinarPlan,
-                consultantProfile: appointment.webinar.webinarPlan
-                  .consultantProfile as any,
-              },
-              status: appointment.webinar.status,
-            }
-          : undefined,
-        class: appointment.class
-          ? {
-              id: appointment.class.id,
-              classPlan: {
-                ...appointment.class.classPlan,
-                consultantProfile: appointment.class.classPlan
-                  .consultantProfile as any,
-              },
-              status: appointment.class.status,
-            }
-          : undefined,
-      }),
-    );
+            },
+            startDate: new Date(
+              appointment.subscription.schedulingPeriodStartsAt,
+            ).toISOString(),
+            endDate: new Date(
+              appointment.subscription.schedulingPeriodEndsAt,
+            ).toISOString(),
+          }
+        : undefined,
+      webinar: appointment.webinar
+        ? {
+            id: appointment.webinar.id,
+            webinarPlan: {
+              ...appointment.webinar.webinarPlan,
+              consultantProfile: appointment.webinar.webinarPlan
+                .consultantProfile as any,
+            },
+            status: appointment.webinar.status,
+          }
+        : undefined,
+      class: appointment.class
+        ? {
+            id: appointment.class.id,
+            classPlan: {
+              ...appointment.class.classPlan,
+              consultantProfile: appointment.class.classPlan
+                .consultantProfile as any,
+            },
+            status: appointment.class.status,
+          }
+        : undefined,
+    }));
 
     // Transform approvals (same logic as fetchHelpers.ts)
-    const consultationApprovals = consultationsData.data.map(
+    const consultationApprovals = consultationsData.map(
       (consultation: TConsultation) => ({
         id: consultation.id,
         type: "Consultation",
@@ -175,7 +350,7 @@ export async function GET(
       }),
     );
 
-    const subscriptionApprovals = subscriptionsData.data.map(
+    const subscriptionApprovals = subscriptionsData.map(
       (subscription: TSubscription) => ({
         id: subscription.id,
         type: "Subscription",

--- a/app/api/dashboard/consultant/[consultantId]/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/route.ts
@@ -148,9 +148,15 @@ const subscriptionInclude = {
 } satisfies Prisma.SubscriptionInclude;
 
 // Derive types from the include objects
-type DashboardAppointment = Prisma.AppointmentGetPayload<{ include: typeof appointmentInclude }>;
-type DashboardConsultation = Prisma.ConsultationGetPayload<{ include: typeof consultationInclude }>;
-type DashboardSubscription = Prisma.SubscriptionGetPayload<{ include: typeof subscriptionInclude }>;
+type DashboardAppointment = Prisma.AppointmentGetPayload<{
+  include: typeof appointmentInclude;
+}>;
+type DashboardConsultation = Prisma.ConsultationGetPayload<{
+  include: typeof consultationInclude;
+}>;
+type DashboardSubscription = Prisma.SubscriptionGetPayload<{
+  include: typeof subscriptionInclude;
+}>;
 
 // =============================================================================
 // Helper Functions

--- a/app/api/dashboard/consultee/[consulteeId]/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/route.ts
@@ -1,5 +1,163 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+// =============================================================================
+// Prisma Query Types - Derived from actual query shape for type safety
+// =============================================================================
+
+const consultationInclude = {
+  consultationPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: true,
+        },
+      },
+    },
+  },
+  requestedBy: {
+    include: {
+      user: true,
+    },
+  },
+  appointment: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+        orderBy: {
+          startsAt: "asc" as const,
+        },
+      },
+      payment: true,
+    },
+  },
+} satisfies Prisma.ConsultationInclude;
+
+const subscriptionInclude = {
+  subscriptionPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: true,
+          domain: true,
+          subDomains: true,
+          tags: true,
+        },
+      },
+    },
+  },
+  requestedBy: {
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          image: true,
+        },
+      },
+    },
+  },
+  appointments: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: true,
+        },
+      },
+      payment: true,
+    },
+  },
+} satisfies Prisma.SubscriptionInclude;
+
+const webinarInclude = {
+  webinarPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+            },
+          },
+        },
+      },
+      topics: true,
+    },
+  },
+  appointment: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+              consulteeProfileId: true,
+            },
+          },
+        },
+      },
+      payment: true,
+    },
+  },
+  // Note: waitlist include is dynamic based on consulteeId, handled separately
+} satisfies Prisma.WebinarInclude;
+
+const classInclude = {
+  classPlan: {
+    include: {
+      consultantProfile: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+            },
+          },
+        },
+      },
+      classContents: {
+        orderBy: {
+          order: "asc" as const,
+        },
+      },
+    },
+  },
+  appointments: {
+    include: {
+      slotsOfAppointment: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              image: true,
+              consulteeProfileId: true,
+            },
+          },
+        },
+      },
+      payment: true,
+    },
+  },
+  // Note: waitlist include is dynamic based on consulteeId, handled separately
+} satisfies Prisma.ClassInclude;
+
+// =============================================================================
+// Route Handler
+// =============================================================================
 
 export async function GET(
   request: NextRequest,
@@ -39,35 +197,7 @@ export async function GET(
         // Fetch consultations for this consultee
         prisma.consultation.findMany({
           where: { requestedById: consulteeId },
-          include: {
-            consultationPlan: {
-              include: {
-                consultantProfile: {
-                  include: {
-                    user: true,
-                  },
-                },
-              },
-            },
-            requestedBy: {
-              include: {
-                user: true,
-              },
-            },
-            appointment: {
-              include: {
-                slotsOfAppointment: {
-                  include: {
-                    user: true,
-                  },
-                  orderBy: {
-                    startsAt: "asc",
-                  },
-                },
-                payment: true,
-              },
-            },
-          },
+          include: consultationInclude,
           orderBy: {
             requestedAt: "desc",
           },
@@ -75,42 +205,7 @@ export async function GET(
         // Fetch subscriptions for this consultee
         prisma.subscription.findMany({
           where: { requestedById: consulteeId },
-          include: {
-            subscriptionPlan: {
-              include: {
-                consultantProfile: {
-                  include: {
-                    user: true,
-                    domain: true,
-                    subDomains: true,
-                    tags: true,
-                  },
-                },
-              },
-            },
-            requestedBy: {
-              include: {
-                user: {
-                  select: {
-                    id: true,
-                    name: true,
-                    email: true,
-                    image: true,
-                  },
-                },
-              },
-            },
-            appointments: {
-              include: {
-                slotsOfAppointment: {
-                  include: {
-                    user: true,
-                  },
-                },
-                payment: true,
-              },
-            },
-          },
+          include: subscriptionInclude,
           orderBy: {
             requestedAt: "desc",
           },
@@ -150,41 +245,7 @@ export async function GET(
             ],
           },
           include: {
-            webinarPlan: {
-              include: {
-                consultantProfile: {
-                  include: {
-                    user: {
-                      select: {
-                        id: true,
-                        name: true,
-                        email: true,
-                        image: true,
-                      },
-                    },
-                  },
-                },
-                topics: true,
-              },
-            },
-            appointment: {
-              include: {
-                slotsOfAppointment: {
-                  include: {
-                    user: {
-                      select: {
-                        id: true,
-                        name: true,
-                        email: true,
-                        image: true,
-                        consulteeProfileId: true,
-                      },
-                    },
-                  },
-                },
-                payment: true,
-              },
-            },
+            ...webinarInclude,
             waitlist: {
               where: {
                 user: {
@@ -244,45 +305,7 @@ export async function GET(
             ],
           },
           include: {
-            classPlan: {
-              include: {
-                consultantProfile: {
-                  include: {
-                    user: {
-                      select: {
-                        id: true,
-                        name: true,
-                        email: true,
-                        image: true,
-                      },
-                    },
-                  },
-                },
-                classContents: {
-                  orderBy: {
-                    order: "asc",
-                  },
-                },
-              },
-            },
-            appointments: {
-              include: {
-                slotsOfAppointment: {
-                  include: {
-                    user: {
-                      select: {
-                        id: true,
-                        name: true,
-                        email: true,
-                        image: true,
-                        consulteeProfileId: true,
-                      },
-                    },
-                  },
-                },
-                payment: true,
-              },
-            },
+            ...classInclude,
             waitlist: {
               where: {
                 userId: consulteeId,

--- a/app/api/dashboard/consultee/[consulteeId]/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/route.ts
@@ -1,69 +1,318 @@
 import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ consulteeId: string }> },
 ) {
+  // Note: request parameter kept for Next.js API route signature compatibility
+  void request;
+
   try {
     const resolvedParams = await params;
     const { consulteeId } = resolvedParams;
 
-    // Fetch all events data in parallel
-    const [consultationsRes, subscriptionsRes, webinarsRes, classesRes] =
-      await Promise.all([
-        fetch(
-          `${request.nextUrl.origin}/api/events/consultations?consulteeProfileId=${consulteeId}`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
-        fetch(
-          `${request.nextUrl.origin}/api/events/subscriptions?consulteeProfileId=${consulteeId}`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
-        fetch(
-          `${request.nextUrl.origin}/api/events/webinars?consulteeProfileId=${consulteeId}`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
-        fetch(
-          `${request.nextUrl.origin}/api/events/classes?consulteeProfileId=${consulteeId}`,
-          { headers: { Cookie: request.headers.get("cookie") || "" } },
-        ),
-      ]);
-
-    // Check for errors
-    if (!consultationsRes.ok) {
-      throw new Error(
-        `Failed to fetch consultations: ${consultationsRes.statusText}`,
+    if (!consulteeId) {
+      return NextResponse.json(
+        { error: "Consultee ID is required" },
+        { status: 400 },
       );
     }
-    if (!subscriptionsRes.ok) {
-      throw new Error(
-        `Failed to fetch subscriptions: ${subscriptionsRes.statusText}`,
+
+    // Verify the consultee profile exists before fetching data
+    const consulteeProfile = await prisma.consulteeProfile.findUnique({
+      where: { id: consulteeId },
+      select: { id: true },
+    });
+
+    if (!consulteeProfile) {
+      return NextResponse.json(
+        { error: "Consultee profile not found" },
+        { status: 404 },
       );
     }
-    if (!webinarsRes.ok) {
-      throw new Error(`Failed to fetch webinars: ${webinarsRes.statusText}`);
-    }
-    if (!classesRes.ok) {
-      throw new Error(`Failed to fetch classes: ${classesRes.statusText}`);
-    }
 
-    // Parse responses in parallel for better performance
-    const [consultationsData, subscriptionsData, webinarsData, classesData] =
-      await Promise.all([
-        consultationsRes.json(),
-        subscriptionsRes.json(),
-        webinarsRes.json(),
-        classesRes.json(),
-      ]);
+    // PERFORMANCE FIX #364: Use direct Prisma queries instead of internal HTTP fetches
+    // This eliminates network overhead and reduces response time significantly
+    const [consultations, subscriptions, webinars, classes] = await Promise.all(
+      [
+        // Fetch consultations for this consultee
+        prisma.consultation.findMany({
+          where: { requestedById: consulteeId },
+          include: {
+            consultationPlan: {
+              include: {
+                consultantProfile: {
+                  include: {
+                    user: true,
+                  },
+                },
+              },
+            },
+            requestedBy: {
+              include: {
+                user: true,
+              },
+            },
+            appointment: {
+              include: {
+                slotsOfAppointment: {
+                  include: {
+                    user: true,
+                  },
+                  orderBy: {
+                    startsAt: "asc",
+                  },
+                },
+                payment: true,
+              },
+            },
+          },
+          orderBy: {
+            requestedAt: "desc",
+          },
+        }),
+        // Fetch subscriptions for this consultee
+        prisma.subscription.findMany({
+          where: { requestedById: consulteeId },
+          include: {
+            subscriptionPlan: {
+              include: {
+                consultantProfile: {
+                  include: {
+                    user: true,
+                    domain: true,
+                    subDomains: true,
+                    tags: true,
+                  },
+                },
+              },
+            },
+            requestedBy: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                    image: true,
+                  },
+                },
+              },
+            },
+            appointments: {
+              include: {
+                slotsOfAppointment: {
+                  include: {
+                    user: true,
+                  },
+                },
+                payment: true,
+              },
+            },
+          },
+          orderBy: {
+            requestedAt: "desc",
+          },
+        }),
+        // Webinars: User registered via waitlist or via appointment slots
+        prisma.webinar.findMany({
+          where: {
+            OR: [
+              // Get webinars where consultee is registered through appointments
+              {
+                appointment: {
+                  slotsOfAppointment: {
+                    some: {
+                      user: {
+                        some: {
+                          consulteeProfile: {
+                            id: consulteeId,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              // Get webinars where consultee is in waitlist
+              {
+                waitlist: {
+                  some: {
+                    user: {
+                      consulteeProfile: {
+                        id: consulteeId,
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          include: {
+            webinarPlan: {
+              include: {
+                consultantProfile: {
+                  include: {
+                    user: {
+                      select: {
+                        id: true,
+                        name: true,
+                        email: true,
+                        image: true,
+                      },
+                    },
+                  },
+                },
+                topics: true,
+              },
+            },
+            appointment: {
+              include: {
+                slotsOfAppointment: {
+                  include: {
+                    user: {
+                      select: {
+                        id: true,
+                        name: true,
+                        email: true,
+                        image: true,
+                        consulteeProfileId: true,
+                      },
+                    },
+                  },
+                },
+                payment: true,
+              },
+            },
+            waitlist: {
+              where: {
+                user: {
+                  consulteeProfile: {
+                    id: consulteeId,
+                  },
+                },
+              },
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    email: true,
+                    image: true,
+                    consulteeProfile: true,
+                  },
+                },
+              },
+            },
+          },
+        }),
+        // Classes: User registered via waitlist or via appointment slots
+        prisma.class.findMany({
+          where: {
+            OR: [
+              // Get classes where consultee is registered through appointments
+              {
+                appointments: {
+                  some: {
+                    slotsOfAppointment: {
+                      some: {
+                        user: {
+                          some: {
+                            consulteeProfile: {
+                              id: consulteeId,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              // Get classes where consultee is in waitlist
+              {
+                waitlist: {
+                  some: {
+                    user: {
+                      consulteeProfile: {
+                        id: consulteeId,
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          include: {
+            classPlan: {
+              include: {
+                consultantProfile: {
+                  include: {
+                    user: {
+                      select: {
+                        id: true,
+                        name: true,
+                        email: true,
+                        image: true,
+                      },
+                    },
+                  },
+                },
+                classContents: {
+                  orderBy: {
+                    order: "asc",
+                  },
+                },
+              },
+            },
+            appointments: {
+              include: {
+                slotsOfAppointment: {
+                  include: {
+                    user: {
+                      select: {
+                        id: true,
+                        name: true,
+                        email: true,
+                        image: true,
+                        consulteeProfileId: true,
+                      },
+                    },
+                  },
+                },
+                payment: true,
+              },
+            },
+            waitlist: {
+              where: {
+                userId: consulteeId,
+              },
+              select: {
+                userId: true,
+                joinedAt: true,
+              },
+            },
+          },
+          orderBy: [
+            {
+              schedulingPeriodStartsAt: "desc",
+            },
+            {
+              status: "asc",
+            },
+          ],
+        }),
+      ],
+    );
 
     // Return consolidated response
     return NextResponse.json({
       success: true,
       data: {
-        consultations: consultationsData?.data || [],
-        subscriptions: subscriptionsData?.data || [],
-        webinars: webinarsData?.data || [],
-        classes: classesData?.data || [],
+        consultations: consultations || [],
+        subscriptions: subscriptions || [],
+        webinars: webinars || [],
+        classes: classes || [],
       },
     });
   } catch (error) {

--- a/app/api/slots/availability-with-allocation/[consultantId]/route.ts
+++ b/app/api/slots/availability-with-allocation/[consultantId]/route.ts
@@ -117,21 +117,35 @@ export async function GET(
     }
 
     // 2. Fetch all appointments to find allocated slots
+    // FIX: Only include APPROVED consultations/subscriptions and SCHEDULED webinars/classes
+    // COMPLETED/CANCELLED events should not block future availability
     const appointments = await prisma.appointment.findMany({
       where: {
         OR: [
           {
             consultation: {
               consultationPlan: { consultantProfileId: consultantId },
+              requestStatus: "APPROVED", // Only approved consultations
             },
           },
           {
             subscription: {
               subscriptionPlan: { consultantProfileId: consultantId },
+              requestStatus: "APPROVED", // Only approved subscriptions
             },
           },
-          { webinar: { webinarPlan: { consultantProfileId: consultantId } } },
-          { class: { classPlan: { consultantProfileId: consultantId } } },
+          {
+            webinar: {
+              webinarPlan: { consultantProfileId: consultantId },
+              status: "SCHEDULED", // Only scheduled webinars (not COMPLETED, CANCELLED)
+            },
+          },
+          {
+            class: {
+              classPlan: { consultantProfileId: consultantId },
+              status: "SCHEDULED", // Only scheduled classes (not COMPLETED, CANCELLED)
+            },
+          },
         ],
         slotsOfAppointment: {
           some: {

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -628,7 +628,7 @@ export function RequestSlotAllocationTab({
 
         {/* Single Allocation Dialog - moved outside map loop to prevent multiple dialogs */}
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogContent className="max-w-7xl">
+          <DialogContent className="max-w-[95vw] w-[1400px]">
             <DialogHeader>
               <DialogTitle>Allocate Slots</DialogTitle>
               <DialogDescription asChild>
@@ -708,7 +708,6 @@ export function RequestSlotAllocationTab({
                 }
                 allowedStart={selectedRequest.startDate}
                 allowedEnd={selectedRequest.endDate}
-                className="min-h-[500px]"
               />
             )}
           </DialogContent>

--- a/utils/timeSlotsProcessing.ts
+++ b/utils/timeSlotsProcessing.ts
@@ -600,6 +600,10 @@ export function groupSlotsByDate(
 
 /**
  * Main function to process all availability slots with allocation detection
+ *
+ * @param durationInHours - Duration for breaking down slots (default: 0.5 = 30 minutes)
+ *   This ensures each returned slot has its own per-interval booking status
+ *   rather than inheriting status from the entire availability block.
  */
 export function processAvailabilitySlots(
   weeklySlots: WeeklySlot[],
@@ -608,6 +612,7 @@ export function processAvailabilitySlots(
   startDate: Date,
   endDate: Date,
   timezone: string,
+  durationInHours: number = 0.5, // Default to 30-minute intervals
 ): Record<
   string,
   (TSlotTiming & {
@@ -641,6 +646,16 @@ export function processAvailabilitySlots(
     timezone,
   );
 
+  // FIX: Break down into smaller intervals (default 30 min) with per-interval booking status
+  // This fixes the bug where an 8-hour availability block with 1-hour appointment
+  // showed ALL intervals as "Partially Booked" instead of only the booked intervals
+  const brokenDownSlots = breakDownSlotsByDuration(
+    slotTimings,
+    durationInHours,
+    appointmentSlots,
+    timezone,
+  );
+
   // Group by date
-  return groupSlotsByDate(slotTimings, timezone);
+  return groupSlotsByDate(brokenDownSlots, timezone);
 }


### PR DESCRIPTION
## Summary

- Replace 15 internal HTTP fetch calls across 4 dashboard routes with direct Prisma queries
- Follow the established pattern in `app/api/dashboard/consultee/[consulteeId]/events/route.ts`
- Maintain identical response structure contracts for all endpoints
- **Fix slot availability calculation to only include active appointments**
- **Fix slot booking status granularity bug** - intervals now show per-interval status instead of inheriting from entire availability block

## Problem

The dashboard routes were making internal HTTP fetch calls instead of using direct Prisma queries, causing:
- Extra network round-trips (~10-50ms per fetch)
- Cookie forwarding complexity
- Base URL detection issues (`VERCEL_URL`, `NEXT_PUBLIC_APP_URL`)
- Complex error handling
- **11+ seconds response time vs <1 second with direct queries** (per reference implementation)

Additionally, the slot availability endpoint was incorrectly including COMPLETED and CANCELLED events when calculating blocked slots, preventing consultants from reusing those time slots.

There was also a bug where large availability blocks (e.g., 8 hours) with a small appointment (e.g., 1 hour) showed ALL intervals as "Partially Booked" instead of the correct per-interval booking status.

## Changes

### API Chaining Elimination

| File | Fetches Removed | Description |
|------|-----------------|-------------|
| `consultant/[consultantId]/planner/route.ts` | 2 | Webinars + Classes |
| `consultant/[consultantId]/route.ts` | 3 | Appointments + Pending Consultations + Pending Subscriptions |
| `consultee/[consulteeId]/route.ts` | 4 | Consultations + Subscriptions + Webinars + Classes |
| `consultant/[consultantId]/requests/route.ts` | 6 | Consultations + Subscriptions + Weekly/Custom Availability + Appointments + Consultant Profile |

### Slot Availability Bug Fix

| File | Change |
|------|--------|
| `api/slots/availability-with-allocation/[consultantId]/route.ts` | Filter appointments by status: only APPROVED consultations/subscriptions and SCHEDULED webinars/classes now block slots |
| `dashboard/consultant/.../RequestSlotAllocationTab.tsx` | Improved dialog sizing for slot allocation modal (95vw, 1400px width) |

### Slot Booking Status Granularity Fix

| File | Change |
|------|--------|
| `utils/timeSlotsProcessing.ts` | Added `durationInHours` parameter (default 0.5 = 30 min) to `processAvailabilitySlots()`. Now breaks down availability into smaller intervals using `breakDownSlotsByDuration()`, each with its own per-interval booking status. |

### Type Safety Improvements

| File | Change |
|------|--------|
| All dashboard routes | Replaced inline type definitions with Prisma `GetPayload` types for better type safety and maintainability |

## Expected Benefits

| Aspect | Before | After |
|--------|--------|-------|
| Total HTTP round-trips | 15 internal | 0 |
| Estimated latency | ~150-750ms overhead | ~0ms overhead |
| Cookie handling | Manual forwarding | Not needed |
| Base URL detection | Complex env logic | Not needed |
| Error handling | HTTP status + JSON parsing | Single try/catch |
| Slot availability | Blocked by all events | Only blocked by active events |
| Slot booking status | Entire block shows same status | Per-interval granularity |

## Commits

1. **fix: eliminate internal API chaining in dashboard routes** - Replace 15 internal HTTP fetch calls with direct Prisma queries
2. **refactor: use Prisma GetPayload types for type safety in dashboard routes** - Better type safety with Prisma-generated types
3. **fix(slots): filter slot availability by active appointment status** - Only APPROVED/SCHEDULED events block slots
4. **fix(slots): correct booking status granularity in processAvailabilitySlots** - Each 30-min interval gets its own booking status

## Test plan

- [ ] TypeScript build passes (`npx tsc --noEmit`)
- [ ] ESLint passes (only pre-existing `any` type warnings)
- [ ] Consultant Dashboard: Verify appointments calendar and pending approvals display
- [ ] Consultant Requests: Check requests page loads pending consultations/subscriptions
- [ ] Consultee Dashboard: Verify all event types (consultations, subscriptions, webinars, classes) display
- [ ] Consultant Planner: Verify webinars and classes with participant counts display
- [ ] **Slot Availability**: Verify completed/cancelled events no longer block slot allocation
- [ ] **Slot Allocation Modal**: Verify improved dialog sizing displays correctly
- [ ] **Slot Booking Status**: Verify individual 30-min intervals show correct per-interval status (not entire availability block status)

Closes #364

Generated with [Claude Code](https://claude.com/claude-code)