### PR TITLE
Issue: Free Trial Sessions Not Marked as "Converted" After Subscription Purchase

### DIFF
--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -68,7 +68,7 @@ type SubscriptionCheckoutResult = {
 function buildPaymentMetadata(
   data: CheckoutInput,
   userId: string,
-): { appointmentId: string; appointmentType: string; [key: string]: string } {
+): { appointmentId: string; appointmentType: string;[key: string]: string } {
   return {
     appointmentId: "pending",
     appointmentType: data.appointmentType,
@@ -439,14 +439,14 @@ export async function validateSlotAvailability(
         // FIX: Filter by consultant - only check slots belonging to this consultant
         ...(consultantUserId
           ? [
-              {
-                user: {
-                  some: {
-                    id: consultantUserId,
-                  },
+            {
+              user: {
+                some: {
+                  id: consultantUserId,
                 },
               },
-            ]
+            },
+          ]
           : []),
       ],
     },
@@ -481,14 +481,14 @@ export async function validateSlotAvailability(
           // FIX: Filter by consultant - only check tentative slots for this consultant
           ...(consultantUserId
             ? [
-                {
-                  user: {
-                    some: {
-                      id: consultantUserId,
-                    },
+              {
+                user: {
+                  some: {
+                    id: consultantUserId,
                   },
                 },
-              ]
+              },
+            ]
             : []),
           {
             appointment: {
@@ -552,14 +552,14 @@ export async function validateSlotAvailability(
         // FIX: Filter by consultant - only count tentative slots for this consultant
         ...(consultantUserId
           ? [
-              {
-                user: {
-                  some: {
-                    id: consultantUserId,
-                  },
+            {
+              user: {
+                some: {
+                  id: consultantUserId,
                 },
               },
-            ]
+            },
+          ]
           : []),
         {
           appointment: {
@@ -1068,6 +1068,39 @@ export async function handleSubscriptionCheckout(
       schedulingPeriodEndsAt: endDate,
     },
   });
+
+  // Link any completed trial to this subscription (trial conversion tracking)
+  // Find a completed trial from the same consultee for this consultant
+  const completedTrial = await tx.trialSession.findFirst({
+    where: {
+      consulteeProfileId: consulteeProfileId,
+      consultantProfileId: plan.consultantProfileId,
+      status: "COMPLETED", // Only link completed trials, not pending/scheduled
+      convertedToSubscriptionId: null, // Not already linked to another subscription
+    },
+  });
+
+  if (completedTrial) {
+    // Mark the trial as converted and link to this subscription
+    await tx.trialSession.update({
+      where: { id: completedTrial.id },
+      data: {
+        status: "CONVERTED",
+        convertedToSubscriptionId: subscription.id,
+      },
+    });
+
+    console.log(
+      JSON.stringify({
+        event: "trial_converted",
+        trialId: completedTrial.id,
+        subscriptionId: subscription.id,
+        consulteeProfileId,
+        consultantProfileId: plan.consultantProfileId,
+        timestamp: new Date().toISOString(),
+      })
+    );
+  }
 
   // FIX Issue #2: Create placeholder appointment for payment linkage
   // This ensures webhook uses NEW FLOW (confirm) not LEGACY FLOW (create duplicate)

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -12,6 +12,7 @@ import {
   PaymentStatus,
   Prisma,
   RequestStatus,
+  TrialSessionStatus,
 } from "@prisma/client";
 import { cancelPaymentIntent, createPaymentIntent } from "../index";
 import {
@@ -1073,9 +1074,9 @@ export async function handleSubscriptionCheckout(
   // Find a completed trial from the same consultee for this consultant
   const completedTrial = await tx.trialSession.findFirst({
     where: {
-      consulteeProfileId: consulteeProfileId,
+      consulteeProfileId,
       consultantProfileId: plan.consultantProfileId,
-      status: "COMPLETED", // Only link completed trials, not pending/scheduled
+      status: TrialSessionStatus.COMPLETED, // Only link completed trials, not pending/scheduled
       convertedToSubscriptionId: null, // Not already linked to another subscription
     },
   });
@@ -1085,7 +1086,7 @@ export async function handleSubscriptionCheckout(
     await tx.trialSession.update({
       where: { id: completedTrial.id },
       data: {
-        status: "CONVERTED",
+        status: TrialSessionStatus.CONVERTED,
         convertedToSubscriptionId: subscription.id,
       },
     });


### PR DESCRIPTION
## Problem Description
When a consultee completes a free trial session with a consultant and subsequently purchases a subscription from the same consultant, the trial session should be marked as CONVERTED. However, this was not happening.

## Observed Behavior:
- Trial status remains COMPLETED instead of transitioning to CONVERTED
- The "Converted" count in the consultant's Free Trial Requests dashboard stays at 0
- No link is created between the trial session and the resulting subscription
- Analytics/conversion tracking is broken

## Expected Behavior:
- When a subscription is purchased, the system should automatically find any completed trial from the same consultee+consultant pair
- The trial should be updated to status CONVERTED
- The trial should be linked to the subscription via convertedToSubscriptionId

## Root Cause Analysis
The subscription checkout flow in lib/payments/operations/checkout.ts → handleSubscriptionCheckout() 
was missing the trial conversion logic entirely.


## Database Schema (TrialSession model):
```
model TrialSession {
  id                        String
  status                    TrialSessionStatus  // PENDING → SCHEDULED → COMPLETED → CONVERTED
  
  // Link to subscription after conversion (was never being set!)
  convertedToSubscription   Subscription?
  convertedToSubscriptionId String?       @unique
}
```

The convertedToSubscriptionId field and CONVERTED status were designed for this purpose but were never being used.


## Solution
Added trial conversion logic to handleSubscriptionCheckout() that runs immediately after a subscription is created:

1. Find completed trial: Queries for a TrialSession where:
     - Same consulteeProfileId as the subscription purchaser
    - Same consultantProfileId as the subscription plan owner
    - Status is COMPLETED
    - Not already linked to another subscription (convertedToSubscriptionId is null)
2. Update trial: If found, updates the trial to:
   - Set status to CONVERTED
   - Link to the new subscription via convertedToSubscriptionId
3. Log conversion: Outputs structured log for monitoring/debugging

