### PR TITLE
refactor(types): extract shared types and establish type conventions

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -27,14 +27,9 @@
         "STRIPE_SECRET_KEY": "<STRIPE_SECRET_KEY>"
       }
     },
-    "serena": {
-      "command": "/home/kaustav/.local/bin/uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server"
-      ]
+     "serena": {
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/oraios/serena", "serena-mcp-server"]
     },
     "directus": {
       "command": "npx",

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,28 @@
+# Familiarise Web - Project Overview
+
+## Purpose
+SaaS platform for consultants and consultees. Supports consultations, subscriptions, webinars, classes, payments (Stripe/Razorpay), video calls (Stream), chat (Stream), notifications (Novu).
+
+## Tech Stack
+- Next.js 15 (App Router, "use client" pages)
+- TypeScript, Prisma ORM, PostgreSQL
+- Tailwind CSS, shadcn/ui components
+- Stream Chat/Video, Novu notifications
+- Stripe + Razorpay payments
+- Jest for testing
+
+## Key Commands
+- `npm run dev` — Start dev server
+- `npm run test` — Run Jest tests
+- `npx tsc --noEmit` — TypeScript type check
+- `npx prisma generate` — Generate Prisma client
+
+## Key Directories
+- `app/` — Next.js App Router pages and API routes
+- `types/` — Shared TypeScript types
+- `schemas/` — Zod validation schemas
+- `actions/` — Server actions
+- `lib/` — Shared utilities
+- `components/` — UI components
+- `prisma/` — Schema and seed files
+- `utils/` — Utility functions

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,7 @@
+# Suggested Commands
+
+- `npm run test` — Run all tests
+- `npx tsc --noEmit` — Check TypeScript types
+- `npm run dev` — Start development server
+- `npx prisma generate` — Regenerate Prisma client
+- `git` — Standard git commands (Darwin/macOS)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,15 +1,27 @@
+# the name by which the project can be referenced within Serena
+project_name: "familiarise_web"
+
+
 # list of languages for which language servers are started; choose from:
-#   al               bash             clojure          cpp              csharp           csharp_omnisharp
-#   dart             elixir           elm              erlang           fortran          go
-#   haskell          java             julia            kotlin           lua              markdown
-#   nix              perl             php              python           python_jedi      r
-#   rego             ruby             ruby_solargraph  rust             scala            swift
-#   terraform        typescript       typescript_vts   yaml             zig
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   powershell          python              python_jedi         r                   rego
+#   ruby                ruby_solargraph     rust                scala               swift
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -20,14 +32,11 @@ languages:
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
 
-# whether to use the project's gitignore file to ignore files
-# Added on 2025-04-07
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore
+# list of additional paths to ignore in all projects
 # same syntax as gitignore, so you can use * and **
-# Was previously called `ignored_dirs`, please update your config if you are using that.
-# Added (renamed) on 2025-04-07
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -37,7 +46,7 @@ read_only: false
 
 # list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
 # Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions,
+# To make sure you have the latest list of tools, and to view their descriptions, 
 # execute `uv run scripts/print_tool_overview.py`.
 #
 #  * `activate_project`: Activates a project by name.
@@ -76,14 +85,12 @@ read_only: false
 #  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
 excluded_tools: []
 
-# initial prompt for the project. It will always be given to the LLM upon activating the project
-# (contrary to the memories, which are loaded on demand).
-initial_prompt: ""
-# the name by which the project can be referenced within Serena
-project_name: "familiarise_web"
-
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
 # The full set of modes to be activated is base_modes + default_modes.
@@ -100,6 +107,6 @@ base_modes:
 # This setting can, in turn, be overridden by CLI parameters (--mode).
 default_modes:
 
-# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
-# This cannot be combined with non-empty excluded_tools or included_optional_tools.
-fixed_tools: []
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""

--- a/app/api/events/classes/[classId]/validate/route.ts
+++ b/app/api/events/classes/[classId]/validate/route.ts
@@ -17,20 +17,9 @@ import {
   eventIdSchema,
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
+import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
-interface ValidationResult {
-  conflicts: {
-    slot: string;
-    existingAppointment: {
-      type: string;
-      with: string;
-      time: string;
-    };
-  }[];
-  outsideAvailability: {
-    slot: string;
-  }[];
-  validSlots: string[];
+interface ValidationResult extends SlotConflictResult {
   weeklyDistributionErrors: {
     week: string;
     slotsCount: number;

--- a/app/api/events/consultations/[consultationId]/validate/route.ts
+++ b/app/api/events/consultations/[consultationId]/validate/route.ts
@@ -18,21 +18,7 @@ import {
   eventIdSchema,
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
-
-interface ValidationResult {
-  conflicts: {
-    slot: string;
-    existingAppointment: {
-      type: string;
-      with: string;
-      time: string;
-    };
-  }[];
-  outsideAvailability: {
-    slot: string;
-  }[];
-  validSlots: string[];
-}
+import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
 const consultationInclude = {
   consultationPlan: {
@@ -127,7 +113,7 @@ export async function POST(
       }
 
       // Parse errors to extract conflicts and availability issues
-      const result: ValidationResult = {
+      const result: SlotConflictResult = {
         conflicts: [],
         outsideAvailability: [],
         validSlots: [],

--- a/app/api/events/subscriptions/[subscriptionId]/validate/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/validate/route.ts
@@ -20,20 +20,9 @@ import {
   eventIdSchema,
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
+import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
-interface ValidationResult {
-  conflicts: {
-    slot: string;
-    existingAppointment: {
-      type: string;
-      with: string;
-      time: string;
-    };
-  }[];
-  outsideAvailability: {
-    slot: string;
-  }[];
-  validSlots: string[];
+interface ValidationResult extends SlotConflictResult {
   subscriptionValidation?: {
     isValid: boolean;
     errors: string[];

--- a/app/api/events/webinars/[webinarId]/validate/route.ts
+++ b/app/api/events/webinars/[webinarId]/validate/route.ts
@@ -17,21 +17,7 @@ import {
   eventIdSchema,
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
-
-interface ValidationResult {
-  conflicts: {
-    slot: string;
-    existingAppointment: {
-      type: string;
-      with: string;
-      time: string;
-    };
-  }[];
-  outsideAvailability: {
-    slot: string;
-  }[];
-  validSlots: string[];
-}
+import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
 const webinarInclude = {
   webinarPlan: {
@@ -121,7 +107,7 @@ export async function POST(
       }
 
       // Parse errors to extract conflicts and availability issues
-      const result: ValidationResult = {
+      const result: SlotConflictResult = {
         conflicts: [],
         outsideAvailability: [],
         validSlots: [],

--- a/app/api/staff/moderation/profiles/route.ts
+++ b/app/api/staff/moderation/profiles/route.ts
@@ -8,6 +8,7 @@ import { getServerSession } from "next-auth";
 import authOptions from "@/app/api/auth/[...nextauth]/options";
 import prisma from "@/lib/prisma";
 import { UserRole, ProfileVerificationStatus, Prisma } from "@prisma/client";
+import type { ProfileVerification } from "@/types/moderation";
 
 /**
  * GET /api/staff/moderation/profiles
@@ -77,29 +78,26 @@ export async function GET(req: NextRequest) {
       (v) => v.consultantProfile && v.consultantProfile.user,
     );
 
-    const formattedVerifications = validVerifications.map((v) => ({
+    const formattedVerifications: ProfileVerification[] = validVerifications.map((v) => ({
       id: v.id,
       status: v.status,
-      submittedAt: v.submittedAt,
+      submittedAt: v.submittedAt.toISOString(),
       notes: v.notes,
       rejectionReason: v.rejectionReason,
       feedbackDetails: v.feedbackDetails,
-      // Return consultantProfile in the shape the frontend expects
-      consultantProfile: {
-        id: v.consultantProfile.id,
-        description: v.consultantProfile.description,
-        headline: v.consultantProfile.headline,
+      // Flatten consultantProfile + user into the "consultant" shape the frontend expects
+      consultant: {
+        profileId: v.consultantProfile.id,
+        userId: v.consultantProfile.user.id,
+        name: v.consultantProfile.user.name,
+        email: v.consultantProfile.user.email,
+        image: v.consultantProfile.user.image,
+        linkedinUrl: v.consultantProfile.user.linkedinUrl,
+        domain: v.consultantProfile.domain?.name ?? "",
         experience: v.consultantProfile.experience,
-        user: {
-          id: v.consultantProfile.user.id,
-          name: v.consultantProfile.user.name,
-          email: v.consultantProfile.user.email,
-          image: v.consultantProfile.user.image,
-          linkedinUrl: v.consultantProfile.user.linkedinUrl,
-          bio: v.consultantProfile.user.bio,
-        },
-        domain: v.consultantProfile.domain,
-        subDomains: v.consultantProfile.subDomains,
+        headline: v.consultantProfile.headline,
+        isVerified: v.status === "APPROVED",
+        verificationStatus: v.status,
       },
       documents: v.documents.map((d) => ({
         id: d.id,
@@ -110,7 +108,7 @@ export async function GET(req: NextRequest) {
         fileUrl: d.fileUrl,
         description: d.description,
       })),
-      reviewedAt: v.reviewedAt,
+      reviewedAt: v.reviewedAt?.toISOString() ?? null,
       reviewedById: v.reviewedById,
       reviewNotes: v.reviewNotes,
     }));

--- a/app/api/staff/support-tickets/route.ts
+++ b/app/api/staff/support-tickets/route.ts
@@ -15,6 +15,7 @@ import {
   Prisma,
 } from "@prisma/client";
 
+
 /**
  * GET /api/staff/support-tickets
  * List all support tickets with filters (staff/admin access)

--- a/app/checkout/plans/class/[classPlanId]/page.tsx
+++ b/app/checkout/plans/class/[classPlanId]/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../utils";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/lib/hooks/useCurrency";
+import type { AppliedDiscount } from "@/types/checkout";
 
 import type {
   Appointment,
@@ -84,12 +85,7 @@ export default function ClassCheckoutPage({
     null,
   );
   const [discountCodeInput, setDiscountCodeInput] = useState("");
-  const [appliedDiscount, setAppliedDiscount] = useState<{
-    code: string;
-    discountType: "PERCENTAGE" | "FIXED_AMOUNT";
-    discountValue: number;
-    discountAmount?: number;
-  } | null>(null);
+  const [appliedDiscount, setAppliedDiscount] = useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
 

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -13,6 +13,7 @@ import {
   consultationSearchParamsSchema,
   createCheckoutData,
 } from "@/schemas/checkout";
+import type { AppliedDiscount } from "@/types/checkout";
 import {
   ConsultantProfile,
   ConsultantReview,
@@ -42,8 +43,6 @@ type ConsultationResponse = {
   data: ConsultationPlanWithConsultant;
 };
 
-// Using the shared consultation schema from utils/payments.ts
-
 type PageProps = {
   params: Promise<{ planId: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -68,12 +67,7 @@ export default function ConsultationCheckoutPage({
     null,
   );
   const [discountCodeInput, setDiscountCodeInput] = useState("");
-  const [appliedDiscount, setAppliedDiscount] = useState<{
-    code: string;
-    discountType: "PERCENTAGE" | "FIXED_AMOUNT";
-    discountValue: number;
-    discountAmount?: number;
-  } | null>(null);
+  const [appliedDiscount, setAppliedDiscount] = useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
 

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -13,25 +13,13 @@ import {
   subscriptionSearchParamsSchema,
   createCheckoutData,
 } from "@/schemas/checkout";
+import type { AppliedDiscount } from "@/types/checkout";
 import {
   ConsultantProfile,
   ConsultantReview,
   SubscriptionPlan,
   PaymentGateway,
 } from "@prisma/client";
-import { loadStripe } from "@stripe/stripe-js";
-import { CreditCard as CreditCardIcon } from "lucide-react";
-import { use, useCallback, useEffect, useMemo, useState } from "react";
-import RazorpayCheckout from "../../../components/RazorpayCheckout";
-import StripeCheckout from "../../../components/StripeCheckout";
-import {
-  createHandleApiError,
-  paymentGateways,
-  createStripeCheckoutHandlers,
-  createRazorpayCheckoutHandlers,
-} from "../../utils";
-import { calculatePricing, formatPercentage } from "../../math";
-import { useCurrency } from "@/lib/hooks/useCurrency";
 
 type SubscriptionPlanWithConsultant = SubscriptionPlan & {
   consultantProfile: ConsultantProfile & {
@@ -47,6 +35,19 @@ type SubscriptionPlanWithConsultant = SubscriptionPlan & {
 type SubscriptionResponse = {
   data: SubscriptionPlanWithConsultant;
 };
+import { loadStripe } from "@stripe/stripe-js";
+import { CreditCard as CreditCardIcon } from "lucide-react";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
+import RazorpayCheckout from "../../../components/RazorpayCheckout";
+import StripeCheckout from "../../../components/StripeCheckout";
+import {
+  createHandleApiError,
+  paymentGateways,
+  createStripeCheckoutHandlers,
+  createRazorpayCheckoutHandlers,
+} from "../../utils";
+import { calculatePricing, formatPercentage } from "../../math";
+import { useCurrency } from "@/lib/hooks/useCurrency";
 
 type PageProps = {
   params: Promise<{ planId: string }>;
@@ -71,12 +72,7 @@ export default function SubscriptionCheckoutPage({
     null,
   );
   const [discountCodeInput, setDiscountCodeInput] = useState("");
-  const [appliedDiscount, setAppliedDiscount] = useState<{
-    code: string;
-    discountType: "PERCENTAGE" | "FIXED_AMOUNT";
-    discountValue: number;
-    discountAmount?: number;
-  } | null>(null);
+  const [appliedDiscount, setAppliedDiscount] = useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
 

--- a/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
+++ b/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../utils";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/lib/hooks/useCurrency";
+import type { AppliedDiscount } from "@/types/checkout";
 
 import type {
   Appointment,
@@ -89,12 +90,7 @@ export default function WebinarCheckoutPage({
     null,
   );
   const [discountCodeInput, setDiscountCodeInput] = useState("");
-  const [appliedDiscount, setAppliedDiscount] = useState<{
-    code: string;
-    discountType: "PERCENTAGE" | "FIXED_AMOUNT";
-    discountValue: number;
-    discountAmount?: number;
-  } | null>(null);
+  const [appliedDiscount, setAppliedDiscount] = useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
 

--- a/app/dashboard/admin/feedback/page.tsx
+++ b/app/dashboard/admin/feedback/page.tsx
@@ -50,36 +50,7 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { FeedbackStatus } from "@prisma/client";
-
-interface FeedbackUser {
-  id: string;
-  name: string | null;
-  email: string | null;
-  image: string | null;
-  phone?: string | null;
-  createdAt?: string;
-}
-
-interface Feedback {
-  id: string;
-  title: string;
-  description: string;
-  rating: number | null;
-  category: string | null;
-  status: FeedbackStatus;
-  user: FeedbackUser;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface FeedbackCounts {
-  total: number;
-  pending: number;
-  acknowledged: number;
-  inProgress: number;
-  resolved: number;
-  closed: number;
-}
+import type { Feedback, FeedbackCounts } from "@/types/feedback";
 
 const STATUS_OPTIONS: { value: FeedbackStatus | "all"; label: string }[] = [
   { value: "all", label: "All Status" },

--- a/app/dashboard/admin/payouts/completed/page.tsx
+++ b/app/dashboard/admin/payouts/completed/page.tsx
@@ -8,19 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
 import { CheckCircle, Download } from "lucide-react";
 
-interface Payout {
-  id: string;
-  consultantName: string;
-  consultantEmail: string;
-  amount: number;
-  currency: string;
-  method: string;
-  provider: string;
-  providerPayoutId?: string;
-  earningsCount: number;
-  processedAt: string;
-  createdAt: string;
-}
+import type { Payout } from "@/types/payouts";
 
 async function fetchCompletedPayouts(
   page: number,

--- a/app/dashboard/admin/payouts/earnings/page.tsx
+++ b/app/dashboard/admin/payouts/earnings/page.tsx
@@ -20,28 +20,7 @@ import {
   CheckCircle,
   AlertTriangle,
 } from "lucide-react";
-
-interface EarningsStats {
-  pending: { count: number; consultantShare: number; platformFee: number };
-  ready: { count: number; consultantShare: number; platformFee: number };
-  paid: { count: number; consultantShare: number; platformFee: number };
-  held: { count: number; consultantShare: number; platformFee: number };
-  refunded: { count: number; consultantShare: number; platformFee: number };
-  totalPlatformRevenue: number;
-}
-
-interface Earning {
-  id: string;
-  consultantProfile: {
-    user: { name: string; email: string };
-  };
-  grossAmount: number;
-  platformFee: number;
-  consultantShare: number;
-  status: string;
-  holdUntil: string;
-  createdAt: string;
-}
+import type { EarningsStats, Earning } from "@/types/payments";
 
 async function fetchEarningsStats() {
   const response = await fetch("/api/admin/earnings/stats");

--- a/app/dashboard/admin/payouts/pending/page.tsx
+++ b/app/dashboard/admin/payouts/pending/page.tsx
@@ -18,18 +18,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Check, X, Loader2 } from "lucide-react";
 
-interface Payout {
-  id: string;
-  consultantName: string;
-  consultantEmail: string;
-  amount: number;
-  currency: string;
-  method: string;
-  provider: string;
-  earningsCount: number;
-  batchId: string;
-  createdAt: string;
-}
+import type { Payout } from "@/types/payouts";
 
 async function fetchPendingPayouts() {
   const response = await fetch("/api/admin/payouts?status=PENDING&limit=100");

--- a/app/dashboard/admin/payouts/processing/page.tsx
+++ b/app/dashboard/admin/payouts/processing/page.tsx
@@ -5,20 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { Loader } from "lucide-react";
 
-interface Payout {
-  id: string;
-  consultantName: string;
-  consultantEmail: string;
-  amount: number;
-  currency: string;
-  method: string;
-  provider: string;
-  providerPayoutId?: string;
-  earningsCount: number;
-  approvedAt: string;
-  approvedBy: string;
-  createdAt: string;
-}
+import type { Payout } from "@/types/payouts";
 
 async function fetchProcessingPayouts() {
   const response = await fetch(

--- a/app/dashboard/admin/subscriptions/page.tsx
+++ b/app/dashboard/admin/subscriptions/page.tsx
@@ -20,22 +20,7 @@ import {
   XCircle,
   Search,
 } from "lucide-react";
-
-interface Subscription {
-  id: string;
-  paymentId: string;
-  amount: number;
-  currency: string;
-  gateway: string;
-  userName: string;
-  userEmail: string;
-  consultantName?: string;
-  startDate?: string;
-  endDate?: string;
-  appointmentStatus?: string;
-  status: "active" | "expiring_soon" | "expired";
-  createdAt: string;
-}
+import type { SubscriptionListItem } from "@/types/subscriptions";
 
 async function fetchSubscriptions(
   page: number,
@@ -272,7 +257,7 @@ export default function AdminSubscriptionsPage() {
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
-                    {data.subscriptions.map((sub: Subscription) => (
+                    {data.subscriptions.map((sub: SubscriptionListItem) => (
                       <tr key={sub.id} className="hover:bg-gray-50">
                         <td className="px-4 py-3">
                           <div>

--- a/app/dashboard/admin/tickets/page.tsx
+++ b/app/dashboard/admin/tickets/page.tsx
@@ -56,51 +56,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-
-interface TicketUser {
-  id: string;
-  name: string | null;
-  email: string | null;
-  image: string | null;
-}
-
-interface TicketResponse {
-  id: string;
-  message: string;
-  isInternal: boolean;
-  createdAt: string;
-  user: {
-    name: string | null;
-    role: string | null;
-  } | null;
-}
-
-interface Ticket {
-  id: string;
-  title: string;
-  description: string;
-  priority: string;
-  status: string;
-  category: string | null;
-  issueType: string | null;
-  user: TicketUser;
-  responses: TicketResponse[];
-  createdAt: string;
-  updatedAt: string;
-  linkedConsultation?: any;
-  linkedSubscription?: any;
-  linkedPayment?: any;
-  linkedRefund?: any;
-}
-
-interface TicketCounts {
-  total: number;
-  open: number;
-  inProgress: number;
-  onHold: number;
-  resolved: number;
-  closed: number;
-}
+import type { Ticket, TicketCounts } from "@/types/tickets";
 
 const getStatusColor = (status: string) => {
   switch (status.toUpperCase()) {
@@ -506,10 +462,10 @@ export default function AdminSupportTicketsPage() {
                         <span className="font-medium truncate max-w-[200px]">
                           {ticket.title}
                         </span>
-                        {ticket.responses?.length > 0 && (
+                        {(ticket.responses?.length ?? 0) > 0 && (
                           <Badge variant="secondary" className="text-xs">
                             <MessageSquare className="h-3 w-3 mr-1" />
-                            {ticket.responses.length}
+                            {ticket.responses!.length}
                           </Badge>
                         )}
                       </div>

--- a/app/dashboard/admin/tickets/page.tsx
+++ b/app/dashboard/admin/tickets/page.tsx
@@ -462,10 +462,10 @@ export default function AdminSupportTicketsPage() {
                         <span className="font-medium truncate max-w-[200px]">
                           {ticket.title}
                         </span>
-                        {(ticket.responses?.length ?? 0) > 0 && (
+                        {ticket.responses && ticket.responses.length > 0 && (
                           <Badge variant="secondary" className="text-xs">
                             <MessageSquare className="h-3 w-3 mr-1" />
-                            {ticket.responses!.length}
+                            {ticket.responses.length}
                           </Badge>
                         )}
                       </div>

--- a/app/dashboard/admin/users/page.tsx
+++ b/app/dashboard/admin/users/page.tsx
@@ -48,30 +48,8 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { UserDetailModal } from "@/components/admin/UserDetailModal";
 import { VerificationQueue } from "@/components/admin/VerificationQueue";
-
-interface User {
-  id: string;
-  name: string | null;
-  email: string | null;
-  role: string;
-  onboardingCompleted: boolean | null;
-  createdAt: string;
-  image?: string | null;
-  phone?: string | null;
-  city?: string | null;
-  country?: string | null;
-}
-
-interface UserListResponse {
-  users: User[];
-  total: number;
-  page: number;
-  totalPages: number;
-}
-
-interface ModerationStats {
-  pendingProfiles: number;
-}
+import type { UserListItem, UserListResponse } from "@/types/admin-users";
+import type { ModerationStats } from "@/types/moderation";
 
 const getRoleColor = (role: string) => {
   switch (role) {
@@ -114,7 +92,7 @@ const formatDate = (dateString: string) => {
 export default function AdminUsersPage() {
   const { toast } = useToast();
   const [activeTab, setActiveTab] = useState("all-users");
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, setUsers] = useState<UserListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [roleFilter, setRoleFilter] = useState("all");

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/classes/[classId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/classes/[classId]/page.tsx
@@ -20,21 +20,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
+import type { WaitlistParticipant } from "@/types/participants";
 
 interface ClassParticipantsData {
   classEvent: ClassEvent;
-  waitlist: Array<{
-    id: string;
-    user: {
-      id: string;
-      name: string | null;
-      email: string | null;
-      image: string | null;
-    };
-    joinedAt: string;
-    status: string;
-    position: number | null;
-  }>;
+  waitlist: WaitlistParticipant[];
 }
 
 // Fetcher function for class participants

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/consultations/[consultationId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/consultations/[consultationId]/page.tsx
@@ -15,26 +15,14 @@ import {
 } from "@/components/ui/table";
 import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-
-interface User {
-  id: string;
-  name?: string;
-  email?: string;
-}
-
-interface ConsultationPlan {
-  id: string;
-  title: string;
-}
-
-interface Consultation {
-  id: string;
-  consultationPlan: ConsultationPlan;
-}
+import type { ParticipantUser } from "@/types/participants";
 
 interface ConsultationParticipantsData {
-  consultation: Consultation;
-  participants: User[];
+  consultation: {
+    id: string;
+    consultationPlan: { id: string; title: string };
+  };
+  participants: ParticipantUser[];
 }
 
 // Fetcher function for consultation participants

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/subscriptions/[subscriptionId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/subscriptions/[subscriptionId]/page.tsx
@@ -15,26 +15,14 @@ import {
 } from "@/components/ui/table";
 import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-
-interface User {
-  id: string;
-  name?: string;
-  email?: string;
-}
-
-interface SubscriptionPlan {
-  id: string;
-  title: string;
-}
-
-interface Subscription {
-  id: string;
-  subscriptionPlan: SubscriptionPlan;
-}
+import type { ParticipantUser } from "@/types/participants";
 
 interface SubscriptionParticipantsData {
-  subscription: Subscription;
-  participants: User[];
+  subscription: {
+    id: string;
+    subscriptionPlan: { id: string; title: string };
+  };
+  participants: ParticipantUser[];
 }
 
 // Fetcher function for subscription participants

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/webinars/[webinarId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/webinars/[webinarId]/page.tsx
@@ -20,21 +20,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { format } from "date-fns";
 import { Badge } from "@/components/ui/badge";
+import type { WaitlistParticipant } from "@/types/participants";
 
 interface WebinarParticipantsData {
   webinarEvent: WebinarEvent;
-  waitlist: Array<{
-    id: string;
-    user: {
-      id: string;
-      name: string | null;
-      email: string | null;
-      image: string | null;
-    };
-    joinedAt: string;
-    status: string;
-    position: number | null;
-  }>;
+  waitlist: WaitlistParticipant[];
 }
 
 // Fetcher function for webinar participants

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
@@ -12,6 +12,7 @@ import { AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AllocationService } from "../../shared/utils/allocationService";
 import { TimeSlot } from "../../shared/utils/calendarUtils";
+import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
 // Slot with tentative status
 interface SlotWithStatus {
@@ -19,22 +20,10 @@ interface SlotWithStatus {
   isTentative: boolean;
 }
 
-interface ValidationResult {
-  conflicts: Array<{
-    slot: string;
-    existingAppointment: {
-      type: string;
-      with: string;
-      time: string;
-    };
-  }>;
-  outsideAvailability: Array<{
-    slot: string;
-  }>;
+interface ValidationResult extends SlotConflictResult {
   outsidePeriod?: Array<{
     slot: string;
   }>;
-  validSlots: string[];
 }
 
 interface RequestedSlotsDialogProps {

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationService.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationService.ts
@@ -1,24 +1,10 @@
 import { TimeSlot } from "./calendarUtils";
+import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
 export interface AllocationRequest {
   isAuto: boolean;
   slots?: string[];
   useRequestedSlots?: boolean;
-}
-
-export interface ValidationResult {
-  conflicts: Array<{
-    slot: string;
-    existingAppointment: {
-      type: string;
-      with: string;
-      time: string;
-    };
-  }>;
-  outsideAvailability: Array<{
-    slot: string;
-  }>;
-  validSlots: string[];
 }
 
 export interface AllocationResponse {
@@ -29,7 +15,7 @@ export interface AllocationResponse {
 
 export interface ValidationResponse {
   success: boolean;
-  data?: ValidationResult;
+  data?: SlotConflictResult;
   error?: string;
 }
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/waitlists/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/waitlists/page.tsx
@@ -26,7 +26,6 @@ import {
 import { WaitlistBadge } from "@/components/waitlist/WaitlistBadge";
 import { SlotAvailableModal } from "@/components/waitlist/SlotAvailableModal";
 import { format } from "date-fns";
-
 interface WaitlistEntry {
   id: string;
   status: "WAITING" | "NOTIFIED";

--- a/app/dashboard/staff/[staffId]/(features)/disputes/[disputeId]/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/disputes/[disputeId]/page.tsx
@@ -23,33 +23,7 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
-interface DisputeDetails {
-  id: string;
-  disputeId: string;
-  amount: number;
-  currency: string;
-  status: string;
-  reason: string | null;
-  paymentGateway: string;
-  dueBy: string | null;
-  evidence: string | null;
-  evidenceSubmittedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-  payment: {
-    id: string;
-    paymentIntent: string;
-    amount: number;
-    currency: string;
-    paymentMethod: string | null;
-    createdAt: string;
-    user: {
-      id: string;
-      name: string | null;
-      email: string;
-    };
-  } | null;
-}
+import type { DisputeDetails } from "@/types/disputes";
 
 const getStatusColor = (status: string) => {
   switch (status.toUpperCase()) {

--- a/app/dashboard/staff/[staffId]/(features)/disputes/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/disputes/page.tsx
@@ -35,30 +35,7 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
-interface Dispute {
-  id: string;
-  disputeId: string;
-  amount: number;
-  currency: string;
-  status: string;
-  reason: string | null;
-  paymentGateway: string;
-  dueBy: string | null;
-  createdAt: string;
-  payment: {
-    id: string;
-    paymentIntent: string;
-  } | null;
-}
-
-interface DisputeListResponse {
-  disputes: Dispute[];
-  total: number;
-  urgentDisputes: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
+import type { Dispute, DisputeListResponse } from "@/types/disputes";
 
 const getStatusColor = (status: string) => {
   switch (status.toUpperCase()) {

--- a/app/dashboard/staff/[staffId]/(features)/feedback/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/feedback/page.tsx
@@ -50,37 +50,8 @@ import {
   Calendar,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import type { Feedback, FeedbackUser, FeedbackCounts } from "@/types/feedback";
 import { FeedbackStatus } from "@prisma/client";
-
-interface FeedbackUser {
-  id: string;
-  name: string | null;
-  email: string | null;
-  image: string | null;
-  phone?: string | null;
-  createdAt?: string;
-}
-
-interface Feedback {
-  id: string;
-  title: string;
-  description: string;
-  rating: number | null;
-  category: string | null;
-  status: FeedbackStatus;
-  user: FeedbackUser;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface FeedbackCounts {
-  total: number;
-  pending: number;
-  acknowledged: number;
-  inProgress: number;
-  resolved: number;
-  closed: number;
-}
 
 const STATUS_OPTIONS: { value: FeedbackStatus | "all"; label: string }[] = [
   { value: "all", label: "All Status" },

--- a/app/dashboard/staff/[staffId]/(features)/home/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/home/page.tsx
@@ -26,16 +26,6 @@ import {
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
-
-// Types
-interface StaffStats {
-  openTickets: number;
-  usersAssisted: number;
-  pendingReviews: number;
-  resolvedToday: number;
-  recentTickets: RecentTicket[];
-}
-
 interface RecentTicket {
   id: string;
   subject: string;
@@ -44,6 +34,14 @@ interface RecentTicket {
   status: string;
   priority: string;
   createdAt: string;
+}
+
+interface StaffStats {
+  openTickets: number;
+  usersAssisted: number;
+  pendingReviews: number;
+  resolvedToday: number;
+  recentTickets: RecentTicket[];
 }
 
 // Static announcements (these could come from an API in the future)

--- a/app/dashboard/staff/[staffId]/(features)/moderation/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/moderation/page.tsx
@@ -47,92 +47,12 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-
-// Types for Staff Moderation API responses
-interface ProfileVerificationDocument {
-  id: string;
-  fileName: string;
-  originalName: string;
-  fileSize: number;
-  mimeType: string;
-  fileUrl: string;
-  description: string | null;
-}
-
-interface ProfileVerificationResponse {
-  id: string;
-  status: string;
-  submittedAt: string;
-  notes: string | null;
-  consultant: {
-    profileId: string;
-    userId: string;
-    name: string | null;
-    email: string;
-    image: string | null;
-    linkedinUrl: string | null;
-    domain: string;
-    experience: number | null;
-    headline: string | null;
-    isVerified: boolean;
-    verificationStatus: string;
-  };
-  documents: ProfileVerificationDocument[];
-  reviewedAt: string | null;
-  reviewedById: string | null;
-  reviewNotes: string | null;
-}
-
-interface ModerationReport {
-  id: string;
-  type: string;
-  reason: string;
-  description: string | null;
-  status: string;
-  createdAt: string;
-  reporter: {
-    id: string;
-    name: string | null;
-    email: string;
-  };
-  reportedUser: {
-    id: string;
-    name: string | null;
-    email: string;
-    role: string;
-  };
-  _count?: {
-    actions: number;
-  };
-}
-
-interface ModerationReview {
-  id: string;
-  rating: number;
-  comment: string | null;
-  createdAt: string;
-  consultee: {
-    id: string;
-    name: string | null;
-    image: string | null;
-  } | null;
-  consultation: {
-    consultant: {
-      user: {
-        id: string;
-        name: string | null;
-        image: string | null;
-      } | null;
-    } | null;
-  } | null;
-}
-
-interface ModerationStats {
-  pendingReports: number;
-  pendingProfiles: number;
-  pendingReviews: number;
-  resolvedToday: number;
-}
+import type {
+  ProfileVerification,
+  ModerationReport,
+  ModerationReview,
+  ModerationStats,
+} from "@/types/moderation";
 
 const getStatusColor = (status: string) => {
   switch (status.toLowerCase()) {
@@ -183,12 +103,12 @@ export default function ContentModerationPage() {
     null,
   );
   const [selectedProfile, setSelectedProfile] =
-    useState<ProfileVerificationResponse | null>(null);
+    useState<ProfileVerification | null>(null);
   const [moderationNote, setModerationNote] = useState("");
 
   // Data states
   const [reports, setReports] = useState<ModerationReport[]>([]);
-  const [profiles, setProfiles] = useState<ProfileVerificationResponse[]>([]);
+  const [profiles, setProfiles] = useState<ProfileVerification[]>([]);
   const [reviews, setReviews] = useState<ModerationReview[]>([]);
   const [stats, setStats] = useState<ModerationStats | null>(null);
 

--- a/app/dashboard/staff/[staffId]/(features)/payments/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/payments/page.tsx
@@ -52,49 +52,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-
-// Types
-interface Payment {
-  id: string;
-  amount: number;
-  currency: string;
-  description: string | null;
-  receiptUrl: string | null;
-  paymentMethod: string;
-  paymentIntent: string;
-  paymentGateway: string;
-  paymentStatus: string;
-  createdAt: string;
-  appointment: {
-    appointmentType: string;
-  } | null;
-}
-
-interface Refund {
-  id: string;
-  amount: number;
-  currency: string;
-  status: string;
-  createdAt: string;
-  payment: {
-    id: string;
-    paymentIntent: string;
-  } | null;
-}
-
-interface PaymentListResponse {
-  payments: Payment[];
-  total: number;
-  page: number;
-  totalPages: number;
-}
-
-interface RefundListResponse {
-  refunds: Refund[];
-  total: number;
-  page: number;
-  totalPages: number;
-}
+import type { Payment, Refund, PaymentListResponse, RefundListResponse } from "@/types/payments";
 
 const getStatusColor = (status: string) => {
   switch (status.toUpperCase()) {

--- a/app/dashboard/staff/[staffId]/(features)/payouts/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/payouts/page.tsx
@@ -20,21 +20,7 @@ import {
   XCircle,
 } from "lucide-react";
 
-interface Payout {
-  id: string;
-  consultantName: string;
-  consultantEmail: string;
-  amount: number;
-  currency: string;
-  status: string;
-  method: string;
-  provider: string;
-  earningsCount: number;
-  approvedAt?: string;
-  processedAt?: string;
-  failureReason?: string;
-  createdAt: string;
-}
+import type { Payout } from "@/types/payouts";
 
 async function fetchPayouts(status?: string, page = 1, limit = 20) {
   const offset = (page - 1) * limit;

--- a/app/dashboard/staff/[staffId]/(features)/refunds/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/refunds/page.tsx
@@ -32,29 +32,7 @@ import {
   Ban,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-
-interface Refund {
-  id: string;
-  refundId: string;
-  amount: number;
-  currency: string;
-  status: string;
-  reason: string | null;
-  paymentGateway: string;
-  createdAt: string;
-  payment: {
-    id: string;
-    paymentIntent: string;
-  } | null;
-}
-
-interface RefundListResponse {
-  refunds: Refund[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
+import type { Refund, RefundListResponse } from "@/types/payments";
 
 const getStatusColor = (status: string) => {
   switch (status.toUpperCase()) {

--- a/app/dashboard/staff/[staffId]/(features)/subscriptions/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/subscriptions/page.tsx
@@ -31,37 +31,7 @@ import {
   Users,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-
-interface Subscription {
-  id: string;
-  paymentId: string;
-  amount: number;
-  currency: string;
-  gateway: string;
-  userName: string;
-  userEmail: string;
-  consultantName: string | null;
-  startDate: string | null;
-  endDate: string | null;
-  subscriptionStatus: string | null;
-  status: string;
-  createdAt: string;
-}
-
-interface SubscriptionListResponse {
-  subscriptions: Subscription[];
-  stats: {
-    activeCount: number;
-    expiringCount: number;
-    expiredCount: number;
-  };
-  pagination: {
-    total: number;
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-  };
-}
+import type { SubscriptionListItem, SubscriptionListResponse } from "@/types/subscriptions";
 
 const getStatusColor = (status: string) => {
   switch (status.toLowerCase()) {
@@ -108,7 +78,7 @@ const formatDate = (dateString: string | null) => {
 
 export default function StaffSubscriptionsPage() {
   const { toast } = useToast();
-  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [subscriptions, setSubscriptions] = useState<SubscriptionListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");

--- a/app/dashboard/staff/[staffId]/(features)/tickets/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/tickets/page.tsx
@@ -58,121 +58,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-
-// Types
-interface TicketUser {
-  id: string;
-  name: string | null;
-  email: string | null;
-  image: string | null;
-  phone?: string | null;
-}
-
-interface TicketResponse {
-  id: string;
-  message: string;
-  isInternal: boolean;
-  createdAt: string;
-  user: {
-    id: string;
-    name: string | null;
-    role: string | null;
-    image: string | null;
-  };
-}
-
-interface TicketAttachment {
-  id: string;
-  fileName: string;
-  originalName: string;
-  fileSize: number;
-  mimeType: string;
-  fileUrl: string;
-  uploadedAt: string;
-}
-
-interface LinkedConsultation {
-  id: string;
-  requestStatus: string;
-  consultationPlan: {
-    title: string;
-    price: number;
-    priceCurrency: string;
-    consultantProfile: {
-      user: { name: string | null; email: string | null };
-    };
-  };
-  appointment: {
-    id: string;
-    scheduledAt: string;
-    status: string;
-  } | null;
-}
-
-interface LinkedPayment {
-  id: string;
-  amount: number;
-  currency: string;
-  paymentStatus: string;
-  paymentGateway: string;
-  createdAt: string;
-}
-
-interface LinkedRefund {
-  id: string;
-  amount: number;
-  currency: string;
-  status: string;
-  reason: string | null;
-  createdAt: string;
-}
-
-interface Ticket {
-  id: string;
-  title: string;
-  description: string;
-  priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
-  status: "OPEN" | "IN_PROGRESS" | "ON_HOLD" | "RESOLVED" | "CLOSED";
-  category: string | null;
-  issueType: string | null;
-  user: TicketUser;
-  assignedToId: string | null;
-  responseCount: number;
-  attachmentCount: number;
-  consultationId: string | null;
-  subscriptionId: string | null;
-  paymentId: string | null;
-  refundId: string | null;
-  createdAt: string;
-  updatedAt: string;
-  // Extended fields for detail view
-  responses?: TicketResponse[];
-  attachments?: TicketAttachment[];
-  linkedConsultation?: LinkedConsultation | null;
-  linkedPayment?: LinkedPayment | null;
-  linkedRefund?: LinkedRefund | null;
-}
-
-interface TicketCounts {
-  total: number;
-  open: number;
-  inProgress: number;
-  onHold: number;
-  resolved: number;
-  closed: number;
-}
-
-interface TicketListResponse {
-  tickets: Ticket[];
-  counts: TicketCounts;
-  pagination: {
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
-    hasMore: boolean;
-  };
-}
+import type { Ticket, TicketCounts, TicketListResponse } from "@/types/tickets";
 
 const getStatusColor = (status: string) => {
   switch (status.toUpperCase()) {
@@ -634,13 +520,13 @@ export default function SupportTicketsPage() {
                         <span className="font-medium truncate max-w-[200px]">
                           {ticket.title}
                         </span>
-                        {ticket.responseCount > 0 && (
+                        {(ticket.responseCount ?? 0) > 0 && (
                           <Badge variant="outline" className="text-xs gap-1">
                             <MessageSquare className="h-3 w-3" />
                             {ticket.responseCount}
                           </Badge>
                         )}
-                        {ticket.attachmentCount > 0 && (
+                        {(ticket.attachmentCount ?? 0) > 0 && (
                           <Badge variant="outline" className="text-xs gap-1">
                             <Paperclip className="h-3 w-3" />
                             {ticket.attachmentCount}
@@ -1049,8 +935,8 @@ export default function SupportTicketsPage() {
                             <div
                               key={response.id}
                               className={`p-3 rounded-lg ${
-                                response.user.role === "STAFF" ||
-                                response.user.role === "ADMIN"
+                                response.user?.role === "STAFF" ||
+                                response.user?.role === "ADMIN"
                                   ? response.isInternal
                                     ? "bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800"
                                     : "bg-blue-50 dark:bg-blue-950"
@@ -1060,16 +946,16 @@ export default function SupportTicketsPage() {
                               <div className="flex items-center gap-2 mb-1">
                                 <Avatar className="h-5 w-5">
                                   <AvatarImage
-                                    src={response.user.image || ""}
+                                    src={response.user?.image || ""}
                                   />
                                   <AvatarFallback className="text-xs">
-                                    {response.user.name?.[0] || "?"}
+                                    {response.user?.name?.[0] || "?"}
                                   </AvatarFallback>
                                 </Avatar>
                                 <span className="text-sm font-medium">
-                                  {response.user.name}
+                                  {response.user?.name}
                                 </span>
-                                {response.user.role && (
+                                {response.user?.role && (
                                   <Badge variant="outline" className="text-xs">
                                     {response.user.role}
                                   </Badge>

--- a/app/dashboard/staff/[staffId]/(features)/users/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/users/page.tsx
@@ -48,30 +48,8 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { UserDetailModal } from "@/components/admin/UserDetailModal";
 import { VerificationQueue } from "@/components/admin/VerificationQueue";
-
-interface User {
-  id: string;
-  name: string | null;
-  email: string | null;
-  role: string;
-  onboardingCompleted: boolean | null;
-  createdAt: string;
-  image?: string | null;
-  phone?: string | null;
-  city?: string | null;
-  country?: string | null;
-}
-
-interface UserListResponse {
-  users: User[];
-  total: number;
-  page: number;
-  totalPages: number;
-}
-
-interface ModerationStats {
-  pendingProfiles: number;
-}
+import type { UserListItem, UserListResponse } from "@/types/admin-users";
+import type { ModerationStats } from "@/types/moderation";
 
 const getRoleColor = (role: string) => {
   switch (role) {
@@ -114,7 +92,7 @@ const formatDate = (dateString: string) => {
 export default function UserManagementPage() {
   const { toast } = useToast();
   const [activeTab, setActiveTab] = useState("all-users");
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, setUsers] = useState<UserListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [roleFilter, setRoleFilter] = useState("all");

--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
@@ -28,6 +28,7 @@ import type {
   Topic,
 } from "@prisma/client";
 import { generateProgramImageUrl } from "@/app/explore/programs/utils";
+import { FeatureItem } from "@/app/explore/programs/plans/components/FeatureItem";
 
 type ClassSessionWithSchedule = PrismaClass & {
   appointments: (PrismaAppointment & {
@@ -66,23 +67,6 @@ const getBadgeVariant = (
   return "default";
 };
 
-type FeatureItemProps = {
-  icon: React.ReactNode;
-  label: string;
-  value: string | number | React.ReactNode;
-};
-
-const FeatureItem = ({ icon, label, value }: FeatureItemProps) => (
-  <div className="flex items-center gap-3 p-4 bg-zinc-50 rounded-xl">
-    <div className="w-10 h-10 rounded-lg bg-white border border-zinc-200 flex items-center justify-center text-zinc-600">
-      {icon}
-    </div>
-    <div>
-      <p className="text-xs text-zinc-500 uppercase tracking-wide">{label}</p>
-      <p className="text-sm font-semibold text-zinc-900">{value}</p>
-    </div>
-  </div>
-);
 
 interface ClassDetailsProps {
   readonly plan: ClassPlanDetailsData;

--- a/app/explore/programs/plans/components/FeatureItem.tsx
+++ b/app/explore/programs/plans/components/FeatureItem.tsx
@@ -1,0 +1,17 @@
+type FeatureItemProps = {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number | React.ReactNode;
+};
+
+export const FeatureItem = ({ icon, label, value }: FeatureItemProps) => (
+  <div className="flex items-center gap-3 p-4 bg-zinc-50 rounded-xl">
+    <div className="w-10 h-10 rounded-lg bg-white border border-zinc-200 flex items-center justify-center text-zinc-600">
+      {icon}
+    </div>
+    <div>
+      <p className="text-xs text-zinc-500 uppercase tracking-wide">{label}</p>
+      <p className="text-sm font-semibold text-zinc-900">{value}</p>
+    </div>
+  </div>
+);

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
@@ -19,6 +19,7 @@ import { ClientWebinarRegistration } from "./ClientWebinarRegistration";
 import { generateProgramImageUrl } from "../../../../utils";
 import { useCurrency } from "@/lib/hooks/useCurrency";
 import type { Prisma, Topic } from "@prisma/client";
+import { FeatureItem } from "@/app/explore/programs/plans/components/FeatureItem";
 
 export type WebinarPlanData = Prisma.WebinarPlanGetPayload<{
   include: {
@@ -46,23 +47,6 @@ export type WebinarPlanData = Prisma.WebinarPlanGetPayload<{
   };
 }>;
 
-type FeatureItemProps = {
-  icon: React.ReactNode;
-  label: string;
-  value: string | number | React.ReactNode;
-};
-
-const FeatureItem = ({ icon, label, value }: FeatureItemProps) => (
-  <div className="flex items-center gap-3 p-4 bg-zinc-50 rounded-xl">
-    <div className="w-10 h-10 rounded-lg bg-white border border-zinc-200 flex items-center justify-center text-zinc-600">
-      {icon}
-    </div>
-    <div>
-      <p className="text-xs text-zinc-500 uppercase tracking-wide">{label}</p>
-      <p className="text-sm font-semibold text-zinc-900">{value}</p>
-    </div>
-  </div>
-);
 
 type SessionStatus =
   | "Upcoming"

--- a/types/admin-users.ts
+++ b/types/admin-users.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared types for Admin/Staff User Management API responses.
+ * Used by admin/users and staff/users pages.
+ */
+
+export interface UserListItem {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: string;
+  onboardingCompleted: boolean | null;
+  createdAt: string;
+  image?: string | null;
+  phone?: string | null;
+  city?: string | null;
+  country?: string | null;
+}
+
+export interface UserListResponse {
+  users: UserListItem[];
+  total: number;
+  page: number;
+  totalPages: number;
+}

--- a/types/checkout.ts
+++ b/types/checkout.ts
@@ -1,5 +1,16 @@
 import { AppointmentsType, PaymentGateway } from "@prisma/client";
 
+/**
+ * Discount applied to a checkout session.
+ * Shared across all 4 checkout pages (consultation, subscription, webinar, class).
+ */
+export interface AppliedDiscount {
+  code: string;
+  discountType: "PERCENTAGE" | "FIXED_AMOUNT";
+  discountValue: number;
+  discountAmount?: number;
+}
+
 export interface CheckoutSession {
   id: string;
   slotId: string;

--- a/types/disputes.ts
+++ b/types/disputes.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared types for Dispute API responses.
+ * Used by staff/disputes and staff/disputes/[disputeId] pages.
+ */
+
+export interface Dispute {
+  id: string;
+  disputeId: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  paymentGateway: string;
+  dueBy: string | null;
+  createdAt: string;
+  payment: {
+    id: string;
+    paymentIntent: string;
+  } | null;
+}
+
+export interface DisputeListResponse {
+  disputes: Dispute[];
+  total: number;
+  urgentDisputes: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface DisputeDetails {
+  id: string;
+  disputeId: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  paymentGateway: string;
+  dueBy: string | null;
+  evidence: string | null;
+  evidenceSubmittedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  payment: {
+    id: string;
+    paymentIntent: string;
+    amount: number;
+    currency: string;
+    paymentMethod: string | null;
+    createdAt: string;
+    user: {
+      id: string;
+      name: string | null;
+      email: string;
+    };
+  } | null;
+}

--- a/types/feedback.ts
+++ b/types/feedback.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared types for Feedback API responses.
+ * Used by admin/feedback page and its API routes.
+ */
+
+import type { FeedbackStatus } from "@prisma/client";
+
+export interface FeedbackUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  phone?: string | null;
+  createdAt?: string;
+}
+
+export interface Feedback {
+  id: string;
+  title: string;
+  description: string;
+  rating: number | null;
+  category: string | null;
+  status: FeedbackStatus;
+  user: FeedbackUser;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FeedbackCounts {
+  total: number;
+  pending: number;
+  acknowledged: number;
+  inProgress: number;
+  resolved: number;
+  closed: number;
+}

--- a/types/moderation.ts
+++ b/types/moderation.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared types for Staff Moderation API responses.
+ * Used by both the API route and the frontend page.
+ */
+
+export interface VerificationConsultant {
+  profileId: string;
+  userId: string;
+  name: string | null;
+  email: string;
+  image: string | null;
+  linkedinUrl: string | null;
+  domain: string;
+  experience: number | null;
+  headline: string | null;
+  isVerified: boolean;
+  verificationStatus: string;
+}
+
+export interface VerificationDocument {
+  id: string;
+  fileName: string;
+  originalName: string;
+  fileSize: number;
+  mimeType: string;
+  fileUrl: string;
+  description: string | null;
+}
+
+export interface ProfileVerification {
+  id: string;
+  status: string;
+  submittedAt: string;
+  notes: string | null;
+  rejectionReason?: string | null;
+  feedbackDetails?: string | null;
+  consultant: VerificationConsultant;
+  documents: VerificationDocument[];
+  reviewedAt: string | null;
+  reviewedById: string | null;
+  reviewNotes: string | null;
+}
+
+export interface ModerationReport {
+  id: string;
+  type: string;
+  reason: string;
+  description: string | null;
+  status: string;
+  createdAt: string;
+  reporter: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+  reportedUser: {
+    id: string;
+    name: string | null;
+    email: string;
+    role: string;
+  };
+  _count?: {
+    actions: number;
+  };
+}
+
+export interface ModerationReview {
+  id: string;
+  rating: number;
+  comment: string | null;
+  createdAt: string;
+  consultee: {
+    id: string;
+    name: string | null;
+    image: string | null;
+  } | null;
+  consultation: {
+    consultant: {
+      user: {
+        id: string;
+        name: string | null;
+        image: string | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
+export interface ModerationStats {
+  pendingReports: number;
+  pendingProfiles: number;
+  pendingReviews: number;
+  resolvedToday: number;
+}

--- a/types/participants.ts
+++ b/types/participants.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared types for Participant API responses.
+ * Used by consultant participant pages (consultation, subscription, webinar, class).
+ */
+
+/** User info in participant lists — shared by consultation + subscription participant pages. */
+export interface ParticipantUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+}
+
+/** Waitlist entry in participant views — shared by webinar + class participant pages. */
+export interface WaitlistParticipant {
+  id: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  };
+  joinedAt: string;
+  status: string;
+  position: number | null;
+}

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types for Payment, Refund, and Earnings API responses.
+ * Used by admin/staff payment, refund, and payout pages.
+ */
+
+export interface Payment {
+  id: string;
+  amount: number;
+  currency: string;
+  description: string | null;
+  receiptUrl: string | null;
+  paymentMethod: string;
+  paymentIntent: string;
+  paymentGateway: string;
+  paymentStatus: string;
+  createdAt: string;
+  appointment: {
+    appointmentType: string;
+  } | null;
+}
+
+export interface Refund {
+  id: string;
+  refundId?: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason?: string | null;
+  paymentGateway?: string;
+  createdAt: string;
+  payment: {
+    id: string;
+    paymentIntent: string;
+  } | null;
+}
+
+export interface PaymentListResponse {
+  payments: Payment[];
+  total: number;
+  page: number;
+  totalPages: number;
+}
+
+export interface RefundListResponse {
+  refunds: Refund[];
+  total: number;
+  page: number;
+  limit?: number;
+  totalPages: number;
+}
+
+export interface EarningsStats {
+  pending: { count: number; consultantShare: number; platformFee: number };
+  ready: { count: number; consultantShare: number; platformFee: number };
+  paid: { count: number; consultantShare: number; platformFee: number };
+  held: { count: number; consultantShare: number; platformFee: number };
+  refunded: { count: number; consultantShare: number; platformFee: number };
+  totalPlatformRevenue: number;
+}
+
+export interface Earning {
+  id: string;
+  consultantProfile: {
+    user: { name: string; email: string };
+  };
+  grossAmount: number;
+  platformFee: number;
+  consultantShare: number;
+  status: string;
+  holdUntil: string;
+  createdAt: string;
+}

--- a/types/payouts.ts
+++ b/types/payouts.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared types for Payout API responses.
+ * Used by admin/payouts (pending, processing, completed) and staff/payouts pages.
+ */
+
+export interface Payout {
+  id: string;
+  consultantName: string;
+  consultantEmail: string;
+  amount: number;
+  currency: string;
+  method: string;
+  provider: string;
+  earningsCount: number;
+  createdAt: string;
+  status: string;
+  batchId?: string;
+  providerPayoutId?: string;
+  approvedAt?: string;
+  approvedBy?: string;
+  processedAt?: string;
+  failureReason?: string;
+}

--- a/types/subscriptions.ts
+++ b/types/subscriptions.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for Subscription Management API responses.
+ * Used by admin/subscriptions and staff/subscriptions pages.
+ */
+
+export interface SubscriptionListItem {
+  id: string;
+  paymentId: string;
+  amount: number;
+  currency: string;
+  gateway: string;
+  userName: string;
+  userEmail: string;
+  consultantName: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  subscriptionStatus?: string | null;
+  status: string;
+  createdAt: string;
+}
+
+export interface SubscriptionListResponse {
+  subscriptions: SubscriptionListItem[];
+  stats: {
+    activeCount: number;
+    expiringCount: number;
+    expiredCount: number;
+  };
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  };
+}

--- a/types/tickets.ts
+++ b/types/tickets.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared types for Support Ticket API responses.
+ * Used by admin/tickets, staff/tickets pages and their API routes.
+ */
+
+export interface TicketUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  phone?: string | null;
+}
+
+export interface TicketResponse {
+  id: string;
+  message: string;
+  isInternal: boolean;
+  createdAt: string;
+  user: {
+    id: string;
+    name: string | null;
+    role: string | null;
+    image: string | null;
+  } | null;
+}
+
+export interface TicketAttachment {
+  id: string;
+  fileName: string;
+  originalName: string;
+  fileSize: number;
+  mimeType: string;
+  fileUrl: string;
+  uploadedAt: string;
+}
+
+export interface LinkedConsultation {
+  id: string;
+  requestStatus: string;
+  consultationPlan: {
+    title: string;
+    price: number;
+    priceCurrency: string;
+    consultantProfile: {
+      user: { name: string | null; email: string | null };
+    };
+  };
+  appointment: {
+    id: string;
+    scheduledAt: string;
+    status: string;
+  } | null;
+}
+
+export interface LinkedPayment {
+  id: string;
+  amount: number;
+  currency: string;
+  paymentStatus: string;
+  paymentGateway: string;
+  createdAt: string;
+}
+
+export interface LinkedRefund {
+  id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  createdAt: string;
+}
+
+export interface Ticket {
+  id: string;
+  title: string;
+  description: string;
+  priority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  status: "OPEN" | "IN_PROGRESS" | "ON_HOLD" | "RESOLVED" | "CLOSED";
+  category: string | null;
+  issueType: string | null;
+  user: TicketUser;
+  assignedToId?: string | null;
+  responseCount?: number;
+  attachmentCount?: number;
+  consultationId?: string | null;
+  subscriptionId?: string | null;
+  paymentId?: string | null;
+  refundId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  responses?: TicketResponse[];
+  attachments?: TicketAttachment[];
+  linkedConsultation?: LinkedConsultation | null;
+  linkedSubscription?: LinkedConsultation | null;
+  linkedPayment?: LinkedPayment | null;
+  linkedRefund?: LinkedRefund | null;
+}
+
+export interface TicketCounts {
+  total: number;
+  open: number;
+  inProgress: number;
+  onHold: number;
+  resolved: number;
+  closed: number;
+}
+
+export interface TicketListResponse {
+  tickets: Ticket[];
+  counts: TicketCounts;
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    hasMore: boolean;
+  };
+}

--- a/utils/slotAllocation/types.ts
+++ b/utils/slotAllocation/types.ts
@@ -51,6 +51,27 @@ export interface ValidationResult {
 }
 
 /**
+ * Result of slot conflict checking — shared across all 4 event validate API routes,
+ * the allocationService utility, and the RequestedSlotsDialog component.
+ *
+ * Routes with extra fields (subscription, class, dialog) extend this base.
+ */
+export interface SlotConflictResult {
+  conflicts: Array<{
+    slot: string;
+    existingAppointment: {
+      type: string;
+      with: string;
+      time: string;
+    };
+  }>;
+  outsideAvailability: Array<{
+    slot: string;
+  }>;
+  validSlots: string[];
+}
+
+/**
  * Result of allocation operation
  */
 export interface AllocationResult {


### PR DESCRIPTION
## Summary

- Extract duplicated inline TypeScript types from ~30 pages into 9 shared type files + extend 1 existing file
- Extract `SlotConflictResult` base interface from 6 identical definitions across API validate routes, allocationService, and RequestedSlotsDialog
- Extract duplicated `FeatureItem` component from explore plan detail pages into a shared local component
- Fix import ordering issue in consultation checkout page
- Fix non-null assertion in admin tickets page with proper type-narrowing guard
- Update moderation API route to use shared types with explicit date serialization (gold standard pattern)
- Net result: **717 insertions, 891 deletions** — ~800+ lines of duplicated type definitions removed

## Motivation and Design Decisions

This PR was driven by a thorough audit of the entire codebase to find duplicated inline types. Below is the reasoning framework that guided every decision — documented here for future reference.

### When to use shared types vs inline types vs Prisma types vs Zod schemas

#### Prisma types (\`@prisma/client\` + \`Prisma.GetPayload<>\`)
- **What**: Auto-generated from \`schema.prisma\`. Includes models (\`User\`, \`Payment\`), enums (\`UserRole\`, \`PaymentStatus\`), and \`Prisma.ModelGetPayload<{ include: ... }>\` for typed nested queries.
- **When to use**: Inside server actions and API route handlers — anywhere you build Prisma queries or handle their results directly. These auto-update when the schema changes.
- **Already used in**: \`types/appointment.ts\`, \`types/consultant.ts\`, \`types/consultee.ts\`, \`types/consultee-events.ts\`, \`types/staff.ts\`, \`types/user.ts\`.
- **Can they be used on the frontend?** Technically yes — \`Prisma.GetPayload<>\` is pure TypeScript with no runtime dependency. But there's a **Date serialization problem**: Prisma types say \`createdAt: Date\`, but after \`NextResponse.json()\` serializes the response, the frontend receives \`createdAt: string\`. Using Prisma types directly on the frontend is a type lie for any Date/Decimal/BigInt field. A recursive \`Serialized<T>\` utility type could fix this, but adds complexity. For now, hand-written interfaces that use \`string\` for date fields are simpler and more explicit.

#### Zod schemas (\`schemas/*.ts\` + \`z.infer<>\`)
- **What**: Runtime validation + compile-time types in one definition.
- **When to use**: Whenever data crosses a **trust boundary** — user form input, API request bodies (POST/PUT/DELETE), URL search params, webhook payloads from external services.
- **Already used in**: \`schemas/checkout.ts\`, \`schemas/plans.ts\`, \`schemas/auth.ts\`, etc.
- **Key rule**: Zod schemas validate **incoming** untrusted data. They are completely separate from **response** types. Never hand-write a duplicate interface for a shape that already has a Zod schema.

#### TypeScript \`interface\` (hand-written, in \`/types/\`)
- **What**: Plain object shape definitions for API response contracts.
- **When to use**: When an API route **transforms/flattens** data before returning it — the response shape doesn't match any Prisma query directly. These are the "API contracts" shared between the route and its consuming pages.
- **This PR creates**: \`types/moderation.ts\`, \`types/tickets.ts\`, \`types/admin-users.ts\`, \`types/payments.ts\`, \`types/subscriptions.ts\`, \`types/feedback.ts\`, \`types/payouts.ts\`, \`types/disputes.ts\`, \`types/participants.ts\`.

#### TypeScript \`type\` aliases
- **What**: Composable types using unions (\`|\`), intersections (\`&\`), conditionals, and mapped types.
- **When to use**: When composing Prisma models (e.g., \`ConsultationPlan & { consultantProfile: ... }\`), creating unions, or extracting subtypes.
- **In this PR**: \`AppliedDiscount\` in \`types/checkout.ts\`, plan-with-consultant types kept inline in checkout pages.

### Decision matrix

| Data source | Runtime validation needed? | Shape = Prisma query? | Use |
|---|---|---|---|
| Prisma query with includes | No | Yes | \`Prisma.GetPayload<>\` |
| User/external input | Yes | No | Zod schema + \`z.infer<>\` |
| API response (transformed/flattened) | No | No | \`interface\` in \`/types/\` |
| Prisma model compositions | No | Partially | \`type\` alias with \`&\` |

### Shared vs inline vs localized — the rule

| Scope | Location | Rationale |
|---|---|---|
| Used by **2+ unrelated modules** | \`/types/\` or \`/utils/.../types.ts\` (global shared) | Eliminates duplication, compiler catches mismatches |
| Used by **2+ files within one feature** | Co-located shared file in feature dir | Shared but scoped (e.g., \`app/explore/programs/plans/components/FeatureItem.tsx\`) |
| Used by **only 1 file** | Inline at top of that file | No benefit to extraction — adds indirection without deduplication |

**We do NOT extract single-consumer types.** During this refactor, several type files were initially created for single-consumer types (\`types/waitlist.ts\`, \`types/staff-dashboard.ts\`, \`types/staff-metrics.ts\`, \`types/staff-appointments.ts\`) and then deliberately reverted back to inline. Extracting single-consumer types adds a layer of indirection with zero deduplication benefit.

**"Same name" ≠ duplicate.** The audit flagged \`RouteParams\` (24 instances), \`PageProps\` (14 instances), \`HomeTabProps\` (2 instances), and \`WaitlistEntry\` (2 instances) — but each has **different fields** per route/page/user-type. These are properly localized, not duplicates.

### Why API routes don't need shared types (mostly)

\`NextResponse.json()\` accepts \`any\` and returns \`NextResponse\` — there's no type-level connection between what the API returns and what the frontend \`fetch\` receives. The shared interfaces in \`/types/\` bridge this gap **manually** for routes that transform data.

For the ~196 API routes that return raw Prisma results (\`return NextResponse.json(prismaResult)\`), Prisma already infers the correct type on the server side. Adding shared types there would be busywork — the interface would just mirror the Prisma query shape.

The **one exception** in this PR is \`app/api/staff/moderation/profiles/route.ts\`, which flattens nested Prisma data into a \`ProfileVerification\` object. The shared type ensures the API route's transformation logic and the frontend page agree on the shape. This is the "gold standard" pattern — if someone changes the flattening logic, \`tsc\` catches the mismatch.

**tRPC would eliminate this entire problem** by creating a direct type-level link between server procedures and client call sites, with automatic serialization handling. But that's an architectural migration beyond the scope of this PR.

### Why not use \`Prisma.GetPayload<>\` on the frontend instead of hand-written interfaces?

It works for non-transformed responses, but:
1. **Date serialization mismatch**: Prisma says \`createdAt: Date\`, frontend receives \`string\`. A \`Serialized<T>\` utility type could fix this but adds complexity.
2. **Include object sync**: You'd need to keep the \`include\` object in sync between the API route query and the frontend type — same desync risk, just in a different place.
3. **Transformed routes**: No Prisma type describes a flattened/reshaped response. Manual interfaces are the only option.

For now, hand-written interfaces are the pragmatic choice. A future \`Serialized<Prisma.GetPayload<>>\` pattern or tRPC migration could replace them.

### Folder organization

Kept the current flat \`/types/\` structure (~20 files). Subdirectories (\`/types/admin/\`, \`/types/checkout/\`) add navigation overhead without real benefit at this scale. The threshold for restructuring is ~30+ files.

## What changed

### New shared type files (9):
- \`types/moderation.ts\` — \`ProfileVerification\`, \`ModerationReport\`, \`ModerationReview\`, \`ModerationStats\` (4 consumers)
- \`types/tickets.ts\` — \`Ticket\`, \`TicketResponse\`, \`TicketAttachment\`, \`TicketCounts\`, \`TicketListResponse\` (2 consumers)
- \`types/admin-users.ts\` — \`UserListItem\`, \`UserListResponse\` (2 consumers)
- \`types/payments.ts\` — \`Payment\`, \`Refund\`, \`PaymentListResponse\`, \`RefundListResponse\`, \`EarningsStats\`, \`Earning\` (3 consumers)
- \`types/subscriptions.ts\` — \`SubscriptionListItem\`, \`SubscriptionListResponse\` (2 consumers)
- \`types/feedback.ts\` — \`FeedbackUser\`, \`Feedback\`, \`FeedbackCounts\` (2 consumers)
- \`types/participants.ts\` — \`ParticipantUser\`, \`WaitlistParticipant\` (2 consumers each)
- \`types/payouts.ts\` — \`Payout\` (4 consumers)
- \`types/disputes.ts\` — \`Dispute\`, \`DisputeListResponse\`, \`DisputeDetails\` (2 consumers)

### Extended existing type files (2):
- \`types/checkout.ts\` — added \`AppliedDiscount\` (4 consumers: consultation, subscription, webinar, class checkout pages)
- \`utils/slotAllocation/types.ts\` — added \`SlotConflictResult\` (6 consumers: 4 API validate routes, allocationService, RequestedSlotsDialog)

### New shared component (1):
- \`app/explore/programs/plans/components/FeatureItem.tsx\` — extracted identical \`FeatureItem\` component + type from \`ClassDetails.tsx\` and \`WebinarDetails.tsx\`

### Updated pages (~30):
- **Admin dashboard**: tickets, users, feedback, subscriptions, earnings, 3 payout pages
- **Staff dashboard**: tickets, users, moderation, payments, refunds, subscriptions, feedback, payouts, disputes, dispute detail, home
- **Consultant dashboard**: 4 participant pages (consultations, subscriptions, webinars, classes), RequestedSlotsDialog
- **Consultee dashboard**: waitlists
- **Checkout**: consultation, subscription, webinar, class
- **Explore**: ClassDetails, WebinarDetails

### Updated API routes (5):
- \`app/api/staff/moderation/profiles/route.ts\` — uses \`ProfileVerification\` from shared types with explicit \`.toISOString()\` date conversion
- \`app/api/events/consultations/[consultationId]/validate/route.ts\` — imports \`SlotConflictResult\`
- \`app/api/events/subscriptions/[subscriptionId]/validate/route.ts\` — extends \`SlotConflictResult\`
- \`app/api/events/classes/[classId]/validate/route.ts\` — extends \`SlotConflictResult\`
- \`app/api/events/webinars/[webinarId]/validate/route.ts\` — imports \`SlotConflictResult\`

### Updated utilities (1):
- \`app/dashboard/consultant/.../shared/utils/allocationService.ts\` — imports \`SlotConflictResult\` instead of defining inline

### Bug fix (1):
- \`app/dashboard/admin/tickets/page.tsx\` — replaced \`ticket.responses!.length\` non-null assertion with \`ticket.responses && ticket.responses.length > 0\` guard for proper TypeScript type narrowing

### Import ordering fix (1):
- \`app/checkout/plans/consultation/[planId]/page.tsx\` — moved \`loadStripe\` and other imports above type definitions

## What we deliberately did NOT do

| Item | Rationale |
|---|---|
| Extract single-consumer types (staff metrics, staff appointments, waitlist entry, staff dashboard stats) | Only 1 file uses them — inline is simpler |
| Add shared types to ~196 API routes that return raw Prisma results | Prisma already infers those types; adding interfaces would be busywork |
| Extract complex Prisma payload types from checkout/explore pages (\`CheckoutWebinarPlanData\`, \`ClassPlanDetailsData\`, \`WebinarPlanData\`) | Single consumer each with 10+ Prisma model imports — not worth extracting until a second consumer appears |
| Extract \`RouteParams\` (24 instances) or \`PageProps\` (14 instances) | Each has different fields — same name does not mean same shape |
| Extract \`WaitlistEntry\` | Consultee version and admin version have completely different structures |
| Restructure \`/types/\` into subdirectories | ~20 files is manageable flat; restructure at 30+ |
| Migrate to tRPC | Would eliminate the type gap between API and frontend entirely, but requires architectural migration |
| Add \`Serialized<Prisma.GetPayload<>>\` utility pattern | Adds complexity; hand-written interfaces are clearer for now |

## Codebase audit results

A comprehensive grep audit was performed across all pages and API routes. **Every inline type/interface with 2+ identical consumers has been extracted.** The remaining inline types are either:
- Single-consumer (correct to keep inline)
- Same name but different shape (e.g., \`RouteParams\`, \`PageProps\`, \`WaitlistEntry\`, \`HomeTabProps\`)
- Prisma \`GetPayload\` compositions specific to one page

## TODO (separate PRs)

The following fixes exist on \`fix/booking-algorithm-5\` and should be merged separately:
- \`actions/stream/chat/event-channel.action.ts\` — Stream Chat upsert fix
- \`__tests__/stream/event-channel-actions.test.ts\` — test mock fix
- \`app/api/stream/meetings/[streamCallId]/recording-info/route.ts\` — auth fix

**Merge order**: This PR → \`dev\`, then \`dev\` → \`fix/booking-algorithm-5\` (so it picks up all shared types).

## Verification

- \`npx tsc --noEmit\` — zero errors
- \`npm run test\` — 204 tests pass
- Grep audit confirmed no remaining inline duplicates for multi-consumer types

🤖 Generated with [Claude Code](https://claude.com/claude-code)