### PR TITLE
fix(meetings): role-based visibility and settings fix

### DIFF
--- a/app/api/events/classes/crud-with-plan/route.ts
+++ b/app/api/events/classes/crud-with-plan/route.ts
@@ -217,30 +217,30 @@ export async function POST(request: NextRequest) {
               // Only create appointments if startDate is defined
               create: start
                 ? Array.from({
-                  // Calculate total sessions based on duration
-                  length:
-                    Math.ceil(durationInMonths * 4.33) * meetingsPerWeek,
-                }).map((_, index) => {
-                  const appointmentDate = new Date(start!);
-                  appointmentDate.setDate(
-                    appointmentDate.getDate() +
-                    Math.floor(index / meetingsPerWeek) * 7,
-                  );
-                  const slotStart = new Date(appointmentDate);
-                  const slotEnd = new Date(appointmentDate);
-                  slotEnd.setHours(slotEnd.getHours() + 1); // Default 1-hour slots
+                    // Calculate total sessions based on duration
+                    length:
+                      Math.ceil(durationInMonths * 4.33) * meetingsPerWeek,
+                  }).map((_, index) => {
+                    const appointmentDate = new Date(start!);
+                    appointmentDate.setDate(
+                      appointmentDate.getDate() +
+                        Math.floor(index / meetingsPerWeek) * 7,
+                    );
+                    const slotStart = new Date(appointmentDate);
+                    const slotEnd = new Date(appointmentDate);
+                    slotEnd.setHours(slotEnd.getHours() + 1); // Default 1-hour slots
 
-                  return {
-                    appointmentType: "CLASS",
-                    slotsOfAppointment: {
-                      create: {
-                        startsAt: slotStart,
-                        endsAt: slotEnd,
-                        isTentative: true, // Mark as tentative until confirmed
+                    return {
+                      appointmentType: "CLASS",
+                      slotsOfAppointment: {
+                        create: {
+                          startsAt: slotStart,
+                          endsAt: slotEnd,
+                          isTentative: true, // Mark as tentative until confirmed
+                        },
                       },
-                    },
-                  };
-                })
+                    };
+                  })
                 : undefined,
             },
           },
@@ -410,8 +410,8 @@ export async function PATCH(request: NextRequest) {
     // Get the class instance - use the provided classId or the first one associated with the plan
     const classToUpdate = classId
       ? await prisma.class.findUnique({
-        where: { id: classId },
-      })
+          where: { id: classId },
+        })
       : existingPlan.classes.length > 0
         ? existingPlan.classes[0]
         : null;

--- a/app/api/events/classes/crud-with-plan/route.ts
+++ b/app/api/events/classes/crud-with-plan/route.ts
@@ -106,6 +106,7 @@ export async function POST(request: NextRequest) {
       consultantProfileId,
       topics: topicNames,
       certificateProvided,
+      recordingEnabled,
       meetingsPerWeek,
       emailSupport,
       classContents,
@@ -175,6 +176,7 @@ export async function POST(request: NextRequest) {
             materialProvided,
             learningOutcomes,
             certificateProvided,
+            recordingEnabled,
             meetingsPerWeek,
             sessionDurationInHours,
             totalSessions,
@@ -215,30 +217,30 @@ export async function POST(request: NextRequest) {
               // Only create appointments if startDate is defined
               create: start
                 ? Array.from({
-                    // Calculate total sessions based on duration
-                    length:
-                      Math.ceil(durationInMonths * 4.33) * meetingsPerWeek,
-                  }).map((_, index) => {
-                    const appointmentDate = new Date(start!);
-                    appointmentDate.setDate(
-                      appointmentDate.getDate() +
-                        Math.floor(index / meetingsPerWeek) * 7,
-                    );
-                    const slotStart = new Date(appointmentDate);
-                    const slotEnd = new Date(appointmentDate);
-                    slotEnd.setHours(slotEnd.getHours() + 1); // Default 1-hour slots
+                  // Calculate total sessions based on duration
+                  length:
+                    Math.ceil(durationInMonths * 4.33) * meetingsPerWeek,
+                }).map((_, index) => {
+                  const appointmentDate = new Date(start!);
+                  appointmentDate.setDate(
+                    appointmentDate.getDate() +
+                    Math.floor(index / meetingsPerWeek) * 7,
+                  );
+                  const slotStart = new Date(appointmentDate);
+                  const slotEnd = new Date(appointmentDate);
+                  slotEnd.setHours(slotEnd.getHours() + 1); // Default 1-hour slots
 
-                    return {
-                      appointmentType: "CLASS",
-                      slotsOfAppointment: {
-                        create: {
-                          startsAt: slotStart,
-                          endsAt: slotEnd,
-                          isTentative: true, // Mark as tentative until confirmed
-                        },
+                  return {
+                    appointmentType: "CLASS",
+                    slotsOfAppointment: {
+                      create: {
+                        startsAt: slotStart,
+                        endsAt: slotEnd,
+                        isTentative: true, // Mark as tentative until confirmed
                       },
-                    };
-                  })
+                    },
+                  };
+                })
                 : undefined,
             },
           },
@@ -359,6 +361,7 @@ export async function PATCH(request: NextRequest) {
       status,
       startDate: startDateString,
       endDate: endDateString,
+      recordingEnabled,
     } = validatedData;
 
     // Find or create topics by name if provided
@@ -407,8 +410,8 @@ export async function PATCH(request: NextRequest) {
     // Get the class instance - use the provided classId or the first one associated with the plan
     const classToUpdate = classId
       ? await prisma.class.findUnique({
-          where: { id: classId },
-        })
+        where: { id: classId },
+      })
       : existingPlan.classes.length > 0
         ? existingPlan.classes[0]
         : null;
@@ -479,6 +482,8 @@ export async function PATCH(request: NextRequest) {
           updateData.priceCurrency = priceCurrency;
         if (certificateProvided !== undefined)
           updateData.certificateProvided = certificateProvided;
+        if (recordingEnabled !== undefined)
+          updateData.recordingEnabled = recordingEnabled;
         if (meetingsPerWeek !== undefined)
           updateData.meetingsPerWeek = meetingsPerWeek;
         if (emailSupport !== undefined) updateData.emailSupport = emailSupport;

--- a/app/api/events/webinars/crud-with-plan/route.ts
+++ b/app/api/events/webinars/crud-with-plan/route.ts
@@ -216,18 +216,18 @@ export async function POST(request: NextRequest) {
             appointment:
               startTime && endTime
                 ? {
-                  // Check if dates were successfully calculated
-                  create: {
-                    appointmentType: "WEBINAR",
-                    slotsOfAppointment: {
-                      create: {
-                        startsAt: startTime, // Use calculated startTime
-                        endsAt: endTime, // Use calculated endTime
-                        isTentative: false,
+                    // Check if dates were successfully calculated
+                    create: {
+                      appointmentType: "WEBINAR",
+                      slotsOfAppointment: {
+                        create: {
+                          startsAt: startTime, // Use calculated startTime
+                          endsAt: endTime, // Use calculated endTime
+                          isTentative: false,
+                        },
                       },
                     },
-                  },
-                }
+                  }
                 : undefined, // Don't create appointment if no valid scheduledAt
           },
           include: {
@@ -414,15 +414,15 @@ export async function PATCH(request: NextRequest) {
     // Get the webinar instance - use the provided webinarId or the first one associated with the plan
     const webinarToUpdate = webinarId
       ? await prisma.webinar.findUnique({
-        where: { id: webinarId },
-        include: {
-          appointment: {
-            include: {
-              slotsOfAppointment: true,
+          where: { id: webinarId },
+          include: {
+            appointment: {
+              include: {
+                slotsOfAppointment: true,
+              },
             },
           },
-        },
-      })
+        })
       : existingPlan.webinars.length > 0
         ? existingPlan.webinars[0]
         : null;

--- a/app/api/events/webinars/crud-with-plan/route.ts
+++ b/app/api/events/webinars/crud-with-plan/route.ts
@@ -184,6 +184,8 @@ export async function POST(request: NextRequest) {
             prerequisites,
             materialProvided,
             learningOutcomes,
+            certificateProvided: validatedData.certificateProvided,
+            recordingEnabled: validatedData.recordingEnabled,
             consultantProfile: { connect: { id: consultantProfileId } },
             topics:
               topicIds.length > 0
@@ -214,18 +216,18 @@ export async function POST(request: NextRequest) {
             appointment:
               startTime && endTime
                 ? {
-                    // Check if dates were successfully calculated
-                    create: {
-                      appointmentType: "WEBINAR",
-                      slotsOfAppointment: {
-                        create: {
-                          startsAt: startTime, // Use calculated startTime
-                          endsAt: endTime, // Use calculated endTime
-                          isTentative: false,
-                        },
+                  // Check if dates were successfully calculated
+                  create: {
+                    appointmentType: "WEBINAR",
+                    slotsOfAppointment: {
+                      create: {
+                        startsAt: startTime, // Use calculated startTime
+                        endsAt: endTime, // Use calculated endTime
+                        isTentative: false,
                       },
                     },
-                  }
+                  },
+                }
                 : undefined, // Don't create appointment if no valid scheduledAt
           },
           include: {
@@ -349,6 +351,8 @@ export async function PATCH(request: NextRequest) {
       status,
       scheduledAt,
       priceCurrency,
+      certificateProvided,
+      recordingEnabled,
     } = validatedData;
 
     // Find or create topics by name if provided
@@ -410,15 +414,15 @@ export async function PATCH(request: NextRequest) {
     // Get the webinar instance - use the provided webinarId or the first one associated with the plan
     const webinarToUpdate = webinarId
       ? await prisma.webinar.findUnique({
-          where: { id: webinarId },
-          include: {
-            appointment: {
-              include: {
-                slotsOfAppointment: true,
-              },
+        where: { id: webinarId },
+        include: {
+          appointment: {
+            include: {
+              slotsOfAppointment: true,
             },
           },
-        })
+        },
+      })
       : existingPlan.webinars.length > 0
         ? existingPlan.webinars[0]
         : null;
@@ -516,6 +520,10 @@ export async function PATCH(request: NextRequest) {
           updateData.prerequisites = prerequisites;
         if (materialProvided !== undefined)
           updateData.materialProvided = materialProvided;
+        if (certificateProvided !== undefined)
+          updateData.certificateProvided = certificateProvided;
+        if (recordingEnabled !== undefined)
+          updateData.recordingEnabled = recordingEnabled;
         if (learningOutcomes !== undefined)
           updateData.learningOutcomes = learningOutcomes;
         if (consultantProfileId !== undefined)

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
@@ -114,46 +114,46 @@ export function EventPlannerForClass({
     resolver: zodResolver(ClassPlanSchema),
     defaultValues: initialData?.classPlan
       ? {
-          title: initialData.classPlan.title,
-          description: initialData.classPlan.description ?? "",
-          price: initialData.classPlan.price,
-          priceCurrency: initialData.classPlan.priceCurrency ?? "INR",
-          durationInMonths: initialData.classPlan.durationInMonths,
-          maxParticipants: initialData.classPlan.maxParticipants,
-          language: initialData.classPlan.language ?? "English",
-          level: initialData.classPlan.level ?? "Beginner",
-          prerequisites: initialData.classPlan.prerequisites ?? "",
-          materialProvided: initialData.classPlan.materialProvided ?? "",
-          learningOutcomes: initialData.classPlan.learningOutcomes,
-          topics: initialData.classPlan.topics ?? [],
-          certificateProvided: initialData.classPlan.certificateProvided,
-          recordingEnabled: initialData.classPlan.recordingEnabled ?? false,
-          meetingsPerWeek: initialData.classPlan.meetingsPerWeek,
-          emailSupport: initialData.classPlan.emailSupport,
-          consultantProfileId: initialData.classPlan.consultantProfileId,
-          classContents: initialData.classPlan.classContents ?? [],
-          planType: "class",
-        }
+        title: initialData.classPlan.title,
+        description: initialData.classPlan.description ?? "",
+        price: initialData.classPlan.price,
+        priceCurrency: initialData.classPlan.priceCurrency ?? "INR",
+        durationInMonths: initialData.classPlan.durationInMonths,
+        maxParticipants: initialData.classPlan.maxParticipants,
+        language: initialData.classPlan.language ?? "English",
+        level: initialData.classPlan.level ?? "Beginner",
+        prerequisites: initialData.classPlan.prerequisites ?? "",
+        materialProvided: initialData.classPlan.materialProvided ?? "",
+        learningOutcomes: initialData.classPlan.learningOutcomes,
+        topics: initialData.classPlan.topics ?? [],
+        certificateProvided: initialData.classPlan.certificateProvided,
+        recordingEnabled: initialData.classPlan.recordingEnabled ?? false,
+        meetingsPerWeek: initialData.classPlan.meetingsPerWeek,
+        emailSupport: initialData.classPlan.emailSupport,
+        consultantProfileId: initialData.classPlan.consultantProfileId,
+        classContents: initialData.classPlan.classContents ?? [],
+        planType: "class",
+      }
       : {
-          title: "",
-          description: "",
-          price: 0,
-          priceCurrency: "INR",
-          durationInMonths: 1,
-          maxParticipants: 30,
-          language: "English",
-          level: "Beginner",
-          prerequisites: "",
-          materialProvided: "",
-          learningOutcomes: [],
-          topics: [],
-          certificateProvided: false,
-          recordingEnabled: false,
-          meetingsPerWeek: 2,
-          emailSupport: "GENERAL" as const,
-          classContents: [],
-          planType: "class",
-        },
+        title: "",
+        description: "",
+        price: 0,
+        priceCurrency: "INR",
+        durationInMonths: 1,
+        maxParticipants: 30,
+        language: "English",
+        level: "Beginner",
+        prerequisites: "",
+        materialProvided: "",
+        learningOutcomes: [],
+        topics: [],
+        certificateProvided: false,
+        recordingEnabled: false,
+        meetingsPerWeek: 2,
+        emailSupport: "GENERAL" as const,
+        classContents: [],
+        planType: "class",
+      },
     mode: "onChange",
   });
 
@@ -209,7 +209,9 @@ export function EventPlannerForClass({
   const canAddMoreTopics = currentTopicCount < maxTopics;
 
   const handleFormSubmit = form.handleSubmit(
-    async () => {
+    async (values) => {
+
+
       // Validate scheduling start date/time is required
       if (!schedulingStartDate) {
         toast({
@@ -222,7 +224,8 @@ export function EventPlannerForClass({
       setShowConfirmation(true);
     },
     (errors) => {
-      console.log("Form validation failed with errors:", errors);
+      console.error("Form validation failed with errors:", JSON.stringify(errors, null, 2));
+      console.log("Current form values:", form.getValues());
       toast({
         title: "Validation Error",
         description: "Please check the form for errors",
@@ -300,11 +303,12 @@ export function EventPlannerForClass({
             4 *
             (initialData?.classPlan?.sessionDurationInHours ?? 1),
           emailSupport: formData.emailSupport ?? "GENERAL",
-          classContents: (formData.classContents ?? []).map((content) => ({
+          classContents: (formData.classContents ?? []).map((content, index) => ({
             ...content,
+            order: index + 1,
             id: content.id || "",
-            createdAt: content.createdAt || now,
-            updatedAt: content.updatedAt || now,
+            createdAt: content.createdAt ? new Date(content.createdAt) : now,
+            updatedAt: content.updatedAt ? new Date(content.updatedAt) : now,
             classPlanId: content.classPlanId || "",
             contentType: content.contentType || null,
             contentUrl: content.contentUrl || null,

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
@@ -114,46 +114,46 @@ export function EventPlannerForClass({
     resolver: zodResolver(ClassPlanSchema),
     defaultValues: initialData?.classPlan
       ? {
-        title: initialData.classPlan.title,
-        description: initialData.classPlan.description ?? "",
-        price: initialData.classPlan.price,
-        priceCurrency: initialData.classPlan.priceCurrency ?? "INR",
-        durationInMonths: initialData.classPlan.durationInMonths,
-        maxParticipants: initialData.classPlan.maxParticipants,
-        language: initialData.classPlan.language ?? "English",
-        level: initialData.classPlan.level ?? "Beginner",
-        prerequisites: initialData.classPlan.prerequisites ?? "",
-        materialProvided: initialData.classPlan.materialProvided ?? "",
-        learningOutcomes: initialData.classPlan.learningOutcomes,
-        topics: initialData.classPlan.topics ?? [],
-        certificateProvided: initialData.classPlan.certificateProvided,
-        recordingEnabled: initialData.classPlan.recordingEnabled ?? false,
-        meetingsPerWeek: initialData.classPlan.meetingsPerWeek,
-        emailSupport: initialData.classPlan.emailSupport,
-        consultantProfileId: initialData.classPlan.consultantProfileId,
-        classContents: initialData.classPlan.classContents ?? [],
-        planType: "class",
-      }
+          title: initialData.classPlan.title,
+          description: initialData.classPlan.description ?? "",
+          price: initialData.classPlan.price,
+          priceCurrency: initialData.classPlan.priceCurrency ?? "INR",
+          durationInMonths: initialData.classPlan.durationInMonths,
+          maxParticipants: initialData.classPlan.maxParticipants,
+          language: initialData.classPlan.language ?? "English",
+          level: initialData.classPlan.level ?? "Beginner",
+          prerequisites: initialData.classPlan.prerequisites ?? "",
+          materialProvided: initialData.classPlan.materialProvided ?? "",
+          learningOutcomes: initialData.classPlan.learningOutcomes,
+          topics: initialData.classPlan.topics ?? [],
+          certificateProvided: initialData.classPlan.certificateProvided,
+          recordingEnabled: initialData.classPlan.recordingEnabled ?? false,
+          meetingsPerWeek: initialData.classPlan.meetingsPerWeek,
+          emailSupport: initialData.classPlan.emailSupport,
+          consultantProfileId: initialData.classPlan.consultantProfileId,
+          classContents: initialData.classPlan.classContents ?? [],
+          planType: "class",
+        }
       : {
-        title: "",
-        description: "",
-        price: 0,
-        priceCurrency: "INR",
-        durationInMonths: 1,
-        maxParticipants: 30,
-        language: "English",
-        level: "Beginner",
-        prerequisites: "",
-        materialProvided: "",
-        learningOutcomes: [],
-        topics: [],
-        certificateProvided: false,
-        recordingEnabled: false,
-        meetingsPerWeek: 2,
-        emailSupport: "GENERAL" as const,
-        classContents: [],
-        planType: "class",
-      },
+          title: "",
+          description: "",
+          price: 0,
+          priceCurrency: "INR",
+          durationInMonths: 1,
+          maxParticipants: 30,
+          language: "English",
+          level: "Beginner",
+          prerequisites: "",
+          materialProvided: "",
+          learningOutcomes: [],
+          topics: [],
+          certificateProvided: false,
+          recordingEnabled: false,
+          meetingsPerWeek: 2,
+          emailSupport: "GENERAL" as const,
+          classContents: [],
+          planType: "class",
+        },
     mode: "onChange",
   });
 
@@ -210,8 +210,6 @@ export function EventPlannerForClass({
 
   const handleFormSubmit = form.handleSubmit(
     async (values) => {
-
-
       // Validate scheduling start date/time is required
       if (!schedulingStartDate) {
         toast({
@@ -224,7 +222,10 @@ export function EventPlannerForClass({
       setShowConfirmation(true);
     },
     (errors) => {
-      console.error("Form validation failed with errors:", JSON.stringify(errors, null, 2));
+      console.error(
+        "Form validation failed with errors:",
+        JSON.stringify(errors, null, 2),
+      );
       console.log("Current form values:", form.getValues());
       toast({
         title: "Validation Error",
@@ -303,16 +304,18 @@ export function EventPlannerForClass({
             4 *
             (initialData?.classPlan?.sessionDurationInHours ?? 1),
           emailSupport: formData.emailSupport ?? "GENERAL",
-          classContents: (formData.classContents ?? []).map((content, index) => ({
-            ...content,
-            order: index + 1,
-            id: content.id || "",
-            createdAt: content.createdAt ? new Date(content.createdAt) : now,
-            updatedAt: content.updatedAt ? new Date(content.updatedAt) : now,
-            classPlanId: content.classPlanId || "",
-            contentType: content.contentType || null,
-            contentUrl: content.contentUrl || null,
-          })),
+          classContents: (formData.classContents ?? []).map(
+            (content, index) => ({
+              ...content,
+              order: index + 1,
+              id: content.id || "",
+              createdAt: content.createdAt ? new Date(content.createdAt) : now,
+              updatedAt: content.updatedAt ? new Date(content.updatedAt) : now,
+              classPlanId: content.classPlanId || "",
+              contentType: content.contentType || null,
+              contentUrl: content.contentUrl || null,
+            }),
+          ),
           createdAt: initialData?.classPlan?.createdAt ?? now,
           updatedAt: now,
         },

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/services/events/webinar-service.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/services/events/webinar-service.ts
@@ -140,7 +140,7 @@ export class WebinarService {
         const errorData = await response.json();
         throw new Error(
           errorData.error ||
-            `Failed to ${isUpdate ? "update" : "create"} webinar`,
+          `Failed to ${isUpdate ? "update" : "create"} webinar`,
         );
       }
 
@@ -213,6 +213,7 @@ export class WebinarService {
       durationInHours: plan?.durationInHours ?? 1,
       maxParticipants: plan?.maxParticipants ?? 1,
       certificateProvided: plan?.certificateProvided,
+      recordingEnabled: plan?.recordingEnabled,
       language: plan?.language ?? undefined,
       level: plan?.level ?? undefined,
       prerequisites: plan?.prerequisites ?? undefined,

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/services/events/webinar-service.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/services/events/webinar-service.ts
@@ -140,7 +140,7 @@ export class WebinarService {
         const errorData = await response.json();
         throw new Error(
           errorData.error ||
-          `Failed to ${isUpdate ? "update" : "create"} webinar`,
+            `Failed to ${isUpdate ? "update" : "create"} webinar`,
         );
       }
 

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/services/planner.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/services/planner.ts
@@ -210,7 +210,7 @@ export class PlannerService {
         return this.saveClass(
           classData as Partial<ClassEvent>,
           consultantId,
-          formData.scheduledAt?.toString()
+          formData.scheduledAt?.toString(),
         );
       }
       case "consultation": {

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/services/planner.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/services/planner.ts
@@ -207,7 +207,11 @@ export class PlannerService {
           existingData as ClassEvent | undefined,
         );
         // Form input is a valid subset of Partial<ClassEvent> - saveClass only uses the fields we provide
-        return this.saveClass(classData as Partial<ClassEvent>, consultantId);
+        return this.saveClass(
+          classData as Partial<ClassEvent>,
+          consultantId,
+          formData.scheduledAt?.toString()
+        );
       }
       case "consultation": {
         const consultationData = this.buildConsultationDataFromForm(
@@ -364,6 +368,7 @@ export class PlannerService {
         meetingsPerWeek: formData.meetingsPerWeek ?? 1,
         maxParticipants: formData.maxParticipants,
         certificateProvided: formData.certificateProvided ?? false,
+        recordingEnabled: formData.recordingEnabled ?? false,
         emailSupport: formData.emailSupport || "GENERAL",
         language: formData.language || null,
         level: formData.level || null,

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/services/types.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/services/types.ts
@@ -20,6 +20,7 @@ export interface CreateWebinarPayload {
   durationInHours: number;
   maxParticipants: number;
   certificateProvided?: boolean;
+  recordingEnabled?: boolean;
   language?: string;
   level?: string;
   prerequisites?: string;

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/types/event.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/types/event.ts
@@ -111,10 +111,10 @@ export type FormData = {
   scheduledAt?: string | Date | null;
   priceCurrency?: string;
 } & (
-    | {
+  | {
       durationInHours: number;
     }
-    | {
+  | {
       durationInMonths: number;
       meetingsPerWeek: number;
       emailSupport: "GENERAL" | "PRIORITY" | "DEDICATED";
@@ -129,7 +129,7 @@ export type FormData = {
         hoursAllotted: number;
       }[];
     }
-  );
+);
 
 export interface BasePlannerProps {
   isOpen: boolean;

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/types/event.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/types/event.ts
@@ -106,14 +106,15 @@ export type FormData = {
   meetingsPerWeek?: number;
   emailSupport?: PlanEmailSupport;
   certificateProvided?: boolean;
+  recordingEnabled?: boolean;
   classContents?: ClassContentInput[];
   scheduledAt?: string | Date | null;
   priceCurrency?: string;
 } & (
-  | {
+    | {
       durationInHours: number;
     }
-  | {
+    | {
       durationInMonths: number;
       meetingsPerWeek: number;
       emailSupport: "GENERAL" | "PRIORITY" | "DEDICATED";
@@ -128,7 +129,7 @@ export type FormData = {
         hoursAllotted: number;
       }[];
     }
-);
+  );
 
 export interface BasePlannerProps {
   isOpen: boolean;
@@ -166,6 +167,9 @@ export type ClassContentInput = {
   contentUrl?: string | null;
   order: number;
   hoursAllotted: number;
+  classPlanId?: string;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
 };
 
 // Form-to-Event input types - used when building event data from form submissions
@@ -204,6 +208,7 @@ export type ClassFormInput = {
     meetingsPerWeek: number;
     maxParticipants: number;
     certificateProvided: boolean;
+    recordingEnabled: boolean;
     emailSupport: string;
     language?: string | null;
     level?: string | null;

--- a/app/meetings/[id]/components/EndCallButton.tsx
+++ b/app/meetings/[id]/components/EndCallButton.tsx
@@ -44,16 +44,11 @@ const EndCallButton = () => {
       "useStreamCall must be used within a StreamCall component.",
     );
 
-  // https://getstream.io/video/docs/react/guides/call-and-participant-state/#participant-state-3
-  const { useLocalParticipant } = useCallStateHooks();
-  const localParticipant = useLocalParticipant();
+  // Only consultants (hosts) should be able to end the call for everyone
+  // Use session role instead of Stream's createdBy, as consultee might join first
+  const isConsultant = session?.user?.role === "CONSULTANT";
 
-  const isMeetingOwner =
-    localParticipant &&
-    call.state.createdBy &&
-    localParticipant.userId === call.state.createdBy.id;
-
-  if (!isMeetingOwner) return null;
+  if (!isConsultant) return null;
 
   // Get proper dashboard URL based on user role and profile
   const getDashboardUrl = () => {

--- a/app/meetings/[id]/components/MeetingRoom.tsx
+++ b/app/meetings/[id]/components/MeetingRoom.tsx
@@ -254,6 +254,18 @@ const MeetingRoom = () => {
               {/* Screen Share */}
               <ScreenShareButton />
 
+              {/* Recording BUTTON for Consultant - Left of Leave Call (only if recording enabled) */}
+              {session?.user?.role === "CONSULTANT" && recordingEnabled && (
+                meetingSessionId ? (
+                  <RecordingControls
+                    meetingSessionId={meetingSessionId}
+                    recordingEnabled={recordingEnabled}
+                    showOnlyButton={true}
+                  />
+                ) : (
+                  <RecordCallButton />
+                )
+              )}
 
               {/* Leave Call Button */}
               <button
@@ -326,32 +338,30 @@ const MeetingRoom = () => {
                 )}
               </button>
 
-              {/* Recording Controls */}
-              {meetingSessionId ? (
-                <>
-                  {session?.user?.role === "CONSULTANT" && (
-                    <div className="w-px h-8 bg-zinc-700 mx-1" />
-                  )}
-                  <RecordingControls
-                    meetingSessionId={meetingSessionId}
-                    recordingEnabled={recordingEnabled}
-                  />
-                </>
-              ) : (
-                /* Fallback to Stream's RecordCallButton when no meeting session */
-                session?.user?.role === "CONSULTANT" && (
-                  <>
-                    <div className="w-px h-8 bg-zinc-700 mx-1" />
-                    <RecordCallButton />
-                  </>
-                )
-              )}
 
               {/* Divider */}
               {!isPersonalRoom && <div className="w-px h-8 bg-zinc-700 mx-1" />}
 
-              {/* End Call Button */}
+              {/* REC TIME Indicator for Consultant - Before End Call (only if recording enabled) */}
+              {session?.user?.role === "CONSULTANT" && meetingSessionId && recordingEnabled && (
+                <RecordingControls
+                  meetingSessionId={meetingSessionId}
+                  recordingEnabled={recordingEnabled}
+                  showOnlyIndicator={true}
+                />
+              )}
+
+              {/* End Call Button - Only for Consultant */}
               {!isPersonalRoom && <EndCallButton />}
+
+              {/* Recording Indicator for Consultee - At the very end (only if recording enabled) */}
+              {session?.user?.role === "CONSULTEE" && meetingSessionId && recordingEnabled && (
+                <RecordingControls
+                  meetingSessionId={meetingSessionId}
+                  recordingEnabled={recordingEnabled}
+                  showOnlyIndicator={true}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/app/meetings/[id]/components/MeetingRoom.tsx
+++ b/app/meetings/[id]/components/MeetingRoom.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import {
-  CallControls,
   CallParticipantsList,
   CallStatsButton,
   CallingState,
@@ -10,10 +9,15 @@ import {
   SpeakerLayout,
   useCall,
   useCallStateHooks,
+  ToggleAudioPublishingButton,
+  ToggleVideoPublishingButton,
+  ReactionsButton,
+  ScreenShareButton,
+  RecordCallButton,
 } from "@stream-io/video-react-sdk";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { Users, LayoutList, Grid3X3, Monitor, X } from "lucide-react";
+import { Users, LayoutList, Grid3X3, Monitor, X, Phone } from "lucide-react";
 
 import {
   DropdownMenu,
@@ -237,13 +241,31 @@ const MeetingRoom = () => {
         <div className="fixed bottom-0 left-0 right-0 z-50">
           <div className="flex items-center justify-center px-4 py-4">
             <div className="flex items-center gap-2 px-4 py-3 bg-zinc-900/90 backdrop-blur-xl rounded-2xl border border-zinc-800 shadow-2xl">
-              {/* Stream Call Controls */}
-              <CallControls
-                onLeave={async () => {
+              {/* Custom Call Controls - Replaces default CallControls */}
+              {/* Audio Toggle */}
+              <ToggleAudioPublishingButton />
+
+              {/* Video Toggle */}
+              <ToggleVideoPublishingButton />
+
+              {/* Reactions */}
+              <ReactionsButton />
+
+              {/* Screen Share */}
+              <ScreenShareButton />
+
+
+              {/* Leave Call Button */}
+              <button
+                onClick={async () => {
                   console.log("Participant leaving call");
                   await cleanupAndNavigate(getDashboardUrl());
                 }}
-              />
+                className="p-3 rounded-full bg-red-500 hover:bg-red-600 transition-colors"
+                title="Leave call"
+              >
+                <Phone className="w-5 h-5 rotate-[135deg] text-white" />
+              </button>
 
               {/* Divider */}
               <div className="w-px h-8 bg-zinc-700 mx-1" />
@@ -305,14 +327,24 @@ const MeetingRoom = () => {
               </button>
 
               {/* Recording Controls */}
-              {meetingSessionId && (
+              {meetingSessionId ? (
                 <>
-                  <div className="w-px h-8 bg-zinc-700 mx-1" />
+                  {session?.user?.role === "CONSULTANT" && (
+                    <div className="w-px h-8 bg-zinc-700 mx-1" />
+                  )}
                   <RecordingControls
                     meetingSessionId={meetingSessionId}
                     recordingEnabled={recordingEnabled}
                   />
                 </>
+              ) : (
+                /* Fallback to Stream's RecordCallButton when no meeting session */
+                session?.user?.role === "CONSULTANT" && (
+                  <>
+                    <div className="w-px h-8 bg-zinc-700 mx-1" />
+                    <RecordCallButton />
+                  </>
+                )
               )}
 
               {/* Divider */}

--- a/app/meetings/[id]/components/MeetingRoom.tsx
+++ b/app/meetings/[id]/components/MeetingRoom.tsx
@@ -255,8 +255,9 @@ const MeetingRoom = () => {
               <ScreenShareButton />
 
               {/* Recording BUTTON for Consultant - Left of Leave Call (only if recording enabled) */}
-              {session?.user?.role === "CONSULTANT" && recordingEnabled && (
-                meetingSessionId ? (
+              {session?.user?.role === "CONSULTANT" &&
+                recordingEnabled &&
+                (meetingSessionId ? (
                   <RecordingControls
                     meetingSessionId={meetingSessionId}
                     recordingEnabled={recordingEnabled}
@@ -264,8 +265,7 @@ const MeetingRoom = () => {
                   />
                 ) : (
                   <RecordCallButton />
-                )
-              )}
+                ))}
 
               {/* Leave Call Button */}
               <button
@@ -338,30 +338,33 @@ const MeetingRoom = () => {
                 )}
               </button>
 
-
               {/* Divider */}
               {!isPersonalRoom && <div className="w-px h-8 bg-zinc-700 mx-1" />}
 
               {/* REC TIME Indicator for Consultant - Before End Call (only if recording enabled) */}
-              {session?.user?.role === "CONSULTANT" && meetingSessionId && recordingEnabled && (
-                <RecordingControls
-                  meetingSessionId={meetingSessionId}
-                  recordingEnabled={recordingEnabled}
-                  showOnlyIndicator={true}
-                />
-              )}
+              {session?.user?.role === "CONSULTANT" &&
+                meetingSessionId &&
+                recordingEnabled && (
+                  <RecordingControls
+                    meetingSessionId={meetingSessionId}
+                    recordingEnabled={recordingEnabled}
+                    showOnlyIndicator={true}
+                  />
+                )}
 
               {/* End Call Button - Only for Consultant */}
               {!isPersonalRoom && <EndCallButton />}
 
               {/* Recording Indicator for Consultee - At the very end (only if recording enabled) */}
-              {session?.user?.role === "CONSULTEE" && meetingSessionId && recordingEnabled && (
-                <RecordingControls
-                  meetingSessionId={meetingSessionId}
-                  recordingEnabled={recordingEnabled}
-                  showOnlyIndicator={true}
-                />
-              )}
+              {session?.user?.role === "CONSULTEE" &&
+                meetingSessionId &&
+                recordingEnabled && (
+                  <RecordingControls
+                    meetingSessionId={meetingSessionId}
+                    recordingEnabled={recordingEnabled}
+                    showOnlyIndicator={true}
+                  />
+                )}
             </div>
           </div>
         </div>

--- a/app/meetings/[id]/components/MeetingSetup.tsx
+++ b/app/meetings/[id]/components/MeetingSetup.tsx
@@ -8,7 +8,16 @@ import {
   useCallStateHooks,
   VideoPreview,
 } from "@stream-io/video-react-sdk";
-import { Mic, MicOff, Video, VideoOff, Settings, Loader2, Volume2, MonitorSpeaker } from "lucide-react";
+import {
+  Mic,
+  MicOff,
+  Video,
+  VideoOff,
+  Settings,
+  Loader2,
+  Volume2,
+  MonitorSpeaker,
+} from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
 import { Label } from "@/components/ui/label";

--- a/app/meetings/[id]/components/MeetingSetup.tsx
+++ b/app/meetings/[id]/components/MeetingSetup.tsx
@@ -4,14 +4,21 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import {
   CallingState,
-  DeviceSettings,
   useCall,
   useCallStateHooks,
   VideoPreview,
 } from "@stream-io/video-react-sdk";
-import { Mic, MicOff, Video, VideoOff, Settings, Loader2 } from "lucide-react";
+import { Mic, MicOff, Video, VideoOff, Settings, Loader2, Volume2, MonitorSpeaker } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { cn } from "@/utils/tailwind";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface MeetingSetupProps {
   setIsSetupComplete: (value: boolean) => void;
@@ -39,6 +46,115 @@ const createAudioAnalyzer = async () => {
     console.error("Error accessing microphone:", error);
     return null;
   }
+};
+
+const DeviceSelector = () => {
+  const { useMicrophoneState, useCameraState, useSpeakerState } =
+    useCallStateHooks();
+  const micState = useMicrophoneState();
+  const camState = useCameraState();
+  const speakerState = useSpeakerState?.();
+
+  const [selectedMic, setSelectedMic] = useState<string>("");
+  const [selectedCam, setSelectedCam] = useState<string>("");
+  const [selectedSpeaker, setSelectedSpeaker] = useState<string>("");
+
+  useEffect(() => {
+    if (micState.selectedDevice) setSelectedMic(micState.selectedDevice);
+  }, [micState.selectedDevice]);
+
+  useEffect(() => {
+    if (camState.selectedDevice) setSelectedCam(camState.selectedDevice);
+  }, [camState.selectedDevice]);
+
+  useEffect(() => {
+    if (speakerState?.selectedDevice)
+      setSelectedSpeaker(speakerState.selectedDevice);
+  }, [speakerState?.selectedDevice]);
+
+  return (
+    <div className="space-y-4">
+      {/* Camera */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-zinc-700">
+          <Video className="w-4 h-4" />
+          <Label className="text-sm font-medium">Camera</Label>
+        </div>
+        <Select
+          value={selectedCam}
+          onValueChange={async (val) => {
+            setSelectedCam(val);
+            await camState.camera.select(val);
+          }}
+        >
+          <SelectTrigger className="bg-white border-zinc-200">
+            <SelectValue placeholder="Select Camera" />
+          </SelectTrigger>
+          <SelectContent>
+            {camState.devices?.map((d) => (
+              <SelectItem key={d.deviceId} value={d.deviceId}>
+                {d.label || `Camera ${d.deviceId}`}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Microphone */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-zinc-700">
+          <Mic className="w-4 h-4" />
+          <Label className="text-sm font-medium">Microphone</Label>
+        </div>
+        <Select
+          value={selectedMic}
+          onValueChange={async (val) => {
+            setSelectedMic(val);
+            await micState.microphone.select(val);
+          }}
+        >
+          <SelectTrigger className="bg-white border-zinc-200">
+            <SelectValue placeholder="Select Microphone" />
+          </SelectTrigger>
+          <SelectContent>
+            {micState.devices?.map((d) => (
+              <SelectItem key={d.deviceId} value={d.deviceId}>
+                {d.label || `Microphone ${d.deviceId}`}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Speakers */}
+      {speakerState?.devices && speakerState.devices.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-zinc-700">
+            <Volume2 className="w-4 h-4" />
+            <Label className="text-sm font-medium">Speakers</Label>
+          </div>
+          <Select
+            value={selectedSpeaker}
+            onValueChange={async (val) => {
+              setSelectedSpeaker(val);
+              await speakerState.speaker.select(val);
+            }}
+          >
+            <SelectTrigger className="bg-white border-zinc-200">
+              <SelectValue placeholder="Select Speakers" />
+            </SelectTrigger>
+            <SelectContent>
+              {speakerState.devices.map((d) => (
+                <SelectItem key={d.deviceId} value={d.deviceId}>
+                  {d.label || `Speaker ${d.deviceId}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  );
 };
 
 const MeetingSetup = ({ setIsSetupComplete }: MeetingSetupProps) => {
@@ -368,9 +484,9 @@ const MeetingSetup = ({ setIsSetupComplete }: MeetingSetupProps) => {
             {showSettings && (
               <div className="mt-4 p-4 bg-zinc-50 rounded-xl border border-zinc-200">
                 <p className="text-sm font-medium text-zinc-700 mb-3">
-                  Device Settings
+                  Audio & Video Settings
                 </p>
-                <DeviceSettings />
+                <DeviceSelector />
               </div>
             )}
           </div>

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -237,7 +237,7 @@ const RecordingControls = ({
         className={cn(
           "w-[46px] h-[46px] rounded-full transition-all duration-200 flex items-center justify-center",
           "bg-zinc-800 hover:bg-zinc-700",
-          isLoading && "opacity-50 cursor-not-allowed"
+          isLoading && "opacity-50 cursor-not-allowed",
         )}
         title={isRecording ? "Stop Recording" : "Start Recording"}
       >
@@ -272,7 +272,7 @@ const RecordingControls = ({
         className={cn(
           "p-3 rounded-full transition-all duration-200 flex items-center justify-center",
           "bg-zinc-800 hover:bg-zinc-700",
-          isLoading && "opacity-50 cursor-not-allowed"
+          isLoading && "opacity-50 cursor-not-allowed",
         )}
         title={isRecording ? "Stop Recording" : "Start Recording"}
       >

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useCall, useCallStateHooks } from "@stream-io/video-react-sdk";
+import { useCall } from "@stream-io/video-react-sdk";
+import { useSession } from "next-auth/react";
 import { Circle, Square, Loader2 } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 import { useToast } from "@/hooks/use-toast";
@@ -17,18 +18,14 @@ const RecordingControls = ({
 }: RecordingControlsProps) => {
   const call = useCall();
   const { toast } = useToast();
+  const { data: session } = useSession();
   const [isRecording, setIsRecording] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [recordingDuration, setRecordingDuration] = useState(0);
 
-  const { useLocalParticipant } = useCallStateHooks();
-  const localParticipant = useLocalParticipant();
-
-  // Check if user is the call owner (consultant)
-  const isCallOwner =
-    localParticipant &&
-    call?.state.createdBy &&
-    localParticipant.userId === call.state.createdBy.id;
+  // Only consultants (hosts) should be able to control recordings
+  // Use session role instead of Stream's createdBy, as consultee might join first
+  const isConsultant = session?.user?.role === "CONSULTANT";
 
   // Subscribe to call recording state changes
   useEffect(() => {
@@ -179,25 +176,27 @@ const RecordingControls = ({
     }
   };
 
-  // Don't render if recording is not enabled for this session
-  if (!recordingEnabled) {
-    return null;
-  }
-
-  // Only show controls to call owner (consultant)
-  // But show recording indicator to everyone
-  if (!isCallOwner) {
-    // Recording indicator for non-owners when recording is active
+  // For non-consultants (consultees), show recording indicator when recording is active
+  if (!isConsultant) {
+    // Show recording indicator when recording is active (so consultee knows they're being recorded)
     if (isRecording) {
       return (
-        <div className="flex items-center gap-2 px-3 py-2 bg-red-500/20 rounded-lg border border-red-500/30">
+        <div
+          className="flex items-center gap-2 px-3 py-2 bg-red-500/20 rounded-lg border border-red-500/30 cursor-not-allowed"
+          title="Recording in progress"
+        >
           <Circle className="w-3 h-3 fill-red-500 text-red-500 animate-pulse" />
           <span className="text-sm font-medium text-red-400">
-            Recording {formatDuration(recordingDuration)}
+            REC {formatDuration(recordingDuration)}
           </span>
         </div>
       );
     }
+    return null;
+  }
+
+  // For consultants, check if recording is enabled
+  if (!recordingEnabled) {
     return null;
   }
 
@@ -222,7 +221,7 @@ const RecordingControls = ({
           isRecording
             ? "bg-red-500 hover:bg-red-600 text-white"
             : "bg-zinc-800 hover:bg-zinc-700 text-white",
-          isLoading && "opacity-50 cursor-not-allowed",
+          isLoading && "opacity-50 cursor-not-allowed"
         )}
         title={isRecording ? "Stop Recording" : "Start Recording"}
       >

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -10,11 +10,15 @@ import { useToast } from "@/hooks/use-toast";
 interface RecordingControlsProps {
   meetingSessionId: string;
   recordingEnabled: boolean;
+  showOnlyButton?: boolean;
+  showOnlyIndicator?: boolean;
 }
 
 const RecordingControls = ({
   meetingSessionId,
   recordingEnabled,
+  showOnlyButton = false,
+  showOnlyIndicator = false,
 }: RecordingControlsProps) => {
   const call = useCall();
   const { toast } = useToast();
@@ -70,12 +74,26 @@ const RecordingControls = ({
       });
     });
 
+    // Also subscribe to general call state updates to catch recording changes
+    const unsubscribeUpdated = call.on("call.updated", () => {
+      const recording = call.state.recording;
+      if (recording && !isRecording) {
+        setIsRecording(true);
+        setIsLoading(false);
+      } else if (!recording && isRecording) {
+        setIsRecording(false);
+        setIsLoading(false);
+        setRecordingDuration(0);
+      }
+    });
+
     return () => {
       unsubscribe();
       unsubscribeStopped();
       unsubscribeFailed();
+      unsubscribeUpdated();
     };
-  }, [call, toast]);
+  }, [call, toast, isRecording]);
 
   // Recording duration timer
   useEffect(() => {
@@ -195,11 +213,48 @@ const RecordingControls = ({
     return null;
   }
 
-  // For consultants, check if recording is enabled
-  if (!recordingEnabled) {
-    return null;
+  // For consultants - render based on props
+
+  // If showOnlyIndicator is true, only render the REC time indicator (when recording)
+  if (showOnlyIndicator) {
+    if (!isRecording) return null;
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 bg-red-500/20 rounded-lg border border-red-500/30">
+        <Circle className="w-3 h-3 fill-red-500 text-red-500 animate-pulse" />
+        <span className="text-sm font-medium text-red-400">
+          REC {formatDuration(recordingDuration)}
+        </span>
+      </div>
+    );
   }
 
+  // If showOnlyButton is true, only render the recording button
+  if (showOnlyButton) {
+    return (
+      <button
+        onClick={isRecording ? handleStopRecording : handleStartRecording}
+        disabled={isLoading}
+        className={cn(
+          "w-[46px] h-[46px] rounded-full transition-all duration-200 flex items-center justify-center",
+          isRecording
+            ? "bg-red-500/20 border-2 border-red-500 hover:bg-red-500/30"
+            : "bg-zinc-800 hover:bg-zinc-700",
+          isLoading && "opacity-50 cursor-not-allowed"
+        )}
+        title={isRecording ? "Stop Recording" : "Start Recording"}
+      >
+        {isLoading ? (
+          <Loader2 className="w-5 h-5 animate-spin text-white" />
+        ) : isRecording ? (
+          <Square className="w-4 h-4 fill-red-500 text-red-500" />
+        ) : (
+          <div className="w-4 h-4 rounded-full bg-red-500" />
+        )}
+      </button>
+    );
+  }
+
+  // Default: render both button and indicator together
   return (
     <div className="flex items-center gap-2">
       {/* Recording indicator when active */}
@@ -217,7 +272,7 @@ const RecordingControls = ({
         onClick={isRecording ? handleStopRecording : handleStartRecording}
         disabled={isLoading}
         className={cn(
-          "p-3 rounded-xl transition-all duration-200 flex items-center gap-2",
+          "p-3 rounded-full transition-all duration-200 flex items-center justify-center",
           isRecording
             ? "bg-red-500 hover:bg-red-600 text-white"
             : "bg-zinc-800 hover:bg-zinc-700 text-white",

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -236,9 +236,7 @@ const RecordingControls = ({
         disabled={isLoading}
         className={cn(
           "w-[46px] h-[46px] rounded-full transition-all duration-200 flex items-center justify-center",
-          isRecording
-            ? "bg-red-500/20 border-2 border-red-500 hover:bg-red-500/30"
-            : "bg-zinc-800 hover:bg-zinc-700",
+          "bg-zinc-800 hover:bg-zinc-700",
           isLoading && "opacity-50 cursor-not-allowed"
         )}
         title={isRecording ? "Stop Recording" : "Start Recording"}
@@ -273,19 +271,17 @@ const RecordingControls = ({
         disabled={isLoading}
         className={cn(
           "p-3 rounded-full transition-all duration-200 flex items-center justify-center",
-          isRecording
-            ? "bg-red-500 hover:bg-red-600 text-white"
-            : "bg-zinc-800 hover:bg-zinc-700 text-white",
+          "bg-zinc-800 hover:bg-zinc-700",
           isLoading && "opacity-50 cursor-not-allowed"
         )}
         title={isRecording ? "Stop Recording" : "Start Recording"}
       >
         {isLoading ? (
-          <Loader2 className="w-5 h-5 animate-spin" />
+          <Loader2 className="w-5 h-5 animate-spin text-white" />
         ) : isRecording ? (
-          <Square className="w-5 h-5 fill-current" />
+          <Square className="w-4 h-4 fill-red-500 text-red-500" />
         ) : (
-          <Circle className="w-5 h-5 fill-red-500 text-red-500" />
+          <div className="w-4 h-4 rounded-full bg-red-500" />
         )}
       </button>
     </div>

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -17,7 +17,7 @@ const prisma =
     adapter,
     log:
       process.env.NODE_ENV === "development"
-        ? ["query", "error", "warn"]
+        ? ["error", "warn"]
         : ["error"],
   });
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -15,10 +15,7 @@ const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
     adapter,
-    log:
-      process.env.NODE_ENV === "development"
-        ? ["error", "warn"]
-        : ["error"],
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
   });
 
 export default prisma;

--- a/schemas/plans.ts
+++ b/schemas/plans.ts
@@ -437,13 +437,13 @@ export const ClassContentSchema = z.object({
       (val) => !val || profanityFreeRefinement(val),
       "URL contains inappropriate language",
     ),
-  order: z.number().min(1, "Order must be a positive number"),
+  order: z.number().optional(),
   hoursAllotted: z
     .number()
     .min(0.5, "Hours allotted must be at least 30 minutes"),
   // Optional fields for Prisma compatibility
-  createdAt: z.date().optional(),
-  updatedAt: z.date().optional(),
+  createdAt: z.union([z.date(), z.string()]).optional(),
+  updatedAt: z.union([z.date(), z.string()]).optional(),
   classPlanId: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
Fixed meeting UI controls to use session role instead of Stream's createdBy for determining user permissions. This ensures proper control visibility regardless of who joins the meeting first.

## Changes

### EndCallButton.tsx
- Changed permission check from Stream's createdBy to session role CONSULTANT
- Only users with CONSULTANT role can see "End call for everyone" button
- This fixes the issue where consultee could see the button if they joined first

### MeetingRoom.tsx
- Replaced Stream's default CallControls with individual control components
- Custom RecordingControls integration with fallback to Stream's RecordCallButton
- Fixed recording controls to use custom component with meetingSessionId
- Added Stream's RecordCallButton fallback when meetingSessionId is unavailable
- Fixed divider visibility - only shows for CONSULTANT users
- Removed duplicate RecordingControls rendering (was in two places)
- Leave call button now has red background styling for better UX

### RecordingControls.tsx
- Changed permission check from Stream's createdBy to session role CONSULTANT
- Consultants see full recording controls (start/stop button)
- Consultees see "REC" indicator with timer when recording is active
- Non-clickable indicator styling with cursor-not-allowed for consultees
- Recording controls call our API endpoint /api/stream/recordings/start
- Toast notifications shown when recording starts/stops

## Problem
The previous implementation used Stream's createdBy property to determine who the meeting owner was. This caused issues when the consultee joined the meeting before the consultant - the consultee would be marked as the owner and could see/use controls meant only for consultants.

## Solution
Use the user's session role (CONSULTANT/CONSULTEE) from next-auth instead of Stream's createdBy. This ensures consistent behavior regardless of join order.

Fixes #meeting-ui-roles