### PR TITLE
feat: referral system + collaborator system with revenue sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Think of it as the "Airbnb for expertise": a platform where professionals can mo
 | **Smart Scheduling**     | Timezone-aware booking with weekly and custom availability                        |
 | **Secure Payments**      | Stripe (global) and Razorpay (India) with escrow protection                       |
 | **Earnings Dashboard**   | 80/20 revenue split with transparent payout tracking                              |
+| **Referral System**      | Viral growth via referral links, credit rewards for referrer and referee           |
+| **Collaborators**        | Multi-creator webinars and classes with role-based revenue sharing                 |
 
 ### Platform Stats
 

--- a/__tests__/booking-algorithm/rescheduleCancel.test.ts
+++ b/__tests__/booking-algorithm/rescheduleCancel.test.ts
@@ -29,15 +29,9 @@ jest.mock("../../lib/prisma", () => ({
   },
 }));
 
-// Mock next-auth
-jest.mock("next-auth", () => ({
-  getServerSession: jest.fn(),
-}));
-
-// Mock auth options (bracket path — literal directory name)
-jest.mock("../../app/api/auth/[...nextauth]/options", () => ({
-  __esModule: true,
-  default: {},
+// Mock auth-server (better-auth)
+jest.mock("../../lib/auth-server", () => ({
+  getSession: jest.fn(),
 }));
 
 // Mock waitlist handler
@@ -53,7 +47,7 @@ jest.mock("../../lib/novu", () => ({
 // ─── Imports ────────────────────────────────────────────────────────────────
 
 import prisma from "@/lib/prisma";
-import { getServerSession } from "next-auth";
+import { getSession } from "@/lib/auth-server";
 import { handleSlotOpening } from "@/lib/waitlist/slot-handler";
 import { notifyAppointmentCancelled } from "@/lib/novu";
 import { POST as rescheduleHandler } from "@/app/api/appointments/[appointmentId]/reschedule/route";
@@ -389,7 +383,7 @@ describe("Reschedule Route Handler - POST", () => {
     mockTx = makeMockTx();
 
     // Default: authenticated user
-    (getServerSession as jest.Mock).mockResolvedValue({
+    (getSession as jest.Mock).mockResolvedValue({
       user: { id: "user-1", name: "John Doe" },
     });
 
@@ -402,7 +396,7 @@ describe("Reschedule Route Handler - POST", () => {
   // ─── Authentication ─────────────────────────────────────────────────────
 
   it("should return 401 when not authenticated", async () => {
-    (getServerSession as jest.Mock).mockResolvedValue(null);
+    (getSession as jest.Mock).mockResolvedValue(null);
 
     const req = makeRescheduleRequest("apt-1", "CONSULTATION");
     const res = await rescheduleHandler(req, makeParams("apt-1"));
@@ -413,7 +407,7 @@ describe("Reschedule Route Handler - POST", () => {
   });
 
   it("should return 401 when session has no user", async () => {
-    (getServerSession as jest.Mock).mockResolvedValue({ user: null });
+    (getSession as jest.Mock).mockResolvedValue({ user: null });
 
     const req = makeRescheduleRequest("apt-1", "CONSULTATION");
     const res = await rescheduleHandler(req, makeParams("apt-1"));
@@ -761,7 +755,7 @@ describe("Cancel Route Handler - POST", () => {
     mockTx = makeMockTx();
 
     // Default: authenticated
-    (getServerSession as jest.Mock).mockResolvedValue({
+    (getSession as jest.Mock).mockResolvedValue({
       user: { id: "user-1", name: "John Doe" },
     });
 
@@ -779,7 +773,7 @@ describe("Cancel Route Handler - POST", () => {
   // ─── Authentication ─────────────────────────────────────────────────────
 
   it("should return 401 when not authenticated", async () => {
-    (getServerSession as jest.Mock).mockResolvedValue(null);
+    (getSession as jest.Mock).mockResolvedValue(null);
 
     const req = makeCancelRequest("apt-1");
     const res = await cancelHandler(req, makeParams("apt-1"));
@@ -1057,7 +1051,7 @@ describe("Cancel Route Handler - POST", () => {
 
   it("should identify canceller as consultant when consultant cancels", async () => {
     // Session user is the consultant
-    (getServerSession as jest.Mock).mockResolvedValue({
+    (getSession as jest.Mock).mockResolvedValue({
       user: { id: "consultant-1", name: "Dr. Smith" },
     });
     (prisma.appointment.findUnique as jest.Mock).mockResolvedValue(
@@ -1077,7 +1071,7 @@ describe("Cancel Route Handler - POST", () => {
 
   it("should identify canceller as consultee when consultee cancels", async () => {
     // Session user is the consultee (user-1)
-    (getServerSession as jest.Mock).mockResolvedValue({
+    (getSession as jest.Mock).mockResolvedValue({
       user: { id: "user-1", name: "John Doe" },
     });
     (prisma.appointment.findUnique as jest.Mock).mockResolvedValue(

--- a/actions/stream/chat/channel.action.ts
+++ b/actions/stream/chat/channel.action.ts
@@ -493,6 +493,109 @@ export async function initializeAllChannels() {
 }
 
 /**
+ * Create a collaborator channel for a webinar or class plan.
+ * Called when a collaborator accepts an invitation.
+ * Members: host + all accepted collaborators.
+ */
+export async function createCollaboratorChannel(
+  planType: "webinar" | "class",
+  planId: string,
+) {
+  channelIdSchema.parse(planId);
+
+  const collaboratorWhere = {
+    status: "ACCEPTED" as const,
+  };
+
+  const collaboratorInclude = {
+    consultantProfile: {
+      include: { user: { select: { id: true } } },
+    },
+  };
+
+  let title: string;
+  let hostUserId: string | undefined;
+  let collaboratorUserIds: string[];
+
+  if (planType === "webinar") {
+    const plan = await prisma.webinarPlan.findUnique({
+      where: { id: planId },
+      include: {
+        consultantProfile: {
+          include: { user: { select: { id: true } } },
+        },
+        collaborators: {
+          where: collaboratorWhere,
+          include: collaboratorInclude,
+        },
+      },
+    });
+
+    if (!plan) throw new Error(`Webinar plan not found: ${planId}`);
+    title = plan.title;
+    hostUserId = plan.consultantProfile?.user?.id;
+    collaboratorUserIds = plan.collaborators
+      .map((c) => c.consultantProfile.user.id)
+      .filter(Boolean);
+  } else {
+    const plan = await prisma.classPlan.findUnique({
+      where: { id: planId },
+      include: {
+        consultantProfile: {
+          include: { user: { select: { id: true } } },
+        },
+        collaborators: {
+          where: collaboratorWhere,
+          include: collaboratorInclude,
+        },
+      },
+    });
+
+    if (!plan) throw new Error(`Class plan not found: ${planId}`);
+    title = plan.title;
+    hostUserId = plan.consultantProfile?.user?.id;
+    collaboratorUserIds = plan.collaborators
+      .map((c) => c.consultantProfile.user.id)
+      .filter(Boolean);
+  }
+
+  if (!hostUserId) {
+    throw new Error(`Host not found for ${planType} plan: ${planId}`);
+  }
+
+  const allMemberIds = [hostUserId, ...collaboratorUserIds];
+
+  if (allMemberIds.length < 2) {
+    streamLogger.debug("Skipping collaborator channel - not enough members", {
+      planType,
+      planId,
+    });
+    return null;
+  }
+
+  const channelId = `collab-${planType}-${planId}`;
+
+  streamLogger.debug("Creating collaborator channel", {
+    channelId,
+    planType,
+    planId,
+    memberCount: allMemberIds.length,
+  });
+
+  return createChannel({
+    channelType: "messaging",
+    channelId,
+    channelName: `${title} - Collaborators`,
+    members: allMemberIds,
+    createdById: hostUserId,
+    additionalData: {
+      [`${planType}_plan_id`]: planId,
+      is_collaborator_channel: true,
+    },
+  });
+}
+
+/**
  * Adds a user to a specific channel
  */
 export async function addMemberToChannel(channelId: string, userId: string) {
@@ -504,7 +607,8 @@ export async function addMemberToChannel(channelId: string, userId: string) {
   // Infer channel type from ID pattern
   const channelType =
     channelId.startsWith("consultation-") ||
-    channelId.startsWith("subscription-")
+    channelId.startsWith("subscription-") ||
+    channelId.startsWith("collab-")
       ? "messaging"
       : "team";
 

--- a/app/api/classes/[classPlanId]/collaborators/[id]/route.ts
+++ b/app/api/classes/[classPlanId]/collaborators/[id]/route.ts
@@ -16,7 +16,24 @@ export async function PATCH(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id } = await params;
+    const { classPlanId, id } = await params;
+
+    // Verify the requester is the plan owner
+    const plan = await prisma.classPlan.findUnique({
+      where: { id: classPlanId },
+    });
+
+    const ownerProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (plan?.consultantProfileId !== ownerProfile?.id) {
+      return NextResponse.json(
+        { error: "Only the plan owner can update collaborators" },
+        { status: 403 },
+      );
+    }
+
     const body = await req.json();
 
     const collab = await updateCollaborator("class", id, body);

--- a/app/api/classes/[classPlanId]/collaborators/[id]/route.ts
+++ b/app/api/classes/[classPlanId]/collaborators/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+import {
+  updateCollaborator,
+  removeCollaborator,
+} from "@/lib/collaborators/service";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ classPlanId: string; id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const body = await req.json();
+
+    const collab = await updateCollaborator("class", id, body);
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Failed to update collaborator" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error updating class collaborator:", error);
+    return NextResponse.json(
+      { error: "Failed to update collaborator" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ classPlanId: string; id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { classPlanId, id } = await params;
+
+    const plan = await prisma.classPlan.findUnique({
+      where: { id: classPlanId },
+    });
+
+    const ownerProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (plan?.consultantProfileId !== ownerProfile?.id) {
+      return NextResponse.json(
+        { error: "Only the plan owner can remove collaborators" },
+        { status: 403 },
+      );
+    }
+
+    const collab = await removeCollaborator("class", id);
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Failed to remove collaborator" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error removing class collaborator:", error);
+    return NextResponse.json(
+      { error: "Failed to remove collaborator" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/classes/[classPlanId]/collaborators/route.ts
+++ b/app/api/classes/[classPlanId]/collaborators/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+import {
+  getCollaborators,
+  inviteCollaborator,
+} from "@/lib/collaborators/service";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ classPlanId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { classPlanId } = await params;
+    const collaborators = await getCollaborators("class", classPlanId);
+    return NextResponse.json({ data: collaborators });
+  } catch (error) {
+    console.error("Error fetching class collaborators:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch collaborators" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ classPlanId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { classPlanId } = await params;
+
+    const plan = await prisma.classPlan.findUnique({
+      where: { id: classPlanId },
+      include: { consultantProfile: true },
+    });
+
+    if (!plan?.consultantProfile) {
+      return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+    }
+
+    const ownerProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (plan.consultantProfileId !== ownerProfile?.id) {
+      return NextResponse.json(
+        { error: "Only the plan owner can invite collaborators" },
+        { status: 403 },
+      );
+    }
+
+    const body = await req.json();
+    const { consultantProfileId, role, revenueSharePercentage } = body;
+
+    if (!consultantProfileId || !role || revenueSharePercentage === undefined) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 },
+      );
+    }
+
+    const collab = await inviteCollaborator(
+      "class",
+      classPlanId,
+      consultantProfileId,
+      role,
+      revenueSharePercentage,
+      ownerProfile.id,
+    );
+
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Failed to invite. Revenue share may exceed limit (max 90% total for collaborators)." },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error inviting class collaborator:", error);
+    return NextResponse.json(
+      { error: "Failed to invite collaborator" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/classes/[id]/revenue-split/route.ts
+++ b/app/api/classes/[id]/revenue-split/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { calculateRevenueSplit } from "@/lib/collaborators/service";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const amount = Number(req.nextUrl.searchParams.get("amount") || "10000");
+
+    const splits = await calculateRevenueSplit("class", id, amount);
+    return NextResponse.json({ data: splits });
+  } catch (error) {
+    console.error("Error calculating revenue split:", error);
+    return NextResponse.json(
+      { error: "Failed to calculate revenue split" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/collaborations/[id]/respond/route.ts
+++ b/app/api/collaborations/[id]/respond/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+import { respondToInvitation } from "@/lib/collaborators/service";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const body = await req.json();
+    const { response, planType } = body;
+
+    if (!response || !["ACCEPTED", "DECLINED"].includes(response)) {
+      return NextResponse.json(
+        { error: "Response must be ACCEPTED or DECLINED" },
+        { status: 400 },
+      );
+    }
+
+    if (!planType || !["webinar", "class"].includes(planType)) {
+      return NextResponse.json(
+        { error: "planType must be webinar or class" },
+        { status: 400 },
+      );
+    }
+
+    const consultantProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (!consultantProfile) {
+      return NextResponse.json(
+        { error: "Consultant profile not found" },
+        { status: 404 },
+      );
+    }
+
+    const collab = await respondToInvitation(
+      planType,
+      id,
+      consultantProfile.id,
+      response,
+    );
+
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Unable to respond to invitation" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error responding to collaboration:", error);
+    return NextResponse.json(
+      { error: "Failed to respond to invitation" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/collaborations/class/[planId]/[id]/route.ts
+++ b/app/api/collaborations/class/[planId]/[id]/route.ts
@@ -36,7 +36,7 @@ export async function PATCH(
 
     const body = await req.json();
 
-    const collab = await updateCollaborator("class", id, body);
+    const collab = await updateCollaborator("class", id, planId, body);
     if (!collab) {
       return NextResponse.json(
         { error: "Failed to update collaborator" },
@@ -81,7 +81,7 @@ export async function DELETE(
       );
     }
 
-    const collab = await removeCollaborator("class", id);
+    const collab = await removeCollaborator("class", id, planId);
     if (!collab) {
       return NextResponse.json(
         { error: "Failed to remove collaborator" },

--- a/app/api/collaborations/class/[planId]/[id]/route.ts
+++ b/app/api/collaborations/class/[planId]/[id]/route.ts
@@ -8,7 +8,7 @@ import {
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: Promise<{ classPlanId: string; id: string }> },
+  { params }: { params: Promise<{ planId: string; id: string }> },
 ) {
   try {
     const session = await getSession();
@@ -16,11 +16,11 @@ export async function PATCH(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { classPlanId, id } = await params;
+    const { planId, id } = await params;
 
     // Verify the requester is the plan owner
     const plan = await prisma.classPlan.findUnique({
-      where: { id: classPlanId },
+      where: { id: planId },
     });
 
     const ownerProfile = await prisma.consultantProfile.findFirst({
@@ -56,7 +56,7 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: Promise<{ classPlanId: string; id: string }> },
+  { params }: { params: Promise<{ planId: string; id: string }> },
 ) {
   try {
     const session = await getSession();
@@ -64,10 +64,10 @@ export async function DELETE(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { classPlanId, id } = await params;
+    const { planId, id } = await params;
 
     const plan = await prisma.classPlan.findUnique({
-      where: { id: classPlanId },
+      where: { id: planId },
     });
 
     const ownerProfile = await prisma.consultantProfile.findFirst({

--- a/app/api/collaborations/class/[planId]/revenue-split/route.ts
+++ b/app/api/collaborations/class/[planId]/revenue-split/route.ts
@@ -4,7 +4,7 @@ import { calculateRevenueSplit } from "@/lib/collaborators/service";
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ planId: string }> },
 ) {
   try {
     const session = await getSession();
@@ -12,10 +12,10 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id } = await params;
+    const { planId } = await params;
     const amount = Number(req.nextUrl.searchParams.get("amount") || "10000");
 
-    const splits = await calculateRevenueSplit("class", id, amount);
+    const splits = await calculateRevenueSplit("class", planId, amount);
     return NextResponse.json({ data: splits });
   } catch (error) {
     console.error("Error calculating revenue split:", error);

--- a/app/api/collaborations/class/[planId]/route.ts
+++ b/app/api/collaborations/class/[planId]/route.ts
@@ -5,6 +5,7 @@ import {
   getCollaborators,
   inviteCollaborator,
 } from "@/lib/collaborators/service";
+import { inviteClassCollaboratorSchema } from "@/schemas/collaborators";
 
 export async function GET(
   _req: NextRequest,
@@ -61,14 +62,16 @@ export async function POST(
     }
 
     const body = await req.json();
-    const { consultantProfileId, role, revenueSharePercentage } = body;
+    const parsed = inviteClassCollaboratorSchema.safeParse(body);
 
-    if (!consultantProfileId || !role || revenueSharePercentage === undefined) {
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "Missing required fields" },
+        { error: parsed.error.errors.map((e) => e.message).join(", ") },
         { status: 400 },
       );
     }
+
+    const { consultantProfileId, role, revenueSharePercentage } = parsed.data;
 
     if (consultantProfileId === ownerProfile.id) {
       return NextResponse.json(

--- a/app/api/collaborations/class/[planId]/route.ts
+++ b/app/api/collaborations/class/[planId]/route.ts
@@ -70,6 +70,27 @@ export async function POST(
       );
     }
 
+    if (consultantProfileId === ownerProfile.id) {
+      return NextResponse.json(
+        { error: "You cannot invite yourself as a collaborator" },
+        { status: 400 },
+      );
+    }
+
+    const existingCollab = await prisma.classCollaborator.findFirst({
+      where: {
+        classPlanId: planId,
+        consultantProfileId,
+        status: { notIn: ["REMOVED", "DECLINED"] },
+      },
+    });
+    if (existingCollab) {
+      return NextResponse.json(
+        { error: "This consultant already has an active or pending collaboration on this plan" },
+        { status: 409 },
+      );
+    }
+
     const collab = await inviteCollaborator(
       "class",
       planId,

--- a/app/api/collaborations/class/[planId]/route.ts
+++ b/app/api/collaborations/class/[planId]/route.ts
@@ -8,7 +8,7 @@ import {
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: Promise<{ classPlanId: string }> },
+  { params }: { params: Promise<{ planId: string }> },
 ) {
   try {
     const session = await getSession();
@@ -16,8 +16,8 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { classPlanId } = await params;
-    const collaborators = await getCollaborators("class", classPlanId);
+    const { planId } = await params;
+    const collaborators = await getCollaborators("class", planId);
     return NextResponse.json({ data: collaborators });
   } catch (error) {
     console.error("Error fetching class collaborators:", error);
@@ -30,7 +30,7 @@ export async function GET(
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: Promise<{ classPlanId: string }> },
+  { params }: { params: Promise<{ planId: string }> },
 ) {
   try {
     const session = await getSession();
@@ -38,10 +38,10 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { classPlanId } = await params;
+    const { planId } = await params;
 
     const plan = await prisma.classPlan.findUnique({
-      where: { id: classPlanId },
+      where: { id: planId },
       include: { consultantProfile: true },
     });
 
@@ -72,7 +72,7 @@ export async function POST(
 
     const collab = await inviteCollaborator(
       "class",
-      classPlanId,
+      planId,
       consultantProfileId,
       role,
       revenueSharePercentage,

--- a/app/api/collaborations/route.ts
+++ b/app/api/collaborations/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+import { getMyCollaborations } from "@/lib/collaborators/service";
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const consultantProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (!consultantProfile) {
+      return NextResponse.json({ data: { webinarCollaborations: [], classCollaborations: [] } });
+    }
+
+    const collaborations = await getMyCollaborations(consultantProfile.id);
+    return NextResponse.json({ data: collaborations });
+  } catch (error) {
+    console.error("Error fetching collaborations:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch collaborations" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/collaborations/route.ts
+++ b/app/api/collaborations/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import prisma from "@/lib/prisma";
-import { getMyCollaborations } from "@/lib/collaborators/service";
+import { getMyCollaborations, getHostedCollaborations } from "@/lib/collaborators/service";
 
 export async function GET() {
   try {
@@ -15,11 +15,32 @@ export async function GET() {
     });
 
     if (!consultantProfile) {
-      return NextResponse.json({ data: { webinarCollaborations: [], classCollaborations: [] } });
+      return NextResponse.json({
+        data: {
+          webinarCollaborations: [],
+          classCollaborations: [],
+          hostedWebinarPlans: [],
+          hostedClassPlans: [],
+        },
+      });
     }
 
-    const collaborations = await getMyCollaborations(consultantProfile.id);
-    return NextResponse.json({ data: collaborations });
+    const [collaborations, hosted] = await Promise.all([
+      getMyCollaborations(consultantProfile.id),
+      getHostedCollaborations(consultantProfile.id),
+    ]);
+
+    return NextResponse.json({
+      data: {
+        ...collaborations,
+        hostedWebinarPlans: hosted.webinarPlans,
+        hostedClassPlans: hosted.classPlans,
+        hostUser: {
+          name: session.user.name ?? null,
+          image: session.user.image ?? null,
+        },
+      },
+    });
   } catch (error) {
     console.error("Error fetching collaborations:", error);
     return NextResponse.json(

--- a/app/api/collaborations/webinar/[planId]/[id]/route.ts
+++ b/app/api/collaborations/webinar/[planId]/[id]/route.ts
@@ -8,7 +8,7 @@ import {
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: Promise<{ webinarPlanId: string; id: string }> },
+  { params }: { params: Promise<{ planId: string; id: string }> },
 ) {
   try {
     const session = await getSession();
@@ -16,11 +16,11 @@ export async function PATCH(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { webinarPlanId, id } = await params;
+    const { planId, id } = await params;
 
     // Verify the requester is the plan owner
     const plan = await prisma.webinarPlan.findUnique({
-      where: { id: webinarPlanId },
+      where: { id: planId },
     });
 
     const ownerProfile = await prisma.consultantProfile.findFirst({
@@ -56,7 +56,7 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: Promise<{ webinarPlanId: string; id: string }> },
+  { params }: { params: Promise<{ planId: string; id: string }> },
 ) {
   try {
     const session = await getSession();
@@ -64,11 +64,11 @@ export async function DELETE(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { webinarPlanId, id } = await params;
+    const { planId, id } = await params;
 
     // Verify the requester is the plan owner
     const plan = await prisma.webinarPlan.findUnique({
-      where: { id: webinarPlanId },
+      where: { id: planId },
     });
 
     const ownerProfile = await prisma.consultantProfile.findFirst({

--- a/app/api/collaborations/webinar/[planId]/[id]/route.ts
+++ b/app/api/collaborations/webinar/[planId]/[id]/route.ts
@@ -36,7 +36,7 @@ export async function PATCH(
 
     const body = await req.json();
 
-    const collab = await updateCollaborator("webinar", id, body);
+    const collab = await updateCollaborator("webinar", id, planId, body);
     if (!collab) {
       return NextResponse.json(
         { error: "Failed to update collaborator" },
@@ -82,7 +82,7 @@ export async function DELETE(
       );
     }
 
-    const collab = await removeCollaborator("webinar", id);
+    const collab = await removeCollaborator("webinar", id, planId);
     if (!collab) {
       return NextResponse.json(
         { error: "Failed to remove collaborator" },

--- a/app/api/collaborations/webinar/[planId]/revenue-split/route.ts
+++ b/app/api/collaborations/webinar/[planId]/revenue-split/route.ts
@@ -4,7 +4,7 @@ import { calculateRevenueSplit } from "@/lib/collaborators/service";
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ planId: string }> },
 ) {
   try {
     const session = await getSession();
@@ -12,10 +12,10 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id } = await params;
+    const { planId } = await params;
     const amount = Number(req.nextUrl.searchParams.get("amount") || "10000");
 
-    const splits = await calculateRevenueSplit("webinar", id, amount);
+    const splits = await calculateRevenueSplit("webinar", planId, amount);
     return NextResponse.json({ data: splits });
   } catch (error) {
     console.error("Error calculating revenue split:", error);

--- a/app/api/collaborations/webinar/[planId]/route.ts
+++ b/app/api/collaborations/webinar/[planId]/route.ts
@@ -71,6 +71,27 @@ export async function POST(
       );
     }
 
+    if (consultantProfileId === ownerProfile.id) {
+      return NextResponse.json(
+        { error: "You cannot invite yourself as a collaborator" },
+        { status: 400 },
+      );
+    }
+
+    const existingCollab = await prisma.webinarCollaborator.findFirst({
+      where: {
+        webinarPlanId: planId,
+        consultantProfileId,
+        status: { notIn: ["REMOVED", "DECLINED"] },
+      },
+    });
+    if (existingCollab) {
+      return NextResponse.json(
+        { error: "This consultant already has an active or pending collaboration on this plan" },
+        { status: 409 },
+      );
+    }
+
     const collab = await inviteCollaborator(
       "webinar",
       planId,

--- a/app/api/collaborations/webinar/[planId]/route.ts
+++ b/app/api/collaborations/webinar/[planId]/route.ts
@@ -5,6 +5,7 @@ import {
   getCollaborators,
   inviteCollaborator,
 } from "@/lib/collaborators/service";
+import { inviteWebinarCollaboratorSchema } from "@/schemas/collaborators";
 
 export async function GET(
   _req: NextRequest,
@@ -62,14 +63,16 @@ export async function POST(
     }
 
     const body = await req.json();
-    const { consultantProfileId, role, revenueSharePercentage } = body;
+    const parsed = inviteWebinarCollaboratorSchema.safeParse(body);
 
-    if (!consultantProfileId || !role || revenueSharePercentage === undefined) {
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "Missing required fields" },
+        { error: parsed.error.errors.map((e) => e.message).join(", ") },
         { status: 400 },
       );
     }
+
+    const { consultantProfileId, role, revenueSharePercentage } = parsed.data;
 
     if (consultantProfileId === ownerProfile.id) {
       return NextResponse.json(

--- a/app/api/collaborations/webinar/[planId]/route.ts
+++ b/app/api/collaborations/webinar/[planId]/route.ts
@@ -8,7 +8,7 @@ import {
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: Promise<{ webinarPlanId: string }> },
+  { params }: { params: Promise<{ planId: string }> },
 ) {
   try {
     const session = await getSession();
@@ -16,8 +16,8 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { webinarPlanId } = await params;
-    const collaborators = await getCollaborators("webinar", webinarPlanId);
+    const { planId } = await params;
+    const collaborators = await getCollaborators("webinar", planId);
     return NextResponse.json({ data: collaborators });
   } catch (error) {
     console.error("Error fetching webinar collaborators:", error);
@@ -30,7 +30,7 @@ export async function GET(
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: Promise<{ webinarPlanId: string }> },
+  { params }: { params: Promise<{ planId: string }> },
 ) {
   try {
     const session = await getSession();
@@ -38,11 +38,11 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { webinarPlanId } = await params;
+    const { planId } = await params;
 
     // Verify the requester is the plan owner
     const plan = await prisma.webinarPlan.findUnique({
-      where: { id: webinarPlanId },
+      where: { id: planId },
       include: { consultantProfile: true },
     });
 
@@ -73,7 +73,7 @@ export async function POST(
 
     const collab = await inviteCollaborator(
       "webinar",
-      webinarPlanId,
+      planId,
       consultantProfileId,
       role,
       revenueSharePercentage,

--- a/app/api/collaborators/[consultantProfileId]/availability/route.ts
+++ b/app/api/collaborators/[consultantProfileId]/availability/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+
+/**
+ * GET /api/collaborators/[consultantProfileId]/availability?date=YYYY-MM-DD
+ * Returns a co-host's availability and booking status for a given date.
+ * Used by the scheduling calendar to show availability overlay.
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ consultantProfileId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { consultantProfileId } = await params;
+    const date = req.nextUrl.searchParams.get("date");
+
+    if (!date) {
+      return NextResponse.json(
+        { error: "date query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const profile = await prisma.consultantProfile.findUnique({
+      where: { id: consultantProfileId },
+      select: { id: true, scheduleType: true },
+    });
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: "Consultant profile not found" },
+        { status: 404 },
+      );
+    }
+
+    const targetDate = new Date(date);
+    const dayStart = new Date(targetDate);
+    dayStart.setHours(0, 0, 0, 0);
+    const dayEnd = new Date(targetDate);
+    dayEnd.setHours(23, 59, 59, 999);
+
+    // Fetch weekly availability slots
+    const weeklySlots = await prisma.slotOfAvailabilityWeekly.findMany({
+      where: { consultantProfileId },
+      select: {
+        dayOfWeekForStartsAt: true,
+        availabilityStartsAt: true,
+        dayOfWeekForEndsAt: true,
+        availabilityEndsAt: true,
+      },
+    });
+
+    // Fetch custom availability slots for the date range
+    const customSlots = await prisma.slotOfAvailabilityCustom.findMany({
+      where: {
+        consultantProfileId,
+        availabilityStartsAt: { gte: dayStart, lte: dayEnd },
+      },
+      select: {
+        availabilityStartsAt: true,
+        availabilityEndsAt: true,
+      },
+    });
+
+    // Fetch booked slots for the date - go through the consultant's various plan types
+    const bookedSlots = await prisma.slotOfAppointment.findMany({
+      where: {
+        startsAt: { gte: dayStart, lte: dayEnd },
+        isTentative: false,
+        appointment: {
+          OR: [
+            {
+              consultation: {
+                consultationPlan: { consultantProfileId },
+              },
+            },
+            {
+              subscription: {
+                subscriptionPlan: { consultantProfileId },
+              },
+            },
+            {
+              webinar: {
+                webinarPlan: { consultantProfileId },
+              },
+            },
+            {
+              class: {
+                classPlan: { consultantProfileId },
+              },
+            },
+          ],
+        },
+      },
+      select: {
+        startsAt: true,
+        endsAt: true,
+      },
+    });
+
+    return NextResponse.json({
+      data: {
+        consultantProfileId,
+        scheduleType: profile.scheduleType,
+        date,
+        weeklySlots,
+        customSlots,
+        bookedSlots,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching collaborator availability:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch availability" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/consultants/search/route.ts
+++ b/app/api/consultants/search/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const query = searchParams.get("q")?.trim();
+    const excludeId = searchParams.get("excludeId");
+
+    if (!query || query.length < 1) {
+      return NextResponse.json({ data: [] });
+    }
+
+    const consultants = await prisma.consultantProfile.findMany({
+      where: {
+        ...(excludeId && { id: { not: excludeId } }),
+        user: {
+          OR: [
+            { name: { contains: query, mode: "insensitive" } },
+            { email: { contains: query, mode: "insensitive" } },
+          ],
+        },
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            name: true,
+            email: true,
+            image: true,
+          },
+        },
+      },
+      take: 10,
+      orderBy: { user: { name: "asc" } },
+    });
+
+    return NextResponse.json({ data: consultants });
+  } catch (error) {
+    console.error("Error searching consultants:", error);
+    return NextResponse.json(
+      { error: "Failed to search consultants" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -47,9 +47,17 @@ type PlannerWebinar = Prisma.WebinarGetPayload<{
 }>;
 type PlannerClass = Prisma.ClassGetPayload<{ include: typeof classInclude }>;
 
-// Response types with discriminators
-type WebinarEvent = PlannerWebinar & { type: "webinar" };
-type ClassEvent = PlannerClass & { type: "class" };
+// Response types with discriminators and role annotations
+type WebinarEvent = PlannerWebinar & {
+  type: "webinar";
+  collaboratorRole: string;
+  isCollaborated: boolean;
+};
+type ClassEvent = PlannerClass & {
+  type: "class";
+  collaboratorRole: string;
+  isCollaborated: boolean;
+};
 
 interface PlannerData {
   webinars: WebinarEvent[];
@@ -159,13 +167,31 @@ export async function GET(
       );
     }
 
-    // PERFORMANCE FIX #364: Use direct Prisma queries instead of internal HTTP fetches
-    // This eliminates network overhead and reduces response time significantly
-    const [webinarsRaw, classesRaw] = await Promise.all([
+    // Fetch owned plans, collaborated plans, and collaborator roles in parallel
+    const [
+      ownedWebinarsRaw,
+      ownedClassesRaw,
+      collabWebinarsRaw,
+      collabClassesRaw,
+      webinarCollabRoles,
+      classCollabRoles,
+    ] = await Promise.all([
+      // Owned plans
+      prisma.webinar.findMany({
+        where: { webinarPlan: { consultantProfileId: consultantId } },
+        include: webinarInclude,
+      }),
+      prisma.class.findMany({
+        where: { classPlan: { consultantProfileId: consultantId } },
+        include: classInclude,
+      }),
+      // Collaborated plans (only ACCEPTED)
       prisma.webinar.findMany({
         where: {
           webinarPlan: {
-            consultantProfileId: consultantId,
+            collaborators: {
+              some: { consultantProfileId: consultantId, status: "ACCEPTED" },
+            },
           },
         },
         include: webinarInclude,
@@ -173,33 +199,76 @@ export async function GET(
       prisma.class.findMany({
         where: {
           classPlan: {
-            consultantProfileId: consultantId,
+            collaborators: {
+              some: { consultantProfileId: consultantId, status: "ACCEPTED" },
+            },
           },
         },
         include: classInclude,
       }),
+      // Collaborator role lookups
+      prisma.webinarCollaborator.findMany({
+        where: { consultantProfileId: consultantId, status: "ACCEPTED" },
+        select: { webinarPlanId: true, role: true },
+      }),
+      prisma.classCollaborator.findMany({
+        where: { consultantProfileId: consultantId, status: "ACCEPTED" },
+        select: { classPlanId: true, role: true },
+      }),
     ]);
 
-    // Transform topics from objects to strings in nested plans (matching original API behavior)
-    const transformedWebinars = webinarsRaw.map((w) =>
-      transformNestedPlanTopics(w, "webinarPlan"),
+    // Build role lookup maps
+    const webinarRoleMap = Object.fromEntries(
+      webinarCollabRoles.map((c) => [c.webinarPlanId, c.role]),
     );
-    const transformedClasses = classesRaw.map((c) =>
-      transformNestedPlanTopics(c, "classPlan"),
+    const classRoleMap = Object.fromEntries(
+      classCollabRoles.map((c) => [c.classPlanId, c.role]),
     );
 
-    // Transform to include type discriminator
-    const webinars: WebinarEvent[] = transformedWebinars.map((webinar) => ({
-      ...webinar,
-      type: "webinar" as const,
-    }));
+    // Collect owned IDs for deduplication
+    const ownedWebinarIds = new Set(ownedWebinarsRaw.map((w) => w.id));
+    const ownedClassIds = new Set(ownedClassesRaw.map((c) => c.id));
 
-    const classes: ClassEvent[] = transformedClasses.map((classEvent) => ({
-      ...classEvent,
-      type: "class" as const,
-    }));
+    // Filter out any collaborated plans that are also owned (defensive)
+    const uniqueCollabWebinars = collabWebinarsRaw.filter(
+      (w) => !ownedWebinarIds.has(w.id),
+    );
+    const uniqueCollabClasses = collabClassesRaw.filter(
+      (c) => !ownedClassIds.has(c.id),
+    );
 
-    // FIX #142: Fetch participant counts using direct Prisma query (not internal API)
+    // Transform topics and annotate with roles
+    const webinars: WebinarEvent[] = [
+      ...ownedWebinarsRaw.map((w) => ({
+        ...transformNestedPlanTopics(w, "webinarPlan"),
+        type: "webinar" as const,
+        collaboratorRole: "HOST",
+        isCollaborated: false,
+      })),
+      ...uniqueCollabWebinars.map((w) => ({
+        ...transformNestedPlanTopics(w, "webinarPlan"),
+        type: "webinar" as const,
+        collaboratorRole: webinarRoleMap[w.webinarPlanId] || "COLLABORATOR",
+        isCollaborated: true,
+      })),
+    ];
+
+    const classes: ClassEvent[] = [
+      ...ownedClassesRaw.map((c) => ({
+        ...transformNestedPlanTopics(c, "classPlan"),
+        type: "class" as const,
+        collaboratorRole: "HOST",
+        isCollaborated: false,
+      })),
+      ...uniqueCollabClasses.map((c) => ({
+        ...transformNestedPlanTopics(c, "classPlan"),
+        type: "class" as const,
+        collaboratorRole: classRoleMap[c.classPlanId] || "COLLABORATOR",
+        isCollaborated: true,
+      })),
+    ];
+
+    // Fetch participant counts for all events (owned + collaborated)
     const webinarIds = webinars.map((w) => w.id);
     const classIds = classes.map((c) => c.id);
 

--- a/app/api/dashboard/consultant/[consultantId]/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/route.ts
@@ -83,6 +83,22 @@ const appointmentInclude = {
               },
             },
           },
+          collaborators: {
+            where: { status: "ACCEPTED" },
+            include: {
+              consultantProfile: {
+                include: {
+                  user: {
+                    select: {
+                      id: true,
+                      name: true,
+                      image: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -95,6 +111,22 @@ const appointmentInclude = {
             include: {
               user: {
                 select: userSelectFields,
+              },
+            },
+          },
+          collaborators: {
+            where: { status: "ACCEPTED" },
+            include: {
+              consultantProfile: {
+                include: {
+                  user: {
+                    select: {
+                      id: true,
+                      name: true,
+                      image: true,
+                    },
+                  },
+                },
               },
             },
           },
@@ -307,8 +339,36 @@ export async function GET(
               },
             },
             {
+              // Collaborated webinars (co-host, moderator, etc.)
+              webinar: {
+                webinarPlan: {
+                  collaborators: {
+                    some: {
+                      consultantProfileId,
+                      status: "ACCEPTED",
+                    },
+                  },
+                },
+                status: "SCHEDULED",
+              },
+            },
+            {
               class: {
                 classPlan: { consultantProfileId },
+                status: "SCHEDULED",
+              },
+            },
+            {
+              // Collaborated classes (co-instructor, TA, etc.)
+              class: {
+                classPlan: {
+                  collaborators: {
+                    some: {
+                      consultantProfileId,
+                      status: "ACCEPTED",
+                    },
+                  },
+                },
                 status: "SCHEDULED",
               },
             },
@@ -440,6 +500,8 @@ export async function GET(
                 ...appointment.webinar.webinarPlan,
                 consultantProfile:
                   appointment.webinar.webinarPlan.consultantProfile,
+                collaborators:
+                  appointment.webinar.webinarPlan.collaborators ?? [],
               },
               status: appointment.webinar.status,
             }
@@ -451,6 +513,8 @@ export async function GET(
                 ...appointment.class.classPlan,
                 consultantProfile:
                   appointment.class.classPlan.consultantProfile,
+                collaborators:
+                  appointment.class.classPlan.collaborators ?? [],
               },
               status: appointment.class.status,
             }

--- a/app/api/dashboard/consultee/[consulteeId]/events/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/events/route.ts
@@ -118,6 +118,22 @@ export async function GET(
                     },
                   },
                 },
+                collaborators: {
+                  where: { status: "ACCEPTED" },
+                  include: {
+                    consultantProfile: {
+                      include: {
+                        user: {
+                          select: {
+                            id: true,
+                            name: true,
+                            image: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
               },
             },
             appointment: {
@@ -156,6 +172,22 @@ export async function GET(
                         name: true,
                         image: true,
                         email: true,
+                      },
+                    },
+                  },
+                },
+                collaborators: {
+                  where: { status: "ACCEPTED" },
+                  include: {
+                    consultantProfile: {
+                      include: {
+                        user: {
+                          select: {
+                            id: true,
+                            name: true,
+                            image: true,
+                          },
+                        },
                       },
                     },
                   },

--- a/app/api/dev/mock-webhook/route.ts
+++ b/app/api/dev/mock-webhook/route.ts
@@ -154,13 +154,13 @@ async function handleMockPaymentCaptured(
 
     // If release flag is set, immediately mark earnings as READY
     if (release) {
-      const earnings = await prisma.consultantEarnings.findUnique({
+      const earningsList = await prisma.consultantEarnings.findMany({
         where: { paymentId: payment.id },
       });
 
-      if (earnings) {
+      for (const earning of earningsList) {
         await prisma.consultantEarnings.update({
-          where: { id: earnings.id },
+          where: { id: earning.id },
           data: {
             status: EarningStatus.READY,
             holdUntil: new Date(),
@@ -170,7 +170,7 @@ async function handleMockPaymentCaptured(
     }
 
     // Check if earnings were created
-    const earnings = await prisma.consultantEarnings.findUnique({
+    const earnings = await prisma.consultantEarnings.findFirst({
       where: { paymentId: payment.id },
     });
 

--- a/app/api/payments/refunds/route.ts
+++ b/app/api/payments/refunds/route.ts
@@ -101,8 +101,8 @@ export async function POST(req: NextRequest) {
       // Once the consultant has received their payout, issuing a refund means
       // the platform absorbs the full loss. Require explicit forceRefund flag.
       if (
-        payment.earnings &&
-        payment.earnings.status === "PAID" &&
+        payment.earnings.length > 0 &&
+        payment.earnings.some((e) => e.status === "PAID") &&
         !forceRefund
       ) {
         throw new Error(

--- a/app/api/plans/classes/[classPlanId]/route.ts
+++ b/app/api/plans/classes/[classPlanId]/route.ts
@@ -235,6 +235,21 @@ export async function DELETE(
       );
     }
 
+    // Check for active collaborators (PENDING or ACCEPTED)
+    const activeCollaborators = await prisma.classCollaborator.count({
+      where: {
+        classPlanId,
+        status: { in: ["PENDING", "ACCEPTED"] },
+      },
+    });
+
+    if (activeCollaborators > 0) {
+      return NextResponse.json(
+        { error: "Cannot delete class plan with active collaborators. Remove or notify collaborators first." },
+        { status: 400 },
+      );
+    }
+
     const classPlan = await prisma.classPlan.delete({
       where: { id: classPlanId },
       include: {

--- a/app/api/plans/classes/[classPlanId]/route.ts
+++ b/app/api/plans/classes/[classPlanId]/route.ts
@@ -50,6 +50,18 @@ export async function GET(
         },
         topics: true,
         classContents: true,
+        collaborators: {
+          where: { status: "ACCEPTED" },
+          include: {
+            consultantProfile: {
+              include: {
+                user: {
+                  select: { id: true, name: true, image: true },
+                },
+              },
+            },
+          },
+        },
       },
     });
 

--- a/app/api/plans/webinars/[webinarPlanId]/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/route.ts
@@ -197,6 +197,21 @@ export async function DELETE(
       );
     }
 
+    // Check for active collaborators (PENDING or ACCEPTED)
+    const activeCollaborators = await prisma.webinarCollaborator.count({
+      where: {
+        webinarPlanId,
+        status: { in: ["PENDING", "ACCEPTED"] },
+      },
+    });
+
+    if (activeCollaborators > 0) {
+      return NextResponse.json(
+        { error: "Cannot delete webinar plan with active collaborators. Remove or notify collaborators first." },
+        { status: 400 },
+      );
+    }
+
     const webinarPlan = await prisma.webinarPlan.delete({
       where: { id: webinarPlanId },
       include: {

--- a/app/api/plans/webinars/[webinarPlanId]/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/route.ts
@@ -50,6 +50,18 @@ export async function GET(
           },
         },
         topics: true,
+        collaborators: {
+          where: { status: "ACCEPTED" },
+          include: {
+            consultantProfile: {
+              include: {
+                user: {
+                  select: { id: true, name: true, image: true },
+                },
+              },
+            },
+          },
+        },
       },
     });
 

--- a/app/api/referrals/apply/route.ts
+++ b/app/api/referrals/apply/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { applyReferralCode } from "@/lib/referrals/service";
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const body = await req.json();
+    const { code } = body;
+
+    if (!code || typeof code !== "string") {
+      return NextResponse.json(
+        { error: "Referral code is required" },
+        { status: 400 },
+      );
+    }
+
+    const referral = await applyReferralCode(session.user.id, code);
+
+    if (!referral) {
+      return NextResponse.json(
+        {
+          error:
+            "Unable to apply referral code. It may be invalid, expired, your own code, or you've already been referred.",
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({
+      data: referral,
+      message: "Referral code applied successfully",
+    });
+  } catch (error) {
+    console.error("Error applying referral code:", error);
+    return NextResponse.json(
+      { error: "Failed to apply referral code" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/referrals/code/check/[code]/route.ts
+++ b/app/api/referrals/code/check/[code]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateReferralCode } from "@/lib/referrals/service";
+import prisma from "@/lib/prisma";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  try {
+    const { code } = await params;
+
+    if (!code) {
+      return NextResponse.json(
+        { error: "Code parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const referralCode = await validateReferralCode(code);
+
+    if (!referralCode) {
+      return NextResponse.json({
+        data: { valid: false, referrerName: null },
+      });
+    }
+
+    // Fetch referrer's name for the signup page banner
+    const user = await prisma.user.findUnique({
+      where: { id: referralCode.userId },
+      select: { name: true },
+    });
+
+    return NextResponse.json({
+      data: {
+        valid: true,
+        referrerName: user?.name ?? null,
+        refereeReward: referralCode.refereeReward,
+      },
+    });
+  } catch (error) {
+    console.error("Error checking referral code:", error);
+    return NextResponse.json(
+      { error: "Failed to check referral code" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/referrals/code/check/[code]/route.ts
+++ b/app/api/referrals/code/check/[code]/route.ts
@@ -1,12 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
 import { validateReferralCode } from "@/lib/referrals/service";
 import prisma from "@/lib/prisma";
+import { Ratelimit } from "@upstash/ratelimit";
+import redis from "@/lib/redis";
+
+// Rate limit: 10 requests per minute per IP to prevent brute-force enumeration
+const ratelimit = new Ratelimit({
+  redis: redis as ConstructorParameters<typeof Ratelimit>[0]["redis"],
+  limiter: Ratelimit.slidingWindow(10, "1 m"),
+  prefix: "ratelimit:referral-check",
+});
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ code: string }> },
 ) {
   try {
+    // Rate limit by IP
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const { success, remaining } = await ratelimit.limit(ip);
+
+    if (!success) {
+      return NextResponse.json(
+        { error: "Too many requests. Please try again later." },
+        {
+          status: 429,
+          headers: { "X-RateLimit-Remaining": String(remaining) },
+        },
+      );
+    }
+
     const { code } = await params;
 
     if (!code) {

--- a/app/api/referrals/code/customize/route.ts
+++ b/app/api/referrals/code/customize/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { setCustomCode } from "@/lib/referrals/service";
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const body = await req.json();
+    const { customCode } = body;
+
+    if (!customCode || typeof customCode !== "string") {
+      return NextResponse.json(
+        { error: "customCode is required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await setCustomCode(session.user.id, customCode);
+
+    if (!result) {
+      return NextResponse.json(
+        {
+          error:
+            "Unable to set custom code. It may be taken, too short (min 3 chars), or too long (max 20 chars).",
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: result });
+  } catch (error) {
+    console.error("Error setting custom code:", error);
+    return NextResponse.json(
+      { error: "Failed to set custom code" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/referrals/code/route.ts
+++ b/app/api/referrals/code/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import {
+  getReferralCode,
+  createReferralCode,
+} from "@/lib/referrals/service";
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const code = await getReferralCode(session.user.id);
+    return NextResponse.json({ data: code });
+  } catch (error) {
+    console.error("Error fetching referral code:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch referral code" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const code = await createReferralCode(session.user.id);
+    return NextResponse.json({ data: code });
+  } catch (error) {
+    console.error("Error creating referral code:", error);
+    return NextResponse.json(
+      { error: "Failed to create referral code" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/referrals/credits/available/route.ts
+++ b/app/api/referrals/credits/available/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { getUserCredits } from "@/lib/referrals/service";
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const { totalAvailable } = await getUserCredits(session.user.id);
+
+    return NextResponse.json({
+      data: { totalAvailable, currency: "INR" },
+    });
+  } catch (error) {
+    console.error("Error fetching available credits:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch available credits" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/referrals/credits/route.ts
+++ b/app/api/referrals/credits/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { getCreditHistory, getUserCredits } from "@/lib/referrals/service";
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const [{ totalAvailable }, history] = await Promise.all([
+      getUserCredits(session.user.id),
+      getCreditHistory(session.user.id),
+    ]);
+
+    return NextResponse.json({
+      data: {
+        totalAvailable,
+        history,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching credits:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch credits" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/referrals/route.ts
+++ b/app/api/referrals/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { getUserReferrals } from "@/lib/referrals/service";
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const referrals = await getUserReferrals(session.user.id);
+    return NextResponse.json({ data: referrals });
+  } catch (error) {
+    console.error("Error fetching referrals:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch referrals" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -186,8 +186,34 @@ async function getAppointments(
           },
         },
         {
+          // Collaborated webinars (co-host, moderator, etc.)
+          webinar: {
+            webinarPlan: {
+              collaborators: {
+                some: {
+                  consultantProfileId,
+                  status: "ACCEPTED",
+                },
+              },
+            },
+          },
+        },
+        {
           class: {
             classPlan: { consultantProfileId },
+          },
+        },
+        {
+          // Collaborated classes (co-instructor, TA, etc.)
+          class: {
+            classPlan: {
+              collaborators: {
+                some: {
+                  consultantProfileId,
+                  status: "ACCEPTED",
+                },
+              },
+            },
           },
         },
       ],
@@ -311,6 +337,22 @@ async function getAppointments(
                   user: true,
                 },
               },
+              collaborators: {
+                where: { status: "ACCEPTED" },
+                include: {
+                  consultantProfile: {
+                    include: {
+                      user: {
+                        select: {
+                          id: true,
+                          name: true,
+                          image: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
         },
@@ -322,6 +364,22 @@ async function getAppointments(
               consultantProfile: {
                 include: {
                   user: true,
+                },
+              },
+              collaborators: {
+                where: { status: "ACCEPTED" },
+                include: {
+                  consultantProfile: {
+                    include: {
+                      user: {
+                        select: {
+                          id: true,
+                          name: true,
+                          image: true,
+                        },
+                      },
+                    },
+                  },
                 },
               },
             },

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -71,28 +71,31 @@ export async function POST(req: NextRequest) {
 
     try {
       switch (eventType) {
-        case "payment.captured":
+        case "payment.captured": {
           const capturedEvent = razorpayPaymentCapturedEventSchema.parse(event);
           await handlePaymentSuccess(
             capturedEvent.payload.payment.entity.order_id,
             capturedEvent.payload.payment.entity.notes || {},
           );
           break;
+        }
 
-        case "order.paid":
+        case "order.paid": {
           const paidEvent = razorpayOrderPaidEventSchema.parse(event);
           await handlePaymentSuccess(
             paidEvent.payload.order.entity.id,
             paidEvent.payload.order.entity.notes || {},
           );
           break;
+        }
 
-        case "payment.failed":
+        case "payment.failed": {
           const failedEvent = razorpayPaymentFailedEventSchema.parse(event);
           await handlePaymentFailure(
             failedEvent.payload.payment.entity.order_id,
           );
           break;
+        }
 
         // Refund events
         // FIX #5: Razorpay refunds use payment_id, but our DB stores order_id as

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -16,6 +16,7 @@ import {
   razorpayPaymentFailedEventSchema,
   razorpayOrderPaidEventSchema,
 } from "../../../../schemas/webhooks/razorpay";
+import { razorpayClient } from "@/lib/payments/core/razorpay";
 
 export async function POST(req: NextRequest) {
   const secret = process.env.RAZORPAY_WEBHOOK_SECRET;
@@ -94,12 +95,30 @@ export async function POST(req: NextRequest) {
           break;
 
         // Refund events
+        // FIX #5: Razorpay refunds use payment_id, but our DB stores order_id as
+        // paymentIntent. Resolve payment_id → order_id via Razorpay API first.
         case "refund.created":
         case "refund.processed": {
           const refundEvent = event.payload.refund.entity;
+          let paymentIntentId = refundEvent.payment_id;
+
+          if (razorpayClient) {
+            try {
+              const rzpPayment = await razorpayClient.payments.fetch(refundEvent.payment_id);
+              if (rzpPayment.order_id) {
+                paymentIntentId = rzpPayment.order_id;
+              }
+            } catch (lookupError) {
+              console.error(
+                `Failed to resolve Razorpay payment_id ${refundEvent.payment_id} to order_id:`,
+                lookupError,
+              );
+            }
+          }
+
           await handleRefundCreated(
             refundEvent.id,
-            refundEvent.payment_id,
+            paymentIntentId,
             refundEvent.amount,
             refundEvent.currency || "INR",
             refundEvent.status,
@@ -110,9 +129,25 @@ export async function POST(req: NextRequest) {
 
         case "refund.failed": {
           const failedRefundEvent = event.payload.refund.entity;
+          let failedPaymentIntentId = failedRefundEvent.payment_id;
+
+          if (razorpayClient) {
+            try {
+              const rzpPayment = await razorpayClient.payments.fetch(failedRefundEvent.payment_id);
+              if (rzpPayment.order_id) {
+                failedPaymentIntentId = rzpPayment.order_id;
+              }
+            } catch (lookupError) {
+              console.error(
+                `Failed to resolve Razorpay payment_id ${failedRefundEvent.payment_id} to order_id:`,
+                lookupError,
+              );
+            }
+          }
+
           await handleRefundCreated(
             failedRefundEvent.id,
-            failedRefundEvent.payment_id,
+            failedPaymentIntentId,
             failedRefundEvent.amount,
             failedRefundEvent.currency || "INR",
             "failed",

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -92,9 +92,12 @@ export async function handleRefundCreated(
 
     // FIX #4: Extract refund side effects into a helper so they run on BOTH
     // new refund creation AND status transitions (e.g. PENDING → SUCCEEDED).
+    // FIX P2-1: Accepts refund amount for partial-refund-aware credit restoration.
     const runRefundSideEffects = async (
       paymentId: string,
       refundStatus: string,
+      refundAmt?: number,
+      originalPaymentAmt?: number,
     ) => {
       if (mapRefundStatus(refundStatus) !== "SUCCEEDED") return;
 
@@ -111,7 +114,12 @@ export async function handleRefundCreated(
       }
 
       try {
-        const restored = await reverseCreditsForPayment(paymentId, tx);
+        const restored = await reverseCreditsForPayment(
+          paymentId,
+          tx,
+          refundAmt,
+          originalPaymentAmt,
+        );
         if (restored > 0) {
           console.log(
             `🔄 Reversed ${restored} referral credits for refunded payment ${paymentId}`,
@@ -142,7 +150,7 @@ export async function handleRefundCreated(
 
         // Run side effects when transitioning TO SUCCEEDED (but not if already SUCCEEDED)
         if (!wasSucceeded) {
-          await runRefundSideEffects(payment.id, status);
+          await runRefundSideEffects(payment.id, status, amount, payment.amount);
         }
       }
       return;
@@ -163,7 +171,7 @@ export async function handleRefundCreated(
     console.log(`✅ Refund ${refundId} created for payment ${payment.id}`);
 
     // Run side effects for new refunds that are already SUCCEEDED
-    await runRefundSideEffects(payment.id, status);
+    await runRefundSideEffects(payment.id, status, amount, payment.amount);
 
     // --- Novu notification (fire-and-forget) ---
     void notifyRefundProcessed(payment.userId, {

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -9,6 +9,7 @@ import {
   notifyDisputeCreated,
   notifyDisputeResolved,
 } from "@/lib/novu";
+import { reverseCreditsForPayment } from "@/lib/referrals/service";
 
 // Re-export payment handlers from lib (architectural fix)
 export {
@@ -118,7 +119,7 @@ export async function handleRefundCreated(
 
     console.log(`✅ Refund ${refundId} created for payment ${payment.id}`);
 
-    // Update earnings if refund succeeded
+    // Update earnings and reverse credits if refund succeeded
     if (mapRefundStatus(status) === "SUCCEEDED") {
       try {
         await refundEarnings(payment.id);
@@ -128,6 +129,21 @@ export async function handleRefundCreated(
         console.error(
           `⚠️ Failed to refund earnings for payment ${payment.id}:`,
           earningsError,
+        );
+      }
+
+      // Reverse any referral credits that were applied to this payment
+      try {
+        const restored = await reverseCreditsForPayment(payment.id, tx);
+        if (restored > 0) {
+          console.log(
+            `🔄 Reversed ${restored} referral credits for refunded payment ${payment.id}`,
+          );
+        }
+      } catch (creditError) {
+        console.error(
+          `⚠️ Failed to reverse referral credits for payment ${payment.id}:`,
+          creditError,
         );
       }
     }

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -90,17 +90,60 @@ export async function handleRefundCreated(
       where: { refundId },
     });
 
+    // FIX #4: Extract refund side effects into a helper so they run on BOTH
+    // new refund creation AND status transitions (e.g. PENDING → SUCCEEDED).
+    const runRefundSideEffects = async (
+      paymentId: string,
+      refundStatus: string,
+    ) => {
+      if (mapRefundStatus(refundStatus) !== "SUCCEEDED") return;
+
+      try {
+        await refundEarnings(paymentId);
+        console.log(`💰 Earnings refunded for payment ${paymentId}`);
+      } catch (earningsError) {
+        // Log but don't fail - earnings can be manually updated
+        // refundEarnings already guards against double-refund (checks REFUNDED status)
+        console.error(
+          `⚠️ Failed to refund earnings for payment ${paymentId}:`,
+          earningsError,
+        );
+      }
+
+      try {
+        const restored = await reverseCreditsForPayment(paymentId, tx);
+        if (restored > 0) {
+          console.log(
+            `🔄 Reversed ${restored} referral credits for refunded payment ${paymentId}`,
+          );
+        }
+      } catch (creditError) {
+        console.error(
+          `⚠️ Failed to reverse referral credits for payment ${paymentId}:`,
+          creditError,
+        );
+      }
+    };
+
     if (existingRefund) {
       // Update status if changed
       if (existingRefund.status !== status) {
+        const newStatus = mapRefundStatus(status);
+        const wasSucceeded = existingRefund.status === "SUCCEEDED";
+
         await tx.refund.update({
           where: { refundId },
           data: {
-            status: mapRefundStatus(status),
+            status: newStatus,
             updatedAt: new Date(),
           },
         });
         console.log(`✅ Refund ${refundId} status updated to ${status}`);
+
+        // Run side effects when transitioning TO SUCCEEDED (but not if already SUCCEEDED)
+        if (!wasSucceeded) {
+          await runRefundSideEffects(payment.id, status);
+        }
       }
       return;
     }
@@ -119,34 +162,8 @@ export async function handleRefundCreated(
 
     console.log(`✅ Refund ${refundId} created for payment ${payment.id}`);
 
-    // Update earnings and reverse credits if refund succeeded
-    if (mapRefundStatus(status) === "SUCCEEDED") {
-      try {
-        await refundEarnings(payment.id);
-        console.log(`💰 Earnings refunded for payment ${payment.id}`);
-      } catch (earningsError) {
-        // Log but don't fail - earnings can be manually updated
-        console.error(
-          `⚠️ Failed to refund earnings for payment ${payment.id}:`,
-          earningsError,
-        );
-      }
-
-      // Reverse any referral credits that were applied to this payment
-      try {
-        const restored = await reverseCreditsForPayment(payment.id, tx);
-        if (restored > 0) {
-          console.log(
-            `🔄 Reversed ${restored} referral credits for refunded payment ${payment.id}`,
-          );
-        }
-      } catch (creditError) {
-        console.error(
-          `⚠️ Failed to reverse referral credits for payment ${payment.id}:`,
-          creditError,
-        );
-      }
-    }
+    // Run side effects for new refunds that are already SUCCEEDED
+    await runRefundSideEffects(payment.id, status);
 
     // --- Novu notification (fire-and-forget) ---
     void notifyRefundProcessed(payment.userId, {

--- a/app/api/webinars/[id]/revenue-split/route.ts
+++ b/app/api/webinars/[id]/revenue-split/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { calculateRevenueSplit } from "@/lib/collaborators/service";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const amount = Number(req.nextUrl.searchParams.get("amount") || "10000");
+
+    const splits = await calculateRevenueSplit("webinar", id, amount);
+    return NextResponse.json({ data: splits });
+  } catch (error) {
+    console.error("Error calculating revenue split:", error);
+    return NextResponse.json(
+      { error: "Failed to calculate revenue split" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/webinars/[webinarPlanId]/collaborators/[id]/route.ts
+++ b/app/api/webinars/[webinarPlanId]/collaborators/[id]/route.ts
@@ -16,7 +16,24 @@ export async function PATCH(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { id } = await params;
+    const { webinarPlanId, id } = await params;
+
+    // Verify the requester is the plan owner
+    const plan = await prisma.webinarPlan.findUnique({
+      where: { id: webinarPlanId },
+    });
+
+    const ownerProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (plan?.consultantProfileId !== ownerProfile?.id) {
+      return NextResponse.json(
+        { error: "Only the plan owner can update collaborators" },
+        { status: 403 },
+      );
+    }
+
     const body = await req.json();
 
     const collab = await updateCollaborator("webinar", id, body);

--- a/app/api/webinars/[webinarPlanId]/collaborators/[id]/route.ts
+++ b/app/api/webinars/[webinarPlanId]/collaborators/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+import {
+  updateCollaborator,
+  removeCollaborator,
+} from "@/lib/collaborators/service";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ webinarPlanId: string; id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const body = await req.json();
+
+    const collab = await updateCollaborator("webinar", id, body);
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Failed to update collaborator" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error updating webinar collaborator:", error);
+    return NextResponse.json(
+      { error: "Failed to update collaborator" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ webinarPlanId: string; id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { webinarPlanId, id } = await params;
+
+    // Verify the requester is the plan owner
+    const plan = await prisma.webinarPlan.findUnique({
+      where: { id: webinarPlanId },
+    });
+
+    const ownerProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (plan?.consultantProfileId !== ownerProfile?.id) {
+      return NextResponse.json(
+        { error: "Only the plan owner can remove collaborators" },
+        { status: 403 },
+      );
+    }
+
+    const collab = await removeCollaborator("webinar", id);
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Failed to remove collaborator" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error removing webinar collaborator:", error);
+    return NextResponse.json(
+      { error: "Failed to remove collaborator" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/webinars/[webinarPlanId]/collaborators/route.ts
+++ b/app/api/webinars/[webinarPlanId]/collaborators/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+import {
+  getCollaborators,
+  inviteCollaborator,
+} from "@/lib/collaborators/service";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ webinarPlanId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { webinarPlanId } = await params;
+    const collaborators = await getCollaborators("webinar", webinarPlanId);
+    return NextResponse.json({ data: collaborators });
+  } catch (error) {
+    console.error("Error fetching webinar collaborators:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch collaborators" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ webinarPlanId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { webinarPlanId } = await params;
+
+    // Verify the requester is the plan owner
+    const plan = await prisma.webinarPlan.findUnique({
+      where: { id: webinarPlanId },
+      include: { consultantProfile: true },
+    });
+
+    if (!plan?.consultantProfile) {
+      return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+    }
+
+    const ownerProfile = await prisma.consultantProfile.findFirst({
+      where: { userId: session.user.id },
+    });
+
+    if (plan.consultantProfileId !== ownerProfile?.id) {
+      return NextResponse.json(
+        { error: "Only the plan owner can invite collaborators" },
+        { status: 403 },
+      );
+    }
+
+    const body = await req.json();
+    const { consultantProfileId, role, revenueSharePercentage } = body;
+
+    if (!consultantProfileId || !role || revenueSharePercentage === undefined) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 },
+      );
+    }
+
+    const collab = await inviteCollaborator(
+      "webinar",
+      webinarPlanId,
+      consultantProfileId,
+      role,
+      revenueSharePercentage,
+      ownerProfile.id,
+    );
+
+    if (!collab) {
+      return NextResponse.json(
+        { error: "Failed to invite. Revenue share may exceed limit (max 90% total for collaborators)." },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ data: collab });
+  } catch (error) {
+    console.error("Error inviting webinar collaborator:", error);
+    return NextResponse.json(
+      { error: "Failed to invite collaborator" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -9,7 +9,20 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState, Suspense } from "react";
 
-// Wrap the component that uses useSearchParams in Suspense
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gray-900">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        </div>
+      }
+    >
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}
+
 function ResetPasswordContent() {
   const { toast } = useToast();
   const router = useRouter();
@@ -202,11 +215,3 @@ function ResetPasswordContent() {
   );
 }
 
-// Export default component wrapped in Suspense
-export default function ResetPasswordPage() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <ResetPasswordContent />
-    </Suspense>
-  );
-}

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -12,6 +12,20 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect, Suspense } from "react";
 
+export default function SignIn() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gray-900">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        </div>
+      }
+    >
+      <SignInContent />
+    </Suspense>
+  );
+}
+
 function SignInContent() {
   const { toast } = useToast();
   const router = useRouter();
@@ -254,20 +268,6 @@ function SignInContent() {
         <div />
       </div>
     </div>
-  );
-}
-
-export default function SignIn() {
-  return (
-    <Suspense
-      fallback={
-        <div className="min-h-screen flex items-center justify-center">
-          Loading...
-        </div>
-      }
-    >
-      <SignInContent />
-    </Suspense>
   );
 }
 

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -6,11 +6,24 @@ import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { signIn, signUp, useSession } from "@/lib/auth-client";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 
 export default function SignUp() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gray-900">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white" />
+        </div>
+      }
+    >
+      <SignUpContent />
+    </Suspense>
+  );
+}
+
+function SignUpContent() {
   const { toast } = useToast();
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -8,16 +8,20 @@ import { signIn, signUp, useSession } from "@/lib/auth-client";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 
 export default function SignUp() {
   const { toast } = useToast();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const referralCode = searchParams.get("ref");
   const { data: session, isPending } = useSession();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [refCode, setRefCode] = useState(referralCode || "");
 
   // Redirect authenticated users based on onboarding status
   useEffect(() => {
@@ -74,6 +78,18 @@ export default function SignUp() {
           variant: "destructive",
         });
       } else if (data) {
+        // Apply referral code if present
+        if (refCode) {
+          try {
+            await fetch("/api/referrals/apply", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ code: refCode }),
+            });
+          } catch {
+            // Non-blocking: referral application failure shouldn't block signup
+          }
+        }
         toast({
           title: "Account Created Successfully!",
           description: "Redirecting to onboarding...",
@@ -180,6 +196,26 @@ export default function SignUp() {
                 disabled={isLoading}
               />
             </div>
+            {!referralCode && (
+              <div className="grid gap-2 mt-4">
+                <Label htmlFor="referral-code">Referral Code (optional)</Label>
+                <Input
+                  id="referral-code"
+                  placeholder="Enter referral code"
+                  type="text"
+                  value={refCode}
+                  onChange={(e) => setRefCode(e.target.value)}
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+            {referralCode && (
+              <div className="mt-4 p-3 rounded-md bg-green-900/30 border border-green-700">
+                <p className="text-sm text-green-400">
+                  Referral code <span className="font-semibold">{referralCode}</span> applied! You&apos;ll receive a welcome bonus after signing up.
+                </p>
+              </div>
+            )}
             <Button
               type="submit"
               className="w-full mt-4 bg-gray-800 hover:bg-gray-700"

--- a/app/checkout/plans/class/[classPlanId]/page.tsx
+++ b/app/checkout/plans/class/[classPlanId]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { fetchReviews } from "@/lib/user";
 import { searchParamsSchema, createCheckoutData } from "@/schemas/checkout";
@@ -89,6 +90,9 @@ export default function ClassCheckoutPage({
     useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
+  const [useReferralCredits, setUseReferralCredits] = useState(false);
+  const [availableCredits, setAvailableCredits] = useState(0);
+  const [isLoadingCredits, setIsLoadingCredits] = useState(true);
 
   const { toast } = useToast();
 
@@ -136,6 +140,24 @@ export default function ClassCheckoutPage({
       setIsApplyingDiscount(false);
     }
   };
+
+  // Fetch available referral credits
+  useEffect(() => {
+    async function fetchCredits() {
+      try {
+        const response = await fetch("/api/referrals/credits/available");
+        if (response.ok) {
+          const data = await response.json();
+          setAvailableCredits(Math.floor((data.data.totalAvailable || 0) / 100));
+        }
+      } catch (error) {
+        console.error("Error fetching referral credits:", error);
+      } finally {
+        setIsLoadingCredits(false);
+      }
+    }
+    fetchCredits();
+  }, []);
 
   const handleApiError = createHandleApiError(toast);
   const handleCheckoutSuccess = createHandleCheckoutSuccess(toast, "CLASS");
@@ -187,6 +209,7 @@ export default function ClassCheckoutPage({
           discountCode: appliedDiscount?.code,
           paymentGateway: gateway,
           fromWaitlist,
+          useReferralCredits,
         });
 
         await handleUnifiedCheckout(
@@ -242,6 +265,7 @@ export default function ClassCheckoutPage({
       handleCheckoutSuccess,
       toast,
       appliedDiscount,
+      useReferralCredits,
     ],
   );
 
@@ -303,8 +327,9 @@ export default function ClassCheckoutPage({
     return calculatePricing(basePrice, {
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
+      creditsApplied: useReferralCredits ? availableCredits : 0,
     });
-  }, [planData?.data?.price, appliedDiscount]);
+  }, [planData?.data?.price, appliedDiscount, useReferralCredits, availableCredits]);
 
   if (isLoading) {
     return (
@@ -514,6 +539,32 @@ export default function ClassCheckoutPage({
             </div>
           </div>
         </div>
+        <Separator className="bg-zinc-200" />
+        <div className="grid gap-4">
+          <div className="font-semibold">Referral Credits</div>
+          {isLoadingCredits ? (
+            <div className="text-sm text-muted-foreground">Loading credits...</div>
+          ) : availableCredits > 0 ? (
+            <div className="flex items-center justify-between bg-blue-50 p-3 rounded-lg border border-blue-200">
+              <div>
+                <div className="font-medium text-blue-700">
+                  {formatPrice(availableCredits)} available
+                </div>
+                <div className="text-sm text-blue-600">
+                  Apply to this purchase
+                </div>
+              </div>
+              <Switch
+                checked={useReferralCredits}
+                onCheckedChange={setUseReferralCredits}
+              />
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No referral credits available
+            </div>
+          )}
+        </div>
       </div>
       <div className="flex flex-col gap-8 p-8 bg-white">
         <Card className="border-zinc-200 shadow-sm">
@@ -571,6 +622,12 @@ export default function ClassCheckoutPage({
                       `(${formatPercentage(pricing.discountPercent)})`}
                   </div>
                   <div>-{formatPrice(pricing.discountAmount)}</div>
+                </div>
+              )}
+              {pricing.creditsApplied > 0 && (
+                <div className="flex items-center justify-between text-blue-600">
+                  <div>Referral Credits</div>
+                  <div>-{formatPrice(pricing.creditsApplied)}</div>
                 </div>
               )}
               <Separator className="bg-zinc-200" />
@@ -641,6 +698,7 @@ export default function ClassCheckoutPage({
                             eventId: planDetails.classes[0]?.id,
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={razorpayHandlers.onPaymentSuccess}
                           onPaymentError={razorpayHandlers.onPaymentError}
@@ -653,6 +711,7 @@ export default function ClassCheckoutPage({
                             eventId: planDetails.classes[0]?.id,
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={stripeHandlers.onPaymentSuccess}
                           onPaymentError={stripeHandlers.onPaymentError}

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { fetchReviews } from "@/lib/user";
 import {
@@ -71,6 +72,9 @@ export default function ConsultationCheckoutPage({
     useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
+  const [useReferralCredits, setUseReferralCredits] = useState(false);
+  const [availableCredits, setAvailableCredits] = useState(0);
+  const [isLoadingCredits, setIsLoadingCredits] = useState(true);
 
   const { toast } = useToast();
 
@@ -118,6 +122,24 @@ export default function ConsultationCheckoutPage({
       setIsApplyingDiscount(false);
     }
   };
+
+  // Fetch available referral credits
+  useEffect(() => {
+    async function fetchCredits() {
+      try {
+        const response = await fetch("/api/referrals/credits/available");
+        if (response.ok) {
+          const data = await response.json();
+          setAvailableCredits(Math.floor((data.data.totalAvailable || 0) / 100));
+        }
+      } catch (error) {
+        console.error("Error fetching referral credits:", error);
+      } finally {
+        setIsLoadingCredits(false);
+      }
+    }
+    fetchCredits();
+  }, []);
 
   // Fetch slot details
   useEffect(() => {
@@ -258,6 +280,7 @@ export default function ConsultationCheckoutPage({
             searchParamsValidation.data.slotOfAvailabilityCustomId,
           discountCode: appliedDiscount?.code, // Use state instead of URL params
           notes: searchParamsValidation.data.notes,
+          useReferralCredits,
         });
 
         // Make single API call - backend decides dev vs prod flow
@@ -357,6 +380,7 @@ export default function ConsultationCheckoutPage({
       toast,
       isCheckoutProcessing,
       appliedDiscount,
+      useReferralCredits,
     ],
   );
 
@@ -445,8 +469,9 @@ export default function ConsultationCheckoutPage({
     return calculatePricing(basePrice, {
       discountPercent: discountAmount > 0 ? 0 : discountPercent, // Don't use percent if we have a fixed amount
       discountAmount,
+      creditsApplied: useReferralCredits ? availableCredits : 0,
     });
-  }, [eventData?.data?.price, appliedDiscount]);
+  }, [eventData?.data?.price, appliedDiscount, useReferralCredits, availableCredits]);
 
   if (isLoading) {
     return (
@@ -614,6 +639,32 @@ export default function ConsultationCheckoutPage({
             </div>
           )}
         </div>
+        <Separator className="bg-zinc-200" />
+        <div className="grid gap-4">
+          <div className="font-semibold">Referral Credits</div>
+          {isLoadingCredits ? (
+            <div className="text-sm text-muted-foreground">Loading credits...</div>
+          ) : availableCredits > 0 ? (
+            <div className="flex items-center justify-between bg-blue-50 p-3 rounded-lg border border-blue-200">
+              <div>
+                <div className="font-medium text-blue-700">
+                  {formatPrice(availableCredits)} available
+                </div>
+                <div className="text-sm text-blue-600">
+                  Apply to this purchase
+                </div>
+              </div>
+              <Switch
+                checked={useReferralCredits}
+                onCheckedChange={setUseReferralCredits}
+              />
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No referral credits available
+            </div>
+          )}
+        </div>
       </div>
       <div className="flex flex-col gap-8 p-8 bg-white">
         <Card className="border-zinc-200 shadow-sm">
@@ -660,6 +711,12 @@ export default function ConsultationCheckoutPage({
                       `(${formatPercentage(pricing.discountPercent)})`}
                   </div>
                   <div>-{formatPrice(pricing.discountAmount)}</div>
+                </div>
+              )}
+              {pricing.creditsApplied > 0 && (
+                <div className="flex items-center justify-between text-blue-600">
+                  <div>Referral Credits</div>
+                  <div>-{formatPrice(pricing.creditsApplied)}</div>
                 </div>
               )}
               <Separator className="bg-zinc-200" />
@@ -757,6 +814,7 @@ export default function ConsultationCheckoutPage({
                             notes: Array.isArray(resolvedSearchParams.notes)
                               ? resolvedSearchParams.notes[0]
                               : resolvedSearchParams.notes,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={(response: {
                             razorpay_payment_id: string;
@@ -809,6 +867,7 @@ export default function ConsultationCheckoutPage({
                             notes: Array.isArray(resolvedSearchParams.notes)
                               ? resolvedSearchParams.notes[0]
                               : resolvedSearchParams.notes,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={(response: any) => {
                             toast({

--- a/app/checkout/plans/math.ts
+++ b/app/checkout/plans/math.ts
@@ -14,6 +14,7 @@ export interface PricingConfig {
   taxRate?: number; // Override tax rate (0.18 = 18%)
   discountPercent?: number; // Applied discount percentage (0.10 = 10%)
   discountAmount?: number; // Fixed discount amount
+  creditsApplied?: number; // Referral credits applied (in major currency unit)
 }
 
 export interface PricingBreakdown {
@@ -22,6 +23,7 @@ export interface PricingBreakdown {
   taxRate: number;
   discountAmount: number;
   discountPercent: number;
+  creditsApplied: number;
   total: number;
 }
 
@@ -101,7 +103,9 @@ export function calculatePricing(
   );
   const netAmount = calculateNetAmount(subtotal, discountAmount);
   const taxAmount = calculateTax(netAmount, taxRate);
-  const total = calculateTotal(netAmount, taxAmount);
+  const totalBeforeCredits = calculateTotal(netAmount, taxAmount);
+  const creditsApplied = Math.min(config.creditsApplied ?? 0, totalBeforeCredits);
+  const total = Math.round((totalBeforeCredits - creditsApplied) * 100) / 100;
 
   return {
     subtotal,
@@ -109,6 +113,7 @@ export function calculatePricing(
     taxRate,
     discountAmount,
     discountPercent,
+    creditsApplied,
     total,
   };
 }

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { fetchReviews } from "@/lib/user";
 import {
@@ -76,6 +77,9 @@ export default function SubscriptionCheckoutPage({
     useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
+  const [useReferralCredits, setUseReferralCredits] = useState(false);
+  const [availableCredits, setAvailableCredits] = useState(0);
+  const [isLoadingCredits, setIsLoadingCredits] = useState(true);
 
   const { toast } = useToast();
 
@@ -123,6 +127,24 @@ export default function SubscriptionCheckoutPage({
       setIsApplyingDiscount(false);
     }
   };
+
+  // Fetch available referral credits
+  useEffect(() => {
+    async function fetchCredits() {
+      try {
+        const response = await fetch("/api/referrals/credits/available");
+        if (response.ok) {
+          const data = await response.json();
+          setAvailableCredits(Math.floor((data.data.totalAvailable || 0) / 100));
+        }
+      } catch (error) {
+        console.error("Error fetching referral credits:", error);
+      } finally {
+        setIsLoadingCredits(false);
+      }
+    }
+    fetchCredits();
+  }, []);
 
   // Create utility functions using the toast instance
   const handleApiError = createHandleApiError(toast);
@@ -186,6 +208,7 @@ export default function SubscriptionCheckoutPage({
             searchParamsValidation.data.schedulingPeriodEndsAt,
           discountCode: appliedDiscount?.code,
           paymentGateway: gateway,
+          useReferralCredits,
         });
 
         // Make API call - backend decides dev vs prod flow
@@ -281,6 +304,7 @@ export default function SubscriptionCheckoutPage({
       planData?.data?.id,
       toast,
       appliedDiscount,
+      useReferralCredits,
     ],
   );
 
@@ -341,8 +365,9 @@ export default function SubscriptionCheckoutPage({
     return calculatePricing(basePrice, {
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
+      creditsApplied: useReferralCredits ? availableCredits : 0,
     });
-  }, [planData?.data?.price, appliedDiscount]);
+  }, [planData?.data?.price, appliedDiscount, useReferralCredits, availableCredits]);
 
   if (isLoading) {
     return (
@@ -554,6 +579,32 @@ export default function SubscriptionCheckoutPage({
             </div>
           </div>
         </div>
+        <Separator className="bg-zinc-200" />
+        <div className="grid gap-4">
+          <div className="font-semibold">Referral Credits</div>
+          {isLoadingCredits ? (
+            <div className="text-sm text-muted-foreground">Loading credits...</div>
+          ) : availableCredits > 0 ? (
+            <div className="flex items-center justify-between bg-blue-50 p-3 rounded-lg border border-blue-200">
+              <div>
+                <div className="font-medium text-blue-700">
+                  {formatPrice(availableCredits)} available
+                </div>
+                <div className="text-sm text-blue-600">
+                  Apply to this purchase
+                </div>
+              </div>
+              <Switch
+                checked={useReferralCredits}
+                onCheckedChange={setUseReferralCredits}
+              />
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No referral credits available
+            </div>
+          )}
+        </div>
       </div>
       <div className="flex flex-col gap-8 p-8 bg-white">
         <Card className="border-zinc-200 shadow-sm">
@@ -618,6 +669,12 @@ export default function SubscriptionCheckoutPage({
                       `(${formatPercentage(pricing.discountPercent)})`}
                   </div>
                   <div>-{formatPrice(pricing.discountAmount)}</div>
+                </div>
+              )}
+              {pricing.creditsApplied > 0 && (
+                <div className="flex items-center justify-between text-blue-600">
+                  <div>Referral Credits</div>
+                  <div>-{formatPrice(pricing.creditsApplied)}</div>
                 </div>
               )}
               <Separator className="bg-zinc-200" />
@@ -690,6 +747,7 @@ export default function SubscriptionCheckoutPage({
                             planId: planData?.data?.id || "",
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={stripeHandlers.onPaymentSuccess}
                           onPaymentError={stripeHandlers.onPaymentError}
@@ -701,6 +759,7 @@ export default function SubscriptionCheckoutPage({
                             planId: planData?.data?.id || "",
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={razorpayHandlers.onPaymentSuccess}
                           onPaymentError={razorpayHandlers.onPaymentError}

--- a/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
+++ b/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { fetchReviews } from "@/lib/user";
 import {
@@ -94,6 +95,9 @@ export default function WebinarCheckoutPage({
     useState<AppliedDiscount | null>(null);
   const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const [discountError, setDiscountError] = useState<string | null>(null);
+  const [useReferralCredits, setUseReferralCredits] = useState(false);
+  const [availableCredits, setAvailableCredits] = useState(0);
+  const [isLoadingCredits, setIsLoadingCredits] = useState(true);
 
   const { toast } = useToast();
 
@@ -142,6 +146,24 @@ export default function WebinarCheckoutPage({
     }
   };
 
+  // Fetch available referral credits
+  useEffect(() => {
+    async function fetchCredits() {
+      try {
+        const response = await fetch("/api/referrals/credits/available");
+        if (response.ok) {
+          const data = await response.json();
+          setAvailableCredits(Math.floor((data.data.totalAvailable || 0) / 100));
+        }
+      } catch (error) {
+        console.error("Error fetching referral credits:", error);
+      } finally {
+        setIsLoadingCredits(false);
+      }
+    }
+    fetchCredits();
+  }, []);
+
   // Create utility functions using the toast instance
   const handleApiError = createHandleApiError(toast);
   const handleCheckoutSuccess = createHandleCheckoutSuccess(toast, "WEBINAR");
@@ -183,6 +205,7 @@ export default function WebinarCheckoutPage({
           discountCode: appliedDiscount?.code,
           paymentGateway: gateway,
           fromWaitlist,
+          useReferralCredits,
         });
 
         // Handle unified checkout flow using the utility
@@ -238,6 +261,7 @@ export default function WebinarCheckoutPage({
       handleCheckoutSuccess,
       toast,
       appliedDiscount,
+      useReferralCredits,
     ],
   );
 
@@ -300,8 +324,9 @@ export default function WebinarCheckoutPage({
     return calculatePricing(basePrice, {
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
+      creditsApplied: useReferralCredits ? availableCredits : 0,
     });
-  }, [planData?.data?.price, appliedDiscount]);
+  }, [planData?.data?.price, appliedDiscount, useReferralCredits, availableCredits]);
 
   if (isLoading) {
     return (
@@ -501,6 +526,32 @@ export default function WebinarCheckoutPage({
             </div>
           </div>
         </div>
+        <Separator className="bg-zinc-200" />
+        <div className="grid gap-4">
+          <div className="font-semibold">Referral Credits</div>
+          {isLoadingCredits ? (
+            <div className="text-sm text-muted-foreground">Loading credits...</div>
+          ) : availableCredits > 0 ? (
+            <div className="flex items-center justify-between bg-blue-50 p-3 rounded-lg border border-blue-200">
+              <div>
+                <div className="font-medium text-blue-700">
+                  {formatPrice(availableCredits)} available
+                </div>
+                <div className="text-sm text-blue-600">
+                  Apply to this purchase
+                </div>
+              </div>
+              <Switch
+                checked={useReferralCredits}
+                onCheckedChange={setUseReferralCredits}
+              />
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No referral credits available
+            </div>
+          )}
+        </div>
       </div>
       <div className="flex flex-col gap-8 p-8 bg-white">
         <Card className="border-zinc-200 shadow-sm">
@@ -545,6 +596,12 @@ export default function WebinarCheckoutPage({
                       `(${formatPercentage(pricing.discountPercent)})`}
                   </div>
                   <div>-{formatPrice(pricing.discountAmount)}</div>
+                </div>
+              )}
+              {pricing.creditsApplied > 0 && (
+                <div className="flex items-center justify-between text-blue-600">
+                  <div>Referral Credits</div>
+                  <div>-{formatPrice(pricing.creditsApplied)}</div>
                 </div>
               )}
               <Separator className="bg-zinc-200" />
@@ -617,6 +674,7 @@ export default function WebinarCheckoutPage({
                             eventId: planDetails.webinars[0]?.id,
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={razorpayHandlers.onPaymentSuccess}
                           onPaymentError={razorpayHandlers.onPaymentError}
@@ -629,6 +687,7 @@ export default function WebinarCheckoutPage({
                             eventId: planDetails.webinars[0]?.id,
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
+                            useReferralCredits,
                           })}
                           onPaymentSuccess={stripeHandlers.onPaymentSuccess}
                           onPaymentError={stripeHandlers.onPaymentError}

--- a/app/dashboard/consultant/[consultantId]/(features)/analytics/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/analytics/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { BarChart3 } from "lucide-react";
+
+export default function AnalyticsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-zinc-900">Analytics</h1>
+        <p className="text-sm text-zinc-500 mt-1">
+          Track your performance and insights.
+        </p>
+      </div>
+
+      <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-white p-16 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-zinc-100 mb-4">
+          <BarChart3 className="h-7 w-7 text-zinc-400" />
+        </div>
+        <h2 className="text-lg font-semibold text-zinc-900">Coming Soon</h2>
+        <p className="mt-2 max-w-sm text-sm text-zinc-500">
+          Analytics and insights for your consultations, earnings, and audience
+          engagement will be available here.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -41,6 +41,9 @@ import {
   groupRecurringAppointments,
   groupAppointmentsByType,
   getAppointmentTypeDisplayName,
+  getCollaboratorRole,
+  formatCollaboratorRole,
+  getRoleBadgeStyle,
 } from "../../utils/appointmentHelpers";
 import { EventTimingsCalendar } from "./components/EventTimingsCalendar";
 import {
@@ -56,7 +59,8 @@ export function AppointmentsTab({
   appointments,
   badgeStyles,
   scheduledTrials = [],
-}: Readonly<AppointmentsTabProps>) {
+  consultantId,
+}: Readonly<AppointmentsTabProps & { consultantId?: string }>) {
   const router = useRouter();
   const client = useStreamVideoClient();
   const { toast } = useToast();
@@ -477,9 +481,26 @@ export function AppointmentsTab({
                                 </AvatarFallback>
                               </Avatar>
                               <div>
-                                <h3 className="font-semibold text-gray-800 text-sm">
-                                  {getConsumeeName(firstAppointment)}
-                                </h3>
+                                <div className="flex items-center gap-2">
+                                  <h3 className="font-semibold text-gray-800 text-sm">
+                                    {getConsumeeName(firstAppointment)}
+                                  </h3>
+                                  {consultantId &&
+                                    (() => {
+                                      const role = getCollaboratorRole(
+                                        firstAppointment,
+                                        consultantId,
+                                      );
+                                      return role ? (
+                                        <Badge
+                                          variant="secondary"
+                                          className={`text-[10px] px-1.5 py-0 h-5 ${getRoleBadgeStyle(role)}`}
+                                        >
+                                          {formatCollaboratorRole(role)}
+                                        </Badge>
+                                      ) : null;
+                                    })()}
+                                </div>
                                 <p className="text-xs text-gray-600">
                                   {groupTitle.split("(")[0].trim()}
                                 </p>
@@ -635,9 +656,29 @@ export function AppointmentsTab({
                                         <div className="min-w-0">
                                           {!isRecurring && (
                                             <>
-                                              <h3 className="font-semibold text-gray-800">
-                                                {getConsumeeName(appointment)}
-                                              </h3>
+                                              <div className="flex items-center gap-2">
+                                                <h3 className="font-semibold text-gray-800">
+                                                  {getConsumeeName(appointment)}
+                                                </h3>
+                                                {consultantId &&
+                                                  (() => {
+                                                    const role =
+                                                      getCollaboratorRole(
+                                                        appointment,
+                                                        consultantId,
+                                                      );
+                                                    return role ? (
+                                                      <Badge
+                                                        variant="secondary"
+                                                        className={`text-[10px] px-1.5 py-0 h-5 ${getRoleBadgeStyle(role)}`}
+                                                      >
+                                                        {formatCollaboratorRole(
+                                                          role,
+                                                        )}
+                                                      </Badge>
+                                                    ) : null;
+                                                  })()}
+                                              </div>
                                               <p className="text-sm text-gray-600">
                                                 {getAppointmentTypeAndPlan(
                                                   appointment,

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/page.tsx
@@ -64,6 +64,7 @@ export default function AppointmentsPage({
         appointments={appointments || []}
         badgeStyles={BADGE_STYLES}
         scheduledTrials={trialsData || []}
+        consultantId={consultantId}
       />
     </DashboardErrorBoundary>
   );

--- a/app/dashboard/consultant/[consultantId]/(features)/collaborations/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/collaborations/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import {
+  DashboardHeader,
+  DashboardContent,
+} from "@/components/dashboard/DashboardShell";
+import { InvitationsPanel } from "@/components/collaborators/InvitationsPanel";
+
+export default function CollaborationsPage() {
+  return (
+    <>
+      <DashboardHeader
+        title="Collaborations"
+        subtitle="Manage invitations and active collaborations on webinars and classes"
+      />
+      <DashboardContent>
+        <InvitationsPanel />
+      </DashboardContent>
+    </>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
@@ -38,6 +38,8 @@ interface EarningRecord {
   status: EarningStatus;
   holdUntil: string | null;
   createdAt: string;
+  role: "OWNER" | "COLLABORATOR";
+  sharePercentage: number;
   payment: {
     id: string;
     amount: number;
@@ -284,6 +286,9 @@ export default function EarningsPage({
                     <th className="text-left px-4 py-3 font-medium text-zinc-600">
                       Type
                     </th>
+                    <th className="text-left px-4 py-3 font-medium text-zinc-600">
+                      Role
+                    </th>
                     <th className="text-right px-4 py-3 font-medium text-zinc-600">
                       Payment
                     </th>
@@ -317,6 +322,19 @@ export default function EarningsPage({
                         <td className="px-4 py-3">
                           <span className="capitalize text-zinc-800">
                             {appointmentType.toLowerCase()}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                            earning.role === "COLLABORATOR"
+                              ? "bg-purple-50 text-purple-700"
+                              : "bg-zinc-100 text-zinc-600"
+                          }`}>
+                            {earning.role === "COLLABORATOR"
+                              ? `Collab ${earning.sharePercentage}%`
+                              : earning.sharePercentage < 100
+                                ? `Owner ${earning.sharePercentage}%`
+                                : "Owner"}
                           </span>
                         </td>
                         <td className="px-4 py-3 text-right text-zinc-600">

--- a/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
@@ -43,6 +43,7 @@ interface EarningRecord {
   payment: {
     id: string;
     amount: number;
+    originalAmount: number;
     currency: string;
     createdAt: string;
     appointment: {
@@ -290,7 +291,7 @@ export default function EarningsPage({
                       Role
                     </th>
                     <th className="text-right px-4 py-3 font-medium text-zinc-600">
-                      Payment
+                      Plan Price
                     </th>
                     <th className="text-right px-4 py-3 font-medium text-zinc-600">
                       Your Earnings
@@ -338,7 +339,7 @@ export default function EarningsPage({
                           </span>
                         </td>
                         <td className="px-4 py-3 text-right text-zinc-600">
-                          {formatEarningAmount((earning.payment?.amount ?? 0) * 100, earning.payment?.currency ?? "INR")}
+                          {formatEarningAmount((earning.payment?.originalAmount ?? 0) * 100, earning.payment?.currency ?? "INR")}
                         </td>
                         <td className="px-4 py-3 text-right font-medium text-zinc-900">
                           {formatEarningAmount(earning.consultantShare, earning.payment?.currency ?? "INR")}

--- a/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
@@ -338,7 +338,7 @@ export default function EarningsPage({
                           </span>
                         </td>
                         <td className="px-4 py-3 text-right text-zinc-600">
-                          {formatEarningAmount(earning.payment?.amount ?? 0, earning.payment?.currency ?? "INR")}
+                          {formatEarningAmount((earning.payment?.amount ?? 0) * 100, earning.payment?.currency ?? "INR")}
                         </td>
                         <td className="px-4 py-3 text-right font-medium text-zinc-900">
                           {formatEarningAmount(earning.consultantShare, earning.payment?.currency ?? "INR")}

--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
@@ -46,6 +46,9 @@ import {
   getUpcomingAppointments,
   groupRecurringAppointments,
   sortAppointmentsByStartTime,
+  getCollaboratorRole,
+  formatCollaboratorRole,
+  getRoleBadgeStyle,
 } from "../../utils/appointmentHelpers";
 
 import { IActivity, IApproval, BADGE_STYLES, getBadgeStyle } from "../../types";
@@ -284,9 +287,24 @@ export function HomeTab({
                               </AvatarFallback>
                             </Avatar>
                             <div className="flex-1 min-w-0">
-                              <h3 className="font-semibold text-zinc-900 truncate">
-                                {userName}
-                              </h3>
+                              <div className="flex items-center gap-2">
+                                <h3 className="font-semibold text-zinc-900 truncate">
+                                  {userName}
+                                </h3>
+                                {(() => {
+                                  const role = getCollaboratorRole(
+                                    appointment,
+                                    consultantId,
+                                  );
+                                  return role ? (
+                                    <Badge
+                                      className={`text-[10px] px-1.5 py-0 h-5 flex-shrink-0 ${getRoleBadgeStyle(role)}`}
+                                    >
+                                      {formatCollaboratorRole(role)}
+                                    </Badge>
+                                  ) : null;
+                                })()}
+                              </div>
                               <p className="text-sm text-zinc-500 truncate">
                                 {getAppointmentTypeAndPlan(appointment)}
                               </p>
@@ -385,6 +403,19 @@ export function HomeTab({
                               <h4 className="font-medium text-zinc-900 truncate">
                                 {userName}
                               </h4>
+                              {(() => {
+                                const role = getCollaboratorRole(
+                                  firstAppointment,
+                                  consultantId,
+                                );
+                                return role ? (
+                                  <Badge
+                                    className={`text-[10px] px-1.5 py-0 h-5 flex-shrink-0 ${getRoleBadgeStyle(role)}`}
+                                  >
+                                    {formatCollaboratorRole(role)}
+                                  </Badge>
+                                ) : null;
+                              })()}
                               {isRecurring && (
                                 <span className="text-xs text-zinc-400">
                                   {completedSessions}/{totalSessions} sessions

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
@@ -13,6 +13,7 @@ import {
   GraduationCap,
   Users,
   Gift,
+  Loader2,
 } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 import { WebinarStatus, ClassStatus } from "@prisma/client";
@@ -36,6 +37,9 @@ interface EventCardProps {
   onEdit: () => void;
   onDelete: () => void;
   onTrialsClick?: () => void;
+  onJoinMeeting?: () => void;
+  canJoinNow?: boolean;
+  isJoiningMeeting?: boolean;
 }
 
 function formatCollaboratorRole(role: string): string {
@@ -241,6 +245,9 @@ export function EventCard({
   onEdit,
   onDelete,
   onTrialsClick,
+  onJoinMeeting,
+  canJoinNow,
+  isJoiningMeeting,
 }: Readonly<EventCardProps>) {
   const config = eventTypeConfig[eventType];
   const Icon = config.icon;
@@ -349,6 +356,46 @@ export function EventCard({
               {status.toString().replace("_", " ")}
             </Badge>
           )}
+        </div>
+      )}
+
+      {/* Join Meeting button for live sessions */}
+      {isLiveSession && onJoinMeeting && (
+        <div className="mt-3">
+          <Button
+            onClick={(e) => {
+              e.stopPropagation();
+              onJoinMeeting();
+            }}
+            disabled={
+              process.env.NODE_ENV === "production"
+                ? !canJoinNow || isJoiningMeeting
+                : isJoiningMeeting
+            }
+            className={cn(
+              "w-full gap-2 font-medium",
+              canJoinNow
+                ? "bg-emerald-600 hover:bg-emerald-700 text-white"
+                : "bg-zinc-100 text-zinc-500",
+            )}
+            size="sm"
+          >
+            {isJoiningMeeting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Joining...
+              </>
+            ) : (
+              <>
+                <Video className="h-4 w-4" />
+                {process.env.NODE_ENV === "production"
+                  ? canJoinNow
+                    ? "Join Meeting"
+                    : "Not Available Yet"
+                  : "Join (Dev)"}
+              </>
+            )}
+          </Button>
         </div>
       )}
 

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
@@ -31,9 +31,22 @@ interface EventCardProps {
   eventType: EventType;
   participantCount: number;
   pendingTrialCount?: number;
+  collaboratorRole?: string;
+  isCollaborated?: boolean;
   onEdit: () => void;
   onDelete: () => void;
   onTrialsClick?: () => void;
+}
+
+function formatCollaboratorRole(role: string): string {
+  const labels: Record<string, string> = {
+    HOST: "Host",
+    CO_HOST: "Co-Host",
+    MODERATOR: "Moderator",
+    CO_INSTRUCTOR: "Co-Instructor",
+    TEACHING_ASSISTANT: "TA",
+  };
+  return labels[role] || role;
 }
 
 // Type guards
@@ -223,6 +236,8 @@ export function EventCard({
   eventType,
   participantCount,
   pendingTrialCount,
+  collaboratorRole,
+  isCollaborated,
   onEdit,
   onDelete,
   onTrialsClick,
@@ -261,31 +276,33 @@ export function EventCard({
         )}
       />
 
-      {/* Hover action buttons - always visible on mobile */}
-      <div className="absolute top-3 right-3 sm:top-4 sm:right-4 flex items-center gap-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all duration-200 sm:transform sm:translate-y-1 sm:group-hover:translate-y-0 z-10">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 sm:h-9 sm:w-9 bg-white/90 backdrop-blur-sm shadow-sm hover:bg-white border border-zinc-200/60"
-          onClick={(e) => {
-            e.stopPropagation();
-            onEdit();
-          }}
-        >
-          <Edit className="h-4 w-4 text-zinc-600" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 sm:h-9 sm:w-9 bg-white/90 backdrop-blur-sm shadow-sm hover:bg-red-50 border border-zinc-200/60"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-        >
-          <Trash2 className="h-4 w-4 text-zinc-400 hover:text-red-500" />
-        </Button>
-      </div>
+      {/* Hover action buttons - hidden for collaborated plans */}
+      {!isCollaborated && (
+        <div className="absolute top-3 right-3 sm:top-4 sm:right-4 flex items-center gap-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all duration-200 sm:transform sm:translate-y-1 sm:group-hover:translate-y-0 z-10">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 sm:h-9 sm:w-9 bg-white/90 backdrop-blur-sm shadow-sm hover:bg-white border border-zinc-200/60"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit();
+            }}
+          >
+            <Edit className="h-4 w-4 text-zinc-600" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 sm:h-9 sm:w-9 bg-white/90 backdrop-blur-sm shadow-sm hover:bg-red-50 border border-zinc-200/60"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash2 className="h-4 w-4 text-zinc-400 hover:text-red-500" />
+          </Button>
+        </div>
+      )}
 
       {/* Main content */}
       <div className="flex items-start gap-3 sm:gap-4">
@@ -304,6 +321,15 @@ export function EventCard({
           <h3 className="font-semibold text-zinc-900 text-base sm:text-lg leading-tight line-clamp-2">
             {title}
           </h3>
+          {collaboratorRole && (
+            <span className={`inline-block mt-1 text-xs font-medium px-2 py-0.5 rounded-full ${
+              isCollaborated
+                ? "bg-purple-50 text-purple-700"
+                : "bg-zinc-100 text-zinc-600"
+            }`}>
+              {formatCollaboratorRole(collaboratorRole)}
+            </span>
+          )}
         </div>
       </div>
 

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
@@ -29,6 +29,9 @@ interface WebinarCarouselProps {
   onDelete: (eventId: string) => Promise<void>;
   eventType: "webinar";
   participantCounts: Record<string, number>;
+  onJoinMeeting?: (event: PlannerWebinarEvent) => void;
+  joinableEventIds?: Set<string>;
+  joiningEventId?: string | null;
 }
 
 interface ClassCarouselProps {
@@ -37,6 +40,9 @@ interface ClassCarouselProps {
   onDelete: (eventId: string) => Promise<void>;
   eventType: "class";
   participantCounts: Record<string, number>;
+  onJoinMeeting?: (event: PlannerClassEvent) => void;
+  joinableEventIds?: Set<string>;
+  joiningEventId?: string | null;
 }
 
 interface ConsultationCarouselProps {
@@ -155,6 +161,26 @@ export function EventCarousel({
     eventType === "subscription"
       ? (props as SubscriptionCarouselProps).onTrialsClick
       : undefined;
+
+  // Extract join meeting props for webinar/class
+  const onJoinMeeting =
+    eventType === "webinar"
+      ? (props as WebinarCarouselProps).onJoinMeeting
+      : eventType === "class"
+        ? (props as ClassCarouselProps).onJoinMeeting
+        : undefined;
+  const joinableEventIds =
+    eventType === "webinar"
+      ? (props as WebinarCarouselProps).joinableEventIds
+      : eventType === "class"
+        ? (props as ClassCarouselProps).joinableEventIds
+        : undefined;
+  const joiningEventId =
+    eventType === "webinar"
+      ? (props as WebinarCarouselProps).joiningEventId
+      : eventType === "class"
+        ? (props as ClassCarouselProps).joiningEventId
+        : undefined;
   const [currentPage, setCurrentPage] = React.useState(1);
   const itemsPerPage = 8;
 
@@ -285,6 +311,13 @@ export function EventCarousel({
                   ? onTrialsClick
                   : undefined
               }
+              onJoinMeeting={
+                onJoinMeeting && (eventType === "webinar" || eventType === "class")
+                  ? () => onJoinMeeting(event as PlannerWebinarEvent & PlannerClassEvent)
+                  : undefined
+              }
+              canJoinNow={joinableEventIds?.has(event.id ?? "") ?? false}
+              isJoiningMeeting={joiningEventId === event.id}
             />
           </motion.div>
         ))}

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
@@ -14,6 +14,8 @@ import { cn } from "@/utils/tailwind";
 import {
   WebinarEvent,
   ClassEvent,
+  PlannerWebinarEvent,
+  PlannerClassEvent,
   ConsultationPlanEvent,
   SubscriptionPlanEvent,
   Event,
@@ -22,16 +24,16 @@ import { EventCard } from "./EventCard";
 import { FormConfirmationDialog } from "./form-fields/FormConfirmationDialog";
 
 interface WebinarCarouselProps {
-  events: WebinarEvent[];
-  onEdit: (event: WebinarEvent) => void;
+  events: PlannerWebinarEvent[];
+  onEdit: (event: PlannerWebinarEvent) => void;
   onDelete: (eventId: string) => Promise<void>;
   eventType: "webinar";
   participantCounts: Record<string, number>;
 }
 
 interface ClassCarouselProps {
-  events: ClassEvent[];
-  onEdit: (event: ClassEvent) => void;
+  events: PlannerClassEvent[];
+  onEdit: (event: PlannerClassEvent) => void;
   onDelete: (eventId: string) => Promise<void>;
   eventType: "class";
   participantCounts: Record<string, number>;
@@ -185,9 +187,9 @@ export function EventCarousel({
 
   const handleEdit = (event: Event) => {
     if (eventType === "webinar" && isWebinarEvent(event)) {
-      onEdit(event);
+      (onEdit as (e: PlannerWebinarEvent) => void)(event as PlannerWebinarEvent);
     } else if (eventType === "class" && isClassEvent(event)) {
-      onEdit(event);
+      (onEdit as (e: PlannerClassEvent) => void)(event as PlannerClassEvent);
     } else if (eventType === "consultation" && isConsultationPlanEvent(event)) {
       onEdit(event);
     } else if (eventType === "subscription" && isSubscriptionPlanEvent(event)) {
@@ -272,6 +274,8 @@ export function EventCarousel({
                   ? pendingTrialCounts[event.id ?? ""]
                   : undefined
               }
+              collaboratorRole={"collaboratorRole" in event ? (event as { collaboratorRole: string }).collaboratorRole : undefined}
+              isCollaborated={"isCollaborated" in event ? (event as { isCollaborated: boolean }).isCollaborated : undefined}
               onEdit={() => handleEdit(event)}
               onDelete={() => handleDeleteClick(event)}
               onTrialsClick={

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventManagementDashboard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventManagementDashboard.tsx
@@ -9,6 +9,8 @@ import { EventPlanner } from "./EventPlanner";
 import {
   WebinarEvent,
   ClassEvent,
+  PlannerWebinarEvent,
+  PlannerClassEvent,
   ConsultationPlanEvent,
   SubscriptionPlanEvent,
   Event,
@@ -37,8 +39,8 @@ import {
 import { cn } from "@/utils/tailwind";
 
 interface PlannerData {
-  webinars: WebinarEvent[];
-  classes: ClassEvent[];
+  webinars: PlannerWebinarEvent[];
+  classes: PlannerClassEvent[];
   participantCounts: Record<string, number>;
 }
 import { addMonths, startOfMonth, endOfMonth } from "date-fns";
@@ -52,10 +54,10 @@ export function EventManagementDashboard({
   consultantId,
   initialData,
 }: Readonly<Props>) {
-  const [webinars, setWebinars] = useState<WebinarEvent[]>(
+  const [webinars, setWebinars] = useState<PlannerWebinarEvent[]>(
     initialData?.webinars || [],
   );
-  const [classes, setClasses] = useState<ClassEvent[]>(
+  const [classes, setClasses] = useState<PlannerClassEvent[]>(
     initialData?.classes || [],
   );
   const [isWebinarDialogOpen, setIsWebinarDialogOpen] = useState(false);
@@ -160,8 +162,9 @@ export function EventManagementDashboard({
           PlannerService.fetchClasses(consultantId, startDate, endDate),
         ]);
 
-        setWebinars(fetchedWebinars);
-        setClasses(fetchedClasses);
+        // Annotate with default role (owned plans from PlannerService)
+        setWebinars(fetchedWebinars.map((w) => ({ ...w, collaboratorRole: "HOST", isCollaborated: false })));
+        setClasses(fetchedClasses.map((c) => ({ ...c, collaboratorRole: "HOST", isCollaborated: false })));
       } catch (err) {
         setError(err instanceof Error ? err.message : "An error occurred");
         console.error("Error fetching events:", err);
@@ -235,12 +238,12 @@ export function EventManagementDashboard({
     }
   };
 
-  const handleEditWebinar = (webinar: WebinarEvent) => {
+  const handleEditWebinar = (webinar: PlannerWebinarEvent) => {
     setEditingEvent(webinar);
     setIsWebinarDialogOpen(true);
   };
 
-  const handleEditClass = (classEvent: ClassEvent) => {
+  const handleEditClass = (classEvent: PlannerClassEvent) => {
     setEditingEvent(classEvent);
     setIsClassDialogOpen(true);
   };

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventManagementDashboard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventManagementDashboard.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import { EventCarousel } from "./EventCarousel";
 import { EventPlanner } from "./EventPlanner";
+import { useStreamVideoClient } from "@stream-io/video-react-sdk";
+import {
+  getOrCreateAppointmentMeeting,
+  MeetingAppointment,
+  MeetingSlot,
+} from "@/lib/meeting";
 import {
   WebinarEvent,
   ClassEvent,
@@ -94,6 +100,186 @@ export function EventManagementDashboard({
   const { refreshPlanner } = usePlannerRefresh(consultantId);
   const [currentDate, setCurrentDate] = useState(new Date());
   const router = useRouter();
+  const streamClient = useStreamVideoClient();
+  const [joiningEventId, setJoiningEventId] = useState<string | null>(null);
+
+  // Compute which webinar/class events are currently joinable (within 10 min before start to end)
+  const joinableEventIds = useMemo(() => {
+    const now = new Date();
+    const ids = new Set<string>();
+
+    for (const webinar of webinars) {
+      const startTimeStr =
+        webinar.appointment?.slotsOfAppointment?.[0]?.startsAt;
+      const endTimeStr = webinar.appointment?.slotsOfAppointment?.[0]?.endsAt;
+      if (startTimeStr) {
+        const startTime = new Date(startTimeStr);
+        const endTime = endTimeStr
+          ? new Date(endTimeStr)
+          : new Date(
+              startTime.getTime() +
+                (webinar.webinarPlan.durationInHours ?? 1) * 60 * 60 * 1000,
+            );
+        const joinWindow = new Date(startTime.getTime() - 10 * 60 * 1000);
+        if (now >= joinWindow && now <= endTime && webinar.id) {
+          ids.add(webinar.id);
+        }
+      }
+    }
+
+    for (const cls of classes) {
+      // For classes, check the nearest upcoming appointment
+      const appointments = cls.appointments ?? [];
+      for (const appt of appointments) {
+        const startTimeStr = appt.slotsOfAppointment?.[0]?.startsAt;
+        const endTimeStr = appt.slotsOfAppointment?.[0]?.endsAt;
+        if (startTimeStr) {
+          const startTime = new Date(startTimeStr);
+          const endTime = endTimeStr
+            ? new Date(endTimeStr)
+            : new Date(startTime.getTime() + 60 * 60 * 1000);
+          const joinWindow = new Date(startTime.getTime() - 10 * 60 * 1000);
+          if (now >= joinWindow && now <= endTime && cls.id) {
+            ids.add(cls.id);
+          }
+        }
+      }
+    }
+
+    return ids;
+  }, [webinars, classes]);
+
+  // Handle joining a meeting from the planner
+  const handleJoinWebinarMeeting = async (webinar: PlannerWebinarEvent) => {
+    if (!streamClient) {
+      toast({
+        title: "Not signed in",
+        description: "Video client not initialized. Please sign in to join.",
+        variant: "warning",
+      });
+      return;
+    }
+
+    const slot = webinar.appointment?.slotsOfAppointment?.[0];
+    if (!slot || !webinar.appointment) {
+      toast({
+        title: "Error",
+        description: "Meeting slot information is not available.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setJoiningEventId(webinar.id ?? null);
+    try {
+      const meetingSlot: MeetingSlot = {
+        id: slot.id,
+        startsAt: slot.startsAt,
+        endsAt: slot.endsAt,
+        appointmentId: webinar.appointment.id,
+      };
+      const meetingAppointment: MeetingAppointment = {
+        id: webinar.appointment.id,
+        appointmentType: "WEBINAR",
+        slotsOfAppointment: [meetingSlot],
+        webinar: { webinarPlan: { title: webinar.webinarPlan.title } },
+      };
+      const meetingId = await getOrCreateAppointmentMeeting(
+        streamClient,
+        meetingAppointment,
+        meetingSlot,
+      );
+      toast({
+        title: "Joining meeting",
+        description: "Redirecting to the meeting room.",
+      });
+      router.push(`/meetings/${meetingId}`);
+    } catch (error) {
+      console.error("Error joining webinar meeting:", error);
+      toast({
+        title: "Error joining meeting",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      });
+      setJoiningEventId(null);
+    }
+  };
+
+  const handleJoinClassMeeting = async (classEvent: PlannerClassEvent) => {
+    if (!streamClient) {
+      toast({
+        title: "Not signed in",
+        description: "Video client not initialized. Please sign in to join.",
+        variant: "warning",
+      });
+      return;
+    }
+
+    // Find the nearest joinable appointment for this class
+    const now = new Date();
+    const appointments = classEvent.appointments ?? [];
+    let targetAppt = null;
+    let targetSlot = null;
+
+    for (const appt of appointments) {
+      const slot = appt.slotsOfAppointment?.[0];
+      if (slot?.startsAt) {
+        const startTime = new Date(slot.startsAt);
+        const endTime = slot.endsAt
+          ? new Date(slot.endsAt)
+          : new Date(startTime.getTime() + 60 * 60 * 1000);
+        const joinWindow = new Date(startTime.getTime() - 10 * 60 * 1000);
+        if (now >= joinWindow && now <= endTime) {
+          targetAppt = appt;
+          targetSlot = slot;
+          break;
+        }
+      }
+    }
+
+    if (!targetAppt || !targetSlot) {
+      toast({
+        title: "Error",
+        description: "No joinable session found for this class.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setJoiningEventId(classEvent.id ?? null);
+    try {
+      const meetingSlot: MeetingSlot = {
+        id: targetSlot.id,
+        startsAt: targetSlot.startsAt,
+        endsAt: targetSlot.endsAt,
+        appointmentId: targetAppt.id,
+      };
+      const meetingAppointment: MeetingAppointment = {
+        id: targetAppt.id,
+        appointmentType: "CLASS",
+        slotsOfAppointment: [meetingSlot],
+        class: { classPlan: { title: classEvent.classPlan.title } },
+      };
+      const meetingId = await getOrCreateAppointmentMeeting(
+        streamClient,
+        meetingAppointment,
+        meetingSlot,
+      );
+      toast({
+        title: "Joining meeting",
+        description: "Redirecting to the meeting room.",
+      });
+      router.push(`/meetings/${meetingId}`);
+    } catch (error) {
+      console.error("Error joining class meeting:", error);
+      toast({
+        title: "Error joining meeting",
+        description: error instanceof Error ? error.message : "Unknown error",
+        variant: "destructive",
+      });
+      setJoiningEventId(null);
+    }
+  };
 
   // Trial management state - just counts for badge display
   const [pendingTrialCounts, setPendingTrialCounts] = useState<
@@ -656,6 +842,9 @@ export function EventManagementDashboard({
               onDelete={handleWebinarDelete}
               eventType="webinar"
               participantCounts={initialData?.participantCounts || {}}
+              onJoinMeeting={handleJoinWebinarMeeting}
+              joinableEventIds={joinableEventIds}
+              joiningEventId={joiningEventId}
             />
           </div>
 
@@ -689,6 +878,9 @@ export function EventManagementDashboard({
               onDelete={handleClassDelete}
               eventType="class"
               participantCounts={initialData?.participantCounts || {}}
+              onJoinMeeting={handleJoinClassMeeting}
+              joinableEventIds={joinableEventIds}
+              joiningEventId={joiningEventId}
             />
           </div>
         </motion.section>

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   Upload,
   CalendarIcon,
+  Users,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -57,6 +58,7 @@ import { TopicsMultiSelect } from "./TopicsMultiSelect";
 import { PlannerService } from "../services/planner";
 import { ClassEvent, ClassPlannerProps } from "../types/event";
 import { PlanMaterialsUpload } from "./PlanMaterialsUpload";
+import { CollaboratorsTab } from "@/components/collaborators/CollaboratorsTab";
 
 export function EventPlannerForClass({
   isOpen,
@@ -947,6 +949,26 @@ export function EventPlannerForClass({
                   </Button>
                 </FormSection>
               )}
+
+              {/* Collaborators Section */}
+              <FormSection
+                title="Collaborators"
+                description="Invite other consultants to co-teach this class"
+                icon={Users}
+              >
+                {initialData?.classPlan?.id ? (
+                  <CollaboratorsTab
+                    planType="class"
+                    planId={initialData.classPlan.id}
+                    isOwner={true}
+                    excludeId={consultantId}
+                  />
+                ) : (
+                  <p className="text-sm text-zinc-500 text-center py-4">
+                    Save this class first to add collaborators
+                  </p>
+                )}
+              </FormSection>
 
               <DialogFooter className="pt-6 border-t">
                 <Button

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
@@ -11,6 +11,7 @@ import {
   GraduationCap,
   Calendar,
   Upload,
+  Users,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -47,6 +48,7 @@ import { TopicsMultiSelect } from "./TopicsMultiSelect";
 import { PlannerService } from "../services/planner";
 import { WebinarEvent, WebinarPlannerProps } from "../types/event";
 import { PlanMaterialsUpload } from "./PlanMaterialsUpload";
+import { CollaboratorsTab } from "@/components/collaborators/CollaboratorsTab";
 
 // Form-specific schema - all required fields explicitly defined
 const WebinarFormSchema = z.object({
@@ -632,6 +634,26 @@ export function EventPlannerForWebinar({
                   </Button>
                 </FormSection>
               )}
+
+              {/* Collaborators Section */}
+              <FormSection
+                title="Collaborators"
+                description="Invite other consultants to co-host this webinar"
+                icon={Users}
+              >
+                {initialData?.webinarPlan?.id ? (
+                  <CollaboratorsTab
+                    planType="webinar"
+                    planId={initialData.webinarPlan.id}
+                    isOwner={true}
+                    excludeId={consultantId}
+                  />
+                ) : (
+                  <p className="text-sm text-zinc-500 text-center py-4">
+                    Save this webinar first to add collaborators
+                  </p>
+                )}
+              </FormSection>
 
               <DialogFooter className="pt-6 border-t">
                 <Button

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/types/event.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/types/event.ts
@@ -69,6 +69,17 @@ export type SubscriptionPlanEvent = {
   };
 };
 
+// Planner-specific event types with role annotations
+export type PlannerWebinarEvent = WebinarEvent & {
+  collaboratorRole: string;
+  isCollaborated: boolean;
+};
+
+export type PlannerClassEvent = ClassEvent & {
+  collaboratorRole: string;
+  isCollaborated: boolean;
+};
+
 // Update base Event type to be a union
 export type Event =
   | WebinarEvent

--- a/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { use, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  DashboardHeader,
+  DashboardContent,
+  DashboardGrid,
+} from "@/components/dashboard/DashboardShell";
+import { StatCard } from "@/components/dashboard/StatCard";
+import { Users, Gift, IndianRupee, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+
+interface ReferralCode {
+  id: string;
+  code: string;
+  customCode: string | null;
+  referrerReward: number;
+  refereeReward: number;
+  totalReferrals: number;
+  successfulReferrals: number;
+  totalEarned: number;
+  isActive: boolean;
+}
+
+interface Referral {
+  id: string;
+  status: string;
+  signedUpAt: string;
+  qualifiedAt: string | null;
+  referrerRewardAmount: number;
+  refereeRewardAmount: number;
+  referredUser: { name: string; image: string | null };
+}
+
+interface CreditData {
+  totalAvailable: number;
+  history: {
+    id: string;
+    amount: number;
+    remainingAmount: number;
+    source: string;
+    createdAt: string;
+    expiresAt: string | null;
+  }[];
+}
+
+export default function ConsultantReferralsPage({
+  params,
+}: {
+  params: Promise<{ consultantId: string }>;
+}) {
+  use(params);
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
+  const [customCode, setCustomCode] = useState("");
+
+  const { data: codeData } = useQuery<{ data: ReferralCode }>({
+    queryKey: ["referral-code"],
+    queryFn: async () => {
+      const res = await fetch("/api/referrals/code", { method: "POST" });
+      if (!res.ok) throw new Error("Failed to fetch referral code");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  const { data: referralsData } = useQuery<{ data: Referral[] }>({
+    queryKey: ["referrals"],
+    queryFn: async () => {
+      const res = await fetch("/api/referrals");
+      if (!res.ok) throw new Error("Failed to fetch referrals");
+      return res.json();
+    },
+    staleTime: 30_000,
+  });
+
+  const { data: creditsData } = useQuery<{ data: CreditData }>({
+    queryKey: ["referral-credits"],
+    queryFn: async () => {
+      const res = await fetch("/api/referrals/credits");
+      if (!res.ok) throw new Error("Failed to fetch credits");
+      return res.json();
+    },
+    staleTime: 30_000,
+  });
+
+  const code = codeData?.data;
+  const referrals = referralsData?.data ?? [];
+  const credits = creditsData?.data;
+  const referralLink = code
+    ? `${window.location.origin}/r/${code.customCode || code.code}`
+    : "";
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(referralLink);
+    setCopied(true);
+    toast({ title: "Referral link copied!" });
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleCustomize = async () => {
+    if (!customCode.trim()) return;
+    const res = await fetch("/api/referrals/code/customize", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ customCode }),
+    });
+    if (res.ok) {
+      toast({ title: "Custom code set!" });
+      setCustomCode("");
+    } else {
+      toast({ title: "Failed to set custom code", variant: "destructive" });
+    }
+  };
+
+  const formatAmount = (paise: number) =>
+    new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: "INR",
+    }).format(paise / 100);
+
+  return (
+    <>
+      <DashboardHeader
+        title="Referrals"
+        subtitle="Invite others and earn credits when they make their first booking"
+      />
+      <DashboardContent>
+        <DashboardGrid columns={4}>
+          <StatCard
+            title="Total Referred"
+            value={code?.totalReferrals ?? 0}
+            icon={Users}
+          />
+          <StatCard
+            title="Qualified"
+            value={code?.successfulReferrals ?? 0}
+            icon={Gift}
+            variant="success"
+          />
+          <StatCard
+            title="Total Earned"
+            value={formatAmount(code?.totalEarned ?? 0)}
+            icon={IndianRupee}
+          />
+          <StatCard
+            title="Credit Balance"
+            value={formatAmount(credits?.totalAvailable ?? 0)}
+            icon={IndianRupee}
+            variant="info"
+          />
+        </DashboardGrid>
+
+        {/* Referral Link */}
+        <div className="mt-6 bg-white rounded-xl border border-zinc-200 p-6">
+          <h3 className="text-sm font-medium text-zinc-900 mb-3">
+            Your Referral Link
+          </h3>
+          <div className="flex gap-2">
+            <Input value={referralLink} readOnly className="flex-1" />
+            <Button variant="outline" onClick={handleCopy}>
+              {copied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+          <div className="flex gap-2 mt-3">
+            <Input
+              placeholder="Set custom code (e.g. MYNAME)"
+              value={customCode}
+              onChange={(e) => setCustomCode(e.target.value)}
+              className="flex-1"
+            />
+            <Button variant="outline" onClick={handleCustomize}>
+              Set
+            </Button>
+          </div>
+        </div>
+
+        {/* Referrals List */}
+        <div className="mt-6 bg-white rounded-xl border border-zinc-200 overflow-hidden">
+          <div className="px-6 py-4 border-b border-zinc-200">
+            <h3 className="text-sm font-medium text-zinc-900">
+              Your Referrals
+            </h3>
+          </div>
+          {referrals.length === 0 ? (
+            <div className="px-6 py-12 text-center text-zinc-500 text-sm">
+              No referrals yet. Share your link to get started!
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100 text-zinc-500">
+                  <th className="px-6 py-3 text-left font-medium">User</th>
+                  <th className="px-6 py-3 text-left font-medium">Status</th>
+                  <th className="px-6 py-3 text-left font-medium">
+                    Signed Up
+                  </th>
+                  <th className="px-6 py-3 text-right font-medium">Reward</th>
+                </tr>
+              </thead>
+              <tbody>
+                {referrals.map((ref) => (
+                  <tr
+                    key={ref.id}
+                    className="border-b border-zinc-50 last:border-0"
+                  >
+                    <td className="px-6 py-3">{ref.referredUser.name}</td>
+                    <td className="px-6 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
+                          ref.status === "REWARDED"
+                            ? "bg-green-100 text-green-700"
+                            : ref.status === "SIGNED_UP"
+                              ? "bg-yellow-100 text-yellow-700"
+                              : "bg-zinc-100 text-zinc-600"
+                        }`}
+                      >
+                        {ref.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-zinc-500">
+                      {new Date(ref.signedUpAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      {ref.status === "REWARDED"
+                        ? formatAmount(ref.referrerRewardAmount)
+                        : "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Credit History */}
+        {credits?.history && credits.history.length > 0 && (
+          <div className="mt-6 bg-white rounded-xl border border-zinc-200 overflow-hidden">
+            <div className="px-6 py-4 border-b border-zinc-200">
+              <h3 className="text-sm font-medium text-zinc-900">
+                Credit History
+              </h3>
+            </div>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100 text-zinc-500">
+                  <th className="px-6 py-3 text-left font-medium">Source</th>
+                  <th className="px-6 py-3 text-left font-medium">Amount</th>
+                  <th className="px-6 py-3 text-left font-medium">
+                    Remaining
+                  </th>
+                  <th className="px-6 py-3 text-left font-medium">Expires</th>
+                </tr>
+              </thead>
+              <tbody>
+                {credits.history.map((credit) => (
+                  <tr
+                    key={credit.id}
+                    className="border-b border-zinc-50 last:border-0"
+                  >
+                    <td className="px-6 py-3">
+                      {credit.source.replace(/_/g, " ")}
+                    </td>
+                    <td className="px-6 py-3">
+                      {formatAmount(credit.amount)}
+                    </td>
+                    <td className="px-6 py-3">
+                      {formatAmount(credit.remainingAmount)}
+                    </td>
+                    <td className="px-6 py-3 text-zinc-500">
+                      {credit.expiresAt
+                        ? new Date(credit.expiresAt).toLocaleDateString()
+                        : "Never"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </DashboardContent>
+    </>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   DashboardHeader,
   DashboardContent,
@@ -54,6 +54,7 @@ export default function ConsultantReferralsPage({
 }) {
   use(params);
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
   const [customCode, setCustomCode] = useState("");
 
@@ -111,6 +112,7 @@ export default function ConsultantReferralsPage({
     if (res.ok) {
       toast({ title: "Custom code set!" });
       setCustomCode("");
+      queryClient.invalidateQueries({ queryKey: ["referral-code"] });
     } else {
       toast({ title: "Failed to set custom code", variant: "destructive" });
     }

--- a/app/dashboard/consultant/[consultantId]/hooks/usePlanner.ts
+++ b/app/dashboard/consultant/[consultantId]/hooks/usePlanner.ts
@@ -5,14 +5,16 @@ import { useToast } from "@/hooks/use-toast";
 import {
   WebinarEvent,
   ClassEvent,
+  PlannerWebinarEvent,
+  PlannerClassEvent,
   ConsultationPlanEvent,
   SubscriptionPlanEvent,
 } from "../(features)/planner/types/event";
 import { ConsultationPlan, SubscriptionPlan } from "@/schemas/plans";
 
 interface PlannerData {
-  webinars: WebinarEvent[];
-  classes: ClassEvent[];
+  webinars: PlannerWebinarEvent[];
+  classes: PlannerClassEvent[];
   consultationPlans: ConsultationPlanEvent[];
   subscriptionPlans: SubscriptionPlanEvent[];
   participantCounts: Record<string, number>;

--- a/app/dashboard/consultant/[consultantId]/layout.tsx
+++ b/app/dashboard/consultant/[consultantId]/layout.tsx
@@ -31,6 +31,8 @@ const NAV_ITEMS: NavItem[] = [
   { name: "Requests", path: "requests", icon: "requests" },
   { name: "Free Trials", path: "trials", icon: "trials" },
   { name: "Earnings", path: "earnings", icon: "wallet" },
+  { name: "Collaborations", path: "collaborations", icon: "users" },
+  { name: "Referrals", path: "referrals", icon: "users" },
   { name: "Documents", path: "documents", icon: "documents" },
   { name: "Help", path: "help", icon: "help" },
 ];

--- a/app/dashboard/consultant/[consultantId]/layout.tsx
+++ b/app/dashboard/consultant/[consultantId]/layout.tsx
@@ -12,6 +12,7 @@ import {
   DashboardSidebar,
   type NavItem,
 } from "@/components/dashboard/DashboardSidebar";
+import { DashboardNavbar } from "@/components/dashboard/DashboardNavbar";
 import { useSession } from "@/lib/auth-client";
 import { usePathname, useRouter } from "next/navigation";
 import { use, useEffect, useMemo } from "react";
@@ -26,18 +27,16 @@ const NAV_ITEMS: NavItem[] = [
   { name: "Home", path: "home", icon: "home" },
   { name: "Chats", path: "chats", icon: "chats" },
   { name: "Appointments", path: "appointments", icon: "appointments" },
-  { name: "Recordings", path: "recordings", icon: "recordings" },
   { name: "Event Planner", path: "planner", icon: "planner" },
   { name: "Requests", path: "requests", icon: "requests" },
-  { name: "Free Trials", path: "trials", icon: "trials" },
-  { name: "Earnings", path: "earnings", icon: "wallet" },
-  { name: "Collaborations", path: "collaborations", icon: "users" },
-  { name: "Referrals", path: "referrals", icon: "users" },
+  { name: "Recordings", path: "recordings", icon: "recordings" },
   { name: "Documents", path: "documents", icon: "documents" },
-  { name: "Help", path: "help", icon: "help" },
+  { name: "Earnings", path: "earnings", icon: "wallet" },
+  { name: "Analytics", path: "analytics", icon: "analytics" },
+  { name: "Collaborations", path: "collaborations", icon: "users" },
+  { name: "Free Trials", path: "trials", icon: "trials" },
+  { name: "Referrals", path: "referrals", icon: "users" },
 ];
-
-const BOTTOM_NAV_ITEMS: NavItem[] = [{ name: "Settings", path: "settings" }];
 
 interface PageProps {
   children: React.ReactNode;
@@ -544,8 +543,19 @@ export default function ConsultantLayout({
       userRole="CONSULTANT"
       basePath={`/dashboard/consultant/${consultantId}`}
       navItems={NAV_ITEMS}
-      bottomNavItems={BOTTOM_NAV_ITEMS}
+      hideBottomActions={true}
       isLoading={isLoading}
+    />
+  );
+
+  // Build top navbar
+  const navbar = (
+    <DashboardNavbar
+      userName={consultantData?.user?.name}
+      userImage={consultantData?.user?.image}
+      userRole="CONSULTANT"
+      settingsPath={`/dashboard/consultant/${consultantId}/settings`}
+      helpPath={`/dashboard/consultant/${consultantId}/help`}
     />
   );
 
@@ -566,7 +576,11 @@ export default function ConsultantLayout({
           resubmitUrl={`/dashboard/consultant/${consultantId}/settings`}
         />
       )}
-      <DashboardShell sidebar={sidebar} headerActions={<NotificationInbox />}>
+      <DashboardShell
+        sidebar={sidebar}
+        navbar={navbar}
+        headerActions={<NotificationInbox />}
+      >
         {memoizedStreamContent}
       </DashboardShell>
     </NovuProvider>

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -1,6 +1,78 @@
 import { format } from "date-fns";
 import { TAppointment } from "@/types/appointment";
 
+// =============================================================================
+// Collaborator Role Helpers
+// =============================================================================
+
+/**
+ * Determine the collaborator role for the current consultant on a webinar/class appointment.
+ * Returns null for consultations/subscriptions (no collaborators) or solo events without collaborators.
+ */
+export function getCollaboratorRole(
+  appointment: TAppointment,
+  consultantId: string,
+): string | null {
+  if (appointment.appointmentType === "WEBINAR" && appointment.webinar) {
+    const plan = appointment.webinar.webinarPlan;
+    if (plan?.consultantProfileId === consultantId) {
+      // Only show "Host" badge if there are collaborators
+      const collaborators = (plan as Record<string, unknown>).collaborators;
+      if (Array.isArray(collaborators) && collaborators.length > 0) {
+        return "HOST";
+      }
+      return null; // Solo event
+    }
+    const collaborators = (plan as Record<string, unknown>).collaborators;
+    if (Array.isArray(collaborators)) {
+      const collab = collaborators.find(
+        (c: Record<string, unknown>) => c.consultantProfileId === consultantId,
+      );
+      if (collab) return (collab as Record<string, unknown>).role as string;
+    }
+  }
+  if (appointment.appointmentType === "CLASS" && appointment.class) {
+    const plan = appointment.class.classPlan;
+    if (plan?.consultantProfileId === consultantId) {
+      const collaborators = (plan as Record<string, unknown>).collaborators;
+      if (Array.isArray(collaborators) && collaborators.length > 0) {
+        return "HOST";
+      }
+      return null;
+    }
+    const collaborators = (plan as Record<string, unknown>).collaborators;
+    if (Array.isArray(collaborators)) {
+      const collab = collaborators.find(
+        (c: Record<string, unknown>) => c.consultantProfileId === consultantId,
+      );
+      if (collab) return (collab as Record<string, unknown>).role as string;
+    }
+  }
+  return null;
+}
+
+/** Format a collaborator role enum value to a human-readable label */
+export function formatCollaboratorRole(role: string): string {
+  const labels: Record<string, string> = {
+    HOST: "Host",
+    CO_HOST: "Co-Host",
+    MODERATOR: "Moderator",
+    GUEST_SPEAKER: "Guest Speaker",
+    TECHNICAL_SUPPORT: "Tech Support",
+    CO_INSTRUCTOR: "Co-Instructor",
+    TEACHING_ASSISTANT: "TA",
+    GUEST_LECTURER: "Guest Lecturer",
+    CONTENT_CREATOR: "Content Creator",
+  };
+  return labels[role] || role;
+}
+
+/** Get the CSS class for a collaborator role badge */
+export function getRoleBadgeStyle(role: string): string {
+  if (role === "HOST") return "bg-gray-900 text-white";
+  return "bg-purple-100 text-purple-800";
+}
+
 /**
  * Type for appointment slot that supports both API response formats
  * - startsAt: Standard Prisma field from direct queries

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/EventCard.tsx
@@ -52,6 +52,13 @@ import {
 } from "@/components/ui/waitlist-status-badge";
 import { STATUS_CONFIG } from "../../utils/statusConfig";
 
+// Collaborator info for co-hosts display
+interface CollaboratorInfo {
+  name: string;
+  image?: string | null;
+  role: string;
+}
+
 interface EventCardProps {
   title: string;
   consultant: string;
@@ -72,6 +79,8 @@ interface EventCardProps {
   // Booking status for webinars/classes
   bookingStatus?: BookingStatus;
   waitlistPosition?: number;
+  // Collaborators (co-hosts) for webinars/classes
+  collaborators?: CollaboratorInfo[];
 }
 
 function formatSlotDate(date: Date | string): string {
@@ -105,6 +114,7 @@ export function EventCard({
   pendingPaymentUrl,
   bookingStatus,
   waitlistPosition,
+  collaborators = [],
 }: Readonly<EventCardProps>) {
   const { toast } = useToast();
   const router = useRouter();
@@ -465,16 +475,40 @@ export function EventCard({
       <div className="bg-white rounded-xl border border-zinc-200 p-4 hover:border-zinc-300 hover:shadow-md transition-all duration-200 h-full flex flex-col">
         {/* Header */}
         <div className="flex items-start gap-3 mb-4">
-          <Avatar className="h-11 w-11 ring-2 ring-zinc-100">
-            <AvatarImage alt={consultant} src={image || undefined} />
-            <AvatarFallback className="bg-gradient-to-br from-zinc-100 to-zinc-200 text-zinc-600 text-sm font-semibold">
-              {consultant
-                ?.split(" ")
-                .slice(0, 2)
-                .map((name) => name[0])
-                .join("")}
-            </AvatarFallback>
-          </Avatar>
+          {/* Avatar group: host + co-hosts */}
+          <div className="flex items-center -space-x-2 shrink-0">
+            <Avatar className="h-11 w-11 ring-2 ring-white z-10">
+              <AvatarImage alt={consultant} src={image || undefined} />
+              <AvatarFallback className="bg-gradient-to-br from-zinc-100 to-zinc-200 text-zinc-600 text-sm font-semibold">
+                {consultant
+                  ?.split(" ")
+                  .slice(0, 2)
+                  .map((name) => name[0])
+                  .join("")}
+              </AvatarFallback>
+            </Avatar>
+            {collaborators.slice(0, 2).map((collab, idx) => (
+              <Avatar
+                key={idx}
+                className={cn("h-8 w-8 ring-2 ring-white", idx === 0 ? "z-[5]" : "z-0")}
+                title={`${collab.name} (${collab.role})`}
+              >
+                <AvatarImage alt={collab.name} src={collab.image || undefined} />
+                <AvatarFallback className="bg-purple-100 text-purple-700 text-[10px] font-semibold">
+                  {collab.name
+                    .split(" ")
+                    .slice(0, 2)
+                    .map((n) => n[0])
+                    .join("")}
+                </AvatarFallback>
+              </Avatar>
+            ))}
+            {collaborators.length > 2 && (
+              <div className="h-8 w-8 rounded-full bg-zinc-100 ring-2 ring-white flex items-center justify-center text-[10px] font-semibold text-zinc-600 z-0">
+                +{collaborators.length - 2}
+              </div>
+            )}
+          </div>
           <div className="flex-1 min-w-0">
             <h3
               className="font-semibold text-zinc-900 text-sm leading-tight line-clamp-2 mb-1"
@@ -482,12 +516,24 @@ export function EventCard({
             >
               {title}
             </h3>
-            <p
-              className="text-xs text-zinc-500 line-clamp-1"
-              title={consultant}
-            >
-              {consultant}
-            </p>
+            {collaborators.length > 0 ? (
+              <p
+                className="text-xs text-zinc-500 line-clamp-1"
+                title={[consultant, ...collaborators.map((c) => c.name)].join(", ")}
+              >
+                {consultant}
+                {collaborators.length === 1
+                  ? ` & ${collaborators[0].name}`
+                  : ` + ${collaborators.length} others`}
+              </p>
+            ) : (
+              <p
+                className="text-xs text-zinc-500 line-clamp-1"
+                title={consultant}
+              >
+                {consultant}
+              </p>
+            )}
           </div>
         </div>
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/Overview.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/Overview.tsx
@@ -36,6 +36,12 @@ interface OverviewProps {
   trials: TrialWithPlan[];
 }
 
+interface CollaboratorInfo {
+  name: string;
+  image?: string | null;
+  role: string;
+}
+
 interface DashboardCardProps {
   title: string;
   icon: typeof Calendar;
@@ -60,7 +66,24 @@ interface DashboardCardProps {
     // Booking status for webinars/classes
     bookingStatus?: BookingStatus;
     waitlistPosition?: number;
+    // Collaborators for webinars/classes
+    collaborators?: CollaboratorInfo[];
   }>;
+}
+
+// Extract collaborators from a webinar or class plan (data exists from API but not in the base type)
+function extractCollaborators(
+  plan: Record<string, unknown>,
+): CollaboratorInfo[] {
+  const collaborators = plan?.collaborators;
+  if (!Array.isArray(collaborators)) return [];
+  return collaborators.map(
+    (c: { consultantProfile?: { user?: { name?: string; image?: string | null } }; role: string }) => ({
+      name: c.consultantProfile?.user?.name ?? "Collaborator",
+      image: c.consultantProfile?.user?.image ?? null,
+      role: c.role ?? "",
+    }),
+  );
 }
 
 // Helper functions
@@ -284,6 +307,11 @@ export function Overview({
                 }
               }
 
+              // Extract collaborators for display
+              const collaborators = extractCollaborators(
+                webinar.webinarPlan as unknown as Record<string, unknown>,
+              );
+
               return {
                 id: webinar.id,
                 title: webinar.webinarPlan.title,
@@ -306,6 +334,7 @@ export function Overview({
                 rawSlots,
                 bookingStatus,
                 waitlistPosition,
+                collaborators,
               };
             }),
           )}
@@ -349,6 +378,11 @@ export function Overview({
                 }
               }
 
+              // Extract collaborators for display
+              const collaborators = extractCollaborators(
+                classItem.classPlan as unknown as Record<string, unknown>,
+              );
+
               return {
                 id: classItem.id,
                 title: classItem.classPlan.title,
@@ -373,6 +407,7 @@ export function Overview({
                 rawSlots,
                 bookingStatus,
                 waitlistPosition,
+                collaborators,
               };
             }),
           )}
@@ -581,6 +616,7 @@ function DashboardCard({
                   pendingPaymentUrl={item.pendingPaymentUrl}
                   bookingStatus={item.bookingStatus}
                   waitlistPosition={item.waitlistPosition}
+                  collaborators={item.collaborators}
                 />
               </div>
             ))}
@@ -608,6 +644,7 @@ function DashboardCard({
                   pendingPaymentUrl={item.pendingPaymentUrl}
                   bookingStatus={item.bookingStatus}
                   waitlistPosition={item.waitlistPosition}
+                  collaborators={item.collaborators}
                 />
               </div>
             ))}

--- a/app/dashboard/consultee/[consulteeId]/(features)/home/HomeTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/home/HomeTab.tsx
@@ -110,25 +110,48 @@ function UpcomingSessionCard({
     >
       {/* Row 1: Avatar + Title/Name + Time Badge - Fixed height 48px */}
       <div className="flex items-center gap-3 h-12 shrink-0">
-        <Avatar className="h-10 w-10 ring-2 ring-zinc-700 shrink-0">
-          <AvatarImage
-            src={event.consultantImage ?? undefined}
-            alt={event.consultantName}
-          />
-          <AvatarFallback className="bg-zinc-700 text-zinc-300 text-xs font-semibold">
-            {event.consultantName
-              .split(" ")
-              .map((n) => n[0])
-              .join("")
-              .slice(0, 2)}
-          </AvatarFallback>
-        </Avatar>
+        <div className="flex items-center -space-x-1.5 shrink-0">
+          <Avatar className="h-10 w-10 ring-2 ring-zinc-800 z-10">
+            <AvatarImage
+              src={event.consultantImage ?? undefined}
+              alt={event.consultantName}
+            />
+            <AvatarFallback className="bg-zinc-700 text-zinc-300 text-xs font-semibold">
+              {event.consultantName
+                .split(" ")
+                .map((n) => n[0])
+                .join("")
+                .slice(0, 2)}
+            </AvatarFallback>
+          </Avatar>
+          {event.collaborators?.slice(0, 1).map((collab, idx) => (
+            <Avatar
+              key={idx}
+              className="h-7 w-7 ring-2 ring-zinc-800 z-0"
+              title={collab.name}
+            >
+              <AvatarImage src={collab.image ?? undefined} alt={collab.name} />
+              <AvatarFallback className="bg-purple-900/50 text-purple-300 text-[9px] font-semibold">
+                {collab.name.split(" ").map((n) => n[0]).join("").slice(0, 2)}
+              </AvatarFallback>
+            </Avatar>
+          ))}
+          {(event.collaborators?.length ?? 0) > 1 && (
+            <div className="h-7 w-7 rounded-full bg-zinc-700 ring-2 ring-zinc-800 flex items-center justify-center text-[9px] font-semibold text-zinc-300 z-0">
+              +{(event.collaborators?.length ?? 0) - 1}
+            </div>
+          )}
+        </div>
         <div className="flex-1 min-w-0 overflow-hidden">
           <h4 className="font-semibold text-white text-sm leading-tight truncate">
             {event.title}
           </h4>
           <p className="text-xs text-zinc-400 truncate">
-            {event.consultantName}
+            {event.collaborators && event.collaborators.length > 0
+              ? event.collaborators.length === 1
+                ? `${event.consultantName} & ${event.collaborators[0].name}`
+                : `${event.consultantName} + ${event.collaborators.length} others`
+              : event.consultantName}
           </p>
         </div>
         <Badge
@@ -239,18 +262,37 @@ function MonthlyEventItem({
         onClick={onToggle}
         className="flex items-center gap-4 p-4 cursor-pointer hover:bg-zinc-50/50 transition-colors"
       >
-        <Avatar className="h-10 w-10 ring-1 ring-zinc-200 flex-shrink-0">
-          <AvatarImage
-            src={event.consultantImage ?? undefined}
-            alt={event.consultantName}
-          />
-          <AvatarFallback className="bg-zinc-100 text-zinc-600 text-xs font-medium">
-            {event.consultantName
-              .split(" ")
-              .map((n) => n[0])
-              .join("")}
-          </AvatarFallback>
-        </Avatar>
+        <div className="flex items-center -space-x-1.5 flex-shrink-0">
+          <Avatar className="h-10 w-10 ring-2 ring-white z-10">
+            <AvatarImage
+              src={event.consultantImage ?? undefined}
+              alt={event.consultantName}
+            />
+            <AvatarFallback className="bg-zinc-100 text-zinc-600 text-xs font-medium">
+              {event.consultantName
+                .split(" ")
+                .map((n) => n[0])
+                .join("")}
+            </AvatarFallback>
+          </Avatar>
+          {event.collaborators?.slice(0, 1).map((collab, idx) => (
+            <Avatar
+              key={idx}
+              className="h-7 w-7 ring-2 ring-white z-0"
+              title={collab.name}
+            >
+              <AvatarImage src={collab.image ?? undefined} alt={collab.name} />
+              <AvatarFallback className="bg-purple-100 text-purple-700 text-[9px] font-medium">
+                {collab.name.split(" ").map((n) => n[0]).join("").slice(0, 2)}
+              </AvatarFallback>
+            </Avatar>
+          ))}
+          {(event.collaborators?.length ?? 0) > 1 && (
+            <div className="h-7 w-7 rounded-full bg-zinc-100 ring-2 ring-white flex items-center justify-center text-[9px] font-medium text-zinc-600 z-0">
+              +{(event.collaborators?.length ?? 0) - 1}
+            </div>
+          )}
+        </div>
         <div className="flex-1 min-w-0">
           {/* Desktop: single row layout */}
           <div className="hidden lg:flex items-center justify-between gap-3">
@@ -259,7 +301,11 @@ function MonthlyEventItem({
                 {event.title}
               </h4>
               <p className="text-xs text-zinc-500 truncate">
-                {event.consultantName}
+                {event.collaborators && event.collaborators.length > 0
+                  ? event.collaborators.length === 1
+                    ? `${event.consultantName} & ${event.collaborators[0].name}`
+                    : `${event.consultantName} + ${event.collaborators.length} others`
+                  : event.consultantName}
               </p>
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
@@ -307,7 +353,11 @@ function MonthlyEventItem({
                   {event.title}
                 </h4>
                 <p className="text-xs text-zinc-500 truncate">
-                  {event.consultantName}
+                  {event.collaborators && event.collaborators.length > 0
+                    ? event.collaborators.length === 1
+                      ? `${event.consultantName} & ${event.collaborators[0].name}`
+                      : `${event.consultantName} + ${event.collaborators.length} others`
+                    : event.consultantName}
                 </p>
               </div>
               <ChevronRight

--- a/app/dashboard/consultee/[consulteeId]/(features)/home/event-processor.ts
+++ b/app/dashboard/consultee/[consulteeId]/(features)/home/event-processor.ts
@@ -18,6 +18,13 @@ import type { BookingStatus } from "@/components/ui/waitlist-status-badge";
 /**
  * Unified event type for display in the dashboard
  */
+// Collaborator info for co-hosts display
+export interface ProcessedCollaborator {
+  name: string;
+  image?: string | null;
+  role: string;
+}
+
 export interface ProcessedEvent {
   id: string;
   type: "consultation" | "subscription" | "class" | "webinar";
@@ -35,6 +42,8 @@ export interface ProcessedEvent {
   // Booking status for webinars/classes (CONFIRMED = paid, WAITLISTED/NOTIFIED = on waitlist)
   bookingStatus?: BookingStatus;
   waitlistPosition?: number;
+  // Collaborators (co-hosts) for webinars/classes
+  collaborators?: ProcessedCollaborator[];
 }
 
 /**
@@ -277,6 +286,15 @@ export function processWebinar(
     }
   }
 
+  // Extract collaborators
+  const collaborators: ProcessedCollaborator[] = (
+    webinar.webinarPlan?.collaborators ?? []
+  ).map((c) => ({
+    name: c.consultantProfile?.user?.name ?? "Collaborator",
+    image: c.consultantProfile?.user?.image,
+    role: c.role,
+  }));
+
   return {
     id: webinar.id,
     type: "webinar",
@@ -293,6 +311,7 @@ export function processWebinar(
     joinableSlot: nextSlot.rawSlot,
     bookingStatus,
     waitlistPosition,
+    collaborators,
   };
 }
 
@@ -373,6 +392,15 @@ export function processClass(
     }
   }
 
+  // Extract collaborators
+  const collaborators: ProcessedCollaborator[] = (
+    classEvent.classPlan?.collaborators ?? []
+  ).map((c) => ({
+    name: c.consultantProfile?.user?.name ?? "Collaborator",
+    image: c.consultantProfile?.user?.image,
+    role: c.role,
+  }));
+
   return {
     id: classEvent.id,
     type: "class",
@@ -389,6 +417,7 @@ export function processClass(
     joinableSlot: nextSlot.rawSlot,
     bookingStatus,
     waitlistPosition,
+    collaborators,
   };
 }
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { use, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  DashboardHeader,
+  DashboardContent,
+  DashboardGrid,
+} from "@/components/dashboard/DashboardShell";
+import { StatCard } from "@/components/dashboard/StatCard";
+import { Users, Gift, IndianRupee, Copy, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+
+interface ReferralCode {
+  id: string;
+  code: string;
+  customCode: string | null;
+  referrerReward: number;
+  refereeReward: number;
+  totalReferrals: number;
+  successfulReferrals: number;
+  totalEarned: number;
+  isActive: boolean;
+}
+
+interface Referral {
+  id: string;
+  status: string;
+  signedUpAt: string;
+  qualifiedAt: string | null;
+  referrerRewardAmount: number;
+  refereeRewardAmount: number;
+  referredUser: { name: string; image: string | null };
+}
+
+interface CreditData {
+  totalAvailable: number;
+  history: {
+    id: string;
+    amount: number;
+    remainingAmount: number;
+    source: string;
+    createdAt: string;
+    expiresAt: string | null;
+  }[];
+}
+
+export default function ConsulteeReferralsPage({
+  params,
+}: {
+  params: Promise<{ consulteeId: string }>;
+}) {
+  use(params);
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
+
+  const { data: codeData } = useQuery<{ data: ReferralCode }>({
+    queryKey: ["referral-code"],
+    queryFn: async () => {
+      const res = await fetch("/api/referrals/code", { method: "POST" });
+      if (!res.ok) throw new Error("Failed to fetch referral code");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  const { data: referralsData } = useQuery<{ data: Referral[] }>({
+    queryKey: ["referrals"],
+    queryFn: async () => {
+      const res = await fetch("/api/referrals");
+      if (!res.ok) throw new Error("Failed to fetch referrals");
+      return res.json();
+    },
+    staleTime: 30_000,
+  });
+
+  const { data: creditsData } = useQuery<{ data: CreditData }>({
+    queryKey: ["referral-credits"],
+    queryFn: async () => {
+      const res = await fetch("/api/referrals/credits");
+      if (!res.ok) throw new Error("Failed to fetch credits");
+      return res.json();
+    },
+    staleTime: 30_000,
+  });
+
+  const code = codeData?.data;
+  const referrals = referralsData?.data ?? [];
+  const credits = creditsData?.data;
+  const referralLink = code
+    ? `${window.location.origin}/r/${code.customCode || code.code}`
+    : "";
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(referralLink);
+    setCopied(true);
+    toast({ title: "Referral link copied!" });
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const formatAmount = (paise: number) =>
+    new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: "INR",
+    }).format(paise / 100);
+
+  return (
+    <>
+      <DashboardHeader
+        title="Referrals"
+        subtitle="Invite friends and earn credits towards your next booking"
+      />
+      <DashboardContent>
+        <DashboardGrid columns={3}>
+          <StatCard
+            title="Total Referred"
+            value={code?.totalReferrals ?? 0}
+            icon={Users}
+          />
+          <StatCard
+            title="Qualified"
+            value={code?.successfulReferrals ?? 0}
+            icon={Gift}
+            variant="success"
+          />
+          <StatCard
+            title="Credit Balance"
+            value={formatAmount(credits?.totalAvailable ?? 0)}
+            icon={IndianRupee}
+            variant="info"
+          />
+        </DashboardGrid>
+
+        {/* Referral Link */}
+        <div className="mt-6 bg-white rounded-xl border border-zinc-200 p-6">
+          <h3 className="text-sm font-medium text-zinc-900 mb-3">
+            Your Referral Link
+          </h3>
+          <div className="flex gap-2">
+            <Input value={referralLink} readOnly className="flex-1" />
+            <Button variant="outline" onClick={handleCopy}>
+              {copied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Referrals List */}
+        <div className="mt-6 bg-white rounded-xl border border-zinc-200 overflow-hidden">
+          <div className="px-6 py-4 border-b border-zinc-200">
+            <h3 className="text-sm font-medium text-zinc-900">
+              Your Referrals
+            </h3>
+          </div>
+          {referrals.length === 0 ? (
+            <div className="px-6 py-12 text-center text-zinc-500 text-sm">
+              No referrals yet. Share your link to get started!
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100 text-zinc-500">
+                  <th className="px-6 py-3 text-left font-medium">User</th>
+                  <th className="px-6 py-3 text-left font-medium">Status</th>
+                  <th className="px-6 py-3 text-left font-medium">
+                    Signed Up
+                  </th>
+                  <th className="px-6 py-3 text-right font-medium">Reward</th>
+                </tr>
+              </thead>
+              <tbody>
+                {referrals.map((ref) => (
+                  <tr
+                    key={ref.id}
+                    className="border-b border-zinc-50 last:border-0"
+                  >
+                    <td className="px-6 py-3">{ref.referredUser.name}</td>
+                    <td className="px-6 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
+                          ref.status === "REWARDED"
+                            ? "bg-green-100 text-green-700"
+                            : ref.status === "SIGNED_UP"
+                              ? "bg-yellow-100 text-yellow-700"
+                              : "bg-zinc-100 text-zinc-600"
+                        }`}
+                      >
+                        {ref.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-zinc-500">
+                      {new Date(ref.signedUpAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-6 py-3 text-right">
+                      {ref.status === "REWARDED"
+                        ? formatAmount(ref.referrerRewardAmount)
+                        : "-"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Credit History */}
+        {credits?.history && credits.history.length > 0 && (
+          <div className="mt-6 bg-white rounded-xl border border-zinc-200 overflow-hidden">
+            <div className="px-6 py-4 border-b border-zinc-200">
+              <h3 className="text-sm font-medium text-zinc-900">
+                Credit History
+              </h3>
+            </div>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100 text-zinc-500">
+                  <th className="px-6 py-3 text-left font-medium">Source</th>
+                  <th className="px-6 py-3 text-left font-medium">Amount</th>
+                  <th className="px-6 py-3 text-left font-medium">
+                    Remaining
+                  </th>
+                  <th className="px-6 py-3 text-left font-medium">Expires</th>
+                </tr>
+              </thead>
+              <tbody>
+                {credits.history.map((credit) => (
+                  <tr
+                    key={credit.id}
+                    className="border-b border-zinc-50 last:border-0"
+                  >
+                    <td className="px-6 py-3">
+                      {credit.source.replace(/_/g, " ")}
+                    </td>
+                    <td className="px-6 py-3">
+                      {formatAmount(credit.amount)}
+                    </td>
+                    <td className="px-6 py-3">
+                      {formatAmount(credit.remainingAmount)}
+                    </td>
+                    <td className="px-6 py-3 text-zinc-500">
+                      {credit.expiresAt
+                        ? new Date(credit.expiresAt).toLocaleDateString()
+                        : "Never"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </DashboardContent>
+    </>
+  );
+}

--- a/app/dashboard/consultee/[consulteeId]/layout.tsx
+++ b/app/dashboard/consultee/[consulteeId]/layout.tsx
@@ -46,6 +46,7 @@ const NAV_ITEMS: NavItem[] = [
   { name: "History", path: "history" },
   { name: "Recordings", path: "recordings" },
   { name: "Messages", path: "messages" },
+  { name: "Referrals", path: "referrals" },
   { name: "Support", path: "feedback" },
   { name: "Settings", path: "settings" },
 ];

--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
@@ -37,6 +37,15 @@ type ClassSessionWithSchedule = PrismaClass & {
   waitlist?: Array<{ userId: string; position: number | null; status: string }>;
 };
 
+type CollaboratorInfo = {
+  id: string;
+  role: string;
+  consultantProfile: {
+    id: string;
+    user: { id: string; name: string | null; image: string | null };
+  };
+};
+
 export type ClassPlanDetailsData = Omit<
   Prisma.ClassPlanGetPayload<{
     include: {
@@ -57,6 +66,7 @@ export type ClassPlanDetailsData = Omit<
   classes: ClassSessionWithSchedule[];
   type: "class";
   imageUrl: string;
+  collaborators?: CollaboratorInfo[];
 };
 
 const getBadgeVariant = (
@@ -408,6 +418,50 @@ export function ClassDetails({ plan }: ClassDetailsProps) {
                   </Link>
                 </CardContent>
               </Card>
+
+              {/* Collaborators */}
+              {plan.collaborators && plan.collaborators.length > 0 && (
+                <Card className="border-zinc-200 shadow-sm">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-lg flex items-center gap-2">
+                      <Users className="w-4 h-4" />
+                      Co-Instructors
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {plan.collaborators.map((collab) => (
+                      <Link
+                        key={collab.id}
+                        href={`/explore/experts/${collab.consultantProfile.id}`}
+                        className="flex items-center gap-3 hover:bg-zinc-50 rounded-lg p-2 -mx-2 transition-colors"
+                      >
+                        <div className="relative h-10 w-10 rounded-full overflow-hidden ring-2 ring-zinc-100">
+                          <Image
+                            src={
+                              collab.consultantProfile.user.image ??
+                              "/placeholder-user.jpg"
+                            }
+                            alt={
+                              collab.consultantProfile.user.name ??
+                              "Co-instructor"
+                            }
+                            fill
+                            className="object-cover"
+                          />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-zinc-900">
+                            {collab.consultantProfile.user.name}
+                          </p>
+                          <p className="text-xs text-zinc-500">
+                            {collab.role.replace(/_/g, " ")}
+                          </p>
+                        </div>
+                      </Link>
+                    ))}
+                  </CardContent>
+                </Card>
+              )}
 
               {/* Registration Card */}
               <ClientClassRegistration

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
@@ -21,6 +21,15 @@ import { useCurrency } from "@/lib/hooks/useCurrency";
 import type { Prisma, Topic } from "@prisma/client";
 import { FeatureItem } from "@/app/explore/programs/plans/components/FeatureItem";
 
+type CollaboratorInfo = {
+  id: string;
+  role: string;
+  consultantProfile: {
+    id: string;
+    user: { id: string; name: string | null; image: string | null };
+  };
+};
+
 export type WebinarPlanData = Prisma.WebinarPlanGetPayload<{
   include: {
     consultantProfile: {
@@ -45,7 +54,9 @@ export type WebinarPlanData = Prisma.WebinarPlanGetPayload<{
       };
     };
   };
-}>;
+}> & {
+  collaborators?: CollaboratorInfo[];
+};
 
 type SessionStatus =
   | "Upcoming"
@@ -328,6 +339,49 @@ export function WebinarDetails({
                   </Link>
                 </CardContent>
               </Card>
+
+              {/* Collaborators */}
+              {plan.collaborators && plan.collaborators.length > 0 && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-lg flex items-center gap-2">
+                      <Users className="w-4 h-4" />
+                      Co-Hosts
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {plan.collaborators.map((collab) => (
+                      <Link
+                        key={collab.id}
+                        href={`/explore/experts/${collab.consultantProfile.id}`}
+                        className="flex items-center gap-3 hover:bg-zinc-50 rounded-lg p-2 -mx-2 transition-colors"
+                      >
+                        <div className="relative h-10 w-10 rounded-full overflow-hidden ring-2 ring-zinc-100">
+                          <Image
+                            src={
+                              collab.consultantProfile.user.image ??
+                              "/placeholder-user.jpg"
+                            }
+                            alt={
+                              collab.consultantProfile.user.name ?? "Co-host"
+                            }
+                            fill
+                            className="object-cover"
+                          />
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-zinc-900">
+                            {collab.consultantProfile.user.name}
+                          </p>
+                          <p className="text-xs text-zinc-500">
+                            {collab.role.replace(/_/g, " ")}
+                          </p>
+                        </div>
+                      </Link>
+                    ))}
+                  </CardContent>
+                </Card>
+              )}
 
               {/* Registration Card */}
               <ClientWebinarRegistration

--- a/app/r/[code]/page.tsx
+++ b/app/r/[code]/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from "next/navigation";
-import { validateReferralCode } from "@/lib/referrals/service";
+import {
+  validateReferralCode,
+  applyReferralCode,
+} from "@/lib/referrals/service";
+import { getSession } from "@/lib/auth-server";
 
 interface ReferralLandingProps {
   params: Promise<{ code: string }>;
@@ -12,10 +16,25 @@ export default async function ReferralLandingPage({
 
   const referralCode = await validateReferralCode(code);
 
-  if (referralCode) {
-    redirect(`/auth/signup?ref=${encodeURIComponent(code)}`);
+  if (!referralCode) {
+    // Invalid code - redirect to signup without ref
+    redirect("/auth/signup");
   }
 
-  // Invalid code - redirect to signup without ref
-  redirect("/auth/signup");
+  // Check if user is already authenticated
+  const session = await getSession();
+
+  if (session?.user?.id) {
+    // Authenticated user: apply the referral code directly and redirect to dashboard
+    try {
+      await applyReferralCode(session.user.id, code);
+    } catch (error) {
+      // If code application fails (already referred, self-referral, etc.), just continue
+      console.error("Failed to apply referral code for logged-in user:", error);
+    }
+    redirect("/dashboard?ref_applied=true");
+  }
+
+  // Unauthenticated user: redirect to signup with ref param
+  redirect(`/auth/signup?ref=${encodeURIComponent(code)}`);
 }

--- a/app/r/[code]/page.tsx
+++ b/app/r/[code]/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { validateReferralCode } from "@/lib/referrals/service";
+
+interface ReferralLandingProps {
+  params: Promise<{ code: string }>;
+}
+
+export default async function ReferralLandingPage({
+  params,
+}: ReferralLandingProps) {
+  const { code } = await params;
+
+  const referralCode = await validateReferralCode(code);
+
+  if (referralCode) {
+    redirect(`/auth/signup?ref=${encodeURIComponent(code)}`);
+  }
+
+  // Invalid code - redirect to signup without ref
+  redirect("/auth/signup");
+}

--- a/components/collaborators/CollaboratorsTab.tsx
+++ b/components/collaborators/CollaboratorsTab.tsx
@@ -5,14 +5,6 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -28,7 +20,9 @@ import {
   Loader2,
   Users,
   Percent,
+  ChevronUp,
 } from "lucide-react";
+import { ConsultantSearchInput } from "./ConsultantSearchInput";
 
 interface Collaborator {
   id: string;
@@ -48,6 +42,7 @@ interface CollaboratorsTabProps {
   planType: "webinar" | "class";
   planId: string;
   isOwner: boolean;
+  excludeId?: string;
 }
 
 const WEBINAR_ROLES = [
@@ -78,6 +73,7 @@ export function CollaboratorsTab({
   planType,
   planId,
   isOwner,
+  excludeId,
 }: CollaboratorsTabProps) {
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [inviteProfileId, setInviteProfileId] = useState("");
@@ -188,7 +184,7 @@ export function CollaboratorsTab({
 
       {/* Collaborator list */}
       {collaborators.length === 0 ? (
-        <div className="text-center py-8 text-zinc-500">
+        <div className="text-center py-6 text-zinc-500">
           <Users className="w-8 h-8 mx-auto mb-2 text-zinc-300" />
           <p className="text-sm">No collaborators yet</p>
           {isOwner && (
@@ -232,6 +228,7 @@ export function CollaboratorsTab({
                   <Badge variant={config.variant}>{config.label}</Badge>
                   {isOwner && collab.status !== "REMOVED" && (
                     <Button
+                      type="button"
                       variant="ghost"
                       size="icon"
                       className="h-7 w-7 text-zinc-400 hover:text-red-500"
@@ -248,9 +245,10 @@ export function CollaboratorsTab({
         </div>
       )}
 
-      {/* Invite button */}
-      {isOwner && (
+      {/* Inline invite form — expands in place, no dialog */}
+      {isOwner && !isInviteOpen && (
         <Button
+          type="button"
           variant="outline"
           className="w-full"
           onClick={() => setIsInviteOpen(true)}
@@ -260,37 +258,45 @@ export function CollaboratorsTab({
         </Button>
       )}
 
-      {/* Invite dialog */}
-      <Dialog open={isInviteOpen} onOpenChange={setIsInviteOpen}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Invite Collaborator</DialogTitle>
-            <DialogDescription>
-              Invite another consultant to collaborate on this{" "}
-              {planType === "webinar" ? "webinar" : "class"}.
-            </DialogDescription>
-          </DialogHeader>
+      {isOwner && isInviteOpen && (
+        <div className="border border-zinc-200 rounded-lg p-4 space-y-3 bg-zinc-50/50">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-zinc-700">
+              Invite Collaborator
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-zinc-400"
+              onClick={() => {
+                setIsInviteOpen(false);
+                setInviteProfileId("");
+                setInviteRole("");
+                setInviteShare(10);
+              }}
+            >
+              <ChevronUp className="w-4 h-4" />
+            </Button>
+          </div>
 
-          <div className="space-y-4 py-4">
-            <div>
-              <label className="text-sm font-medium text-zinc-700">
-                Consultant Profile ID
-              </label>
-              <Input
-                placeholder="Enter consultant profile ID"
-                value={inviteProfileId}
-                onChange={(e) => setInviteProfileId(e.target.value)}
-                className="mt-1"
+          <div>
+            <label className="text-xs font-medium text-zinc-600">
+              Search Consultant
+            </label>
+            <div className="mt-1">
+              <ConsultantSearchInput
+                excludeId={excludeId}
+                onSelect={(id) => setInviteProfileId(id)}
               />
-              <p className="text-xs text-zinc-500 mt-1">
-                The consultant&apos;s profile ID from their dashboard URL
-              </p>
             </div>
+          </div>
 
+          <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-sm font-medium text-zinc-700">Role</label>
+              <label className="text-xs font-medium text-zinc-600">Role</label>
               <Select value={inviteRole} onValueChange={setInviteRole}>
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-1 h-9">
                   <SelectValue placeholder="Select role" />
                 </SelectTrigger>
                 <SelectContent>
@@ -304,7 +310,7 @@ export function CollaboratorsTab({
             </div>
 
             <div>
-              <label className="text-sm font-medium text-zinc-700">
+              <label className="text-xs font-medium text-zinc-600">
                 Revenue Share (%)
               </label>
               <Input
@@ -313,37 +319,34 @@ export function CollaboratorsTab({
                 max={90 - totalShare}
                 value={inviteShare}
                 onChange={(e) => setInviteShare(Number(e.target.value))}
-                className="mt-1"
+                className="mt-1 h-9"
               />
-              <p className="text-xs text-zinc-500 mt-1">
-                Max {90 - totalShare}% available (host keeps minimum 10%)
+              <p className="text-[10px] text-zinc-400 mt-0.5">
+                Max {90 - totalShare}% available
               </p>
             </div>
           </div>
 
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsInviteOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => inviteMutation.mutate()}
-              disabled={
-                !inviteProfileId ||
-                !inviteRole ||
-                inviteShare < 1 ||
-                inviteMutation.isPending
-              }
-            >
-              {inviteMutation.isPending ? (
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              ) : (
-                <UserPlus className="w-4 h-4 mr-2" />
-              )}
-              Send Invitation
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          <Button
+            type="button"
+            className="w-full"
+            onClick={() => inviteMutation.mutate()}
+            disabled={
+              !inviteProfileId ||
+              !inviteRole ||
+              inviteShare < 1 ||
+              inviteMutation.isPending
+            }
+          >
+            {inviteMutation.isPending ? (
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            ) : (
+              <UserPlus className="w-4 h-4 mr-2" />
+            )}
+            Send Invitation
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/collaborators/CollaboratorsTab.tsx
+++ b/components/collaborators/CollaboratorsTab.tsx
@@ -86,10 +86,7 @@ export function CollaboratorsTab({
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  const basePath =
-    planType === "webinar"
-      ? `/api/webinars/${planId}/collaborators`
-      : `/api/classes/${planId}/collaborators`;
+  const basePath = `/api/collaborations/${planType}/${planId}`;
 
   const roles = planType === "webinar" ? WEBINAR_ROLES : CLASS_ROLES;
 

--- a/components/collaborators/CollaboratorsTab.tsx
+++ b/components/collaborators/CollaboratorsTab.tsx
@@ -21,6 +21,7 @@ import {
   Users,
   Percent,
   ChevronUp,
+  AlertTriangle,
 } from "lucide-react";
 import { ConsultantSearchInput } from "./ConsultantSearchInput";
 
@@ -161,6 +162,8 @@ export function CollaboratorsTab({
 
   const ownerShare = 100 - totalShare;
 
+  const pendingCollabs = collaborators.filter((c) => c.status === "PENDING");
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
@@ -181,6 +184,19 @@ export function CollaboratorsTab({
           </span>
         </div>
       </div>
+
+      {/* Pending collaborator warning */}
+      {pendingCollabs.length > 0 && (
+        <div className="flex items-start gap-3 p-3 bg-amber-50 rounded-lg border border-amber-200">
+          <AlertTriangle className="w-4 h-4 text-amber-600 mt-0.5 shrink-0" />
+          <p className="text-sm text-amber-800">
+            {pendingCollabs.length} collaborator
+            {pendingCollabs.length > 1 ? "s" : ""} haven&apos;t accepted yet.
+            Purchases made before they accept won&apos;t include their revenue
+            split.
+          </p>
+        </div>
+      )}
 
       {/* Collaborator list */}
       {collaborators.length === 0 ? (

--- a/components/collaborators/CollaboratorsTab.tsx
+++ b/components/collaborators/CollaboratorsTab.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import {
+  UserPlus,
+  Trash2,
+  Loader2,
+  Users,
+  Percent,
+} from "lucide-react";
+
+interface Collaborator {
+  id: string;
+  role: string;
+  revenueSharePercentage: number;
+  status: "PENDING" | "ACCEPTED" | "DECLINED" | "REMOVED";
+  consultantProfile: {
+    id: string;
+    user: {
+      name: string | null;
+      image: string | null;
+    };
+  };
+}
+
+interface CollaboratorsTabProps {
+  planType: "webinar" | "class";
+  planId: string;
+  isOwner: boolean;
+}
+
+const WEBINAR_ROLES = [
+  { value: "CO_HOST", label: "Co-Host" },
+  { value: "MODERATOR", label: "Moderator" },
+  { value: "GUEST_SPEAKER", label: "Guest Speaker" },
+  { value: "TECHNICAL_SUPPORT", label: "Technical Support" },
+];
+
+const CLASS_ROLES = [
+  { value: "CO_INSTRUCTOR", label: "Co-Instructor" },
+  { value: "TEACHING_ASSISTANT", label: "Teaching Assistant" },
+  { value: "GUEST_LECTURER", label: "Guest Lecturer" },
+  { value: "CONTENT_CREATOR", label: "Content Creator" },
+];
+
+const statusConfig: Record<
+  string,
+  { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
+> = {
+  PENDING: { label: "Pending", variant: "secondary" },
+  ACCEPTED: { label: "Accepted", variant: "default" },
+  DECLINED: { label: "Declined", variant: "destructive" },
+  REMOVED: { label: "Removed", variant: "outline" },
+};
+
+export function CollaboratorsTab({
+  planType,
+  planId,
+  isOwner,
+}: CollaboratorsTabProps) {
+  const [isInviteOpen, setIsInviteOpen] = useState(false);
+  const [inviteProfileId, setInviteProfileId] = useState("");
+  const [inviteRole, setInviteRole] = useState("");
+  const [inviteShare, setInviteShare] = useState(10);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const basePath =
+    planType === "webinar"
+      ? `/api/webinars/${planId}/collaborators`
+      : `/api/classes/${planId}/collaborators`;
+
+  const roles = planType === "webinar" ? WEBINAR_ROLES : CLASS_ROLES;
+
+  const { data: collaborators = [], isLoading } = useQuery<Collaborator[]>({
+    queryKey: ["collaborators", planType, planId],
+    queryFn: async () => {
+      const res = await fetch(basePath);
+      if (!res.ok) throw new Error("Failed to fetch collaborators");
+      const json = await res.json();
+      return json.data;
+    },
+    staleTime: 30_000,
+  });
+
+  const inviteMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(basePath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          consultantProfileId: inviteProfileId,
+          role: inviteRole,
+          revenueSharePercentage: inviteShare,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || "Failed to invite collaborator");
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["collaborators", planType, planId],
+      });
+      setIsInviteOpen(false);
+      setInviteProfileId("");
+      setInviteRole("");
+      setInviteShare(10);
+      toast({ title: "Collaborator invited successfully" });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Failed to invite",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: async (collaboratorId: string) => {
+      const res = await fetch(`${basePath}/${collaboratorId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to remove collaborator");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["collaborators", planType, planId],
+      });
+      toast({ title: "Collaborator removed" });
+    },
+    onError: () => {
+      toast({
+        title: "Failed to remove collaborator",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const totalShare = collaborators
+    .filter((c) => c.status === "PENDING" || c.status === "ACCEPTED")
+    .reduce((sum, c) => sum + c.revenueSharePercentage, 0);
+
+  const ownerShare = 100 - totalShare;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Revenue split overview */}
+      <div className="flex items-center gap-4 p-3 bg-zinc-50 rounded-lg border border-zinc-200">
+        <Percent className="w-4 h-4 text-zinc-500" />
+        <div className="text-sm">
+          <span className="font-medium text-zinc-800">Revenue Split:</span>{" "}
+          <span className="text-zinc-600">
+            Host {ownerShare}% | Collaborators {totalShare}%
+          </span>
+        </div>
+      </div>
+
+      {/* Collaborator list */}
+      {collaborators.length === 0 ? (
+        <div className="text-center py-8 text-zinc-500">
+          <Users className="w-8 h-8 mx-auto mb-2 text-zinc-300" />
+          <p className="text-sm">No collaborators yet</p>
+          {isOwner && (
+            <p className="text-xs mt-1">
+              Invite other consultants to collaborate on this plan
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {collaborators.map((collab) => {
+            const config = statusConfig[collab.status] ?? statusConfig.PENDING;
+            const roleLabel =
+              roles.find((r) => r.value === collab.role)?.label ?? collab.role;
+
+            return (
+              <div
+                key={collab.id}
+                className="flex items-center justify-between p-3 bg-white border border-zinc-200 rounded-lg"
+              >
+                <div className="flex items-center gap-3">
+                  <Avatar className="w-8 h-8">
+                    <AvatarImage
+                      src={collab.consultantProfile.user.image ?? undefined}
+                    />
+                    <AvatarFallback>
+                      {(collab.consultantProfile.user.name ?? "?").charAt(0)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-sm font-medium text-zinc-800">
+                      {collab.consultantProfile.user.name ?? "Unknown"}
+                    </p>
+                    <p className="text-xs text-zinc-500">
+                      {roleLabel} &middot; {collab.revenueSharePercentage}%
+                      share
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={config.variant}>{config.label}</Badge>
+                  {isOwner && collab.status !== "REMOVED" && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-zinc-400 hover:text-red-500"
+                      onClick={() => removeMutation.mutate(collab.id)}
+                      disabled={removeMutation.isPending}
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Invite button */}
+      {isOwner && (
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => setIsInviteOpen(true)}
+        >
+          <UserPlus className="w-4 h-4 mr-2" />
+          Invite Collaborator
+        </Button>
+      )}
+
+      {/* Invite dialog */}
+      <Dialog open={isInviteOpen} onOpenChange={setIsInviteOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Invite Collaborator</DialogTitle>
+            <DialogDescription>
+              Invite another consultant to collaborate on this{" "}
+              {planType === "webinar" ? "webinar" : "class"}.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div>
+              <label className="text-sm font-medium text-zinc-700">
+                Consultant Profile ID
+              </label>
+              <Input
+                placeholder="Enter consultant profile ID"
+                value={inviteProfileId}
+                onChange={(e) => setInviteProfileId(e.target.value)}
+                className="mt-1"
+              />
+              <p className="text-xs text-zinc-500 mt-1">
+                The consultant&apos;s profile ID from their dashboard URL
+              </p>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-zinc-700">Role</label>
+              <Select value={inviteRole} onValueChange={setInviteRole}>
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="Select role" />
+                </SelectTrigger>
+                <SelectContent>
+                  {roles.map((role) => (
+                    <SelectItem key={role.value} value={role.value}>
+                      {role.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-zinc-700">
+                Revenue Share (%)
+              </label>
+              <Input
+                type="number"
+                min={1}
+                max={90 - totalShare}
+                value={inviteShare}
+                onChange={(e) => setInviteShare(Number(e.target.value))}
+                className="mt-1"
+              />
+              <p className="text-xs text-zinc-500 mt-1">
+                Max {90 - totalShare}% available (host keeps minimum 10%)
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsInviteOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => inviteMutation.mutate()}
+              disabled={
+                !inviteProfileId ||
+                !inviteRole ||
+                inviteShare < 1 ||
+                inviteMutation.isPending
+              }
+            >
+              {inviteMutation.isPending ? (
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              ) : (
+                <UserPlus className="w-4 h-4 mr-2" />
+              )}
+              Send Invitation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/collaborators/ConsultantSearchInput.tsx
+++ b/components/collaborators/ConsultantSearchInput.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, X, Loader2 } from "lucide-react";
+
+interface ConsultantResult {
+  id: string;
+  user: {
+    name: string | null;
+    email: string;
+    image: string | null;
+  };
+}
+
+interface ConsultantSearchInputProps {
+  excludeId?: string;
+  onSelect: (consultantProfileId: string) => void;
+}
+
+export function ConsultantSearchInput({
+  excludeId,
+  onSelect,
+}: ConsultantSearchInputProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ConsultantResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<ConsultantResult | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const search = useCallback(
+    async (q: string) => {
+      if (q.length < 1) {
+        setResults([]);
+        setIsOpen(false);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const params = new URLSearchParams({ q });
+        if (excludeId) params.set("excludeId", excludeId);
+
+        const res = await fetch(`/api/consultants/search?${params}`);
+        if (res.ok) {
+          const { data } = await res.json();
+          setResults(data);
+          setIsOpen(data.length > 0);
+        }
+      } catch {
+        setResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [excludeId],
+  );
+
+  // Debounce search calls by 300ms
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(query), 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, search]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelect = (consultant: ConsultantResult) => {
+    setSelected(consultant);
+    setQuery("");
+    setIsOpen(false);
+    onSelect(consultant.id);
+  };
+
+  const handleClear = () => {
+    setSelected(null);
+    setQuery("");
+    onSelect("");
+  };
+
+  if (selected) {
+    return (
+      <div className="flex items-center gap-3 p-2 border border-zinc-200 rounded-lg bg-zinc-50">
+        <Avatar className="w-7 h-7">
+          <AvatarImage src={selected.user.image ?? undefined} />
+          <AvatarFallback className="text-xs">
+            {(selected.user.name ?? "?").charAt(0)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-zinc-800 truncate">
+            {selected.user.name ?? "Unknown"}
+          </p>
+          <p className="text-xs text-zinc-500 truncate">
+            {selected.user.email}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-zinc-400 hover:text-zinc-600"
+          onClick={handleClear}
+        >
+          <X className="w-3.5 h-3.5" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400" />
+        <Input
+          placeholder="Search by name or email..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => results.length > 0 && setIsOpen(true)}
+          className="pl-8 pr-8"
+        />
+        {isLoading && (
+          <Loader2 className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-zinc-400" />
+        )}
+      </div>
+
+      {isOpen && (
+        <div className="absolute z-50 w-full mt-1 bg-white border border-zinc-200 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+          {results.map((consultant) => (
+            <button
+              key={consultant.id}
+              type="button"
+              className="flex items-center gap-3 w-full px-3 py-2 text-left hover:bg-zinc-50 transition-colors"
+              onClick={() => handleSelect(consultant)}
+            >
+              <Avatar className="w-7 h-7">
+                <AvatarImage src={consultant.user.image ?? undefined} />
+                <AvatarFallback className="text-xs">
+                  {(consultant.user.name ?? "?").charAt(0)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-zinc-800 truncate">
+                  {consultant.user.name ?? "Unknown"}
+                </p>
+                <p className="text-xs text-zinc-500 truncate">
+                  {consultant.user.email}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isOpen && results.length === 0 && !isLoading && query.length >= 1 && (
+        <div className="absolute z-50 w-full mt-1 bg-white border border-zinc-200 rounded-lg shadow-lg p-3">
+          <p className="text-sm text-zinc-500 text-center">
+            No consultants found
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/collaborators/ConsultantSearchInput.tsx
+++ b/components/collaborators/ConsultantSearchInput.tsx
@@ -30,7 +30,7 @@ export function ConsultantSearchInput({
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<ConsultantResult | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const search = useCallback(
     async (q: string) => {

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Check, X, Loader2, Inbox } from "lucide-react";

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Check, X, Loader2, Inbox } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { formatCurrencyAmount } from "@/lib/utils";
+
+interface Collaboration {
+  id: string;
+  role: string;
+  revenueSharePercentage: number;
+  status: "PENDING" | "ACCEPTED";
+  createdAt: string;
+  webinarPlan?: { id: string; title: string; price: number };
+  classPlan?: { id: string; title: string; price: number };
+  invitedBy: {
+    user: { name: string | null };
+  };
+}
+
+interface CollaborationsData {
+  webinarCollaborations: Collaboration[];
+  classCollaborations: Collaboration[];
+}
+
+export function InvitationsPanel() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery<CollaborationsData>({
+    queryKey: ["my-collaborations"],
+    queryFn: async () => {
+      const res = await fetch("/api/collaborations");
+      if (!res.ok) throw new Error("Failed to fetch collaborations");
+      const json = await res.json();
+      return json.data;
+    },
+    staleTime: 30_000,
+  });
+
+  const respondMutation = useMutation({
+    mutationFn: async ({
+      id,
+      planType,
+      response,
+    }: {
+      id: string;
+      planType: "webinar" | "class";
+      response: "ACCEPTED" | "DECLINED";
+    }) => {
+      const res = await fetch(`/api/collaborations/${id}/respond`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ response, planType }),
+      });
+      if (!res.ok) throw new Error("Failed to respond");
+      return res.json();
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["my-collaborations"] });
+      toast({
+        title:
+          variables.response === "ACCEPTED"
+            ? "Invitation accepted"
+            : "Invitation declined",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Failed to respond to invitation",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const allCollaborations = [
+    ...(data?.webinarCollaborations.map((c) => ({
+      ...c,
+      planType: "webinar" as const,
+      planTitle: c.webinarPlan?.title ?? "Webinar",
+      planPrice: c.webinarPlan?.price ?? 0,
+    })) ?? []),
+    ...(data?.classCollaborations.map((c) => ({
+      ...c,
+      planType: "class" as const,
+      planTitle: c.classPlan?.title ?? "Class",
+      planPrice: c.classPlan?.price ?? 0,
+    })) ?? []),
+  ];
+
+  const pending = allCollaborations.filter((c) => c.status === "PENDING");
+  const accepted = allCollaborations.filter((c) => c.status === "ACCEPTED");
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-400" />
+      </div>
+    );
+  }
+
+  if (allCollaborations.length === 0) {
+    return (
+      <div className="text-center py-12 text-zinc-500">
+        <Inbox className="w-10 h-10 mx-auto mb-3 text-zinc-300" />
+        <p className="font-medium">No collaborations</p>
+        <p className="text-sm mt-1">
+          When another consultant invites you to collaborate, it will appear
+          here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Pending invitations */}
+      {pending.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-700 mb-3">
+            Pending Invitations ({pending.length})
+          </h3>
+          <div className="space-y-3">
+            {pending.map((collab) => (
+              <div
+                key={collab.id}
+                className="p-4 bg-amber-50 border border-amber-200 rounded-lg"
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <p className="font-medium text-zinc-800">
+                      {collab.planTitle}
+                    </p>
+                    <p className="text-sm text-zinc-600 mt-0.5">
+                      Invited by{" "}
+                      <span className="font-medium">
+                        {collab.invitedBy.user.name ?? "Unknown"}
+                      </span>
+                    </p>
+                    <div className="flex items-center gap-2 mt-2">
+                      <Badge variant="secondary" className="text-xs">
+                        {collab.planType === "webinar" ? "Webinar" : "Class"}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs">
+                        {collab.role.replace(/_/g, " ")}
+                      </Badge>
+                      <span className="text-xs text-zinc-500">
+                        {collab.revenueSharePercentage}% revenue share
+                      </span>
+                      {collab.planPrice > 0 && (
+                        <span className="text-xs text-zinc-500">
+                          &middot; Plan price{" "}
+                          {formatCurrencyAmount(collab.planPrice, "INR")}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex gap-2 ml-4">
+                    <Button
+                      size="sm"
+                      variant="default"
+                      onClick={() =>
+                        respondMutation.mutate({
+                          id: collab.id,
+                          planType: collab.planType,
+                          response: "ACCEPTED",
+                        })
+                      }
+                      disabled={respondMutation.isPending}
+                    >
+                      <Check className="w-3.5 h-3.5 mr-1" />
+                      Accept
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() =>
+                        respondMutation.mutate({
+                          id: collab.id,
+                          planType: collab.planType,
+                          response: "DECLINED",
+                        })
+                      }
+                      disabled={respondMutation.isPending}
+                    >
+                      <X className="w-3.5 h-3.5 mr-1" />
+                      Decline
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Accepted collaborations */}
+      {accepted.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-700 mb-3">
+            Active Collaborations ({accepted.length})
+          </h3>
+          <div className="space-y-2">
+            {accepted.map((collab) => (
+              <div
+                key={collab.id}
+                className="flex items-center justify-between p-3 bg-white border border-zinc-200 rounded-lg"
+              >
+                <div>
+                  <p className="text-sm font-medium text-zinc-800">
+                    {collab.planTitle}
+                  </p>
+                  <p className="text-xs text-zinc-500">
+                    {collab.role.replace(/_/g, " ")} &middot;{" "}
+                    {collab.revenueSharePercentage}% share &middot; by{" "}
+                    {collab.invitedBy.user.name ?? "Unknown"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-xs">
+                    {collab.planType === "webinar" ? "Webinar" : "Class"}
+                  </Badge>
+                  <Badge
+                    variant="default"
+                    className="bg-emerald-50 text-emerald-700 border-emerald-200"
+                  >
+                    Active
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +18,8 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { formatCurrencyAmount } from "@/lib/utils";
+
+// ─── Shared schedule types ───────────────────────────────────────────────────
 
 interface SlotSchedule {
   startsAt: string;
@@ -43,8 +46,21 @@ interface ClassEventSchedule {
   }[];
 }
 
+// ─── Collaborator perspective types ──────────────────────────────────────────
+
 interface PlanOwner {
   user: { name: string | null; image: string | null };
+}
+
+interface PlanCollaboratorInfo {
+  id: string;
+  role: string;
+  revenueSharePercentage: number;
+  status: "PENDING" | "ACCEPTED";
+  consultantProfile: {
+    id: string;
+    user: { name: string | null; image: string | null };
+  };
 }
 
 interface Collaboration {
@@ -63,6 +79,7 @@ interface Collaboration {
     level: string | null;
     webinars: WebinarEventSchedule[];
     consultantProfile: PlanOwner | null;
+    collaborators: PlanCollaboratorInfo[];
   };
   classPlan?: {
     id: string;
@@ -75,16 +92,62 @@ interface Collaboration {
     totalSessions: number;
     classes: ClassEventSchedule[];
     consultantProfile: PlanOwner | null;
+    collaborators: PlanCollaboratorInfo[];
   };
   invitedBy: {
     user: { name: string | null };
   };
 }
 
+// ─── Host perspective types ──────────────────────────────────────────────────
+
+interface CollaboratorInfo {
+  id: string;
+  role: string;
+  revenueSharePercentage: number;
+  status: "PENDING" | "ACCEPTED";
+  consultantProfile: {
+    id: string;
+    user: { name: string | null; image: string | null };
+  };
+}
+
+interface HostedWebinarPlan {
+  id: string;
+  title: string;
+  price: number;
+  durationInHours: number;
+  maxParticipants: number;
+  language: string | null;
+  level: string | null;
+  collaborators: CollaboratorInfo[];
+  webinars: WebinarEventSchedule[];
+}
+
+interface HostedClassPlan {
+  id: string;
+  title: string;
+  price: number;
+  sessionDurationInHours: number;
+  maxParticipants: number;
+  meetingsPerWeek: number;
+  durationInMonths: number;
+  totalSessions: number;
+  collaborators: CollaboratorInfo[];
+  classes: ClassEventSchedule[];
+}
+
+// ─── Combined data from API ──────────────────────────────────────────────────
+
 interface CollaborationsData {
   webinarCollaborations: Collaboration[];
   classCollaborations: Collaboration[];
+  hostedWebinarPlans: HostedWebinarPlan[];
+  hostedClassPlans: HostedClassPlan[];
+  hostUser?: { name: string | null; image: string | null };
 }
+
+// ─── Formatting helpers ──────────────────────────────────────────────────────
 
 function formatDateTime(dateStr: string) {
   const d = new Date(dateStr);
@@ -105,10 +168,40 @@ function formatTime(dateStr: string) {
   });
 }
 
+function formatRole(role: string): string {
+  const labels: Record<string, string> = {
+    CO_HOST: "Co-Host",
+    MODERATOR: "Moderator",
+    GUEST_SPEAKER: "Guest Speaker",
+    TECHNICAL_SUPPORT: "Technical Support",
+    CO_INSTRUCTOR: "Co-Instructor",
+    TEACHING_ASSISTANT: "TA",
+    GUEST_LECTURER: "Guest Lecturer",
+    CONTENT_CREATOR: "Content Creator",
+  };
+  return labels[role] || role.replace(/_/g, " ");
+}
+
+// ─── Schedule summary components (shared) ────────────────────────────────────
+
+interface WebinarPlanSchedule {
+  durationInHours: number;
+  maxParticipants: number;
+  webinars: WebinarEventSchedule[];
+}
+
+interface ClassPlanSchedule {
+  sessionDurationInHours: number;
+  maxParticipants: number;
+  meetingsPerWeek: number;
+  totalSessions: number;
+  classes: ClassEventSchedule[];
+}
+
 function WebinarScheduleSummary({
   plan,
 }: {
-  plan: NonNullable<Collaboration["webinarPlan"]>;
+  plan: WebinarPlanSchedule;
 }) {
   const webinar = plan.webinars[0];
   const slot = webinar?.appointment?.slotsOfAppointment[0];
@@ -177,7 +270,7 @@ function WebinarScheduleSummary({
 function WebinarEventList({
   plan,
 }: {
-  plan: NonNullable<Collaboration["webinarPlan"]>;
+  plan: WebinarPlanSchedule;
 }) {
   return (
     <div className="space-y-2">
@@ -239,7 +332,7 @@ function WebinarEventList({
 function ClassScheduleSummary({
   plan,
 }: {
-  plan: NonNullable<Collaboration["classPlan"]>;
+  plan: ClassPlanSchedule;
 }) {
   if (plan.classes.length === 0) {
     return (
@@ -247,7 +340,6 @@ function ClassScheduleSummary({
     );
   }
 
-  // Show summary for the most relevant class (first IN_PROGRESS, or first SCHEDULED)
   const activeClass =
     plan.classes.find((c) => c.status === "IN_PROGRESS") ?? plan.classes[0];
   const allSlots = activeClass.appointments.flatMap(
@@ -389,7 +481,7 @@ function ClassSessionList({ cls }: { cls: ClassEventSchedule }) {
 
 function ClassEventCard({ cls, plan }: {
   cls: ClassEventSchedule;
-  plan: NonNullable<Collaboration["classPlan"]>;
+  plan: ClassPlanSchedule;
 }) {
   const [sessionsExpanded, setSessionsExpanded] = useState(false);
   const allSlots = cls.appointments.flatMap((a) => a.slotsOfAppointment);
@@ -462,7 +554,7 @@ function ClassEventCard({ cls, plan }: {
 function ClassEventList({
   plan,
 }: {
-  plan: NonNullable<Collaboration["classPlan"]>;
+  plan: ClassPlanSchedule;
 }) {
   return (
     <div className="space-y-2">
@@ -473,8 +565,11 @@ function ClassEventList({
   );
 }
 
+// ─── Collaborator perspective card ───────────────────────────────────────────
+
 function ActiveCollaborationCard({
   collab,
+  currentUser,
 }: {
   collab: {
     id: string;
@@ -486,6 +581,7 @@ function ActiveCollaborationCard({
     webinarPlan?: Collaboration["webinarPlan"];
     classPlan?: Collaboration["classPlan"];
   };
+  currentUser?: { name: string | null; image: string | null };
 }) {
   const [slotsExpanded, setSlotsExpanded] = useState(false);
 
@@ -493,6 +589,16 @@ function ActiveCollaborationCard({
     collab.planType === "webinar"
       ? collab.webinarPlan?.consultantProfile
       : collab.classPlan?.consultantProfile;
+
+  // Filter out the current user from the collaborators list (they're shown in the banner)
+  const allCollaboratorsOnPlan = (
+    collab.planType === "webinar"
+      ? collab.webinarPlan?.collaborators
+      : collab.classPlan?.collaborators
+  ) ?? [];
+  const otherCollaborators = allCollaboratorsOnPlan.filter(
+    (c) => c.id !== collab.id,
+  );
 
   const hasExpandableDetails =
     (collab.planType === "webinar" &&
@@ -503,38 +609,119 @@ function ActiveCollaborationCard({
       collab.classPlan.classes.length > 1);
 
   return (
-    <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden p-3">
-      {/* Header — always visible */}
+    <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
+      {/* Role banner */}
+      <div className="bg-purple-600 px-3 py-1.5 flex items-center justify-between">
+        <span className="text-xs font-semibold text-white tracking-wide uppercase">{formatRole(collab.role)}</span>
+        <Badge variant="secondary" className="text-[10px] bg-purple-500 text-purple-100 border-purple-400">
+          {collab.planType === "webinar" ? "Webinar" : "Class"}
+        </Badge>
+      </div>
+
+      <div className="p-3">
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div className="min-w-0">
           <p className="text-sm font-medium text-zinc-800 truncate">
             {collab.planTitle}
           </p>
           <p className="text-xs text-zinc-500">
-            {collab.role.replace(/_/g, " ")} &middot;{" "}
-            {collab.revenueSharePercentage}% share
-            {owner?.user.name && (
-              <>
-                {" "}
-                &middot; by {owner.user.name}
-              </>
-            )}
+            by {owner?.user.name ?? "Unknown"}
           </p>
-        </div>
-        <div className="flex items-center gap-2 ml-3 shrink-0">
-          <Badge variant="secondary" className="text-xs">
-            {collab.planType === "webinar" ? "Webinar" : "Class"}
-          </Badge>
-          <Badge
-            variant="default"
-            className="bg-emerald-50 text-emerald-700 border-emerald-200"
-          >
-            Active
-          </Badge>
         </div>
       </div>
 
-      {/* Schedule summary — always visible */}
+      {/* Revenue share */}
+      <div className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-zinc-50 rounded-md border border-zinc-100">
+        <div className="flex items-center gap-1.5 text-xs text-zinc-600">
+          {currentUser && (
+            <Avatar className="w-5 h-5">
+              <AvatarImage src={currentUser.image ?? undefined} />
+              <AvatarFallback className="text-[8px]">
+                {(currentUser.name ?? "Y").charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+          )}
+          <span className="font-medium">You {collab.revenueSharePercentage}%</span>
+          {owner && (
+            <span>&middot; {owner.user.name} {100 - collab.revenueSharePercentage}%</span>
+          )}
+        </div>
+      </div>
+
+      {/* Team — host + other collaborators (excludes self) */}
+      <div className="border-t border-zinc-100 mt-3 pt-3">
+        <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+          Team ({1 + otherCollaborators.length})
+        </p>
+        <div className="space-y-2">
+          {/* Host (plan owner) */}
+          {owner && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2.5">
+                <Avatar className="w-7 h-7">
+                  <AvatarImage src={owner.user.image ?? undefined} />
+                  <AvatarFallback className="text-[10px]">
+                    {(owner.user.name ?? "H").charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-xs font-medium text-zinc-800">
+                    {owner.user.name ?? "Unknown"}
+                  </p>
+                  <p className="text-[11px] text-zinc-500">
+                    Host &middot; {100 - allCollaboratorsOnPlan.reduce((sum, c) => sum + c.revenueSharePercentage, 0)}% share
+                  </p>
+                </div>
+              </div>
+              <Badge
+                variant="default"
+                className="bg-zinc-100 text-zinc-700 border-zinc-200 text-[10px]"
+              >
+                Owner
+              </Badge>
+            </div>
+          )}
+          {/* Other collaborators (not the current user) */}
+          {otherCollaborators.map((c) => (
+            <div
+              key={c.id}
+              className="flex items-center justify-between"
+            >
+              <div className="flex items-center gap-2.5">
+                <Avatar className="w-7 h-7">
+                  <AvatarImage
+                    src={c.consultantProfile.user.image ?? undefined}
+                  />
+                  <AvatarFallback className="text-[10px]">
+                    {(c.consultantProfile.user.name ?? "?").charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-xs font-medium text-zinc-800">
+                    {c.consultantProfile.user.name ?? "Unknown"}
+                  </p>
+                  <p className="text-[11px] text-zinc-500">
+                    {formatRole(c.role)} &middot; {c.revenueSharePercentage}% share
+                  </p>
+                </div>
+              </div>
+              <Badge
+                variant={c.status === "ACCEPTED" ? "default" : "secondary"}
+                className={
+                  c.status === "ACCEPTED"
+                    ? "bg-emerald-50 text-emerald-700 border-emerald-200 text-[10px]"
+                    : "text-[10px]"
+                }
+              >
+                {c.status === "ACCEPTED" ? "Accepted" : "Pending"}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Schedule summary */}
       <div className="border-t border-zinc-100 mt-3 pt-3">
         <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
           Schedule
@@ -550,7 +737,7 @@ function ActiveCollaborationCard({
         )}
       </div>
 
-      {/* All events — collapsible (multiple webinars or multiple class batches) */}
+      {/* All events — collapsible */}
       {hasExpandableDetails && (
         <div className="mt-2">
           <button
@@ -576,9 +763,205 @@ function ActiveCollaborationCard({
           )}
         </div>
       )}
+      </div>
     </div>
   );
 }
+
+// ─── Host perspective card ───────────────────────────────────────────────────
+
+function HostedPlanCard({
+  plan,
+  hostUser,
+}: {
+  plan: {
+    planType: "webinar" | "class";
+    title: string;
+    price: number;
+    collaborators: CollaboratorInfo[];
+    webinarPlan?: HostedWebinarPlan;
+    classPlan?: HostedClassPlan;
+  };
+  hostUser?: { name: string | null; image: string | null };
+}) {
+  const [eventsExpanded, setEventsExpanded] = useState(false);
+
+  const totalCollabShare = plan.collaborators
+    .filter((c) => c.status === "PENDING" || c.status === "ACCEPTED")
+    .reduce((sum, c) => sum + c.revenueSharePercentage, 0);
+  const hostShare = 100 - totalCollabShare;
+
+  const pendingCollabs = plan.collaborators.filter((c) => c.status === "PENDING");
+  const acceptedCollabs = plan.collaborators.filter((c) => c.status === "ACCEPTED");
+
+  const hasExpandableDetails =
+    (plan.planType === "webinar" &&
+      plan.webinarPlan &&
+      plan.webinarPlan.webinars.length > 1) ||
+    (plan.planType === "class" &&
+      plan.classPlan &&
+      plan.classPlan.classes.length > 1);
+
+  return (
+    <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
+      {/* Role banner */}
+      <div className="bg-zinc-800 px-3 py-1.5 flex items-center justify-between">
+        <span className="text-xs font-semibold text-white tracking-wide uppercase">Host</span>
+        <Badge variant="secondary" className="text-[10px] bg-zinc-700 text-zinc-200 border-zinc-600">
+          {plan.planType === "webinar" ? "Webinar" : "Class"}
+        </Badge>
+      </div>
+
+      <div className="p-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-zinc-800 truncate">
+            {plan.title}
+          </p>
+          {plan.price > 0 && (
+            <p className="text-xs text-zinc-500">
+              {formatCurrencyAmount(plan.price, "INR")}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Revenue split */}
+      <div className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-zinc-50 rounded-md border border-zinc-100">
+        <div className="flex items-center gap-1.5 text-xs text-zinc-600">
+          {hostUser && (
+            <Avatar className="w-5 h-5">
+              <AvatarImage src={hostUser.image ?? undefined} />
+              <AvatarFallback className="text-[8px]">
+                {(hostUser.name ?? "H").charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+          )}
+          <span className="font-medium">You {hostShare}%</span>
+          <span>&middot; Collaborators {totalCollabShare}%</span>
+        </div>
+      </div>
+
+      {/* Collaborators list */}
+      <div className="border-t border-zinc-100 mt-3 pt-3">
+        <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+          Collaborators ({plan.collaborators.length})
+        </p>
+        <div className="space-y-2">
+          {acceptedCollabs.map((collab) => (
+            <div
+              key={collab.id}
+              className="flex items-center justify-between"
+            >
+              <div className="flex items-center gap-2.5">
+                <Avatar className="w-7 h-7">
+                  <AvatarImage
+                    src={collab.consultantProfile.user.image ?? undefined}
+                  />
+                  <AvatarFallback className="text-[10px]">
+                    {(collab.consultantProfile.user.name ?? "?").charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-xs font-medium text-zinc-800">
+                    {collab.consultantProfile.user.name ?? "Unknown"}
+                  </p>
+                  <p className="text-[11px] text-zinc-500">
+                    {formatRole(collab.role)} &middot; {collab.revenueSharePercentage}% share
+                  </p>
+                </div>
+              </div>
+              <Badge
+                variant="default"
+                className="bg-emerald-50 text-emerald-700 border-emerald-200 text-[10px]"
+              >
+                Accepted
+              </Badge>
+            </div>
+          ))}
+          {pendingCollabs.map((collab) => (
+            <div
+              key={collab.id}
+              className="flex items-center justify-between"
+            >
+              <div className="flex items-center gap-2.5">
+                <Avatar className="w-7 h-7">
+                  <AvatarImage
+                    src={collab.consultantProfile.user.image ?? undefined}
+                  />
+                  <AvatarFallback className="text-[10px]">
+                    {(collab.consultantProfile.user.name ?? "?").charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-xs font-medium text-zinc-800">
+                    {collab.consultantProfile.user.name ?? "Unknown"}
+                  </p>
+                  <p className="text-[11px] text-zinc-500">
+                    {formatRole(collab.role)} &middot; {collab.revenueSharePercentage}% share
+                  </p>
+                </div>
+              </div>
+              <Badge
+                variant="secondary"
+                className="text-[10px]"
+              >
+                Pending
+              </Badge>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Schedule summary */}
+      <div className="border-t border-zinc-100 mt-3 pt-3">
+        <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+          Schedule
+        </p>
+        {plan.planType === "webinar" && plan.webinarPlan ? (
+          <WebinarScheduleSummary plan={plan.webinarPlan} />
+        ) : plan.planType === "class" && plan.classPlan ? (
+          <ClassScheduleSummary plan={plan.classPlan} />
+        ) : (
+          <p className="text-xs text-zinc-400 italic">
+            No schedule data available
+          </p>
+        )}
+      </div>
+
+      {/* All events — collapsible */}
+      {hasExpandableDetails && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setEventsExpanded((prev) => !prev)}
+            className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-700 transition-colors"
+          >
+            {eventsExpanded ? (
+              <ChevronUp className="w-3 h-3" />
+            ) : (
+              <ChevronDown className="w-3 h-3" />
+            )}
+            {eventsExpanded ? "Hide" : "Show"} all events
+          </button>
+          {eventsExpanded && (
+            <div className="mt-2 border-t border-zinc-100 pt-2">
+              {plan.planType === "webinar" && plan.webinarPlan ? (
+                <WebinarEventList plan={plan.webinarPlan} />
+              ) : plan.planType === "class" && plan.classPlan ? (
+                <ClassEventList plan={plan.classPlan} />
+              ) : null}
+            </div>
+          )}
+        </div>
+      )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ──────────────────────────────────────────────────────────
 
 export function InvitationsPanel() {
   const { toast } = useToast();
@@ -630,6 +1013,7 @@ export function InvitationsPanel() {
     },
   });
 
+  // ── Collaborator perspective data ──
   const allCollaborations = [
     ...(data?.webinarCollaborations.map((c) => ({
       ...c,
@@ -648,6 +1032,28 @@ export function InvitationsPanel() {
   const pending = allCollaborations.filter((c) => c.status === "PENDING");
   const accepted = allCollaborations.filter((c) => c.status === "ACCEPTED");
 
+  // ── Host perspective data ──
+  const hostedPlans = [
+    ...(data?.hostedWebinarPlans?.map((p) => ({
+      planType: "webinar" as const,
+      title: p.title,
+      price: p.price,
+      collaborators: p.collaborators,
+      webinarPlan: p,
+      classPlan: undefined as HostedClassPlan | undefined,
+    })) ?? []),
+    ...(data?.hostedClassPlans?.map((p) => ({
+      planType: "class" as const,
+      title: p.title,
+      price: p.price,
+      collaborators: p.collaborators,
+      webinarPlan: undefined as HostedWebinarPlan | undefined,
+      classPlan: p,
+    })) ?? []),
+  ];
+
+  const hasAnyData = allCollaborations.length > 0 || hostedPlans.length > 0;
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
@@ -656,14 +1062,14 @@ export function InvitationsPanel() {
     );
   }
 
-  if (allCollaborations.length === 0) {
+  if (!hasAnyData) {
     return (
       <div className="text-center py-12 text-zinc-500">
         <Inbox className="w-10 h-10 mx-auto mb-3 text-zinc-300" />
         <p className="font-medium">No collaborations</p>
         <p className="text-sm mt-1">
-          When another consultant invites you to collaborate, it will appear
-          here.
+          When you invite collaborators to your plans or another consultant
+          invites you, it will appear here.
         </p>
       </div>
     );
@@ -671,7 +1077,25 @@ export function InvitationsPanel() {
 
   return (
     <div className="space-y-6">
-      {/* Pending invitations */}
+      {/* ── Host section: My Plans with Collaborators ── */}
+      {hostedPlans.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-700 mb-3">
+            My Plans with Collaborators ({hostedPlans.length})
+          </h3>
+          <div className="space-y-2">
+            {hostedPlans.map((plan) => (
+              <HostedPlanCard
+                key={`${plan.planType}-${plan.webinarPlan?.id ?? plan.classPlan?.id}`}
+                plan={plan}
+                hostUser={data?.hostUser}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Collaborator section: Pending Invitations ── */}
       {pending.length > 0 && (
         <div>
           <h3 className="text-sm font-semibold text-zinc-700 mb-3">
@@ -699,7 +1123,7 @@ export function InvitationsPanel() {
                         {collab.planType === "webinar" ? "Webinar" : "Class"}
                       </Badge>
                       <Badge variant="outline" className="text-xs">
-                        {collab.role.replace(/_/g, " ")}
+                        {formatRole(collab.role)}
                       </Badge>
                       <span className="text-xs text-zinc-500">
                         {collab.revenueSharePercentage}% revenue share
@@ -751,7 +1175,7 @@ export function InvitationsPanel() {
         </div>
       )}
 
-      {/* Accepted collaborations */}
+      {/* ── Collaborator section: Active Collaborations ── */}
       {accepted.length > 0 && (
         <div>
           <h3 className="text-sm font-semibold text-zinc-700 mb-3">
@@ -759,7 +1183,7 @@ export function InvitationsPanel() {
           </h3>
           <div className="space-y-2">
             {accepted.map((collab) => (
-              <ActiveCollaborationCard key={collab.id} collab={collab} />
+              <ActiveCollaborationCard key={collab.id} collab={collab} currentUser={data?.hostUser} />
             ))}
           </div>
         </div>

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -15,6 +15,7 @@ import {
   Users,
   ChevronDown,
   ChevronUp,
+  AlertTriangle,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { formatCurrencyAmount } from "@/lib/utils";
@@ -1080,7 +1081,7 @@ export function InvitationsPanel() {
       {/* ── Host section: My Plans with Collaborators ── */}
       {hostedPlans.length > 0 && (
         <div>
-          <h3 className="text-sm font-semibold text-zinc-700 mb-3">
+          <h3 className="text-base font-semibold text-zinc-700 mb-3">
             My Plans with Collaborators ({hostedPlans.length})
           </h3>
           <div className="space-y-2">
@@ -1098,7 +1099,7 @@ export function InvitationsPanel() {
       {/* ── Collaborator section: Pending Invitations ── */}
       {pending.length > 0 && (
         <div>
-          <h3 className="text-sm font-semibold text-zinc-700 mb-3">
+          <h3 className="text-base font-semibold text-zinc-700 mb-3">
             Pending Invitations ({pending.length})
           </h3>
           <div className="space-y-3">
@@ -1134,6 +1135,13 @@ export function InvitationsPanel() {
                           {formatCurrencyAmount(collab.planPrice, "INR")}
                         </span>
                       )}
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-2 text-xs text-amber-700">
+                      <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+                      <span>
+                        You won&apos;t earn from purchases made before you
+                        accept the collaborations request.
+                      </span>
                     </div>
                   </div>
                   <div className="flex gap-2 ml-4">
@@ -1178,7 +1186,7 @@ export function InvitationsPanel() {
       {/* ── Collaborator section: Active Collaborations ── */}
       {accepted.length > 0 && (
         <div>
-          <h3 className="text-sm font-semibold text-zinc-700 mb-3">
+          <h3 className="text-base font-semibold text-zinc-700 mb-3">
             Active Collaborations ({accepted.length})
           </h3>
           <div className="space-y-2">

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -174,7 +174,7 @@ function WebinarScheduleSummary({
   );
 }
 
-function WebinarSlotDetails({
+function WebinarEventList({
   plan,
 }: {
   plan: NonNullable<Collaboration["webinarPlan"]>;
@@ -187,35 +187,47 @@ function WebinarSlotDetails({
         return (
           <div
             key={webinar.id}
-            className="flex items-center justify-between text-xs text-zinc-600 py-1.5 border-b border-zinc-50 last:border-0"
+            className="rounded-md border border-zinc-100 bg-zinc-50/50 px-3 py-2"
           >
-            <div className="flex items-center gap-3">
-              <Badge
-                variant="outline"
-                className={
-                  webinar.status === "IN_PROGRESS"
-                    ? "border-green-300 text-green-700 bg-green-50 text-[10px]"
-                    : "border-blue-300 text-blue-700 bg-blue-50 text-[10px]"
-                }
-              >
-                {webinar.status === "IN_PROGRESS" ? "Live" : "Scheduled"}
-              </Badge>
-              <span>{formatDateTime(slot.startsAt)}</span>
-              <span className="text-zinc-400">
-                {formatTime(slot.startsAt)} &ndash; {formatTime(slot.endsAt)}
-              </span>
-            </div>
-            <div className="flex items-center gap-1.5 text-zinc-400">
-              <Users className="w-3 h-3" />
-              <span>{slot._count.user} / {plan.maxParticipants}</span>
-              {slot.isTentative && (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
                 <Badge
                   variant="outline"
-                  className="border-amber-300 text-amber-700 bg-amber-50 text-[10px] ml-1"
+                  className={
+                    webinar.status === "IN_PROGRESS"
+                      ? "border-green-300 text-green-700 bg-green-50 text-[10px]"
+                      : "border-blue-300 text-blue-700 bg-blue-50 text-[10px]"
+                  }
                 >
-                  Tentative
+                  {webinar.status === "IN_PROGRESS" ? "Live" : "Scheduled"}
                 </Badge>
-              )}
+                {slot.isTentative && (
+                  <Badge
+                    variant="outline"
+                    className="border-amber-300 text-amber-700 bg-amber-50 text-[10px]"
+                  >
+                    Tentative
+                  </Badge>
+                )}
+              </div>
+              <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+                <Users className="w-3 h-3" />
+                <span>
+                  {slot._count.user} / {plan.maxParticipants}
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 mt-1.5 text-xs text-zinc-600">
+              <div className="flex items-center gap-1.5">
+                <Calendar className="w-3 h-3 text-zinc-400" />
+                <span>{formatDateTime(slot.startsAt)}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <Clock className="w-3 h-3 text-zinc-400" />
+                <span>
+                  {formatTime(slot.startsAt)} &ndash; {formatTime(slot.endsAt)}
+                </span>
+              </div>
             </div>
           </div>
         );
@@ -229,15 +241,18 @@ function ClassScheduleSummary({
 }: {
   plan: NonNullable<Collaboration["classPlan"]>;
 }) {
-  const cls = plan.classes[0];
-
-  if (!cls) {
+  if (plan.classes.length === 0) {
     return (
       <p className="text-xs text-zinc-400 italic">No classes scheduled yet</p>
     );
   }
 
-  const allSlots = cls.appointments.flatMap((a) => a.slotsOfAppointment);
+  // Show summary for the most relevant class (first IN_PROGRESS, or first SCHEDULED)
+  const activeClass =
+    plan.classes.find((c) => c.status === "IN_PROGRESS") ?? plan.classes[0];
+  const allSlots = activeClass.appointments.flatMap(
+    (a) => a.slotsOfAppointment,
+  );
   const now = new Date();
   const upcomingSlots = allSlots.filter((s) => new Date(s.startsAt) > now);
   const nextSlot = upcomingSlots[0];
@@ -249,25 +264,31 @@ function ClassScheduleSummary({
         <Badge
           variant="outline"
           className={
-            cls.status === "IN_PROGRESS"
+            activeClass.status === "IN_PROGRESS"
               ? "border-green-300 text-green-700 bg-green-50 text-[11px]"
               : "border-blue-300 text-blue-700 bg-blue-50 text-[11px]"
           }
         >
-          {cls.status === "IN_PROGRESS" ? "In Progress" : "Scheduled"}
+          {activeClass.status === "IN_PROGRESS" ? "In Progress" : "Scheduled"}
         </Badge>
+        {plan.classes.length > 1 && (
+          <span className="text-[11px] text-zinc-400">
+            ({plan.classes.length} batches)
+          </span>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600">
-        {cls.schedulingPeriodStartsAt && cls.schedulingPeriodEndsAt && (
-          <div className="flex items-center gap-1.5 col-span-2">
-            <Calendar className="w-3 h-3 text-zinc-400" />
-            <span>
-              {formatDateTime(cls.schedulingPeriodStartsAt)} &ndash;{" "}
-              {formatDateTime(cls.schedulingPeriodEndsAt)}
-            </span>
-          </div>
-        )}
+        {activeClass.schedulingPeriodStartsAt &&
+          activeClass.schedulingPeriodEndsAt && (
+            <div className="flex items-center gap-1.5 col-span-2">
+              <Calendar className="w-3 h-3 text-zinc-400" />
+              <span>
+                {formatDateTime(activeClass.schedulingPeriodStartsAt)} &ndash;{" "}
+                {formatDateTime(activeClass.schedulingPeriodEndsAt)}
+              </span>
+            </div>
+          )}
         <div className="flex items-center gap-1.5">
           <Clock className="w-3 h-3 text-zinc-400" />
           <span>
@@ -298,7 +319,7 @@ function ClassScheduleSummary({
         )}
       </div>
 
-      {!cls.schedulingPeriodStartsAt && allSlots.length === 0 && (
+      {!activeClass.schedulingPeriodStartsAt && allSlots.length === 0 && (
         <p className="text-xs text-zinc-400 italic">
           Sessions not yet scheduled
         </p>
@@ -307,16 +328,15 @@ function ClassScheduleSummary({
   );
 }
 
-function ClassSlotDetails({
-  plan,
-}: {
-  plan: NonNullable<Collaboration["classPlan"]>;
-}) {
-  const cls = plan.classes[0];
-  if (!cls) return null;
-
+function ClassSessionList({ cls }: { cls: ClassEventSchedule }) {
   const allSlots = cls.appointments.flatMap((a) => a.slotsOfAppointment);
-  if (allSlots.length === 0) return null;
+  if (allSlots.length === 0) {
+    return (
+      <p className="text-xs text-zinc-400 italic py-1">
+        Sessions not yet scheduled
+      </p>
+    );
+  }
 
   const now = new Date();
 
@@ -367,6 +387,92 @@ function ClassSlotDetails({
   );
 }
 
+function ClassEventCard({ cls, plan }: {
+  cls: ClassEventSchedule;
+  plan: NonNullable<Collaboration["classPlan"]>;
+}) {
+  const [sessionsExpanded, setSessionsExpanded] = useState(false);
+  const allSlots = cls.appointments.flatMap((a) => a.slotsOfAppointment);
+  const totalEnrolled = allSlots[0]?._count.user ?? 0;
+
+  return (
+    <div className="rounded-md border border-zinc-100 bg-zinc-50/50 px-3 py-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Badge
+            variant="outline"
+            className={
+              cls.status === "IN_PROGRESS"
+                ? "border-green-300 text-green-700 bg-green-50 text-[10px]"
+                : "border-blue-300 text-blue-700 bg-blue-50 text-[10px]"
+            }
+          >
+            {cls.status === "IN_PROGRESS" ? "In Progress" : "Scheduled"}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+          <Users className="w-3 h-3" />
+          <span>
+            {totalEnrolled} / {plan.maxParticipants}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center gap-3 mt-1.5 text-xs text-zinc-600">
+        {cls.schedulingPeriodStartsAt && cls.schedulingPeriodEndsAt && (
+          <div className="flex items-center gap-1.5">
+            <Calendar className="w-3 h-3 text-zinc-400" />
+            <span>
+              {formatDateTime(cls.schedulingPeriodStartsAt)} &ndash;{" "}
+              {formatDateTime(cls.schedulingPeriodEndsAt)}
+            </span>
+          </div>
+        )}
+        <div className="flex items-center gap-1.5 text-zinc-400">
+          <Clock className="w-3 h-3" />
+          <span>
+            {allSlots.length} / {plan.totalSessions} sessions
+          </span>
+        </div>
+      </div>
+      {allSlots.length > 0 && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setSessionsExpanded((prev) => !prev)}
+            className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-700 transition-colors"
+          >
+            {sessionsExpanded ? (
+              <ChevronUp className="w-3 h-3" />
+            ) : (
+              <ChevronDown className="w-3 h-3" />
+            )}
+            {sessionsExpanded ? "Hide" : "Show"} sessions
+          </button>
+          {sessionsExpanded && (
+            <div className="mt-1.5 border-t border-zinc-100 pt-1.5">
+              <ClassSessionList cls={cls} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ClassEventList({
+  plan,
+}: {
+  plan: NonNullable<Collaboration["classPlan"]>;
+}) {
+  return (
+    <div className="space-y-2">
+      {plan.classes.map((cls) => (
+        <ClassEventCard key={cls.id} cls={cls} plan={plan} />
+      ))}
+    </div>
+  );
+}
+
 function ActiveCollaborationCard({
   collab,
 }: {
@@ -388,15 +494,13 @@ function ActiveCollaborationCard({
       ? collab.webinarPlan?.consultantProfile
       : collab.classPlan?.consultantProfile;
 
-  const hasSlotDetails =
+  const hasExpandableDetails =
     (collab.planType === "webinar" &&
       collab.webinarPlan &&
       collab.webinarPlan.webinars.length > 1) ||
     (collab.planType === "class" &&
       collab.classPlan &&
-      collab.classPlan.classes[0]?.appointments.some(
-        (a) => a.slotsOfAppointment.length > 0,
-      ));
+      collab.classPlan.classes.length > 1);
 
   return (
     <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden p-3">
@@ -446,8 +550,8 @@ function ActiveCollaborationCard({
         )}
       </div>
 
-      {/* Detailed slots — collapsible */}
-      {hasSlotDetails && (
+      {/* All events — collapsible (multiple webinars or multiple class batches) */}
+      {hasExpandableDetails && (
         <div className="mt-2">
           <button
             type="button"
@@ -459,14 +563,14 @@ function ActiveCollaborationCard({
             ) : (
               <ChevronDown className="w-3 h-3" />
             )}
-            {slotsExpanded ? "Hide" : "Show"} all sessions
+            {slotsExpanded ? "Hide" : "Show"} all events
           </button>
           {slotsExpanded && (
             <div className="mt-2 border-t border-zinc-100 pt-2">
               {collab.planType === "webinar" && collab.webinarPlan ? (
-                <WebinarSlotDetails plan={collab.webinarPlan} />
+                <WebinarEventList plan={collab.webinarPlan} />
               ) : collab.planType === "class" && collab.classPlan ? (
-                <ClassSlotDetails plan={collab.classPlan} />
+                <ClassEventList plan={collab.classPlan} />
               ) : null}
             </div>
           )}

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -1,11 +1,51 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Check, X, Loader2, Inbox } from "lucide-react";
+import {
+  Check,
+  X,
+  Loader2,
+  Inbox,
+  Calendar,
+  Clock,
+  Users,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { formatCurrencyAmount } from "@/lib/utils";
+
+interface SlotSchedule {
+  startsAt: string;
+  endsAt: string;
+  isTentative: boolean;
+  _count: { user: number };
+}
+
+interface WebinarEventSchedule {
+  id: string;
+  status: string;
+  appointment: {
+    slotsOfAppointment: SlotSchedule[];
+  } | null;
+}
+
+interface ClassEventSchedule {
+  id: string;
+  status: string;
+  schedulingPeriodStartsAt: string | null;
+  schedulingPeriodEndsAt: string | null;
+  appointments: {
+    slotsOfAppointment: SlotSchedule[];
+  }[];
+}
+
+interface PlanOwner {
+  user: { name: string | null; image: string | null };
+}
 
 interface Collaboration {
   id: string;
@@ -13,8 +53,29 @@ interface Collaboration {
   revenueSharePercentage: number;
   status: "PENDING" | "ACCEPTED";
   createdAt: string;
-  webinarPlan?: { id: string; title: string; price: number };
-  classPlan?: { id: string; title: string; price: number };
+  webinarPlan?: {
+    id: string;
+    title: string;
+    price: number;
+    durationInHours: number;
+    maxParticipants: number;
+    language: string | null;
+    level: string | null;
+    webinars: WebinarEventSchedule[];
+    consultantProfile: PlanOwner | null;
+  };
+  classPlan?: {
+    id: string;
+    title: string;
+    price: number;
+    sessionDurationInHours: number;
+    maxParticipants: number;
+    meetingsPerWeek: number;
+    durationInMonths: number;
+    totalSessions: number;
+    classes: ClassEventSchedule[];
+    consultantProfile: PlanOwner | null;
+  };
   invitedBy: {
     user: { name: string | null };
   };
@@ -23,6 +84,267 @@ interface Collaboration {
 interface CollaborationsData {
   webinarCollaborations: Collaboration[];
   classCollaborations: Collaboration[];
+}
+
+function formatDateTime(dateStr: string) {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-IN", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatTime(dateStr: string) {
+  const d = new Date(dateStr);
+  return d.toLocaleTimeString("en-IN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+function WebinarSchedule({
+  plan,
+}: {
+  plan: NonNullable<Collaboration["webinarPlan"]>;
+}) {
+  const webinar = plan.webinars[0];
+  const slot = webinar?.appointment?.slotsOfAppointment[0];
+
+  if (!webinar) {
+    return (
+      <p className="text-xs text-zinc-400 italic">No events scheduled yet</p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Badge
+          variant="outline"
+          className={
+            webinar.status === "IN_PROGRESS"
+              ? "border-green-300 text-green-700 bg-green-50 text-[11px]"
+              : "border-blue-300 text-blue-700 bg-blue-50 text-[11px]"
+          }
+        >
+          {webinar.status === "IN_PROGRESS" ? "Live" : "Scheduled"}
+        </Badge>
+        {slot?.isTentative && (
+          <Badge
+            variant="outline"
+            className="border-amber-300 text-amber-700 bg-amber-50 text-[11px]"
+          >
+            Tentative
+          </Badge>
+        )}
+      </div>
+
+      {slot ? (
+        <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600">
+          <div className="flex items-center gap-1.5">
+            <Calendar className="w-3 h-3 text-zinc-400" />
+            <span>{formatDateTime(slot.startsAt)}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Clock className="w-3 h-3 text-zinc-400" />
+            <span>
+              {formatTime(slot.startsAt)} &ndash; {formatTime(slot.endsAt)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Clock className="w-3 h-3 text-zinc-400" />
+            <span>{plan.durationInHours}h duration</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Users className="w-3 h-3 text-zinc-400" />
+            <span>
+              {slot._count.user} / {plan.maxParticipants} participants
+            </span>
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-zinc-400 italic">
+          Event exists but no time slot set
+        </p>
+      )}
+
+      {plan.webinars.length > 1 && (
+        <p className="text-[11px] text-zinc-400">
+          +{plan.webinars.length - 1} more event
+          {plan.webinars.length > 2 ? "s" : ""}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ClassSchedule({
+  plan,
+}: {
+  plan: NonNullable<Collaboration["classPlan"]>;
+}) {
+  const cls = plan.classes[0];
+
+  if (!cls) {
+    return (
+      <p className="text-xs text-zinc-400 italic">No classes scheduled yet</p>
+    );
+  }
+
+  const allSlots = cls.appointments.flatMap((a) => a.slotsOfAppointment);
+  const now = new Date();
+  const upcomingSlots = allSlots.filter((s) => new Date(s.startsAt) > now);
+  const nextSlot = upcomingSlots[0];
+  const totalEnrolled = allSlots[0]?._count.user ?? 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Badge
+          variant="outline"
+          className={
+            cls.status === "IN_PROGRESS"
+              ? "border-green-300 text-green-700 bg-green-50 text-[11px]"
+              : "border-blue-300 text-blue-700 bg-blue-50 text-[11px]"
+          }
+        >
+          {cls.status === "IN_PROGRESS" ? "In Progress" : "Scheduled"}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-zinc-600">
+        {cls.schedulingPeriodStartsAt && cls.schedulingPeriodEndsAt && (
+          <div className="flex items-center gap-1.5 col-span-2">
+            <Calendar className="w-3 h-3 text-zinc-400" />
+            <span>
+              {formatDateTime(cls.schedulingPeriodStartsAt)} &ndash;{" "}
+              {formatDateTime(cls.schedulingPeriodEndsAt)}
+            </span>
+          </div>
+        )}
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-3 h-3 text-zinc-400" />
+          <span>
+            {allSlots.length} / {plan.totalSessions} sessions
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Users className="w-3 h-3 text-zinc-400" />
+          <span>
+            {totalEnrolled} / {plan.maxParticipants} participants
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-3 h-3 text-zinc-400" />
+          <span>
+            {plan.sessionDurationInHours}h/session &middot;{" "}
+            {plan.meetingsPerWeek}x/week
+          </span>
+        </div>
+        {nextSlot && (
+          <div className="flex items-center gap-1.5">
+            <Calendar className="w-3 h-3 text-zinc-400" />
+            <span>
+              Next: {formatDateTime(nextSlot.startsAt)}{" "}
+              {formatTime(nextSlot.startsAt)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {!cls.schedulingPeriodStartsAt && allSlots.length === 0 && (
+        <p className="text-xs text-zinc-400 italic">
+          Sessions not yet scheduled
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ActiveCollaborationCard({
+  collab,
+}: {
+  collab: {
+    id: string;
+    role: string;
+    revenueSharePercentage: number;
+    planType: "webinar" | "class";
+    planTitle: string;
+    invitedBy: { user: { name: string | null } };
+    webinarPlan?: Collaboration["webinarPlan"];
+    classPlan?: Collaboration["classPlan"];
+  };
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const owner =
+    collab.planType === "webinar"
+      ? collab.webinarPlan?.consultantProfile
+      : collab.classPlan?.consultantProfile;
+
+  return (
+    <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="w-full p-3 flex items-center justify-between text-left hover:bg-zinc-50 transition-colors"
+      >
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-zinc-800 truncate">
+            {collab.planTitle}
+          </p>
+          <p className="text-xs text-zinc-500">
+            {collab.role.replace(/_/g, " ")} &middot;{" "}
+            {collab.revenueSharePercentage}% share
+            {owner?.user.name && (
+              <>
+                {" "}
+                &middot; by {owner.user.name}
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 ml-3 shrink-0">
+          <Badge variant="secondary" className="text-xs">
+            {collab.planType === "webinar" ? "Webinar" : "Class"}
+          </Badge>
+          <Badge
+            variant="default"
+            className="bg-emerald-50 text-emerald-700 border-emerald-200"
+          >
+            Active
+          </Badge>
+          {expanded ? (
+            <ChevronUp className="w-4 h-4 text-zinc-400" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-zinc-400" />
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 pt-0">
+          <div className="border-t border-zinc-100 pt-3">
+            <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+              Schedule
+            </p>
+            {collab.planType === "webinar" && collab.webinarPlan ? (
+              <WebinarSchedule plan={collab.webinarPlan} />
+            ) : collab.planType === "class" && collab.classPlan ? (
+              <ClassSchedule plan={collab.classPlan} />
+            ) : (
+              <p className="text-xs text-zinc-400 italic">
+                No schedule data available
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function InvitationsPanel() {
@@ -204,32 +526,7 @@ export function InvitationsPanel() {
           </h3>
           <div className="space-y-2">
             {accepted.map((collab) => (
-              <div
-                key={collab.id}
-                className="flex items-center justify-between p-3 bg-white border border-zinc-200 rounded-lg"
-              >
-                <div>
-                  <p className="text-sm font-medium text-zinc-800">
-                    {collab.planTitle}
-                  </p>
-                  <p className="text-xs text-zinc-500">
-                    {collab.role.replace(/_/g, " ")} &middot;{" "}
-                    {collab.revenueSharePercentage}% share &middot; by{" "}
-                    {collab.invitedBy.user.name ?? "Unknown"}
-                  </p>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary" className="text-xs">
-                    {collab.planType === "webinar" ? "Webinar" : "Class"}
-                  </Badge>
-                  <Badge
-                    variant="default"
-                    className="bg-emerald-50 text-emerald-700 border-emerald-200"
-                  >
-                    Active
-                  </Badge>
-                </div>
-              </div>
+              <ActiveCollaborationCard key={collab.id} collab={collab} />
             ))}
           </div>
         </div>

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -105,7 +105,7 @@ function formatTime(dateStr: string) {
   });
 }
 
-function WebinarSchedule({
+function WebinarScheduleSummary({
   plan,
 }: {
   plan: NonNullable<Collaboration["webinarPlan"]>;
@@ -170,18 +170,61 @@ function WebinarSchedule({
           Event exists but no time slot set
         </p>
       )}
-
-      {plan.webinars.length > 1 && (
-        <p className="text-[11px] text-zinc-400">
-          +{plan.webinars.length - 1} more event
-          {plan.webinars.length > 2 ? "s" : ""}
-        </p>
-      )}
     </div>
   );
 }
 
-function ClassSchedule({
+function WebinarSlotDetails({
+  plan,
+}: {
+  plan: NonNullable<Collaboration["webinarPlan"]>;
+}) {
+  return (
+    <div className="space-y-2">
+      {plan.webinars.map((webinar) => {
+        const slot = webinar.appointment?.slotsOfAppointment[0];
+        if (!slot) return null;
+        return (
+          <div
+            key={webinar.id}
+            className="flex items-center justify-between text-xs text-zinc-600 py-1.5 border-b border-zinc-50 last:border-0"
+          >
+            <div className="flex items-center gap-3">
+              <Badge
+                variant="outline"
+                className={
+                  webinar.status === "IN_PROGRESS"
+                    ? "border-green-300 text-green-700 bg-green-50 text-[10px]"
+                    : "border-blue-300 text-blue-700 bg-blue-50 text-[10px]"
+                }
+              >
+                {webinar.status === "IN_PROGRESS" ? "Live" : "Scheduled"}
+              </Badge>
+              <span>{formatDateTime(slot.startsAt)}</span>
+              <span className="text-zinc-400">
+                {formatTime(slot.startsAt)} &ndash; {formatTime(slot.endsAt)}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5 text-zinc-400">
+              <Users className="w-3 h-3" />
+              <span>{slot._count.user} / {plan.maxParticipants}</span>
+              {slot.isTentative && (
+                <Badge
+                  variant="outline"
+                  className="border-amber-300 text-amber-700 bg-amber-50 text-[10px] ml-1"
+                >
+                  Tentative
+                </Badge>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ClassScheduleSummary({
   plan,
 }: {
   plan: NonNullable<Collaboration["classPlan"]>;
@@ -264,6 +307,66 @@ function ClassSchedule({
   );
 }
 
+function ClassSlotDetails({
+  plan,
+}: {
+  plan: NonNullable<Collaboration["classPlan"]>;
+}) {
+  const cls = plan.classes[0];
+  if (!cls) return null;
+
+  const allSlots = cls.appointments.flatMap((a) => a.slotsOfAppointment);
+  if (allSlots.length === 0) return null;
+
+  const now = new Date();
+
+  return (
+    <div className="space-y-1">
+      {allSlots.map((slot, i) => {
+        const isPast = new Date(slot.endsAt) < now;
+        return (
+          <div
+            key={i}
+            className={`flex items-center justify-between text-xs py-1.5 border-b border-zinc-50 last:border-0 ${
+              isPast ? "text-zinc-400" : "text-zinc-600"
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              <span className="w-5 text-center text-[10px] text-zinc-400">
+                {i + 1}
+              </span>
+              <span>{formatDateTime(slot.startsAt)}</span>
+              <span className="text-zinc-400">
+                {formatTime(slot.startsAt)} &ndash; {formatTime(slot.endsAt)}
+              </span>
+              {isPast && (
+                <Badge
+                  variant="outline"
+                  className="border-zinc-200 text-zinc-400 text-[10px]"
+                >
+                  Done
+                </Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-1.5 text-zinc-400">
+              <Users className="w-3 h-3" />
+              <span>{slot._count.user}</span>
+              {slot.isTentative && (
+                <Badge
+                  variant="outline"
+                  className="border-amber-300 text-amber-700 bg-amber-50 text-[10px] ml-1"
+                >
+                  Tentative
+                </Badge>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function ActiveCollaborationCard({
   collab,
 }: {
@@ -278,20 +381,27 @@ function ActiveCollaborationCard({
     classPlan?: Collaboration["classPlan"];
   };
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [slotsExpanded, setSlotsExpanded] = useState(false);
 
   const owner =
     collab.planType === "webinar"
       ? collab.webinarPlan?.consultantProfile
       : collab.classPlan?.consultantProfile;
 
+  const hasSlotDetails =
+    (collab.planType === "webinar" &&
+      collab.webinarPlan &&
+      collab.webinarPlan.webinars.length > 1) ||
+    (collab.planType === "class" &&
+      collab.classPlan &&
+      collab.classPlan.classes[0]?.appointments.some(
+        (a) => a.slotsOfAppointment.length > 0,
+      ));
+
   return (
-    <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setExpanded((prev) => !prev)}
-        className="w-full p-3 flex items-center justify-between text-left hover:bg-zinc-50 transition-colors"
-      >
+    <div className="bg-white border border-zinc-200 rounded-lg overflow-hidden p-3">
+      {/* Header — always visible */}
+      <div className="flex items-center justify-between">
         <div className="min-w-0">
           <p className="text-sm font-medium text-zinc-800 truncate">
             {collab.planTitle}
@@ -317,30 +427,49 @@ function ActiveCollaborationCard({
           >
             Active
           </Badge>
-          {expanded ? (
-            <ChevronUp className="w-4 h-4 text-zinc-400" />
-          ) : (
-            <ChevronDown className="w-4 h-4 text-zinc-400" />
-          )}
         </div>
-      </button>
+      </div>
 
-      {expanded && (
-        <div className="px-3 pb-3 pt-0">
-          <div className="border-t border-zinc-100 pt-3">
-            <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
-              Schedule
-            </p>
-            {collab.planType === "webinar" && collab.webinarPlan ? (
-              <WebinarSchedule plan={collab.webinarPlan} />
-            ) : collab.planType === "class" && collab.classPlan ? (
-              <ClassSchedule plan={collab.classPlan} />
+      {/* Schedule summary — always visible */}
+      <div className="border-t border-zinc-100 mt-3 pt-3">
+        <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+          Schedule
+        </p>
+        {collab.planType === "webinar" && collab.webinarPlan ? (
+          <WebinarScheduleSummary plan={collab.webinarPlan} />
+        ) : collab.planType === "class" && collab.classPlan ? (
+          <ClassScheduleSummary plan={collab.classPlan} />
+        ) : (
+          <p className="text-xs text-zinc-400 italic">
+            No schedule data available
+          </p>
+        )}
+      </div>
+
+      {/* Detailed slots — collapsible */}
+      {hasSlotDetails && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setSlotsExpanded((prev) => !prev)}
+            className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-700 transition-colors"
+          >
+            {slotsExpanded ? (
+              <ChevronUp className="w-3 h-3" />
             ) : (
-              <p className="text-xs text-zinc-400 italic">
-                No schedule data available
-              </p>
+              <ChevronDown className="w-3 h-3" />
             )}
-          </div>
+            {slotsExpanded ? "Hide" : "Show"} all sessions
+          </button>
+          {slotsExpanded && (
+            <div className="mt-2 border-t border-zinc-100 pt-2">
+              {collab.planType === "webinar" && collab.webinarPlan ? (
+                <WebinarSlotDetails plan={collab.webinarPlan} />
+              ) : collab.planType === "class" && collab.classPlan ? (
+                <ClassSlotDetails plan={collab.classPlan} />
+              ) : null}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/components/dashboard/DashboardNavbar.tsx
+++ b/components/dashboard/DashboardNavbar.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { NotificationInbox } from "@/components/notifications/NotificationInbox";
+import { UserDropdown } from "./UserDropdown";
+import { HelpCircle } from "lucide-react";
+import Link from "next/link";
+
+interface DashboardNavbarProps {
+  userName?: string | null;
+  userImage?: string | null;
+  userRole: "CONSULTANT" | "CONSULTEE" | "ADMIN" | "STAFF";
+  settingsPath: string;
+  profilePath?: string;
+  helpPath?: string;
+}
+
+export function DashboardNavbar({
+  userName,
+  userImage,
+  userRole,
+  settingsPath,
+  profilePath,
+  helpPath,
+}: DashboardNavbarProps) {
+  return (
+    <div
+      className="flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl"
+      style={{ zIndex: 9999, overflow: "visible" }}
+    >
+      {/* Left spacer - future home for breadcrumbs */}
+      <div className="flex-1" />
+
+      {/* Right actions */}
+      <TooltipProvider delayDuration={200}>
+        <div className="flex items-center gap-2">
+          {helpPath && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9 text-zinc-500 hover:text-zinc-900"
+                >
+                  <Link href={helpPath}>
+                    <HelpCircle className="h-4 w-4" />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Help & FAQ</TooltipContent>
+            </Tooltip>
+          )}
+
+          <NotificationInbox />
+
+          <UserDropdown
+            userName={userName}
+            userImage={userImage}
+            userRole={userRole}
+            settingsPath={settingsPath}
+            profilePath={profilePath}
+          />
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -30,6 +30,8 @@ interface DashboardShellProps {
   sidebar: ReactNode;
   className?: string;
   headerActions?: ReactNode;
+  navbar?: ReactNode;
+  mobileHeaderActions?: ReactNode;
 }
 
 export function DashboardShell({
@@ -37,6 +39,8 @@ export function DashboardShell({
   sidebar,
   className,
   headerActions,
+  navbar,
+  mobileHeaderActions,
 }: DashboardShellProps) {
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
 
@@ -110,25 +114,29 @@ export function DashboardShell({
             <span className="font-semibold text-zinc-900 flex-1">
               Familiarise
             </span>
-            {headerActions && (
+            {(mobileHeaderActions || headerActions) && (
               <div
                 className="flex items-center gap-2 shrink-0"
                 style={{ overflow: "visible" }}
               >
-                {headerActions}
+                {mobileHeaderActions || headerActions}
               </div>
             )}
           </div>
 
-          {/* Desktop header actions (notification bell etc.) */}
-          {headerActions && (
+          {/* Desktop header - full navbar or simple header actions */}
+          {navbar ? (
+            <div className="hidden lg:block relative" style={{ zIndex: 9999, overflow: "visible" }}>
+              {navbar}
+            </div>
+          ) : headerActions ? (
             <div
               className="hidden lg:flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl relative"
               style={{ zIndex: 9999, overflow: "visible" }}
             >
               {headerActions}
             </div>
-          )}
+          ) : null}
 
           <AnimatePresence mode="wait">
             <motion.div

--- a/components/dashboard/DashboardSidebar.tsx
+++ b/components/dashboard/DashboardSidebar.tsx
@@ -102,6 +102,7 @@ interface DashboardSidebarProps {
   navSections?: NavSection[];
   isLoading?: boolean;
   bottomNavItems?: NavItem[];
+  hideBottomActions?: boolean;
 }
 
 export function DashboardSidebar({
@@ -113,6 +114,7 @@ export function DashboardSidebar({
   navSections = [],
   isLoading = false,
   bottomNavItems = [],
+  hideBottomActions = false,
 }: DashboardSidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
@@ -315,60 +317,62 @@ export function DashboardSidebar({
       </nav>
 
       {/* Bottom Section */}
-      <div className="border-t border-zinc-800/50 p-3 space-y-1">
-        <Link
-          href="/"
-          className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-100 transition-all"
-        >
-          <span className="flex h-8 w-8 items-center justify-center rounded-md bg-zinc-800/50 text-zinc-500">
-            <ArrowLeft className="w-5 h-5" />
-          </span>
-          <span>Back to Home</span>
-        </Link>
+      {!hideBottomActions && (
+        <div className="border-t border-zinc-800/50 p-3 space-y-1">
+          <Link
+            href="/"
+            className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-100 transition-all"
+          >
+            <span className="flex h-8 w-8 items-center justify-center rounded-md bg-zinc-800/50 text-zinc-500">
+              <ArrowLeft className="w-5 h-5" />
+            </span>
+            <span>Back to Home</span>
+          </Link>
 
-        {bottomNavItems.map((item) => {
-          const isActive =
-            relativePath === item.path ||
-            relativePath.startsWith(item.path + "/");
+          {bottomNavItems.map((item) => {
+            const isActive =
+              relativePath === item.path ||
+              relativePath.startsWith(item.path + "/");
 
-          return (
-            <Link
-              key={item.path}
-              href={`${basePath}/${item.path}`}
-              className={cn(
-                "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all",
-                isActive
-                  ? "bg-zinc-800 text-white"
-                  : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-100",
-              )}
-              prefetch={true}
-              onMouseEnter={() => handleNavHover(item.path)}
-            >
-              <span
+            return (
+              <Link
+                key={item.path}
+                href={`${basePath}/${item.path}`}
                 className={cn(
-                  "flex h-8 w-8 items-center justify-center rounded-md",
+                  "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all",
                   isActive
-                    ? "bg-zinc-700 text-white"
-                    : "bg-zinc-800/50 text-zinc-500",
+                    ? "bg-zinc-800 text-white"
+                    : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-100",
                 )}
+                prefetch={true}
+                onMouseEnter={() => handleNavHover(item.path)}
               >
-                {renderIcon(item.path)}
-              </span>
-              <span>{item.name}</span>
-            </Link>
-          );
-        })}
+                <span
+                  className={cn(
+                    "flex h-8 w-8 items-center justify-center rounded-md",
+                    isActive
+                      ? "bg-zinc-700 text-white"
+                      : "bg-zinc-800/50 text-zinc-500",
+                  )}
+                >
+                  {renderIcon(item.path)}
+                </span>
+                <span>{item.name}</span>
+              </Link>
+            );
+          })}
 
-        <button
-          onClick={() => signOut()}
-          className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-red-400 hover:bg-red-500/10 hover:text-red-300 transition-all"
-        >
-          <span className="flex h-8 w-8 items-center justify-center rounded-md bg-red-500/10 text-red-500">
-            <LogOut className="w-5 h-5" />
-          </span>
-          <span>Sign Out</span>
-        </button>
-      </div>
+          <button
+            onClick={() => signOut()}
+            className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-red-400 hover:bg-red-500/10 hover:text-red-300 transition-all"
+          >
+            <span className="flex h-8 w-8 items-center justify-center rounded-md bg-red-500/10 text-red-500">
+              <LogOut className="w-5 h-5" />
+            </span>
+            <span>Sign Out</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/dashboard/UserDropdown.tsx
+++ b/components/dashboard/UserDropdown.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { signOut } from "@/lib/auth-client";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { User, Settings, ArrowLeft, LogOut } from "lucide-react";
+import Link from "next/link";
+
+interface UserDropdownProps {
+  userName?: string | null;
+  userImage?: string | null;
+  userRole: "CONSULTANT" | "CONSULTEE" | "ADMIN" | "STAFF";
+  settingsPath: string;
+  profilePath?: string;
+}
+
+export function UserDropdown({
+  userName,
+  userImage,
+  userRole,
+  settingsPath,
+  profilePath,
+}: UserDropdownProps) {
+  const getRoleBadgeColor = () => {
+    switch (userRole) {
+      case "ADMIN":
+        return "text-red-600 bg-red-50";
+      case "CONSULTANT":
+        return "text-emerald-600 bg-emerald-50";
+      case "CONSULTEE":
+        return "text-blue-600 bg-blue-50";
+      case "STAFF":
+        return "text-amber-600 bg-amber-50";
+      default:
+        return "text-zinc-600 bg-zinc-50";
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button className="relative h-8 w-8 rounded-full ring-2 ring-zinc-200 hover:ring-zinc-400 transition-all focus:outline-none focus:ring-2 focus:ring-zinc-400">
+          <Avatar className="h-8 w-8">
+            <AvatarImage
+              src={userImage || "/placeholder-user.jpg"}
+              alt={userName || ""}
+            />
+            <AvatarFallback className="bg-zinc-100 text-zinc-600 text-sm">
+              {userName?.charAt(0) || "U"}
+            </AvatarFallback>
+          </Avatar>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="w-56"
+        style={{ zIndex: 9999 }}
+      >
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm font-medium">{userName || "User"}</p>
+            <span
+              className={`inline-flex w-fit items-center px-2 py-0.5 rounded text-xs font-medium ${getRoleBadgeColor()}`}
+            >
+              {userRole}
+            </span>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {profilePath && (
+          <DropdownMenuItem asChild>
+            <Link href={profilePath} className="cursor-pointer">
+              <User className="mr-2 h-4 w-4" />
+              Profile
+            </Link>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem asChild>
+          <Link href={settingsPath} className="cursor-pointer">
+            <Settings className="mr-2 h-4 w-4" />
+            Settings
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/" className="cursor-pointer">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Home
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => signOut()}
+          className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50"
+        >
+          <LogOut className="mr-2 h-4 w-4" />
+          Sign Out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/docs/booking/01-architecture.md
+++ b/docs/booking/01-architecture.md
@@ -178,12 +178,12 @@ erDiagram
     ConsultationPlan ||--o{ Consultation : creates
     SubscriptionPlan ||--o{ Subscription : creates
     WebinarPlan ||--o{ Webinar : creates
-    ClassPlan ||--o{ Class : creates
+    ClassPlan ||--o{ ClassEvent : creates
 
     Consultation ||--o| Appointment : "has one"
     Subscription ||--o{ Appointment : "has many"
     Webinar ||--o| Appointment : "has one"
-    Class ||--o{ Appointment : "has many"
+    ClassEvent ||--o{ Appointment : "has many"
 
     Appointment ||--|{ SlotOfAppointment : contains
 
@@ -211,6 +211,7 @@ erDiagram
         string appointmentId FK
     }
 ```
+> Note: we are using ClassEvent instead of Class because Class is a reserved keyword in Mermaid.
 
 **Key relationships**:
 

--- a/docs/booking/06-dependency-graphs.md
+++ b/docs/booking/06-dependency-graphs.md
@@ -1,0 +1,399 @@
+# Dependency Graphs
+
+Visual maps of how files in the booking system relate to each other.
+
+---
+
+## 1. System Layer Architecture
+
+How the 5 layers stack. Each layer only calls the layer directly below it.
+
+```mermaid
+block-beta
+  columns 1
+  block:UI["FRONTEND COMPONENTS"]
+    A["UnifiedCalendar.tsx (1222)"]
+    B["EventPlannerFor*.tsx"]
+    C["EventCard.tsx (1031)"]
+  end
+  block:HOOKS["FRONTEND HOOKS"]
+    D["useSlotAllocation (2171)"]
+    E["useCalendarData (737)"]
+    F["useSubscriptionValidation (260)"]
+  end
+  block:UTILS["FRONTEND UTILITIES"]
+    G["calendarUtils (786)"]
+    H["allocationAlgorithms (850)"]
+    I["allocationService (612)"]
+  end
+  block:API["API ROUTES (Next.js)"]
+    J["*/validate (POST)"]
+    K["*/allocate (PATCH)"]
+    L["slots/* & appointments/*"]
+  end
+  block:SERVICES["BACKEND SERVICES"]
+    M["SlotCalculationService (416)"]
+    N["SlotValidationService (808)"]
+    O["SlotAllocationService (1140)"]
+    P["appointmentlock (698)"]
+  end
+
+  UI --> HOOKS
+  HOOKS --> UTILS
+  UTILS --> API
+  API --> SERVICES
+```
+
+---
+
+## 2. Backend Dependency Graph
+
+Which backend file imports which. Read bottom-up (leaf nodes first).
+
+```mermaid
+flowchart BT
+  subgraph types ["Types & Schemas (read first)"]
+    T["types.ts (143)\nEventType, EventConfig,\nTimeSlot, ProgressInfo"]
+    ZOD["validationSchemas.ts (215)\nZod: allocationRequestSchema,\nvalidationRequestSchema"]
+  end
+
+  subgraph services ["Core Services"]
+    CALC["SlotCalculationService.ts (416)\nPure math, no DB\ncountWeeks, getSlotsPerCall,\ncalculateRequiredSlots"]
+    VAL["SlotValidationService.ts (808)\nvalidate(), validateNoConflicts,\nvalidateMatchesSchedule,\nvalidateConsecutiveSlots"]
+    ALLOC["SlotAllocationService.ts (1140)\nautoAllocate, manualAllocate,\nuseRequestedSlots"]
+  end
+
+  subgraph infra ["Infrastructure"]
+    PRISMA["lib/prisma\n(Prisma client)"]
+    REDIS["lib/redis\n(Upstash Redis)"]
+    LOCK["appointmentlock.ts (698)\nDistributed locking\nvia Redis"]
+  end
+
+  subgraph routes ["API Routes"]
+    R_ALLOC["*/allocate/route.ts\nPATCH handler"]
+    R_VAL["*/validate/route.ts\nPOST handler"]
+    R_RESCH["*/reschedule/route.ts\nPOST handler"]
+    R_SLOTS["slots/*/route.ts\nCRUD handlers"]
+  end
+
+  T --> CALC
+  T --> VAL
+  T --> ALLOC
+  CALC --> VAL
+  CALC --> ALLOC
+  VAL --> ALLOC
+  PRISMA --> VAL
+  PRISMA --> ALLOC
+  REDIS --> LOCK
+
+  ZOD --> R_ALLOC
+  ZOD --> R_VAL
+  ALLOC --> R_ALLOC
+  VAL --> R_VAL
+  PRISMA --> R_RESCH
+  PRISMA --> R_SLOTS
+```
+
+**Reading order**: `types.ts` -> `SlotCalculationService` -> `SlotValidationService` -> `SlotAllocationService` -> API routes
+
+---
+
+## 3. Frontend Dependency Graph
+
+Which frontend file imports which. Read bottom-up.
+
+```mermaid
+flowchart BT
+  subgraph shared_types ["Shared Types"]
+    ST["@/types/slots\nTCustomSlot, TWeeklySlot"]
+    BT2["@/utils/slotAllocation/types\nSlotConflictResult"]
+  end
+
+  subgraph utils ["Frontend Utilities"]
+    CU["calendarUtils.ts (786)\nTimeSlot, mapWeeklySlots,\nmapCustomSlots,\ncalculateRequiredSlots"]
+    AS["allocationService.ts (612)\nAPI client: validateSlots,\nallocateSlots, fetchAvailability"]
+    AA["allocationAlgorithms.ts (850)\nPreference-based auto allocation\nwith time/day scoring"]
+  end
+
+  subgraph hooks ["Frontend Hooks"]
+    USA["useSlotAllocation (2171)\ntoggleSlot, validateWeekly,\nprogress tracking"]
+    UCD["useCalendarData (737)\ngetSlotStatusForInterval,\nfetch availability + appointments"]
+    USV["useSubscriptionValidation (260)\nvalidateSlots, getAvailableWeeks"]
+  end
+
+  subgraph components ["Components"]
+    UC["UnifiedCalendar.tsx (1222)\nMain calendar rendering"]
+    EP["EventPlannerFor*.tsx\nConsultation/Subscription/\nWebinar/Class planners"]
+    AT["AppointmentsTab.tsx (855)\nConsultant appointment list"]
+  end
+
+  ST --> CU
+  BT2 --> AS
+  CU --> AS
+  CU --> AA
+  AS --> AA
+  CU --> USA
+  AA --> USA
+  AS --> UCD
+  UCD --> UC
+  USA --> UC
+  CU --> UC
+```
+
+**Reading order**: `types/slots` -> `calendarUtils` -> `allocationService` -> `allocationAlgorithms` -> `useCalendarData` -> `useSlotAllocation` -> `UnifiedCalendar`
+
+---
+
+## 4. Consultee Side (Separate Dependency Chain)
+
+The consultee dashboard has its own simpler chain.
+
+```mermaid
+flowchart BT
+  subgraph consultee_utils ["Consultee Utilities"]
+    SH["scheduleHelpers.ts\ngetActualSlots"]
+    SC["statusConfig.ts\nSTATUS_CONFIG"]
+    GM["getMetadata.ts\ngetStatusColor"]
+  end
+
+  subgraph consultee_components ["Consultee Components"]
+    EC["EventCard.tsx (1031)\nBooking card with\nreschedule/cancel/join"]
+    DU["DocumentUpload.tsx (809)"]
+    CAL["Calendar.tsx (323)"]
+    RID["ReportIssueDialog.tsx"]
+    CCD["CancelConfirmationDialog.tsx"]
+  end
+
+  SC --> EC
+  DU --> EC
+  RID --> EC
+  CCD --> EC
+  SH --> CAL
+  GM --> CAL
+```
+
+---
+
+## 5. Request Flow: Slot Allocation (The Main Path)
+
+What happens when the consultant clicks "Allocate Slots":
+
+```mermaid
+sequenceDiagram
+  participant UC as UnifiedCalendar
+  participant USA as useSlotAllocation
+  participant AA as allocationAlgorithms
+  participant AS as allocationService
+  participant API as allocate/route.ts
+  participant ZOD as validationSchemas
+  participant SAS as SlotAllocationService
+  participant SVS as SlotValidationService
+  participant SCS as SlotCalculationService
+  participant DB as Prisma + PostgreSQL
+  participant LOCK as appointmentlock + Redis
+
+  UC->>USA: User selects slots via toggleSlot()
+  USA->>AA: Auto-expand consecutive slots
+  USA->>UC: Update UI (selected slots, progress)
+
+  Note over UC: User clicks "Allocate"
+
+  UC->>AS: allocateSlots(type, id, mode, slots)
+  AS->>API: PATCH /api/events/{type}/{id}/allocate
+
+  API->>ZOD: Parse request body
+  ZOD-->>API: Validated {isAuto, slots?, useRequestedSlots?}
+
+  alt Auto Mode
+    API->>SAS: autoAllocate(type, id)
+    SAS->>DB: Fetch event config + availability
+    SAS->>SCS: calculateRequiredSlots()
+    SAS->>SCS: getSlotsPerCall()
+    SAS->>SAS: Build available slots lookup set
+    SAS->>SAS: findAvailableSlots()
+  else Manual Mode
+    API->>SAS: manualAllocate(type, id, slots)
+  else Requested Mode
+    API->>SAS: useRequestedSlots(type, id)
+  end
+
+  SAS->>LOCK: Acquire distributed lock (Redis)
+  LOCK-->>SAS: Lock acquired
+
+  SAS->>SVS: validate(type, id, slots, consultant, config)
+  SVS->>SCS: validateDuration()
+  SVS->>DB: validateNoConflicts() - check existing appointments
+  SVS->>SVS: validateMatchesSchedule()
+  SVS->>SVS: validateConsecutiveSlots()
+  SVS-->>SAS: ValidationResult
+
+  SAS->>DB: BEGIN TRANSACTION (60s timeout)
+  SAS->>DB: Delete old appointments (if any)
+  SAS->>DB: Create Appointment records
+  SAS->>DB: Create SlotOfAppointment records
+  SAS->>DB: Update event status
+  SAS->>DB: COMMIT
+
+  SAS->>LOCK: Release lock
+  SAS-->>API: AllocationResult
+  API-->>AS: JSON response
+  AS-->>UC: Success -> refresh calendar
+```
+
+---
+
+## 6. Request Flow: Slot Validation (Pre-flight Check)
+
+What happens when the frontend validates slots before allocation:
+
+```mermaid
+sequenceDiagram
+  participant UC as UnifiedCalendar
+  participant AS as allocationService
+  participant API as validate/route.ts
+  participant ZOD as validationSchemas
+  participant SVS as SlotValidationService
+  participant DB as Prisma + PostgreSQL
+
+  UC->>AS: validateSlots(type, id, slots)
+  AS->>API: POST /api/events/{type}/{id}/validate
+
+  API->>ZOD: Parse {slots: ["ISO...", ...]}
+  API->>DB: Fetch event + consultant + availability
+
+  API->>SVS: validate(type, id, slots, consultant, config)
+  SVS->>SVS: validateSlotsInFuture (now + 5s buffer)
+  SVS->>DB: validateNoConflicts (range overlap query)
+  SVS->>SVS: validateMatchesSchedule (weekly/custom)
+  SVS->>SVS: validateSchedulingPeriod
+  SVS->>SVS: Event-specific validation
+
+  SVS-->>API: {conflicts, outsideAvailability, validSlots}
+  API-->>AS: JSON response
+  AS-->>UC: Show warnings/errors in UI
+```
+
+---
+
+## 7. Maintenance & Cleanup Flow
+
+How cron jobs keep the system healthy:
+
+```mermaid
+flowchart LR
+  subgraph triggers ["GitHub Actions (Cron Triggers)"]
+    GH1["cleanup-tentative-slots.yml\nevery 15 min"]
+    GH2["auto-complete-appointments.yml\nevery hour"]
+    GH3["cleanup-invalid-appointments.yml\ndaily"]
+    GH4["reconcile-slot-availability.yml\ndaily"]
+    GH5["expire-stale-requests.yml\nevery 30 min"]
+  end
+
+  subgraph jobs ["Job Files (Lightweight)"]
+    J1["cleanup-tentative-slots.ts"]
+    J2["auto-complete-appointments.ts"]
+    J3["cleanup-invalid-appointments.ts"]
+    J4["reconcile-slot-availability.ts"]
+    J5["expire-stale-requests.ts"]
+  end
+
+  subgraph scripts ["Script Files (Verbose, for manual runs)"]
+    S1["scripts/appointments/\ncleanup-tentative-slots.ts"]
+    S2["scripts/appointments/\nauto-complete-appointments.ts"]
+  end
+
+  subgraph cleanup_actions ["What They Do"]
+    A1["Remove tentative appointments\nolder than 30 minutes"]
+    A2["Mark past appointments\nas COMPLETED"]
+    A3["Remove orphaned records\nwith missing FKs"]
+    A4["Sync slot availability\nstate with appointments"]
+    A5["Expire PENDING requests\nolder than threshold"]
+  end
+
+  GH1 --> J1 --> A1
+  GH2 --> J2 --> A2
+  GH3 --> J3 --> A3
+  GH4 --> J4 --> A4
+  GH5 --> J5 --> A5
+  J1 -.->|same logic, verbose| S1
+  J2 -.->|same logic, verbose| S2
+```
+
+---
+
+## 8. Data Model Relationships (Simplified)
+
+```mermaid
+erDiagram
+  ConsultantProfile ||--o{ SlotOfAvailabilityWeekly : "sets availability"
+  ConsultantProfile ||--o{ SlotOfAvailabilityCustom : "sets availability"
+
+  ConsultationPlan ||--o{ Consultation : creates
+  SubscriptionPlan ||--o{ Subscription : creates
+  WebinarPlan ||--o{ Webinar : creates
+  ClassPlan ||--o{ ClassEvent : creates
+
+  Consultation ||--o| Appointment : "1 appointment"
+  Subscription ||--o{ Appointment : "M appointments"
+  Webinar ||--o| Appointment : "1 appointment"
+  ClassEvent ||--o{ Appointment : "M appointments"
+
+  Appointment ||--|{ SlotOfAppointment : "N slots per session"
+  SlotOfAppointment ||--o| MeetingSession : "video call"
+```
+
+---
+
+## 9. File Dependency Summary Table
+
+Quick reference: what imports what.
+
+### Backend
+
+| File | Imports From |
+|------|-------------|
+| `types.ts` | _(leaf node - no local deps)_ |
+| `validationSchemas.ts` | _(leaf node - only zod)_ |
+| `SlotCalculationService.ts` | `types.ts` |
+| `SlotValidationService.ts` | `types.ts`, `SlotCalculationService`, `lib/prisma` |
+| `SlotAllocationService.ts` | `types.ts`, `SlotCalculationService`, `SlotValidationService`, `lib/prisma` |
+| `appointmentlock.ts` | `lib/redis`, `errors/SlotLockError` |
+| `*/allocate/route.ts` | `SlotAllocationService`, `types`, `validationSchemas` |
+| `*/validate/route.ts` | `SlotValidationService`, `types`, `validationSchemas`, `lib/prisma` |
+| `*/reschedule/route.ts` | `lib/prisma`, `lib/auth-server` |
+
+### Frontend
+
+| File | Imports From |
+|------|-------------|
+| `calendarUtils.ts` | `@/types/slots` |
+| `allocationService.ts` | `calendarUtils`, `@/utils/slotAllocation/types` |
+| `allocationAlgorithms.ts` | `calendarUtils`, `allocationService` |
+| `useCalendarData.ts` | `allocationService` |
+| `useSlotAllocation.ts` | `calendarUtils`, `allocationAlgorithms` |
+| `useSubscriptionValidation.ts` | _(independent - no local deps)_ |
+| `UnifiedCalendar.tsx` | `calendarUtils`, `useCalendarData`, `useSlotAllocation` |
+| `EventPlannerFor*.tsx` | `types/event`, `services/planner`, form components |
+| `EventCard.tsx` (consultee) | `DocumentUpload`, `ReportIssueDialog`, `CancelConfirmationDialog`, `statusConfig` |
+
+---
+
+## How to Read This
+
+**If you want to understand the backend algorithm:**
+```
+types.ts -> SlotCalculationService -> SlotValidationService -> SlotAllocationService
+   (4 files, read left to right, ~2500 LOC total)
+```
+
+**If you want to understand the frontend:**
+```
+calendarUtils -> allocationService -> allocationAlgorithms -> useCalendarData + useSlotAllocation -> UnifiedCalendar
+   (6 files, read left to right, ~5400 LOC total)
+```
+
+**If you want to trace a full request:**
+```
+UnifiedCalendar -> useSlotAllocation -> allocationService -> API route -> SlotAllocationService -> SlotValidationService -> SlotCalculationService -> Prisma -> PostgreSQL
+   (follow Diagram 5 above)
+```

--- a/docs/collaborators/00-overview.md
+++ b/docs/collaborators/00-overview.md
@@ -162,14 +162,14 @@ EarningRole:
 | `lib/collaborators/service.ts` | Core business logic (invite, respond, remove, revenue split) |
 | `lib/collaborators/permissions.ts` | Role-based permission checking |
 | `lib/payments/payouts/earnings-service.ts` | `createCollaboratorEarnings()` function |
-| `app/api/webinars/[webinarPlanId]/collaborators/route.ts` | GET/POST webinar collaborators |
-| `app/api/webinars/[webinarPlanId]/collaborators/[id]/route.ts` | PATCH/DELETE specific collaborator |
-| `app/api/classes/[classPlanId]/collaborators/route.ts` | GET/POST class collaborators |
-| `app/api/classes/[classPlanId]/collaborators/[id]/route.ts` | PATCH/DELETE specific collaborator |
+| `app/api/collaborations/webinar/[planId]/route.ts` | GET/POST webinar collaborators |
+| `app/api/collaborations/webinar/[planId]/[id]/route.ts` | PATCH/DELETE specific webinar collaborator |
+| `app/api/collaborations/class/[planId]/route.ts` | GET/POST class collaborators |
+| `app/api/collaborations/class/[planId]/[id]/route.ts` | PATCH/DELETE specific class collaborator |
 | `app/api/collaborations/[id]/respond/route.ts` | PATCH accept/decline invitation |
 | `app/api/collaborations/route.ts` | GET all my collaborations |
-| `app/api/webinars/[id]/revenue-split/route.ts` | GET revenue split preview |
-| `app/api/classes/[id]/revenue-split/route.ts` | GET revenue split preview |
+| `app/api/collaborations/webinar/[planId]/revenue-split/route.ts` | GET webinar revenue split preview |
+| `app/api/collaborations/class/[planId]/revenue-split/route.ts` | GET class revenue split preview |
 | `app/api/collaborators/[consultantProfileId]/availability/route.ts` | GET co-host availability |
 | `components/collaborators/CollaboratorsTab.tsx` | Reusable UI for managing collaborators |
 | `components/collaborators/InvitationsPanel.tsx` | Invitation management UI |

--- a/docs/collaborators/00-overview.md
+++ b/docs/collaborators/00-overview.md
@@ -1,0 +1,188 @@
+# Collaborator System
+
+**Status**: Implemented (Feb 2026)
+**Branch**: `feat/referral-collaborator-system`
+**Scope**: Webinars and Classes only
+
+## Overview
+
+The collaborator system enables multi-creator content on the Familiarise platform. A consultant (the "host") who owns a webinar or class plan can invite other consultants to collaborate with defined roles and revenue shares. Collaborators can accept or decline invitations, and when participants pay for the service, earnings are automatically split among all collaborators.
+
+### Goals
+
+- Enable team-taught webinars and classes
+- Fair, transparent revenue sharing with per-collaborator splits
+- Automated earnings distribution on payment success
+- Private communication channels for collaborator coordination
+- Co-host availability visibility for scheduling
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | Webinars + Classes only | Podcasts model doesn't exist yet |
+| Scheduling | Host-only | Simplicity — only the owner creates events and sets timings |
+| Revenue split | Host sets it, collaborator accepts/declines | Owner controls the deal |
+| Minimum host share | 10% | Prevents giving away entire revenue |
+| Max collaborator total | 90% | Enforced at invite time |
+| Platform fee | Applied per share independently | Each collaborator's share is subject to 20% platform fee |
+| Permissions | Role-based with optional JSON override | Flexible without complexity |
+| Chat channels | Auto-created on acceptance | Collaborators need a place to coordinate |
+| Video roles | Deferred | Calls are created client-side; needs deeper changes |
+
+---
+
+## Architecture
+
+### Data Model
+
+```
+ConsultantProfile ──────────────────────────────────────────────┐
+  │                                                              │
+  │ owns                                                         │ collaborates on
+  │                                                              │
+  ▼                                                              │
+┌──────────────┐     1:many      ┌─────────────────────────┐    │
+│ WebinarPlan  │────────────────>│ WebinarCollaborator      │<───┘
+│              │                 │                          │
+│ title        │                 │ consultantProfileId      │
+│ price        │                 │ webinarPlanId            │
+│ ...          │                 │ role                     │
+└──────────────┘                 │ revenueSharePercentage   │
+                                 │ status                   │
+                                 │ invitedById              │
+                                 │ permissions (JSON)       │
+                                 └─────────────────────────┘
+
+┌──────────────┐     1:many      ┌─────────────────────────┐
+│ ClassPlan    │────────────────>│ ClassCollaborator        │<───┐
+│              │                 │                          │    │
+│ title        │                 │ consultantProfileId      │    │
+│ price        │                 │ classPlanId              │    │
+│ ...          │                 │ role                     │    │
+└──────────────┘                 │ revenueSharePercentage   │    │
+                                 │ status                   │    │
+                                 │ invitedById              │    │
+                                 │ permissions (JSON)       │    │
+                                 └─────────────────────────┘    │
+                                                                 │
+ConsultantProfile ───────────────────────────────────────────────┘
+```
+
+### Earnings Split Model
+
+```
+                        Payment (₹1000)
+                             │
+                             ▼
+                    ┌──────────────────┐
+                    │ Split Calculator │
+                    │                  │
+                    │ Host: 60%        │
+                    │ Collab A: 25%    │
+                    │ Collab B: 15%    │
+                    └────────┬─────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+              ▼              ▼              ▼
+    ┌────────────────┐ ┌──────────────┐ ┌──────────────┐
+    │ ConsultantEarnings │ ConsultantEarnings │ ConsultantEarnings │
+    │                │ │              │ │              │
+    │ role: OWNER    │ │ role: COLLAB │ │ role: COLLAB │
+    │ share: 60%     │ │ share: 25%   │ │ share: 15%   │
+    │ gross: 600     │ │ gross: 250   │ │ gross: 150   │
+    │ fee: 120 (20%) │ │ fee: 50(20%) │ │ fee: 30(20%) │
+    │ net: 480       │ │ net: 200     │ │ net: 120     │
+    └────────────────┘ └──────────────┘ └──────────────┘
+```
+
+---
+
+### Models
+
+**WebinarCollaborator**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | String | Primary key (cuid) |
+| `consultantProfileId` | String | The collaborator's profile |
+| `webinarPlanId` | String | The webinar plan |
+| `role` | WebinarCollaboratorRole | CO_HOST, MODERATOR, GUEST_SPEAKER, TECHNICAL_SUPPORT |
+| `permissions` | Json? | Optional permission overrides |
+| `revenueSharePercentage` | Float | Collaborator's share (e.g. 25.0) |
+| `status` | CollaboratorStatus | PENDING, ACCEPTED, DECLINED, REMOVED |
+| `invitedById` | String | The host who sent the invitation |
+| `respondedAt` | DateTime? | When the collaborator responded |
+
+Unique constraint: `@@unique([consultantProfileId, webinarPlanId])` — a consultant can only be invited once per plan.
+
+**ClassCollaborator** — Same structure with `classPlanId` and `ClassCollaboratorRole`.
+
+**ConsultantEarnings** (modified)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | EarningRole | `OWNER` or `COLLABORATOR` |
+| `sharePercentage` | Float | The share this earning represents (e.g. 60.0) |
+| `paymentId` | String | No longer unique — multiple earnings per payment |
+
+### Enums
+
+```
+CollaboratorStatus:
+  PENDING   — Invitation sent, awaiting response
+  ACCEPTED  — Collaborator accepted the invitation
+  DECLINED  — Collaborator declined
+  REMOVED   — Host removed the collaborator
+
+WebinarCollaboratorRole:
+  CO_HOST            — Full co-host capabilities
+  MODERATOR          — Chat/audience management
+  GUEST_SPEAKER      — Presenting role
+  TECHNICAL_SUPPORT  — Behind-the-scenes support
+
+ClassCollaboratorRole:
+  CO_INSTRUCTOR       — Full teaching capabilities
+  TEACHING_ASSISTANT  — Support role
+  GUEST_LECTURER      — Single-session guest
+  CONTENT_CREATOR     — Creates materials, may not teach live
+
+EarningRole:
+  OWNER        — The plan owner's earnings
+  COLLABORATOR — A collaborator's share of earnings
+```
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `lib/collaborators/service.ts` | Core business logic (invite, respond, remove, revenue split) |
+| `lib/collaborators/permissions.ts` | Role-based permission checking |
+| `lib/payments/payouts/earnings-service.ts` | `createCollaboratorEarnings()` function |
+| `app/api/webinars/[webinarPlanId]/collaborators/route.ts` | GET/POST webinar collaborators |
+| `app/api/webinars/[webinarPlanId]/collaborators/[id]/route.ts` | PATCH/DELETE specific collaborator |
+| `app/api/classes/[classPlanId]/collaborators/route.ts` | GET/POST class collaborators |
+| `app/api/classes/[classPlanId]/collaborators/[id]/route.ts` | PATCH/DELETE specific collaborator |
+| `app/api/collaborations/[id]/respond/route.ts` | PATCH accept/decline invitation |
+| `app/api/collaborations/route.ts` | GET all my collaborations |
+| `app/api/webinars/[id]/revenue-split/route.ts` | GET revenue split preview |
+| `app/api/classes/[id]/revenue-split/route.ts` | GET revenue split preview |
+| `app/api/collaborators/[consultantProfileId]/availability/route.ts` | GET co-host availability |
+| `components/collaborators/CollaboratorsTab.tsx` | Reusable UI for managing collaborators |
+| `components/collaborators/InvitationsPanel.tsx` | Invitation management UI |
+| `app/dashboard/consultant/.../collaborations/page.tsx` | Dashboard page |
+| `actions/stream/chat/channel.action.ts` | `createCollaboratorChannel()` |
+| `prisma/seedFiles/14b-create-collaborators.ts` | Seed data |
+
+---
+
+## Related Docs
+
+- [01 — Architecture & Flows](./01-architecture.md)
+- [02 — API Reference](./02-api-reference.md)
+- [03 — Revenue Sharing](./03-revenue-sharing.md)
+- [04 — Permissions](./04-permissions.md)
+- [05 — Stream Integration](./05-stream-integration.md)

--- a/docs/collaborators/01-architecture.md
+++ b/docs/collaborators/01-architecture.md
@@ -1,0 +1,472 @@
+# Collaborator System — Architecture & Flows
+
+This document tells the story of how multi-creator collaboration works on Familiarise. It follows the journey from a host inviting a collaborator, through acceptance and coordination, to how revenue is split when a customer pays, and what happens during refunds. Each section builds on the last.
+
+---
+
+## Table of Contents
+
+1. [The Big Picture](#1-the-big-picture)
+2. [Inviting a Collaborator](#2-inviting-a-collaborator)
+3. [Responding to an Invitation](#3-responding-to-an-invitation)
+4. [Coordinating via Stream Chat](#4-coordinating-via-stream-chat)
+5. [Scheduling with Availability Overlay](#5-scheduling-with-availability-overlay)
+6. [How Revenue Gets Split on Payment](#6-how-revenue-gets-split-on-payment)
+7. [Refund Cascade — Unwinding Multi-Party Earnings](#7-refund-cascade--unwinding-multi-party-earnings)
+8. [Removing a Collaborator](#8-removing-a-collaborator)
+9. [The Complete Lifecycle](#9-the-complete-lifecycle)
+
+---
+
+## 1. The Big Picture
+
+Familiarise supports four service types: consultations, subscriptions, webinars, and classes. Consultations and subscriptions are inherently one-on-one — a single consultant works with a single consultee. But webinars and classes are group events, and in the real world, these are often team efforts. A React webinar might have a primary instructor and a co-host managing Q&A. A bootcamp class might have a lead teacher, a teaching assistant, and a guest lecturer for specific modules.
+
+The collaborator system makes this possible. It sits on top of the existing plan/event architecture without changing how events are scheduled or how participants register. The key principle is: **the host owns the plan; collaborators participate on the host's terms**.
+
+Here's the bird's-eye view of how a collaboration plays out:
+
+```
+  Consultant A (Host)                              Consultant B (Collaborator)
+       │                                                    │
+       │  1. Creates WebinarPlan                            │
+       │     "Advanced React Patterns"                      │
+       │     Price: ₹1,000                                  │
+       │                                                    │
+       │  2. Invites Consultant B                           │
+       │     Role: CO_HOST                                  │
+       │     Share: 25%                                     │
+       │───────────────────────────────────────────────────>│
+       │                                                    │
+       │                                    3. Sees invite  │
+       │                                       in dashboard │
+       │                                                    │
+       │                                    4. Accepts      │
+       │  <─────────────────────────────────────────────────│
+       │                                                    │
+       │  5. Stream chat channel auto-created               │
+       │     "Advanced React Patterns - Collaborators"      │
+       │     Members: [A, B]                                │
+       │                                                    │
+       │  6. A schedules the webinar event                  │
+       │     (host-only — B cannot schedule)                │
+       │                                                    │
+       │  7. User C buys a ticket (₹1,000)                  │
+       │                                                    │
+       │  8. Earnings split automatically:                  │
+       │     A (Host, 75%):  ₹750 gross → ₹600 net         │
+       │     B (Co-Host, 25%): ₹250 gross → ₹200 net       │
+       │     Platform: ₹200 (20% total)                     │
+```
+
+The system touches five areas: the Prisma schema (collaborator junction tables + modified earnings), a service layer for business logic, API routes for CRUD operations, Stream.io for auto-created chat channels, and dashboard UI for managing invitations.
+
+---
+
+## 2. Inviting a Collaborator
+
+A host can invite collaborators from the "Collaborators" tab in their plan editor (the `CollaboratorsTab` component). The invitation specifies three things: **who** (consultant profile ID), **what role** (CO_HOST, MODERATOR, etc.), and **what share** (a percentage of the plan's revenue).
+
+### The invitation request
+
+When the host clicks "Send Invitation," the frontend sends:
+
+```
+POST /api/webinars/{webinarPlanId}/collaborators
+{
+  "consultantProfileId": "clx_consultant_b",
+  "role": "CO_HOST",
+  "revenueSharePercentage": 25
+}
+```
+
+### What the service validates
+
+The `inviteCollaborator()` function in `lib/collaborators/service.ts` performs several checks before creating the record. These validations are critical because they enforce the system's invariants:
+
+1. **Ownership check**: The API route verifies that the authenticated user is the plan owner by comparing the session user's consultant profile ID against `plan.consultantProfileId`. Only the owner can invite.
+
+2. **Self-invitation prevention**: The consultant profile ID in the request body must differ from the owner's. You can't collaborate with yourself.
+
+3. **Duplicate prevention**: The database has a `@@unique([consultantProfileId, webinarPlanId])` constraint. If Consultant B has already been invited (in any status), the insert fails.
+
+4. **Revenue share validation**: This is the most important check. The service calls `validateRevenueShares()`, which sums up the `revenueSharePercentage` of all existing collaborators in `PENDING` or `ACCEPTED` status, adds the new share, and verifies the total doesn't exceed 90%. This ensures the host always keeps at least 10%.
+
+```
+validateRevenueShares("webinar", planId, newShare=25)
+        │
+        ▼
+  Query existing collaborators:
+    WHERE webinarPlanId = planId
+    AND status IN (PENDING, ACCEPTED)
+        │
+        ▼
+  Sum existing shares:
+    Co-Host A: 25% (ACCEPTED)
+    Moderator B: 15% (PENDING)
+    Total existing: 40%
+        │
+        ▼
+  Check: 40% + 25% = 65% ≤ 90%?
+    YES → valid, proceed
+    NO  → return null, API returns 400
+```
+
+Note that **PENDING invitations count toward the total**. This prevents over-allocation. If the host invites three people at 35% each before any of them respond, the third invitation would be rejected (35 + 35 + 35 = 105% > 90%).
+
+### The created record
+
+If all validations pass, a `WebinarCollaborator` (or `ClassCollaborator`) record is created with `status: PENDING`. The record captures the deal terms — role, revenue share, and who invited whom — so the collaborator can review before accepting.
+
+```
+WebinarCollaborator {
+  id: "clx_collab_123"
+  consultantProfileId: "clx_consultant_b"
+  webinarPlanId: "clx_plan_456"
+  role: CO_HOST
+  revenueSharePercentage: 25.0
+  status: PENDING
+  invitedById: "clx_consultant_a"
+  respondedAt: null
+}
+```
+
+---
+
+## 3. Responding to an Invitation
+
+When Consultant B logs into their dashboard, they see the invitation on the "Collaborations" page (powered by the `InvitationsPanel` component). The page fetches from `GET /api/collaborations`, which queries both `webinarCollaborator` and `classCollaborator` tables for the authenticated consultant's profile.
+
+### The invitation card
+
+Each pending invitation shows:
+- Plan title and type (Webinar/Class)
+- Who invited them
+- The proposed role (e.g., "CO HOST")
+- The revenue share percentage
+- The plan's price (so they can estimate their earnings)
+- Accept and Decline buttons
+
+### Accepting
+
+When Consultant B clicks "Accept," the frontend sends:
+
+```
+PATCH /api/collaborations/{id}/respond
+{
+  "response": "ACCEPTED",
+  "planType": "webinar"
+}
+```
+
+The `respondToInvitation()` function in the service performs these checks:
+
+1. **Identity verification**: The service looks up the collaboration record and verifies that `consultantProfileId` matches the authenticated user's consultant profile. You can only respond to your own invitations.
+
+2. **Status check**: The collaboration must be in `PENDING` status. You can't re-accept an already accepted invitation or revive a declined one.
+
+If valid, the service updates the record:
+
+```
+UPDATE WebinarCollaborator
+SET status = 'ACCEPTED',
+    respondedAt = NOW()
+WHERE id = 'clx_collab_123'
+```
+
+### The Stream channel side-effect
+
+After a successful acceptance, something important happens: a Stream.io chat channel is automatically created for the collaboration team. This is covered in detail in the next section, but it's worth noting here because it's part of the acceptance transaction. If the channel creation fails (e.g., Stream API is down), the acceptance still succeeds — the channel creation is wrapped in a try/catch and logged as a non-blocking error.
+
+```
+Consultant B            PATCH /api/.../respond          Service                   Stream.io
+     │                          │                          │                         │
+     │  Click "Accept"          │                          │                         │
+     │─────────────────────────>│                          │                         │
+     │                          │  respondToInvitation()   │                         │
+     │                          │─────────────────────────>│                         │
+     │                          │                          │                         │
+     │                          │                          │  1. Verify identity     │
+     │                          │                          │  2. Check PENDING       │
+     │                          │                          │  3. UPDATE → ACCEPTED   │
+     │                          │                          │                         │
+     │                          │                          │  4. Dynamic import:     │
+     │                          │                          │     createCollaborator  │
+     │                          │                          │     Channel()           │
+     │                          │                          │────────────────────────>│
+     │                          │                          │                         │
+     │                          │                          │  Channel created:       │
+     │                          │                          │  collab-webinar-{planId}│
+     │                          │                          │  Members: [A, B]        │
+     │                          │                          │<────────────────────────│
+     │                          │                          │                         │
+     │                          │  200 OK                  │                         │
+     │                          │<─────────────────────────│                         │
+     │  Toast: "Accepted"       │                          │                         │
+     │<─────────────────────────│                          │                         │
+```
+
+### Declining
+
+Declining is simpler. The status is updated to `DECLINED`, `respondedAt` is set, and no side effects occur. The revenue share that was reserved for this collaborator is freed up — the host can now invite someone else with that percentage.
+
+---
+
+## 4. Coordinating via Stream Chat
+
+Once a collaborator accepts, the team needs a way to communicate. The system automatically creates a private Stream.io messaging channel for this purpose.
+
+### Channel naming convention
+
+The platform uses a structured channel ID pattern to distinguish different types of conversations:
+
+```
+consultation-{consultationId}     messaging    1:1 (consultant + consultee)
+subscription-{subscriptionId}     messaging    1:1 (consultant + consultee)
+webinar-{webinarId}               team         Group (host + all participants)
+class-{classId}                   team         Group (host + all participants)
+collab-webinar-{webinarPlanId}    messaging    Private (host + collaborators only)
+collab-class-{classPlanId}        messaging    Private (host + collaborators only)
+```
+
+Collaborator channels use the `messaging` type (private, invitation-only) rather than `team` (open), because participants in the webinar shouldn't see the behind-the-scenes coordination between host and collaborators.
+
+### How the channel is created
+
+The `createCollaboratorChannel()` function in `actions/stream/chat/channel.action.ts` does the following:
+
+1. Queries the plan to get the host's user ID
+2. Queries all accepted collaborators to get their user IDs
+3. If there are at least 2 members (host + 1 collaborator), creates the channel
+4. Uses Stream's `getOrCreate` behavior, which is idempotent — if the channel already exists (e.g., a second collaborator accepts later), the member list is updated rather than creating a duplicate
+
+The channel carries metadata (`is_collaborator_channel: true`, `{planType}_plan_id: planId`) that the chat UI can use to group and display these channels differently from regular conversations.
+
+### Why dynamic import?
+
+The service layer (`lib/collaborators/service.ts`) uses `await import("@/actions/stream/chat/channel.action")` rather than a static import. This prevents circular dependency issues between the server action module and the service module, and keeps the Stream.io SDK out of the service layer's bundle.
+
+---
+
+## 5. Scheduling with Availability Overlay
+
+Scheduling is host-only — collaborators cannot create events or set timings. But the host needs to know when their collaborators are available. The system provides a co-host availability API that powers a calendar overlay.
+
+### The availability endpoint
+
+```
+GET /api/collaborators/{consultantProfileId}/availability?date=2026-03-15
+```
+
+This returns three pieces of data for the given date:
+
+1. **Weekly slots**: The collaborator's recurring weekly availability (e.g., "every Saturday 9am-5pm"). Uses the `SlotOfAvailabilityWeekly` model.
+
+2. **Custom slots**: Any one-off availability the collaborator has set for that specific date. Uses the `SlotOfAvailabilityCustom` model.
+
+3. **Booked slots**: Existing appointments that the collaborator has on that date. Determined by querying `SlotOfAppointment` through the nested consultation/subscription/webinar/class relations.
+
+### How the host interprets this
+
+The scheduling calendar shows a color-coded overlay:
+
+- **Green**: The co-host has availability defined AND no existing booking → they're free
+- **Yellow**: The co-host has no availability defined for that time → they may be flexible (their schedule just hasn't been set)
+- **Red**: The co-host has an existing booking during that time → they're unavailable
+
+The overlay is purely informational. Since scheduling is host-only, the host makes the final call. If a co-host isn't available, the host can either pick a different time or proceed anyway (the collaborator can always adjust their own schedule).
+
+---
+
+## 6. How Revenue Gets Split on Payment
+
+This is the most consequential part of the system. When a customer buys a ticket for a webinar (or enrolls in a class) that has collaborators, the payment amount must be correctly divided among all parties.
+
+### The trigger point
+
+The split happens inside the payment webhook handler (`lib/payments/webhooks/handlers.ts`). After a successful payment, the handler checks whether the associated service has accepted collaborators. If it does, it calls `createCollaboratorEarnings()` instead of the standard `createEarningsFromPayment()`.
+
+```
+Payment webhook fires (payment succeeded)
+        │
+        ▼
+  Is this a webinar or class payment?
+        │
+        ├── NO → createEarningsFromPayment() (standard 1:1 flow)
+        │
+        ▼ YES
+  Does the plan have accepted collaborators?
+        │
+        ├── NO → createEarningsFromPayment() (solo host)
+        │
+        ▼ YES
+  createCollaboratorEarnings(payment, collaborators)
+```
+
+### The split calculation
+
+The `calculateRevenueSplit()` function in `lib/collaborators/service.ts` computes the split. Each collaborator gets their percentage, and the **host gets the remainder** (not a fixed percentage). This is important because rounding can cause fractions of a paise — the host absorbs the rounding error.
+
+Let's walk through a concrete example. A webinar costs ₹1,000. Two collaborators are accepted:
+
+```
+Collaborators:
+  Co-Host A:   25% → Math.round(1000 * 25/100) = ₹250
+  Moderator B: 15% → Math.round(1000 * 15/100) = ₹150
+
+Host gets remainder:
+  ₹1,000 - ₹250 - ₹150 = ₹600 (60%)
+```
+
+### Creating the earnings records
+
+For each party, the system creates a `ConsultantEarnings` record. The platform fee (20%) is applied independently to each share:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Party        │ Share %  │ Gross    │ Fee (20%)│ Net Payout  │
+├──────────────┼──────────┼──────────┼──────────┼─────────────┤
+│ Host         │ 60%      │ ₹600     │ ₹120     │ ₹480        │
+│ Co-Host A    │ 25%      │ ₹250     │ ₹50      │ ₹200        │
+│ Moderator B  │ 15%      │ ₹150     │ ₹30      │ ₹120        │
+├──────────────┼──────────┼──────────┼──────────┼─────────────┤
+│ TOTAL        │ 100%     │ ₹1,000   │ ₹200     │ ₹800        │
+└──────────────┴──────────┴──────────┴──────────┴─────────────┘
+```
+
+Three `ConsultantEarnings` records are created, all linked to the same `paymentId`:
+
+```
+Earnings #1: { consultantProfileId: Host,  paymentId: pay_xxx, role: OWNER,        sharePercentage: 60,  grossAmount: 600, platformFee: 120, consultantShare: 480 }
+Earnings #2: { consultantProfileId: A,     paymentId: pay_xxx, role: COLLABORATOR, sharePercentage: 25,  grossAmount: 250, platformFee: 50,  consultantShare: 200 }
+Earnings #3: { consultantProfileId: B,     paymentId: pay_xxx, role: COLLABORATOR, sharePercentage: 15,  grossAmount: 150, platformFee: 30,  consultantShare: 120 }
+```
+
+### The 1:1 → 1:many migration
+
+This was the riskiest schema change in the entire feature. Previously, `ConsultantEarnings.paymentId` had a `@unique` constraint — one earning per payment. To support collaborator splits, this constraint was removed and replaced with a regular `@@index([paymentId])`.
+
+The `Payment` model's relation changed from `earnings ConsultantEarnings?` (optional singular) to `earnings ConsultantEarnings[]` (array). Every location in the codebase that accessed `payment.earnings` as a singular value needed to be updated to handle an array. TypeScript caught all of these at compile time (`tsc --noEmit`), which is why we ran it after every schema change.
+
+### Independent payouts
+
+Each `ConsultantEarnings` record is processed independently by the existing payout system. When a payout batch runs, it groups earnings by `consultantProfileId`. So the host gets their payout, Co-Host A gets theirs, and Moderator B gets theirs — all separately. There's no dependency between them.
+
+---
+
+## 7. Refund Cascade — Unwinding Multi-Party Earnings
+
+When a payment is refunded, all earnings associated with that payment must be refunded. Before collaborators, this was simple: find the one earnings record, mark it refunded, decrement the consultant's `pendingRevenue`. With collaborators, there may be two, three, or more records.
+
+### How refunds work now
+
+```
+refundEarnings(paymentId)
+        │
+        ▼
+  findMany({ where: { paymentId } })
+  // Was findUnique — now returns array
+        │
+        ▼
+  For EACH earning in the array:
+    1. SET status → REFUNDED
+    2. DECREMENT consultant's pendingRevenue
+       by the earning's consultantShare
+```
+
+This same pattern applies to dispute handling (`scripts/disputes/handle-lost-disputes.ts`) and the earnings sync job (`scripts/earnings/sync-payment-earnings.ts`). All three scripts were updated from singular to array iteration.
+
+The key insight is that refunds are all-or-nothing for a payment. You can't refund just the host's share — if the customer gets their money back, everyone's earnings for that payment are reversed.
+
+---
+
+## 8. Removing a Collaborator
+
+The host can remove a collaborator at any time by clicking the trash icon in the `CollaboratorsTab` component. This sends:
+
+```
+DELETE /api/webinars/{webinarPlanId}/collaborators/{id}
+```
+
+The service sets `status: REMOVED` (a soft delete — the record persists for audit purposes). The collaborator's revenue share is freed up, and the host can invite someone new.
+
+Important: removing a collaborator only affects **future** payments. If 10 people already bought tickets when the collaborator was active, those 10 earnings records remain. The collaborator keeps what they earned.
+
+---
+
+## 9. The Complete Lifecycle
+
+Here's every state a collaboration can pass through, from creation to final payout:
+
+```
+Host creates plan
+       │
+       ▼
+Host invites Consultant B
+  (role: CO_HOST, share: 25%)
+       │
+       ▼
+┌──────────────┐
+│   PENDING    │  Invitation sent, awaiting response.
+│              │  Share is reserved (counts toward 90% cap).
+└──────┬───────┘
+       │
+  ┌────┴────────────┐
+  │                 │
+  ▼                 ▼
+┌──────────┐  ┌──────────┐
+│ ACCEPTED │  │ DECLINED │  Collaborator responded.
+│          │  │          │  DECLINED frees the share.
+│ + Stream │  └──────────┘
+│   channel│
+│   created│
+└──────┬───┘
+       │
+  ┌────┴──────────────────────────────────────┐
+  │                                           │
+  │  Active collaboration                     │  Host removes
+  │                                           │
+  │  - Visible on public plan page            ▼
+  │  - Gets earnings share on payments   ┌──────────┐
+  │  - Has Stream chat access            │ REMOVED  │  Soft delete.
+  │  - Shows in earnings dashboard       │          │  Share freed.
+  │                                      │ Existing │  Past earnings
+  └──────────────────┐                   │ earnings │  preserved.
+                     │                   │ kept     │
+                     │                   └──────────┘
+                     ▼
+           Customer purchases service
+                     │
+                     ▼
+           ┌────────────────────────────┐
+           │ Earnings split:            │
+           │                            │
+           │ Host: remainder (e.g. 75%) │
+           │ Collab B: 25%              │
+           │                            │
+           │ Platform: 20% of each      │
+           │ share independently        │
+           └────────────┬───────────────┘
+                        │
+                        ▼
+           ┌────────────────────────────┐
+           │ Each consultant's earnings │
+           │ processed independently:   │
+           │                            │
+           │ Hold period (7 days)       │
+           │     ↓                      │
+           │ Payout batch groups by     │
+           │ consultant profile         │
+           │     ↓                      │
+           │ Separate payouts to        │
+           │ separate bank accounts     │
+           └────────────────────────────┘
+```
+
+### What's NOT in the collaborator system (deliberate exclusions)
+
+- **Podcast collaborators**: The `PodcastPlan` model doesn't exist yet. When it does, the same `ClassCollaborator` pattern can be replicated.
+- **Stream video call roles**: Calls are created client-side. Assigning collaborator-specific roles (host, moderator, speaker) would require server-side call creation — deferred for now.
+- **Collaborator-initiated scheduling**: Only the host can create events and set times. Collaborators see an availability overlay but can't create slots.
+- **Channel member removal on REMOVED status**: When a collaborator is removed, they're not automatically kicked from the Stream chat channel. This is a future improvement.
+- **Notifications**: The Novu workflow stubs exist but the notification triggers aren't wired up yet.

--- a/docs/collaborators/01-architecture.md
+++ b/docs/collaborators/01-architecture.md
@@ -72,7 +72,7 @@ A host can invite collaborators from the "Collaborators" tab in their plan edito
 When the host clicks "Send Invitation," the frontend sends:
 
 ```
-POST /api/webinars/{webinarPlanId}/collaborators
+POST /api/collaborations/webinar/{planId}
 {
   "consultantProfileId": "clx_consultant_b",
   "role": "CO_HOST",
@@ -385,7 +385,7 @@ The key insight is that refunds are all-or-nothing for a payment. You can't refu
 The host can remove a collaborator at any time by clicking the trash icon in the `CollaboratorsTab` component. This sends:
 
 ```
-DELETE /api/webinars/{webinarPlanId}/collaborators/{id}
+DELETE /api/collaborations/webinar/{planId}/{id}
 ```
 
 The service sets `status: REMOVED` (a soft delete — the record persists for audit purposes). The collaborator's revenue share is freed up, and the host can invite someone new.

--- a/docs/collaborators/02-api-reference.md
+++ b/docs/collaborators/02-api-reference.md
@@ -6,7 +6,7 @@ All endpoints require authentication (via BetterAuth session).
 
 ## Collaborator Management
 
-### GET /api/webinars/[webinarPlanId]/collaborators
+### GET /api/collaborations/webinar/[planId]
 
 List all collaborators for a webinar plan.
 
@@ -38,7 +38,7 @@ List all collaborators for a webinar plan.
 
 ---
 
-### POST /api/webinars/[webinarPlanId]/collaborators
+### POST /api/collaborations/webinar/[planId]
 
 Invite a collaborator to a webinar plan.
 
@@ -79,7 +79,7 @@ Invite a collaborator to a webinar plan.
 
 ---
 
-### PATCH /api/webinars/[webinarPlanId]/collaborators/[id]
+### PATCH /api/collaborations/webinar/[planId]/[id]
 
 Update a collaborator's role or revenue share.
 
@@ -104,7 +104,7 @@ Update a collaborator's role or revenue share.
 
 ---
 
-### DELETE /api/webinars/[webinarPlanId]/collaborators/[id]
+### DELETE /api/collaborations/webinar/[planId]/[id]
 
 Remove a collaborator (sets status to REMOVED).
 
@@ -124,10 +124,10 @@ Remove a collaborator (sets status to REMOVED).
 
 Identical to the webinar endpoints above, but at:
 
-- `GET /api/classes/[classPlanId]/collaborators`
-- `POST /api/classes/[classPlanId]/collaborators`
-- `PATCH /api/classes/[classPlanId]/collaborators/[id]`
-- `DELETE /api/classes/[classPlanId]/collaborators/[id]`
+- `GET /api/collaborations/class/[planId]`
+- `POST /api/collaborations/class/[planId]`
+- `PATCH /api/collaborations/class/[planId]/[id]`
+- `DELETE /api/collaborations/class/[planId]/[id]`
 
 Same request/response shapes. Uses `ClassCollaboratorRole` enum values:
 `CO_INSTRUCTOR`, `TEACHING_ASSISTANT`, `GUEST_LECTURER`, `CONTENT_CREATOR`
@@ -219,7 +219,7 @@ Get all collaborations for the authenticated consultant (both webinar and class)
 
 ## Revenue Split Preview
 
-### GET /api/webinars/[id]/revenue-split
+### GET /api/collaborations/webinar/[planId]/revenue-split
 
 Preview how earnings would be split for a webinar plan.
 
@@ -260,7 +260,7 @@ Preview how earnings would be split for a webinar plan.
 }
 ```
 
-### GET /api/classes/[id]/revenue-split
+### GET /api/collaborations/class/[planId]/revenue-split
 
 Same format for class plans.
 

--- a/docs/collaborators/02-api-reference.md
+++ b/docs/collaborators/02-api-reference.md
@@ -1,0 +1,306 @@
+# Collaborator System — API Reference
+
+All endpoints require authentication (via BetterAuth session).
+
+---
+
+## Collaborator Management
+
+### GET /api/webinars/[webinarPlanId]/collaborators
+
+List all collaborators for a webinar plan.
+
+**Response** `200`:
+```json
+{
+  "data": [
+    {
+      "id": "clx...",
+      "consultantProfileId": "clx...",
+      "webinarPlanId": "clx...",
+      "role": "CO_HOST",
+      "revenueSharePercentage": 25,
+      "status": "ACCEPTED",
+      "invitedById": "clx...",
+      "respondedAt": "2026-02-10T...",
+      "consultantProfile": {
+        "id": "clx...",
+        "user": {
+          "id": "clx...",
+          "name": "Alice Smith",
+          "image": "/uploads/alice.jpg"
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+### POST /api/webinars/[webinarPlanId]/collaborators
+
+Invite a collaborator to a webinar plan.
+
+**Body**:
+```json
+{
+  "consultantProfileId": "clx...",
+  "role": "CO_HOST",
+  "revenueSharePercentage": 25
+}
+```
+
+**Validations**:
+- Requester must be the plan owner
+- Target must be a valid consultant profile
+- Cannot invite yourself
+- Cannot invite someone already invited (unique constraint)
+- Total collaborator shares must not exceed 90%
+
+**Response** `201`:
+```json
+{
+  "data": {
+    "id": "clx...",
+    "consultantProfileId": "clx...",
+    "role": "CO_HOST",
+    "revenueSharePercentage": 25,
+    "status": "PENDING"
+  }
+}
+```
+
+**Errors**:
+- `403` — Not the plan owner
+- `400` — Cannot invite yourself
+- `400` — Revenue share exceeds 90% total
+- `409` — Already invited (unique constraint)
+
+---
+
+### PATCH /api/webinars/[webinarPlanId]/collaborators/[id]
+
+Update a collaborator's role or revenue share.
+
+**Body**:
+```json
+{
+  "role": "MODERATOR",
+  "revenueSharePercentage": 15
+}
+```
+
+**Validations**:
+- Requester must be the plan owner
+- New total shares must not exceed 90%
+
+**Response** `200`:
+```json
+{
+  "data": { "id": "clx...", "role": "MODERATOR", "revenueSharePercentage": 15 }
+}
+```
+
+---
+
+### DELETE /api/webinars/[webinarPlanId]/collaborators/[id]
+
+Remove a collaborator (sets status to REMOVED).
+
+**Validations**:
+- Requester must be the plan owner
+
+**Response** `200`:
+```json
+{
+  "data": { "id": "clx...", "status": "REMOVED" }
+}
+```
+
+---
+
+### Class Collaborator Endpoints
+
+Identical to the webinar endpoints above, but at:
+
+- `GET /api/classes/[classPlanId]/collaborators`
+- `POST /api/classes/[classPlanId]/collaborators`
+- `PATCH /api/classes/[classPlanId]/collaborators/[id]`
+- `DELETE /api/classes/[classPlanId]/collaborators/[id]`
+
+Same request/response shapes. Uses `ClassCollaboratorRole` enum values:
+`CO_INSTRUCTOR`, `TEACHING_ASSISTANT`, `GUEST_LECTURER`, `CONTENT_CREATOR`
+
+---
+
+## Invitation Response
+
+### PATCH /api/collaborations/[id]/respond
+
+Accept or decline a collaboration invitation.
+
+**Body**:
+```json
+{
+  "response": "ACCEPTED",
+  "planType": "webinar"
+}
+```
+
+**Validations**:
+- Requester must be the invited consultant
+- Collaboration must be in PENDING status
+- `planType` must be `"webinar"` or `"class"`
+
+**Side effects on ACCEPTED**:
+- Updates status to ACCEPTED, sets respondedAt
+- Creates Stream.io chat channel (`collab-{planType}-{planId}`)
+- Sends notification to the host
+
+**Response** `200`:
+```json
+{
+  "data": { "id": "clx...", "status": "ACCEPTED", "respondedAt": "2026-02-10T..." }
+}
+```
+
+---
+
+## My Collaborations
+
+### GET /api/collaborations
+
+Get all collaborations for the authenticated consultant (both webinar and class).
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "webinarCollaborations": [
+      {
+        "id": "clx...",
+        "role": "CO_HOST",
+        "revenueSharePercentage": 25,
+        "status": "PENDING",
+        "createdAt": "2026-02-10T...",
+        "webinarPlan": {
+          "id": "clx...",
+          "title": "Advanced React Patterns",
+          "price": 100000
+        },
+        "invitedBy": {
+          "user": { "name": "Kaustav Ghosh" }
+        }
+      }
+    ],
+    "classCollaborations": [
+      {
+        "id": "clx...",
+        "role": "TEACHING_ASSISTANT",
+        "revenueSharePercentage": 15,
+        "status": "ACCEPTED",
+        "createdAt": "2026-02-08T...",
+        "classPlan": {
+          "id": "clx...",
+          "title": "Full-Stack Bootcamp",
+          "price": 500000
+        },
+        "invitedBy": {
+          "user": { "name": "Alice Smith" }
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Revenue Split Preview
+
+### GET /api/webinars/[id]/revenue-split
+
+Preview how earnings would be split for a webinar plan.
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "planId": "clx...",
+    "planType": "webinar",
+    "price": 100000,
+    "splits": [
+      {
+        "consultantProfileId": "clx...",
+        "role": "OWNER",
+        "sharePercentage": 60,
+        "grossAmount": 60000,
+        "platformFee": 12000,
+        "netAmount": 48000
+      },
+      {
+        "consultantProfileId": "clx...",
+        "role": "COLLABORATOR",
+        "sharePercentage": 25,
+        "grossAmount": 25000,
+        "platformFee": 5000,
+        "netAmount": 20000
+      },
+      {
+        "consultantProfileId": "clx...",
+        "role": "COLLABORATOR",
+        "sharePercentage": 15,
+        "grossAmount": 15000,
+        "platformFee": 3000,
+        "netAmount": 12000
+      }
+    ]
+  }
+}
+```
+
+### GET /api/classes/[id]/revenue-split
+
+Same format for class plans.
+
+---
+
+## Co-host Availability
+
+### GET /api/collaborators/[consultantProfileId]/availability
+
+Get a collaborator's availability for a specific date. Used by the host's scheduling calendar to show availability overlay.
+
+**Query params**:
+- `date` — ISO date string (e.g. `2026-03-15`)
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "consultantProfileId": "clx...",
+    "scheduleType": "WEEKLY",
+    "date": "2026-03-15",
+    "weeklySlots": [
+      {
+        "dayOfWeekForStartsAt": 6,
+        "availabilityStartsAt": "2026-02-10T09:00:00Z",
+        "availabilityEndsAt": "2026-02-10T17:00:00Z"
+      }
+    ],
+    "customSlots": [],
+    "bookedSlots": [
+      {
+        "startsAt": "2026-03-15T10:00:00Z",
+        "endsAt": "2026-03-15T11:00:00Z"
+      }
+    ]
+  }
+}
+```
+
+**Interpretation for calendar overlay**:
+- **Green**: Co-host has availability AND no booking → free
+- **Yellow**: Co-host has no availability defined for that time → may be flexible
+- **Red**: Co-host has a booking during that time → not available

--- a/docs/collaborators/03-revenue-sharing.md
+++ b/docs/collaborators/03-revenue-sharing.md
@@ -1,0 +1,218 @@
+# Collaborator Revenue Sharing — Detailed Guide
+
+## Overview
+
+When a service (webinar or class) has accepted collaborators, payments for that service are split among all parties. The platform takes its 20% fee from each party's share independently.
+
+---
+
+## Rules
+
+| Rule | Value | Enforcement |
+|------|-------|-------------|
+| Minimum host share | 10% | Validated at invite time: total collaborator shares ≤ 90% |
+| Maximum single collaborator share | 90% | By extension of the above rule |
+| Platform fee | 20% of each party's gross share | Applied independently per earning |
+| Host share calculation | 100% - sum(collaborator shares) | Automatic remainder |
+
+---
+
+## Revenue Split Calculation
+
+### Formula
+
+```
+For a payment of amount P with N collaborators:
+
+  collaborator_i_gross = P * (collaborator_i_share / 100)
+  collaborator_i_fee   = collaborator_i_gross * 0.20
+  collaborator_i_net   = collaborator_i_gross - collaborator_i_fee
+
+  total_collab_share   = sum(all collaborator share percentages)
+  host_share_pct       = 100 - total_collab_share
+  host_gross           = P * (host_share_pct / 100)
+  host_fee             = host_gross * 0.20
+  host_net             = host_gross - host_fee
+```
+
+### Example
+
+**Setup**: Webinar priced at ₹1,000. Two collaborators accepted:
+- Co-Host A: 25% share
+- Moderator B: 15% share
+- Host gets remainder: 100% - 25% - 15% = 60%
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    REVENUE SPLIT                              │
+│                    Total: ₹1,000                             │
+├──────────────┬──────────┬──────────┬──────────┬─────────────┤
+│ Party        │ Share %  │ Gross    │ Fee (20%)│ Net Payout  │
+├──────────────┼──────────┼──────────┼──────────┼─────────────┤
+│ Host         │ 60%      │ ₹600     │ ₹120     │ ₹480        │
+│ Co-Host A    │ 25%      │ ₹250     │ ₹50      │ ₹200        │
+│ Moderator B  │ 15%      │ ₹150     │ ₹30      │ ₹120        │
+├──────────────┼──────────┼──────────┼──────────┼─────────────┤
+│ TOTAL        │ 100%     │ ₹1,000   │ ₹200     │ ₹800        │
+└──────────────┴──────────┴──────────┴──────────┴─────────────┘
+
+Platform revenue: ₹200 (20% of ₹1,000)
+```
+
+---
+
+## Validation Logic
+
+### At Invitation Time
+
+```typescript
+// lib/collaborators/service.ts — validateRevenueShares()
+
+function validateRevenueShares(
+  planType: "webinar" | "class",
+  planId: string,
+  newSharePercentage: number,
+  excludeCollaboratorId?: string  // For updates
+): boolean {
+  // 1. Get all active collaborators (PENDING + ACCEPTED, excluding removed/declined)
+  const existing = getCollaborators(planType, planId)
+    .filter(c => c.status === "PENDING" || c.status === "ACCEPTED")
+    .filter(c => c.id !== excludeCollaboratorId);
+
+  // 2. Sum existing shares
+  const existingTotal = existing.reduce((sum, c) => sum + c.revenueSharePercentage, 0);
+
+  // 3. Check: existing + new ≤ 90%
+  return (existingTotal + newSharePercentage) <= 90;
+}
+```
+
+**Why PENDING counts**: If a collaborator is invited with 25% but hasn't responded yet, that 25% is reserved. Otherwise the host could over-allocate by inviting multiple people whose shares overlap.
+
+### Revenue Split Preview
+
+```typescript
+// lib/collaborators/service.ts — calculateRevenueSplit()
+
+function calculateRevenueSplit(
+  planType: "webinar" | "class",
+  planId: string,
+  totalAmount: number
+) {
+  const collaborators = getAcceptedCollaborators(planType, planId);
+  const PLATFORM_FEE_RATE = 0.20;
+
+  const totalCollabShare = collaborators.reduce(
+    (sum, c) => sum + c.revenueSharePercentage, 0
+  );
+  const ownerSharePct = 100 - totalCollabShare;
+
+  const splits = [
+    // Owner
+    {
+      role: "OWNER",
+      sharePercentage: ownerSharePct,
+      grossAmount: Math.round(totalAmount * ownerSharePct / 100),
+      platformFee: Math.round(totalAmount * ownerSharePct / 100 * PLATFORM_FEE_RATE),
+      netAmount: Math.round(totalAmount * ownerSharePct / 100 * (1 - PLATFORM_FEE_RATE)),
+    },
+    // Collaborators
+    ...collaborators.map(c => ({
+      role: "COLLABORATOR",
+      sharePercentage: c.revenueSharePercentage,
+      grossAmount: Math.round(totalAmount * c.revenueSharePercentage / 100),
+      platformFee: Math.round(totalAmount * c.revenueSharePercentage / 100 * PLATFORM_FEE_RATE),
+      netAmount: Math.round(totalAmount * c.revenueSharePercentage / 100 * (1 - PLATFORM_FEE_RATE)),
+    })),
+  ];
+
+  return splits;
+}
+```
+
+---
+
+## ConsultantEarnings Records
+
+### Before Collaborators (1:1)
+
+```
+Payment ──── 1:1 ──── ConsultantEarnings
+                       role: OWNER
+                       sharePercentage: 100
+                       paymentId: UNIQUE
+```
+
+### After Collaborators (1:many)
+
+```
+Payment ──── 1:many ──── ConsultantEarnings[]
+                          ├── role: OWNER,        share: 60%
+                          ├── role: COLLABORATOR,  share: 25%
+                          └── role: COLLABORATOR,  share: 15%
+                          paymentId: INDEX (not unique)
+```
+
+### Migration Impact
+
+The `@unique` constraint on `paymentId` was removed. This was the riskiest schema change because every location in the codebase that accessed `payment.earnings` (singular) needed to be updated to handle `payment.earnings[]` (array).
+
+**Affected files**:
+- `lib/payments/payouts/earnings-service.ts` — `refundEarnings()` now uses `findMany` + iterates
+- `scripts/refunds/cascade-refund-earnings.ts` — Array iteration
+- `scripts/disputes/handle-lost-disputes.ts` — Array iteration
+- `scripts/earnings/sync-payment-earnings.ts` — `{ none: {} }` instead of `null`
+
+---
+
+## Payout Processing
+
+Each `ConsultantEarnings` record is processed independently by the existing payout system:
+
+1. **Hold period**: All earnings have a `holdUntil` date (typically 7 days after payment)
+2. **Batch grouping**: Payouts are grouped by `consultantProfileId` — so each consultant gets their own payout
+3. **No cross-dependency**: Host's payout is independent of collaborator payouts
+
+```
+Payout Batch Run:
+  ├── Consultant A (Host):
+  │    ├── Earning from Webinar 1 (OWNER, 60%, ₹480)
+  │    ├── Earning from Webinar 2 (OWNER, 100%, ₹800)
+  │    └── Total payout: ₹1,280
+  │
+  ├── Consultant B (Collaborator):
+  │    ├── Earning from Webinar 1 (COLLABORATOR, 25%, ₹200)
+  │    └── Total payout: ₹200
+  │
+  └── Consultant C (Collaborator):
+       ├── Earning from Webinar 1 (COLLABORATOR, 15%, ₹120)
+       └── Total payout: ₹120
+```
+
+---
+
+## Earnings Dashboard
+
+The consultant earnings dashboard now shows a "Role" column:
+
+| Date | Service | Role | Share | Gross | Fee | Net | Status |
+|------|---------|------|-------|-------|-----|-----|--------|
+| Feb 10 | React Webinar | Owner | 60% | ₹600 | ₹120 | ₹480 | Pending |
+| Feb 10 | React Webinar | Collaborator | 25% | ₹250 | ₹50 | ₹200 | Pending |
+
+Role badges:
+- **Owner** — Zinc/gray badge
+- **Collaborator** — Purple badge with percentage (e.g. "Collaborator (25%)")
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No collaborators accepted | Standard 1:1 earnings (role: OWNER, share: 100%) |
+| Collaborator removed after payment | Existing earnings for past payments remain; future payments use new split |
+| Collaborator declined after being pending | Share freed up, no earnings created |
+| Rounding errors | `Math.round()` applied to each share; total may differ by ±1 paise |
+| Free service (price = 0) | No earnings created for anyone |
+| Refund on collaborative service | All earnings (owner + collaborators) refunded |

--- a/docs/collaborators/04-permissions.md
+++ b/docs/collaborators/04-permissions.md
@@ -1,0 +1,181 @@
+# Collaborator Permissions
+
+## Overview
+
+The permission system controls what collaborators can do on plans they're invited to. Permissions are role-based with optional JSON overrides per collaborator.
+
+**File**: `lib/collaborators/permissions.ts`
+
+---
+
+## Permission Types
+
+```typescript
+type Permission =
+  | "edit"        // Edit plan details (title, description, etc.)
+  | "publish"     // Publish/unpublish the plan
+  | "invite"      // Invite other collaborators
+  | "analytics"   // View analytics and stats
+  | "manage"      // Manage participants and waitlists
+  | "schedule"    // Create events and set timings (HOST-ONLY, never granted to collaborators)
+```
+
+---
+
+## Default Role Permissions
+
+### Webinar Roles
+
+| Permission | CO_HOST | MODERATOR | GUEST_SPEAKER | TECHNICAL_SUPPORT |
+|------------|---------|-----------|---------------|-------------------|
+| edit | Yes | No | No | No |
+| publish | Yes | No | No | No |
+| invite | Yes | No | No | No |
+| analytics | Yes | Yes | No | No |
+| manage | Yes | Yes | No | No |
+| schedule | **No** | **No** | **No** | **No** |
+
+### Class Roles
+
+| Permission | CO_INSTRUCTOR | TEACHING_ASSISTANT | GUEST_LECTURER | CONTENT_CREATOR |
+|------------|---------------|-------------------|----------------|-----------------|
+| edit | Yes | No | No | Yes |
+| publish | Yes | No | No | No |
+| invite | Yes | No | No | No |
+| analytics | Yes | Yes | No | No |
+| manage | Yes | Yes | No | No |
+| schedule | **No** | **No** | **No** | **No** |
+
+**Scheduling is always host-only.** No collaborator role grants scheduling permission. Only the plan owner can create events, set times, and manage slots.
+
+---
+
+## Permission Checking
+
+### Functions
+
+```typescript
+// Check if a consultant has a specific permission on a webinar plan
+checkWebinarPermission(
+  consultantProfileId: string,
+  webinarPlanId: string,
+  permission: Permission
+): Promise<boolean>
+
+// Check if a consultant has a specific permission on a class plan
+checkClassPermission(
+  consultantProfileId: string,
+  classPlanId: string,
+  permission: Permission
+): Promise<boolean>
+```
+
+### Logic
+
+```
+1. Is the consultant the plan owner?
+   → YES: All permissions granted (including schedule)
+
+2. Is the consultant an ACCEPTED collaborator?
+   → NO: No permissions
+
+3. Does the collaborator have custom permissions JSON?
+   → YES: Use custom permissions
+   → NO: Use role defaults
+
+4. Does the role/custom grant the requested permission?
+   → Return true/false
+```
+
+---
+
+## Custom Permission Overrides
+
+The `permissions` field on `WebinarCollaborator` / `ClassCollaborator` is an optional JSON column. When set, it overrides the role defaults entirely.
+
+### Schema
+
+```json
+{
+  "edit": true,
+  "publish": false,
+  "invite": false,
+  "analytics": true,
+  "manage": true
+}
+```
+
+### Use Case
+
+A host invites someone as GUEST_SPEAKER (which by default has no permissions), but wants to give them analytics access:
+
+```json
+// WebinarCollaborator.permissions
+{
+  "analytics": true
+}
+```
+
+When `permissions` JSON exists:
+- Only the permissions listed as `true` are granted
+- Missing keys are treated as `false`
+- Role defaults are ignored entirely
+
+---
+
+## Implementation Pattern
+
+Permissions are checked in API route handlers and server actions:
+
+```typescript
+// Example: Before allowing plan edit
+import { checkWebinarPermission } from "@/lib/collaborators/permissions";
+
+export async function PUT(request, { params }) {
+  const { webinarPlanId } = await params;
+  const session = await auth.api.getSession({ headers: request.headers });
+
+  // Get consultant profile ID from session
+  const profile = await getConsultantProfile(session.user.id);
+
+  const canEdit = await checkWebinarPermission(
+    profile.id,
+    webinarPlanId,
+    "edit"
+  );
+
+  if (!canEdit) {
+    return NextResponse.json(
+      { error: "You don't have permission to edit this plan" },
+      { status: 403 }
+    );
+  }
+
+  // ... proceed with edit
+}
+```
+
+---
+
+## Host vs Collaborator Capability Summary
+
+```
+┌────────────────────────────────┬─────────┬──────────────┐
+│ Capability                     │ Host    │ Collaborator │
+├────────────────────────────────┼─────────┼──────────────┤
+│ Create the plan                │ ✓       │ ✗            │
+│ Edit plan details              │ ✓       │ Role-based   │
+│ Publish / unpublish            │ ✓       │ Role-based   │
+│ Create events (schedule)       │ ✓       │ ✗ (NEVER)    │
+│ Set event times                │ ✓       │ ✗ (NEVER)    │
+│ Manage participant slots       │ ✓       │ Role-based   │
+│ Invite collaborators           │ ✓       │ Role-based   │
+│ Remove collaborators           │ ✓       │ ✗            │
+│ View analytics                 │ ✓       │ Role-based   │
+│ Join video call                │ ✓       │ ✓            │
+│ Chat in collaborator channel   │ ✓       │ ✓            │
+│ Accept/decline own invitation  │ N/A     │ ✓            │
+│ Receive earnings               │ ✓       │ ✓            │
+│ Delete the plan                │ ✓       │ ✗            │
+└────────────────────────────────┴─────────┴──────────────┘
+```

--- a/docs/collaborators/05-stream-integration.md
+++ b/docs/collaborators/05-stream-integration.md
@@ -1,0 +1,185 @@
+# Collaborator Stream.io Integration
+
+## Overview
+
+When a collaborator accepts an invitation, a private Stream.io messaging channel is auto-created for team coordination. This allows the host and all accepted collaborators to communicate before, during, and after events.
+
+**File**: `actions/stream/chat/channel.action.ts` — `createCollaboratorChannel()`
+
+---
+
+## Channel Architecture
+
+### Channel Naming Convention
+
+The platform uses different channel ID patterns to distinguish channel purposes:
+
+| Purpose | Channel ID Pattern | Channel Type | Members |
+|---------|--------------------|-------------|---------|
+| 1:1 Consultation | `consultation-{consultationId}` | `messaging` | Consultant + consultee |
+| 1:1 Subscription | `subscription-{subscriptionId}` | `messaging` | Consultant + consultee |
+| Webinar Event | `webinar-{webinarId}` | `team` | Host + all participants |
+| Class Event | `class-{classId}` | `team` | Host + all participants |
+| **Collaborator (Webinar)** | `collab-webinar-{webinarPlanId}` | `messaging` | Host + accepted collaborators |
+| **Collaborator (Class)** | `collab-class-{classPlanId}` | `messaging` | Host + accepted collaborators |
+
+### Why `messaging` type?
+
+Collaborator channels use `messaging` (private, invitation-only) rather than `team` (open) because:
+- Only the host and accepted collaborators should have access
+- Participants should not see collaborator coordination
+- Private channels prevent accidental information leakage
+
+---
+
+## Channel Creation Flow
+
+### Trigger
+
+A collaborator channel is created (or updated) when a collaborator **accepts** an invitation.
+
+**Location**: `lib/collaborators/service.ts` — `respondToInvitation()`
+
+```typescript
+// When response is ACCEPTED:
+if (response === "ACCEPTED") {
+  try {
+    const { createCollaboratorChannel } = await import(
+      "@/actions/stream/chat/channel.action"
+    );
+    await createCollaboratorChannel(planType, planId);
+  } catch (err) {
+    console.error("Failed to create collaborator channel:", err);
+    // Non-blocking: collaboration still accepted even if channel creation fails
+  }
+}
+```
+
+**Note**: Dynamic `import()` is used to avoid circular dependencies between the service layer and server actions.
+
+### Channel Creation Logic
+
+```
+createCollaboratorChannel("webinar", planId)
+        │
+        ▼
+  Query plan with:
+    - consultantProfile.user.id (host)
+    - collaborators where status = ACCEPTED
+      └─ consultantProfile.user.id (each collaborator)
+        │
+        ▼
+  Collect member IDs:
+    [hostUserId, ...collaboratorUserIds]
+        │
+        ▼
+  Skip if < 2 members
+  (no channel needed if host is alone)
+        │
+        ▼
+  createChannel({
+    channelType: "messaging",
+    channelId: "collab-webinar-{planId}",
+    channelName: "{Plan Title} - Collaborators",
+    members: allMemberIds,
+    createdById: hostUserId,
+    additionalData: {
+      webinar_plan_id: planId,
+      is_collaborator_channel: true,
+    },
+  })
+```
+
+### Idempotency
+
+If the channel already exists (e.g., a second collaborator accepts), Stream.io's `getOrCreate` behavior updates the member list rather than failing. New members are added to the existing channel.
+
+---
+
+## Channel Type Inference
+
+The `addMemberToChannel()` function in `channel.action.ts` infers channel type from the ID prefix:
+
+```typescript
+const channelType =
+  channelId.startsWith("consultation-") ||
+  channelId.startsWith("subscription-") ||
+  channelId.startsWith("collab-")
+    ? "messaging"
+    : "team";
+```
+
+This ensures that when new members are added to collaborator channels, the correct Stream.io channel type is used.
+
+---
+
+## Channel Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                COLLABORATOR CHANNEL LIFECYCLE                 │
+│                                                              │
+│  1. Collaborator A accepts invitation                        │
+│     └─ Channel created: collab-webinar-{planId}              │
+│        Members: [Host, Collaborator A]                       │
+│                                                              │
+│  2. Collaborator B accepts invitation                        │
+│     └─ Channel updated (getOrCreate)                         │
+│        Members: [Host, Collaborator A, Collaborator B]       │
+│                                                              │
+│  3. Team coordinates via private chat                        │
+│     └─ Discuss content, logistics, timings                   │
+│                                                              │
+│  4. Host removes Collaborator B                              │
+│     └─ Channel member removal NOT auto-triggered             │
+│        (future improvement: remove from channel on REMOVED)  │
+│                                                              │
+│  5. Channel persists for ongoing collaboration               │
+│     └─ No auto-deletion                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Video Call Roles (Deferred)
+
+Stream.io video calls support role-based permissions:
+
+| Collaborator Role | Intended Stream Role | Status |
+|-------------------|---------------------|--------|
+| CO_HOST / CO_INSTRUCTOR | `host` | Deferred |
+| MODERATOR / TEACHING_ASSISTANT | `moderator` | Deferred |
+| GUEST_SPEAKER / GUEST_LECTURER | `speaker` | Deferred |
+| TECHNICAL_SUPPORT / CONTENT_CREATOR | `attendee` | Deferred |
+
+**Why deferred**: Video calls are currently created client-side using `call.getOrCreate()` in `lib/meeting.ts`. Assigning collaborator-specific roles requires either:
+1. Server-side call creation (architectural change), or
+2. Client-side role assignment after call creation (race conditions)
+
+The foundation (collaborator data in the DB) is in place for a future implementation.
+
+---
+
+## Chat UI Integration
+
+Collaborator channels appear in the consultant's chat interface. The channel ID prefix `collab-` allows the UI to:
+
+1. Display these channels in a "Collaborations" section
+2. Show the plan title as the channel name
+3. Distinguish them from 1:1 consultation/subscription chats
+
+### Channel Data
+
+Each channel carries metadata in `additionalData`:
+
+```json
+{
+  "webinar_plan_id": "clx...",
+  "is_collaborator_channel": true
+}
+```
+
+This enables the UI to:
+- Link to the plan management page
+- Show plan-specific context
+- Filter/group channels by type

--- a/docs/collaborators/06-scheduling-approaches.md
+++ b/docs/collaborators/06-scheduling-approaches.md
@@ -1,0 +1,168 @@
+# Collaborator Scheduling Approaches
+
+This document outlines three approaches to collaborator scheduling visibility and control, from simplest (current) to most complex (future).
+
+---
+
+## 1. View-Only (Current MVP)
+
+### What We Implemented
+
+Collaborators with **ACCEPTED** status see a read-only schedule section on each active collaboration card in the Collaborations dashboard page.
+
+### What Collaborators See
+
+**Webinar collaborations:**
+- Event status badge (Scheduled / Live) and tentative indicator
+- Event date and time (from the first upcoming slot)
+- Duration (from plan's `durationInHours`)
+- Participant count vs. max capacity
+- Plan owner name
+- Count of additional upcoming events ("+N more events")
+
+**Class collaborations:**
+- Class status badge (Scheduled / In Progress)
+- Scheduling period (start date to end date)
+- Session count (completed/scheduled vs. total from plan)
+- Session frequency and duration (e.g., "1h/session, 2x/week")
+- Participant count vs. max capacity
+- Next upcoming session date and time
+
+### How It Works
+
+**Backend** (`lib/collaborators/service.ts`):
+- `getMyCollaborations` expanded to include nested `webinars` / `classes` with their `appointment` and `slotsOfAppointment` data
+- Only fetches events with status `SCHEDULED` or `IN_PROGRESS`
+- Limited to 5 most recent events per plan
+- Includes plan owner via `consultantProfile.user`
+
+**Frontend** (`components/collaborators/InvitationsPanel.tsx`):
+- Active collaboration cards are clickable to expand/collapse a "Schedule" section
+- `WebinarSchedule` and `ClassSchedule` components render event details in a grid layout
+- Handles edge cases: no events scheduled, event exists but no time slot, class with no sessions yet
+
+### Edge Cases Handled
+
+| Scenario | Display |
+|---|---|
+| No webinar events exist | "No events scheduled yet" |
+| Webinar exists but no appointment/slot | "Event exists but no time slot set" |
+| No class instances exist | "No classes scheduled yet" |
+| Class exists but no scheduling period or sessions | "Sessions not yet scheduled" |
+
+---
+
+## 2. View + Suggest (Future Option)
+
+### Concept
+
+Collaborators can **view** the schedule (as above) and additionally **suggest** schedule changes. The plan owner reviews and approves/rejects suggestions. This preserves host authority while giving collaborators a voice.
+
+### Required DB Changes
+
+New model:
+
+```prisma
+model ScheduleSuggestion {
+  id          String   @id @default(cuid())
+  type        SuggestionType
+  status      SuggestionStatus @default(PENDING)
+
+  // What they're suggesting
+  suggestedStartsAt DateTime?
+  suggestedEndsAt   DateTime?
+  reason            String?
+
+  // Who suggested it
+  suggestedByProfileId String
+  suggestedByProfile   ConsultantProfile @relation(fields: [suggestedByProfileId], references: [id])
+
+  // What plan/event it's for
+  webinarPlanId String?
+  classPlanId   String?
+
+  // Owner response
+  respondedAt   DateTime?
+  responseNote  String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+enum SuggestionType {
+  NEW_EVENT
+  RESCHEDULE
+  CANCEL
+}
+
+enum SuggestionStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+```
+
+### Workflow
+
+1. Collaborator clicks "Suggest Change" next to a scheduled event
+2. Modal opens with date/time picker and a reason field
+3. Suggestion is created with `PENDING` status
+4. Notification sent to plan owner via Novu
+5. Owner sees suggestion in their Event Planner or a dedicated "Suggestions" tab
+6. Owner approves (auto-applies the change) or rejects (with optional note)
+7. Collaborator receives notification of the outcome
+
+### Notification Integration
+
+- `SCHEDULE_SUGGESTION_CREATED` - sent to plan owner
+- `SCHEDULE_SUGGESTION_RESOLVED` - sent to suggesting collaborator
+
+---
+
+## 3. Full Editing for Senior Roles (Future Option)
+
+### Concept
+
+Senior collaborators (CO_HOST for webinars, CO_INSTRUCTOR for classes) get direct scheduling permissions. They can create, reschedule, and cancel events without owner approval.
+
+### Permission Model
+
+Add a `canScheduleOnPlan` permission check:
+
+```typescript
+function canScheduleOnPlan(role: string, planType: "webinar" | "class"): boolean {
+  if (planType === "webinar") {
+    return role === "CO_HOST";
+  }
+  return role === "CO_INSTRUCTOR";
+}
+```
+
+### Required Changes
+
+1. **Authorization layer**: PATCH/POST/DELETE endpoints for events need to check collaborator permissions alongside owner auth
+2. **Event Planner tab**: Add a filtered view showing only plans the collaborator has scheduling access to
+3. **Optimistic locking**: Add a `version` field to events to handle race conditions when multiple people edit
+4. **Audit trail**: Log who created/modified each event for accountability
+
+### Race Condition Considerations
+
+- Two collaborators (or owner + collaborator) could try to schedule the same time slot
+- Solution: Use database-level unique constraints on slot times per plan, plus optimistic locking with version checks
+- Alternative: Use Prisma's `@@unique` constraint on `[appointmentId, startsAt]` in `SlotOfAppointment`
+
+---
+
+## Competitor Research
+
+| Platform | Scheduling Model |
+|---|---|
+| **Zoom** | Only meeting host can schedule; co-hosts have in-meeting powers only |
+| **Thinkific** | Course admin can manage schedule; instructors cannot |
+| **TopMate** | Single-host model, no collaborator concept |
+| **Google Calendar** | Shared calendars with granular read/write permissions per user |
+| **Calendly** | Team events allow round-robin but scheduling is admin-controlled |
+
+**Industry consensus**: Most platforms keep scheduling as a host/admin-only action. Google Calendar's granular permission model is the closest analog to Approach 3, but it's designed for general calendaring, not event management.
+
+**Recommendation**: Approach 1 (view-only) is the right MVP. Consider Approach 2 (suggest) if collaborator feedback indicates scheduling friction. Approach 3 should only be built if there's clear demand from power users running large multi-instructor programs.

--- a/docs/referrals/00-overview.md
+++ b/docs/referrals/00-overview.md
@@ -1,0 +1,170 @@
+# Referral System
+
+**Status**: Implemented (Feb 2026)
+**Branch**: `feat/referral-collaborator-system`
+
+## Overview
+
+The referral system enables viral growth by rewarding both referrers and referees with platform credits. Any user (consultant or consultee) can generate a unique referral link, share it, and earn credits when the referred user makes their first paid booking.
+
+### Goals
+
+- Lower customer acquisition cost through word-of-mouth
+- Incentivize both sides of the marketplace (referrer + referee)
+- Create a credit-based wallet that drives repeat purchases
+- Track referral lifecycle from signup through qualification
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Who can refer | Both consultants and consultees | Maximizes growth surface |
+| Qualifying action | First paid booking | Ensures real engagement, not just signups |
+| Reward type | Platform credits (not cash) | Drives GMV, avoids payout complexity |
+| Qualification window | 30 days | Balances urgency with fairness |
+| Credit expiry | 6 months | Prevents stale liabilities |
+| Credit consumption | FIFO by expiry date | Minimizes expired unused credits |
+| Anti-fraud | Deferred for MVP | Ship fast, add safeguards later |
+
+---
+
+## Architecture
+
+### Data Model
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                          User                                │
+│  id, name, email, role                                       │
+├──────────────┬──────────────────────┬───────────────────────┤
+│              │                      │                        │
+│    1:1       │    1:1 (as referee)  │    1:many              │
+│              │                      │                        │
+▼              ▼                      ▼                        │
+┌──────────┐  ┌──────────┐  ┌──────────────┐                  │
+│ Referral │  │ Referral │  │ ReferralCredit│                  │
+│ Code     │  │          │  │              │                  │
+│          │  │          │  │ amount       │                  │
+│ code     │  │ status   │  │ remaining    │                  │
+│ custom   │  │ rewards  │  │ source       │                  │
+│ Code     │  │ qualify  │  │ expiresAt    │                  │
+│ rewards  │  │ dates    │  │              │                  │
+└──────────┘  └──────────┘  └──────────────┘                  │
+     │              ▲                                          │
+     │  1:many      │                                          │
+     └──────────────┘                                          │
+```
+
+### Models
+
+**ReferralCode** — One per user. Stores the shareable code and reward configuration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | String | Primary key (cuid) |
+| `userId` | String | Owner (unique — one code per user) |
+| `code` | String | Auto-generated code (unique) |
+| `customCode` | String? | Vanity code set by user (unique) |
+| `referrerReward` | Int? | Reward for referrer in paise |
+| `refereeReward` | Int? | Reward for referee in paise |
+| `totalReferrals` | Int | Total signups via this code |
+| `successfulReferrals` | Int | Referrals that reached REWARDED |
+| `totalEarned` | Int | Cumulative referrer rewards in paise |
+| `isActive` | Boolean | Can be deactivated by admin |
+
+**Referral** — Created when a new user signs up via a referral link.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | String | Primary key (cuid) |
+| `referralCodeId` | String | FK to ReferralCode |
+| `referredUserId` | String | The new user (unique — user can only be referred once) |
+| `status` | ReferralStatus | Lifecycle state |
+| `referrerRewardAmount` | Int? | Reward paid to referrer (paise) |
+| `refereeRewardAmount` | Int? | Reward given to referee (paise) |
+| `signedUpAt` | DateTime | When the referred user signed up |
+| `qualifiedAt` | DateTime? | When qualifying action occurred |
+| `qualifyingAction` | String? | e.g. `"first_paid_booking"` |
+
+**ReferralCredit** — A credit entry in the user's wallet.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | String | Primary key (cuid) |
+| `userId` | String | Credit owner |
+| `amount` | Int | Original credit amount (paise) |
+| `currency` | String | Default `"INR"` |
+| `source` | CreditSource | How this credit was earned |
+| `referralId` | String? | Optional link to specific referral |
+| `usedAmount` | Int | How much has been consumed |
+| `remainingAmount` | Int | `amount - usedAmount` |
+| `expiresAt` | DateTime? | When this credit expires |
+| `usedAt` | DateTime? | When fully consumed |
+| `usedOnPaymentId` | String? | Reserved for future use |
+
+### Enums
+
+```
+ReferralStatus:
+  SIGNED_UP   — User signed up but hasn't made a paid booking yet
+  QUALIFIED   — User made first paid booking within 30 days
+  REWARDED    — Referrer has received their credit reward
+  EXPIRED     — 30-day qualification window elapsed
+  FRAUDULENT  — Flagged by admin (reserved, not auto-triggered)
+
+CreditSource:
+  REFERRAL_BONUS  — Earned by referring someone who qualified
+  REFEREE_BONUS   — Given to new user upon signup via referral
+  PROMOTION       — Platform promotional campaign
+  COMPENSATION    — Customer support compensation
+  MANUAL          — Added manually by admin/staff
+```
+
+---
+
+## Reward Amounts
+
+All amounts are stored in **paise** (smallest INR unit: 100 paise = 1 INR).
+
+| Reward | Amount (paise) | Amount (INR) |
+|--------|---------------|--------------|
+| Referrer bonus | 50,000 | 500 |
+| Referee welcome bonus | 20,000 | 200 |
+
+These defaults are defined as constants in `lib/referrals/service.ts`:
+
+```typescript
+const DEFAULT_REFERRER_REWARD = 50000; // ₹500
+const DEFAULT_REFEREE_REWARD  = 20000; // ₹200
+const QUALIFICATION_WINDOW_DAYS = 30;
+const CREDIT_EXPIRY_MONTHS = 6;
+```
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `lib/referrals/service.ts` | Core business logic (all referral operations) |
+| `app/api/referrals/code/route.ts` | GET/POST user's referral code |
+| `app/api/referrals/code/customize/route.ts` | POST set vanity code |
+| `app/api/referrals/code/check/[code]/route.ts` | GET validate code (public) |
+| `app/api/referrals/route.ts` | GET list user's referrals |
+| `app/api/referrals/apply/route.ts` | POST apply code to new user |
+| `app/api/referrals/credits/route.ts` | GET credit balance + history |
+| `app/api/referrals/credits/available/route.ts` | GET available balance (lightweight) |
+| `app/r/[code]/page.tsx` | Referral landing page (redirect) |
+| `app/dashboard/consultant/.../referrals/page.tsx` | Consultant referral dashboard |
+| `app/dashboard/consultee/.../referrals/page.tsx` | Consultee referral dashboard |
+| `scripts/referrals/expire-referrals.ts` | Cron: expire stale referrals |
+| `scripts/referrals/expire-credits.ts` | Cron: expire old credits |
+| `prisma/seedFiles/14a-create-referral-codes.ts` | Seed data |
+
+---
+
+## Related Docs
+
+- [01 — Architecture & Flows](./01-architecture.md)
+- [02 — API Reference](./02-api-reference.md)
+- [03 — Credit System](./03-credit-system.md)

--- a/docs/referrals/01-architecture.md
+++ b/docs/referrals/01-architecture.md
@@ -1,0 +1,418 @@
+# Referral System — Architecture & Flows
+
+This document walks through the referral system end to end: from how a referral code is generated, to how a new user signs up through it, to how rewards are earned and spent. Each section builds on the previous one to tell the full story of a referral's lifecycle.
+
+---
+
+## Table of Contents
+
+1. [The Big Picture](#1-the-big-picture)
+2. [Referral Code Generation](#2-referral-code-generation)
+3. [The Signup Journey](#3-the-signup-journey)
+4. [Qualification and Rewards](#4-qualification-and-rewards)
+5. [Spending Credits at Checkout](#5-spending-credits-at-checkout)
+6. [Expiration and Cleanup](#6-expiration-and-cleanup)
+7. [Custom Vanity Codes](#7-custom-vanity-codes)
+8. [The Complete Lifecycle](#8-the-complete-lifecycle)
+
+---
+
+## 1. The Big Picture
+
+The referral system creates a viral growth loop. Every existing user becomes a potential ambassador for the platform. The mechanics are straightforward: share a link, earn credits when your referral pays for something. But the implementation has several moving parts that need to work together cleanly.
+
+Here's the high-level flow that every referral follows:
+
+```
+  User A (existing)                                    User B (new)
+       │                                                    │
+       │  1. Generates referral link                        │
+       │     familiarise.com/r/kaustav3x7                   │
+       │                                                    │
+       │  2. Shares via social media,                       │
+       │     email, or direct message                       │
+       │─────────────────────────────────────────────────>│
+       │                                                    │
+       │                                    3. Clicks link  │
+       │                                    4. Signs up     │
+       │                                    5. Gets ₹200    │
+       │                                       credit       │
+       │                                                    │
+       │                                    6. Makes first  │
+       │                                       paid booking │
+       │                                       (within 30d) │
+       │                                                    │
+       │  7. Earns ₹500 credit  <───────────────────────────│
+       │                                                    │
+       │  8. Both use credits                               │
+       │     at future checkouts                            │
+```
+
+The system involves three database models (`ReferralCode`, `Referral`, `ReferralCredit`), seven API endpoints, two cron jobs, and integration points in the signup page and payment webhook. Let's walk through each stage.
+
+---
+
+## 2. Referral Code Generation
+
+Every journey starts with a code. When a user visits their referral dashboard and clicks "Get Referral Link," the system either returns their existing code or generates a new one.
+
+### How codes are generated
+
+The algorithm tries to create a human-readable code based on the user's name, falling back to a random string if there's a collision:
+
+```
+Step 1:  Take the user's name         →  "Kaustav Ghosh"
+Step 2:  Lowercase, strip non-alpha   →  "kaustavghosh"
+Step 3:  Take first 8 characters      →  "kaustavg"
+Step 4:  Append 4 random alphanumeric →  "kaustavga3x7"
+Step 5:  Try inserting into database
+         ├─ Success → done
+         └─ Unique constraint fails → generate fallback: "ref" + 9 random chars
+```
+
+This approach gives most users a recognizable, memorable code while guaranteeing uniqueness through the database constraint. The code is stored in the `ReferralCode` model, which has `@unique` on the `code` field.
+
+### What happens under the hood
+
+```
+User                  Frontend              POST /api/referrals/code         Service
+ │                       │                          │                          │
+ │  Click "Get Link"     │                          │                          │
+ │──────────────────────>│                          │                          │
+ │                       │  POST (empty body)       │                          │
+ │                       │─────────────────────────>│                          │
+ │                       │                          │                          │
+ │                       │                          │  1. Look up existing     │
+ │                       │                          │     code for this user   │
+ │                       │                          │                          │
+ │                       │                          │  [Found] → return it     │
+ │                       │                          │                          │
+ │                       │                          │  [Not found] →           │
+ │                       │                          │  2. Generate name-based  │
+ │                       │                          │     code                 │
+ │                       │                          │  3. Insert with default  │
+ │                       │                          │     reward config        │
+ │                       │                          │     (₹500 / ₹200)       │
+ │                       │                          │  4. Return new code      │
+ │                       │                          │                          │
+ │                       │  { code, customCode }    │                          │
+ │                       │<─────────────────────────│                          │
+ │                       │                          │                          │
+ │  Display:             │                          │                          │
+ │  familiarise.com      │                          │                          │
+ │  /r/kaustavga3x7      │                          │                          │
+ │<──────────────────────│                          │                          │
+```
+
+The `POST` endpoint is idempotent — calling it repeatedly for the same user always returns the same code. This is important because the dashboard fetches the code on every page load via a `useQuery` hook, and we don't want to create duplicates.
+
+The `ReferralCode` record also stores running statistics (`totalReferrals`, `successfulReferrals`, `totalEarned`) that are incremented as referrals progress through their lifecycle. These power the stats cards on the dashboard.
+
+---
+
+## 3. The Signup Journey
+
+This is where the referral link does its work. A new user clicks the link, arrives at the platform, signs up, and gets their welcome bonus.
+
+### Step by step
+
+The flow has three distinct phases: landing, signup, and application.
+
+**Phase 1 — Landing (`/r/[code]`)**: This is a server-rendered Next.js page. When a user visits `familiarise.com/r/kaustavga3x7`, the server calls `validateReferralCode()` from the referral service. If the code is valid and active, the user is redirected to `/auth/signup?ref=kaustavga3x7`. If invalid, they're redirected to `/auth/signup` without the `ref` parameter. This is a pure redirect — no UI is shown on the `/r/` page itself.
+
+**Phase 2 — Signup page**: The signup page reads the `?ref=` query parameter. If present, it makes a `GET /api/referrals/code/check/{code}` call (which is a public, unauthenticated endpoint) to fetch the referrer's name and the referee reward amount. This powers the banner that says "Referred by Kaustav Ghosh — You'll get ₹200 bonus!" The page also has an optional text input where users can manually enter a referral code if they didn't use a link.
+
+**Phase 3 — Application**: After the user successfully creates their account (through BetterAuth), the frontend calls `POST /api/referrals/apply` with the code. This is where the actual referral record is created.
+
+```
+                         /r/kaustavga3x7
+                               │
+                               ▼
+                    ┌────────────────────────┐
+                    │  Validate code          │
+                    │  (server-side)          │
+                    └──────────┬─────────────┘
+                               │
+                   ┌───────────┴───────────┐
+                   │ Valid                  │ Invalid
+                   ▼                       ▼
+         ┌──────────────────┐    ┌──────────────────┐
+         │ redirect 302     │    │ redirect 302     │
+         │ /auth/signup     │    │ /auth/signup     │
+         │ ?ref=CODE        │    │ (no ref param)   │
+         └────────┬─────────┘    └──────────────────┘
+                  │
+                  ▼
+         ┌──────────────────────────────────────┐
+         │  Signup page shows:                   │
+         │  "Referred by Kaustav Ghosh"          │
+         │  "You'll receive ₹200 bonus"          │
+         │                                       │
+         │  User fills in name, email, password   │
+         │  → Creates account via BetterAuth      │
+         └────────┬─────────────────────────────┘
+                  │
+                  ▼
+         ┌──────────────────────────────────────┐
+         │  POST /api/referrals/apply            │
+         │  { code: "kaustavga3x7" }             │
+         │                                       │
+         │  Service: applyReferralCode()          │
+         │                                       │
+         │  Validations:                          │
+         │  ✓ Code exists and is active           │
+         │  ✓ User is not self-referring          │
+         │  ✓ User hasn't been referred before    │
+         │                                       │
+         │  On success:                           │
+         │  1. Create Referral (SIGNED_UP)        │
+         │  2. Create ReferralCredit (₹200)       │
+         │     for the new user                   │
+         │  3. Increment totalReferrals on code   │
+         └──────────────────────────────────────┘
+```
+
+### Why the "apply" step is separate from signup
+
+The referral application happens in a separate API call after account creation — not during signup itself. This is intentional:
+
+1. **Auth-first**: The `/api/referrals/apply` endpoint requires authentication. The user must have a valid session before we create referral records linked to their user ID.
+2. **Decoupling**: If the referral system has a bug, it shouldn't block account creation. Signup succeeds independently.
+3. **Manual entry**: Users who arrive without a link but know a code can enter it manually on the signup page. The same POST endpoint handles both cases.
+
+### The `referredUserId @unique` constraint
+
+A user can only be referred once. The `Referral` model has `referredUserId String @unique`, which means if someone tries to apply a second referral code, the database rejects it. The API returns a friendly "You have already been referred" error.
+
+---
+
+## 4. Qualification and Rewards
+
+At this point, User B has signed up and received their ₹200 welcome bonus. But User A (the referrer) hasn't earned anything yet. The referral is in `SIGNED_UP` status — a holding state that means "this person signed up, but we're not sure they're a real, engaged user yet."
+
+### What triggers qualification
+
+The qualifying action is the user's **first successful payment** on the platform. This could be booking a consultation, subscribing to a mentorship program, purchasing a webinar ticket, or enrolling in a class. The trigger point is in the payment webhook handler.
+
+When a payment succeeds, `handlePaymentSuccess()` in `lib/payments/webhooks/handlers.ts` calls:
+
+```typescript
+processQualifyingAction(userId, "first_paid_booking")
+```
+
+This function is the heart of the reward logic. Here's what it does:
+
+```
+processQualifyingAction(userId, action)
+        │
+        ▼
+  Find Referral WHERE
+    referredUserId = userId
+    AND status = "SIGNED_UP"
+        │
+        ├── Not found → return (user wasn't referred, or already qualified)
+        │
+        ▼
+  Found referral. Check qualification window:
+  Is (signedUpAt + 30 days) > now?
+        │
+        ├── NO (expired) ──────────────────────────────────┐
+        │                                                   │
+        │                                                   ▼
+        │                                     UPDATE Referral
+        │                                       status → EXPIRED
+        │                                     (no rewards given)
+        │
+        ▼ YES (within window)
+  Qualify and reward:
+  1. UPDATE Referral
+       status → REWARDED
+       qualifiedAt = now
+       qualifyingAction = "first_paid_booking"
+       referrerRewardAmount = 50000
+       refereeRewardAmount = 20000
+
+  2. CREATE ReferralCredit for referrer
+       amount = 50000 (₹500)
+       source = REFERRAL_BONUS
+       expiresAt = now + 6 months
+
+  3. UPDATE ReferralCode
+       successfulReferrals += 1
+       totalEarned += 50000
+```
+
+### The 30-day window
+
+The qualification window exists to prevent gaming. Without it, someone could sign up via a referral link, never use the platform, and then make a purchase months later — giving the referrer a reward for a connection that was essentially cold. The 30-day window ensures the referral has some causal relationship to the signup.
+
+If the window expires and the user later makes a purchase, the referral status changes to `EXPIRED` rather than `REWARDED`. The referrer gets nothing. The cron job (`scripts/referrals/expire-referrals.ts`) handles bulk expiration daily, but the `processQualifyingAction` function also handles it inline to avoid a race between the cron job and a late payment.
+
+### Why the referral goes directly to REWARDED (not QUALIFIED)
+
+The plan originally had `QUALIFIED` and `REWARDED` as separate states, but in the current implementation, qualification and reward happen atomically in the same transaction. There's no intermediate step where the referral is qualified but the reward hasn't been given yet. The `QUALIFIED` status could be used in the future if we add manual approval or delayed rewards, but for now `SIGNED_UP → REWARDED` is the happy path.
+
+---
+
+## 5. Spending Credits at Checkout
+
+Both users now have credits in their wallet (User B has ₹200 from signup, User A has ₹500 from the referral reward). These credits can be spent on any service purchase.
+
+### How the checkout page works
+
+When a user reaches a checkout page (for any service type — consultation, subscription, webinar, or class), the frontend calls `GET /api/referrals/credits/available` to check if the user has a credit balance. This is a lightweight endpoint that returns just the total and currency:
+
+```json
+{ "data": { "totalAvailable": 70000, "currency": "INR" } }
+```
+
+If the balance is greater than zero, the checkout page shows a toggle:
+
+```
+┌─────────────────────────────────────────────┐
+│  ☑ Apply referral credits                    │
+│    Available: ₹700.00                        │
+│    Applied: -₹500.00 (capped at order total) │
+└─────────────────────────────────────────────┘
+```
+
+Credits are capped at the order total — you can't use ₹700 in credits on a ₹500 purchase.
+
+### FIFO consumption
+
+When the payment succeeds and credits are applied, the system uses **FIFO by expiry date** — it consumes the credits that expire soonest first. This minimizes the chance of credits expiring unused.
+
+Here's a worked example. Suppose User A has accumulated three credits from different sources:
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Credit A:  ₹200  remaining, expires June 15, 2026      │  ← consumed first
+│ Credit B:  ₹500  remaining, expires August 1, 2026     │  ← consumed second
+│ Credit C:  ₹100  remaining, never expires              │  ← consumed last
+└────────────────────────────────────────────────────────┘
+```
+
+User A wants to apply ₹400 at checkout:
+
+**Iteration 1**: Consume Credit A completely (₹200). Remaining to apply: ₹200. Credit A is now fully used (`usedAt` is set).
+
+**Iteration 2**: Consume ₹200 from Credit B (which has ₹500). Remaining to apply: ₹0. Credit B now has ₹300 remaining.
+
+**Result**: ₹400 applied. Credit A depleted. Credit B partially used. Credit C untouched.
+
+The function `applyCreditsToPayment()` in `lib/referrals/service.ts` implements this as a sequential loop over credits ordered by `expiresAt ASC` (nulls last, since credits with no expiry should be consumed last).
+
+---
+
+## 6. Expiration and Cleanup
+
+Two daily cron jobs handle the referral system's cleanup needs.
+
+### Referral expiration
+
+**Script**: `scripts/referrals/expire-referrals.ts`
+
+This job finds all referrals that are still in `SIGNED_UP` status (meaning the referred user never made a payment) where the signup happened more than 30 days ago, and sets their status to `EXPIRED`.
+
+```sql
+-- Conceptually:
+UPDATE "Referral"
+SET status = 'EXPIRED', "updatedAt" = NOW()
+WHERE status = 'SIGNED_UP'
+  AND "signedUpAt" < NOW() - INTERVAL '30 days'
+```
+
+This is a cleanup operation — it doesn't affect rewards (those were already handled or skipped by `processQualifyingAction`). It just ensures the referral dashboard shows accurate statuses.
+
+### Credit expiration
+
+**Script**: `scripts/referrals/expire-credits.ts`
+
+This job finds all credits with `remainingAmount > 0` that have passed their `expiresAt` date, and sets `remainingAmount` to 0.
+
+```sql
+-- Conceptually:
+UPDATE "ReferralCredit"
+SET "remainingAmount" = 0
+WHERE "remainingAmount" > 0
+  AND "expiresAt" IS NOT NULL
+  AND "expiresAt" < NOW()
+```
+
+Expired credits are effectively "zeroed out" — they still exist in the database for historical purposes (the user can see them in their credit history), but they can't be used at checkout.
+
+Both jobs should be scheduled to run daily via a task scheduler (e.g., Vercel Cron, GitHub Actions, or a simple crontab).
+
+---
+
+## 7. Custom Vanity Codes
+
+Users can optionally set a vanity code (e.g., `kaustav` instead of `kaustavga3x7`). This makes referral links more memorable and professional-looking.
+
+### How it works
+
+The `POST /api/referrals/code/customize` endpoint accepts a `customCode` string with these rules:
+
+- 3-20 characters long
+- Alphanumeric only (a-z, 0-9), lowercased before storage
+- Must not collide with any existing `code` or `customCode` in the database
+
+The vanity code is stored in the `customCode` field on `ReferralCode`. The original auto-generated `code` is preserved — both work as referral links. The validation endpoint (`GET /api/referrals/code/check/[code]`) checks both columns.
+
+On the dashboard, the consultant's referral page has a "Set Custom Code" input field. Consultees don't have this feature (a deliberate simplification for MVP).
+
+---
+
+## 8. The Complete Lifecycle
+
+Putting it all together, here's the full journey of a referral from creation to completion:
+
+```
+ DAY 0                     DAY 0                        DAY 5                     DAY 5+
+ ─────                     ─────                        ─────                     ─────
+
+ User A generates          User B clicks link           User B books a            Credits used
+ referral code             and signs up                 consultation              at checkout
+
+ ┌──────────────┐         ┌──────────────────┐         ┌──────────────────┐      ┌──────────────┐
+ │ ReferralCode │         │ Referral created │         │ Payment webhook  │      │ FIFO credit  │
+ │ created      │─────>│ status: SIGNED_UP│─────>│ fires              │─────>│ consumption  │
+ │              │         │                  │         │                  │      │              │
+ │ code:        │         │ Credit created   │         │ processQualify   │      │ Credits      │
+ │ kaustavga3x7 │         │ for User B (₹200)│         │ Action()         │      │ applied to   │
+ └──────────────┘         └──────────────────┘         │                  │      │ payment      │
+                                                        │ Referral status  │      │              │
+                                                        │ → REWARDED       │      │ Remaining    │
+                                                        │                  │      │ balance      │
+                                                        │ Credit created   │      │ decremented  │
+                                                        │ for User A (₹500)│      └──────────────┘
+                                                        └──────────────────┘
+
+
+ DAY 180+ (if unused)
+ ─────────────────────
+
+ ┌──────────────────┐
+ │ Cron job runs    │
+ │                  │
+ │ Expired credits: │
+ │ remaining → 0    │
+ │                  │
+ │ Expired referrals│
+ │ status → EXPIRED │
+ └──────────────────┘
+```
+
+### The unhappy paths
+
+Not every referral ends in a reward. Here are the alternative outcomes:
+
+**User B never pays (30 days elapse)**: The referral stays in `SIGNED_UP` until the daily cron job sets it to `EXPIRED`. User A earns nothing. User B still has their ₹200 welcome credit (it expires independently after 6 months).
+
+**User B pays on day 35**: When `processQualifyingAction` runs, it sees the referral is past the 30-day window and sets it to `EXPIRED` inline. No reward for User A.
+
+**User B was already referred by someone else**: The `referredUserId @unique` constraint prevents a second referral. The `/api/referrals/apply` endpoint returns "You have already been referred."
+
+**User A tries to refer themselves**: The service checks `referralCode.userId !== newUserId` and returns "You cannot refer yourself."
+
+**Referral code is deactivated by admin**: The `isActive` flag on `ReferralCode` is checked during validation. Deactivated codes return `{ valid: false }` from the check endpoint, and the `/r/[code]` page redirects to plain signup.

--- a/docs/referrals/02-api-reference.md
+++ b/docs/referrals/02-api-reference.md
@@ -1,0 +1,292 @@
+# Referral System — API Reference
+
+All endpoints require authentication (via BetterAuth session) unless marked **Public**.
+
+Base URL: `/api/referrals`
+
+---
+
+## Endpoints
+
+### GET /api/referrals/code
+
+Get the authenticated user's referral code.
+
+**Auth**: Required
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "id": "clx...",
+    "userId": "clx...",
+    "code": "kaustavga3x7",
+    "customCode": "kaustav",
+    "referrerReward": 50000,
+    "refereeReward": 20000,
+    "totalReferrals": 5,
+    "successfulReferrals": 2,
+    "totalEarned": 100000,
+    "isActive": true,
+    "createdAt": "2026-02-10T..."
+  }
+}
+```
+
+**Response** `404`:
+```json
+{ "error": "No referral code found" }
+```
+
+---
+
+### POST /api/referrals/code
+
+Create a referral code for the authenticated user (or return existing one).
+
+**Auth**: Required
+
+**Body**: Empty (no body required)
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "id": "clx...",
+    "code": "kaustavga3x7",
+    "customCode": null,
+    "referrerReward": 50000,
+    "refereeReward": 20000,
+    "totalReferrals": 0,
+    "successfulReferrals": 0,
+    "totalEarned": 0,
+    "isActive": true
+  }
+}
+```
+
+---
+
+### POST /api/referrals/code/customize
+
+Set a vanity code for the authenticated user.
+
+**Auth**: Required
+
+**Body**:
+```json
+{ "customCode": "kaustav" }
+```
+
+**Validation**:
+- 3-20 characters
+- Alphanumeric only (`/^[a-z0-9]+$/`)
+- Must not already exist as a `code` or `customCode` in the database
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "id": "clx...",
+    "code": "kaustavga3x7",
+    "customCode": "kaustav"
+  }
+}
+```
+
+**Error** `400`:
+```json
+{ "error": "Custom code must be 3-20 alphanumeric characters" }
+```
+
+**Error** `409`:
+```json
+{ "error": "This code is already taken" }
+```
+
+---
+
+### GET /api/referrals/code/check/[code]  (Public)
+
+Validate a referral code without authentication. Used on the signup page.
+
+**Auth**: Not required
+
+**Params**: `code` — The referral code to validate
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "valid": true,
+    "referrerName": "Kaustav Ghosh",
+    "refereeReward": 20000
+  }
+}
+```
+
+Invalid code:
+```json
+{
+  "data": {
+    "valid": false,
+    "referrerName": null,
+    "refereeReward": 0
+  }
+}
+```
+
+---
+
+### GET /api/referrals
+
+List the authenticated user's referrals (people they referred).
+
+**Auth**: Required
+
+**Response** `200`:
+```json
+{
+  "data": [
+    {
+      "id": "clx...",
+      "referredUserId": "clx...",
+      "status": "REWARDED",
+      "referrerRewardAmount": 50000,
+      "refereeRewardAmount": 20000,
+      "signedUpAt": "2026-02-01T...",
+      "qualifiedAt": "2026-02-05T...",
+      "qualifyingAction": "first_paid_booking",
+      "referredUser": {
+        "name": "Alice Smith",
+        "image": "/uploads/alice.jpg"
+      }
+    }
+  ]
+}
+```
+
+---
+
+### POST /api/referrals/apply
+
+Apply a referral code to the authenticated (newly signed-up) user.
+
+**Auth**: Required
+
+**Body**:
+```json
+{ "code": "kaustavga3x7" }
+```
+
+**Validations**:
+1. Code exists and is active
+2. User is not referring themselves
+3. User hasn't already been referred (referredUserId is unique)
+
+**Response** `200`:
+```json
+{ "data": { "success": true } }
+```
+
+**Error** `400`:
+```json
+{ "error": "Invalid referral code" }
+```
+```json
+{ "error": "You cannot refer yourself" }
+```
+```json
+{ "error": "You have already been referred" }
+```
+
+---
+
+### GET /api/referrals/credits
+
+Get the authenticated user's full credit history and total available balance.
+
+**Auth**: Required
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "totalAvailable": 70000,
+    "credits": [
+      {
+        "id": "clx...",
+        "amount": 50000,
+        "currency": "INR",
+        "source": "REFERRAL_BONUS",
+        "remainingAmount": 50000,
+        "usedAmount": 0,
+        "expiresAt": "2026-08-10T...",
+        "createdAt": "2026-02-10T..."
+      },
+      {
+        "id": "clx...",
+        "amount": 20000,
+        "currency": "INR",
+        "source": "REFEREE_BONUS",
+        "remainingAmount": 20000,
+        "usedAmount": 0,
+        "expiresAt": "2026-08-10T...",
+        "createdAt": "2026-02-10T..."
+      }
+    ]
+  }
+}
+```
+
+---
+
+### GET /api/referrals/credits/available
+
+Lightweight endpoint — returns only the available balance. Used by checkout pages.
+
+**Auth**: Required
+
+**Response** `200`:
+```json
+{
+  "data": {
+    "totalAvailable": 70000,
+    "currency": "INR"
+  }
+}
+```
+
+---
+
+## Integration Points
+
+### Payment Webhook
+
+**File**: `lib/payments/webhooks/handlers.ts`
+
+After a successful payment, the webhook handler calls:
+
+```typescript
+processQualifyingAction(userId, "first_paid_booking")
+```
+
+This checks if the paying user was referred and, if so, triggers the reward flow.
+
+### Referral Landing Page
+
+**File**: `app/r/[code]/page.tsx`
+
+Server-side rendered page that:
+1. Validates the code via `validateReferralCode(code)`
+2. Redirects to `/auth/signup?ref={code}` if valid
+3. Redirects to `/auth/signup` if invalid
+
+### Signup Page
+
+**File**: `app/auth/signup/page.tsx`
+
+Reads `?ref=CODE` from URL params:
+- Calls `GET /api/referrals/code/check/{code}` to display referral banner
+- After successful signup, calls `POST /api/referrals/apply` with the code
+- Also shows an optional manual code input field

--- a/docs/referrals/03-credit-system.md
+++ b/docs/referrals/03-credit-system.md
@@ -1,0 +1,194 @@
+# Referral Credits — Detailed Guide
+
+## Overview
+
+Referral credits are a platform currency denominated in paise (100 paise = 1 INR). They function as a wallet system where users accumulate credits from referral rewards and spend them on service purchases.
+
+---
+
+## Credit Sources
+
+| Source | Recipient | Amount | Trigger |
+|--------|-----------|--------|---------|
+| `REFEREE_BONUS` | New user (referee) | ₹200 (20,000 paise) | Signs up via referral link |
+| `REFERRAL_BONUS` | Existing user (referrer) | ₹500 (50,000 paise) | Referee makes first paid booking |
+| `PROMOTION` | Any user | Variable | Platform campaign (admin-created) |
+| `COMPENSATION` | Any user | Variable | Customer support resolution |
+| `MANUAL` | Any user | Variable | Staff/admin manual entry |
+
+---
+
+## Credit Lifecycle
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   CREATED    │────>│   ACTIVE     │────>│  PARTIALLY   │────>│   CONSUMED   │
+│              │     │              │     │   USED       │     │              │
+│ amount=50000 │     │ remaining=   │     │ remaining=   │     │ remaining=0  │
+│ remaining=   │     │  50000       │     │  30000       │     │ usedAt=now   │
+│  50000       │     │              │     │              │     │              │
+│ usedAmount=0 │     │ usedAmount=0 │     │ usedAmount=  │     │ usedAmount=  │
+│              │     │              │     │  20000       │     │  50000       │
+└──────────────┘     └──────────────┘     └──────────────┘     └──────────────┘
+                            │
+                            │ (if expiresAt < now)
+                            ▼
+                     ┌──────────────┐
+                     │   EXPIRED    │
+                     │              │
+                     │ remaining→0  │
+                     │ (by cron)    │
+                     └──────────────┘
+```
+
+There is no explicit `status` field on ReferralCredit. Status is inferred:
+- **Active**: `remainingAmount > 0` and (`expiresAt IS NULL` or `expiresAt > now`)
+- **Partially Used**: `usedAmount > 0` and `remainingAmount > 0`
+- **Consumed**: `remainingAmount = 0` and `usedAt IS NOT NULL`
+- **Expired**: `remainingAmount = 0` and was zeroed by the expiry cron job
+
+---
+
+## Consumption Algorithm (FIFO)
+
+When a user applies credits at checkout, the system consumes from the oldest-expiring credit first:
+
+```typescript
+// lib/referrals/service.ts — applyCreditsToPayment()
+
+async function applyCreditsToPayment(userId: string, amount: number) {
+  // 1. Fetch all active credits, ordered by expiresAt ASC (nulls last)
+  const credits = await prisma.referralCredit.findMany({
+    where: {
+      userId,
+      remainingAmount: { gt: 0 },
+      OR: [
+        { expiresAt: null },
+        { expiresAt: { gt: new Date() } },
+      ],
+    },
+    orderBy: { expiresAt: "asc" },  // Earliest expiry first
+  });
+
+  let remaining = amount;
+
+  // 2. Consume credits one by one
+  for (const credit of credits) {
+    if (remaining <= 0) break;
+
+    const deduction = Math.min(credit.remainingAmount, remaining);
+
+    await prisma.referralCredit.update({
+      where: { id: credit.id },
+      data: {
+        remainingAmount: credit.remainingAmount - deduction,
+        usedAmount: credit.usedAmount + deduction,
+        ...(credit.remainingAmount - deduction === 0
+          ? { usedAt: new Date() }
+          : {}),
+      },
+    });
+
+    remaining -= deduction;
+  }
+
+  return amount - remaining; // Actual amount applied
+}
+```
+
+### Example
+
+User has 3 credits:
+
+| Credit | Amount | Remaining | Expires |
+|--------|--------|-----------|---------|
+| A | ₹200 | ₹200 | 2026-06-15 |
+| B | ₹500 | ₹300 | 2026-08-01 |
+| C | ₹100 | ₹100 | never |
+
+User wants to apply ₹400 at checkout:
+
+1. Consume Credit A: ₹200 → remaining = ₹0, usedAt = now. ₹200 left to apply.
+2. Consume Credit B: ₹200 of ₹300 → remaining = ₹100. ₹0 left to apply.
+3. Credit C untouched.
+
+Result: ₹400 applied. Credit A fully consumed. Credit B partially used.
+
+---
+
+## Expiry
+
+### Rules
+
+- Credits from referral rewards expire **6 months** after creation
+- `PROMOTION` credits may have custom expiry dates
+- `MANUAL` credits can be set to never expire (`expiresAt = null`)
+
+### Cron Job
+
+```
+File: scripts/referrals/expire-credits.ts
+Schedule: Daily
+
+Action:
+  For all credits where:
+    - remainingAmount > 0
+    - expiresAt IS NOT NULL
+    - expiresAt < now()
+
+  Set remainingAmount = 0
+```
+
+---
+
+## Available Balance Calculation
+
+```sql
+SELECT SUM(remaining_amount)
+FROM referral_credits
+WHERE user_id = ?
+  AND remaining_amount > 0
+  AND (expires_at IS NULL OR expires_at > NOW())
+```
+
+This is what `GET /api/referrals/credits/available` returns.
+
+---
+
+## Dashboard Display
+
+### Credit History Table
+
+Shown on both consultant and consultee referral dashboard pages:
+
+| Column | Source |
+|--------|--------|
+| Amount | `amount` formatted as INR |
+| Source | `source` enum label |
+| Remaining | `remainingAmount` formatted as INR |
+| Expires | `expiresAt` formatted, or "Never" |
+| Status | Derived: Active / Used / Expired |
+
+### Available Balance Card
+
+Prominent stat card showing total available credits:
+
+```
+┌───────────────────────┐
+│  Credit Balance        │
+│  ₹700.00              │
+│  Available to use      │
+└───────────────────────┘
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Credits exceed order total | Only apply up to order total |
+| All credits expired | Toggle hidden, no credits applied |
+| Credit expires mid-checkout | Caught at payment time; partial application |
+| User has credits from multiple sources | All treated equally in FIFO queue |
+| Concurrent credit usage (race condition) | Transactional updates prevent double-spend |

--- a/docs/roadmap/features/collaborators/implementation.md
+++ b/docs/roadmap/features/collaborators/implementation.md
@@ -1,9 +1,17 @@
 # Collaborators Implementation Guide
 
-**Last Updated**: 2025-10-12
-**Status**: Architecture Design
-**Purpose**: Implement multi-creator collaboration for webinars, classes, and podcasts with revenue sharing
+**Last Updated**: 2026-02-10
+**Status**: IMPLEMENTED (webinars + classes only)
+**Purpose**: Implement multi-creator collaboration for webinars and classes with revenue sharing
 
+> **Implementation Notes** (Feb 2026, branch `feat/referral-collaborator-system`):
+> - Podcast collaborators not implemented (PodcastPlan model doesn't exist yet)
+> - Scheduling is host-only; collaborators cannot create events
+> - Host sets revenue split, collaborator accepts/declines the package
+> - Minimum 10% host share (collaborator total capped at 90%)
+> - Stream.io chat channels auto-created on collaborator acceptance
+> - Stream video call role assignment deferred (calls created client-side)
+>
 > **📋 Related Documentation**: See `podcast-schema-integration.md` for podcast architecture decisions (ADR-001: Naming Convention using `PodcastPlan` + `PodcastAccess` pattern)
 
 ---

--- a/docs/roadmap/features/referral-program/README.md
+++ b/docs/roadmap/features/referral-program/README.md
@@ -1,5 +1,9 @@
 # Referral Program
 
+> **Status: IMPLEMENTED** (Feb 2026) on branch `feat/referral-collaborator-system`
+>
+> **Deviations from spec**: Affiliate system skipped for MVP. Anti-fraud/gaming prevention deferred. Credits use FIFO expiry (6 months). Qualifying action = first paid booking only.
+
 ## Overview
 
 A referral system that rewards users for bringing new consultees and consultants to the platform. Both referrer and referee receive benefits, creating a viral growth loop.

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -42,16 +42,30 @@ export async function inviteCollaborator(
     );
     if (!valid) return null;
 
-    // Check for existing active collaboration (not REMOVED/DECLINED)
+    // FIX #6: Check for ANY existing collaboration (including REMOVED/DECLINED).
+    // If REMOVED/DECLINED, re-activate instead of creating to respect unique constraint.
     if (planType === "webinar") {
       const existing = await tx.webinarCollaborator.findFirst({
-        where: {
-          webinarPlanId: planId,
-          consultantProfileId,
-          status: { notIn: ["REMOVED", "DECLINED"] },
-        },
+        where: { webinarPlanId: planId, consultantProfileId },
       });
-      if (existing) return null;
+
+      if (existing) {
+        if (existing.status === "REMOVED" || existing.status === "DECLINED") {
+          // Re-activate with new parameters
+          return tx.webinarCollaborator.update({
+            where: { id: existing.id },
+            data: {
+              role: role as WebinarCollaboratorRole,
+              revenueSharePercentage,
+              status: "PENDING",
+              invitedById,
+              respondedAt: null,
+            },
+          });
+        }
+        // PENDING or ACCEPTED — already active
+        return null;
+      }
 
       return tx.webinarCollaborator.create({
         data: {
@@ -65,13 +79,26 @@ export async function inviteCollaborator(
       });
     } else {
       const existing = await tx.classCollaborator.findFirst({
-        where: {
-          classPlanId: planId,
-          consultantProfileId,
-          status: { notIn: ["REMOVED", "DECLINED"] },
-        },
+        where: { classPlanId: planId, consultantProfileId },
       });
-      if (existing) return null;
+
+      if (existing) {
+        if (existing.status === "REMOVED" || existing.status === "DECLINED") {
+          // Re-activate with new parameters
+          return tx.classCollaborator.update({
+            where: { id: existing.id },
+            data: {
+              role: role as ClassCollaboratorRole,
+              revenueSharePercentage,
+              status: "PENDING",
+              invitedById,
+              respondedAt: null,
+            },
+          });
+        }
+        // PENDING or ACCEPTED — already active
+        return null;
+      }
 
       return tx.classCollaborator.create({
         data: {
@@ -153,17 +180,29 @@ export async function respondToInvitation(
 
 /**
  * Remove a collaborator (soft-delete: set status to REMOVED).
+ * Requires planId to prevent IDOR — ensures the collaborator belongs to the specified plan.
  */
 export async function removeCollaborator(
   planType: PlanType,
   collaborationId: string,
+  planId: string,
 ): Promise<WebinarCollaborator | ClassCollaborator | null> {
   if (planType === "webinar") {
+    const collab = await prisma.webinarCollaborator.findFirst({
+      where: { id: collaborationId, webinarPlanId: planId },
+    });
+    if (!collab) return null;
+
     return prisma.webinarCollaborator.update({
       where: { id: collaborationId },
       data: { status: "REMOVED" },
     });
   } else {
+    const collab = await prisma.classCollaborator.findFirst({
+      where: { id: collaborationId, classPlanId: planId },
+    });
+    if (!collab) return null;
+
     return prisma.classCollaborator.update({
       where: { id: collaborationId },
       data: { status: "REMOVED" },
@@ -173,10 +212,12 @@ export async function removeCollaborator(
 
 /**
  * Update a collaborator's revenue share or role.
+ * Requires planId to prevent IDOR — ensures the collaborator belongs to the specified plan.
  */
 export async function updateCollaborator(
   planType: PlanType,
   collaborationId: string,
+  planId: string,
   updates: { revenueSharePercentage?: number; role?: string },
 ): Promise<WebinarCollaborator | ClassCollaborator | null> {
   // Validate percentage range if updating
@@ -188,8 +229,9 @@ export async function updateCollaborator(
 
   return prisma.$transaction(async (tx) => {
     if (planType === "webinar") {
-      const collab = await tx.webinarCollaborator.findUnique({
-        where: { id: collaborationId },
+      // Verify collaborator belongs to this plan (IDOR prevention)
+      const collab = await tx.webinarCollaborator.findFirst({
+        where: { id: collaborationId, webinarPlanId: planId },
       });
       if (!collab) return null;
 
@@ -216,8 +258,9 @@ export async function updateCollaborator(
         },
       });
     } else {
-      const collab = await tx.classCollaborator.findUnique({
-        where: { id: collaborationId },
+      // Verify collaborator belongs to this plan (IDOR prevention)
+      const collab = await tx.classCollaborator.findFirst({
+        where: { id: collaborationId, classPlanId: planId },
       });
       if (!collab) return null;
 

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -348,6 +348,22 @@ export async function getMyCollaborations(consultantProfileId: string) {
             consultantProfile: {
               select: { user: { select: { name: true, image: true } } },
             },
+            collaborators: {
+              where: { status: { in: ["PENDING", "ACCEPTED"] } },
+              select: {
+                id: true,
+                role: true,
+                revenueSharePercentage: true,
+                status: true,
+                consultantProfile: {
+                  select: {
+                    id: true,
+                    user: { select: { name: true, image: true } },
+                  },
+                },
+              },
+              orderBy: { createdAt: "asc" },
+            },
             webinars: {
               where: { status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
               include: {
@@ -394,6 +410,22 @@ export async function getMyCollaborations(consultantProfileId: string) {
             consultantProfile: {
               select: { user: { select: { name: true, image: true } } },
             },
+            collaborators: {
+              where: { status: { in: ["PENDING", "ACCEPTED"] } },
+              select: {
+                id: true,
+                role: true,
+                revenueSharePercentage: true,
+                status: true,
+                consultantProfile: {
+                  select: {
+                    id: true,
+                    user: { select: { name: true, image: true } },
+                  },
+                },
+              },
+              orderBy: { createdAt: "asc" },
+            },
             classes: {
               where: { status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
               include: {
@@ -428,6 +460,111 @@ export async function getMyCollaborations(consultantProfileId: string) {
     webinarCollaborations: webinarCollabs,
     classCollaborations: classCollabs,
   };
+}
+
+/**
+ * Get all plans owned by this consultant that have collaborators.
+ * Returns plans with their collaborator lists and schedule data (host perspective).
+ */
+export async function getHostedCollaborations(consultantProfileId: string) {
+  const [webinarPlans, classPlans] = await Promise.all([
+    prisma.webinarPlan.findMany({
+      where: {
+        consultantProfileId,
+        collaborators: {
+          some: { status: { in: ["PENDING", "ACCEPTED"] } },
+        },
+      },
+      select: {
+        id: true,
+        title: true,
+        price: true,
+        durationInHours: true,
+        maxParticipants: true,
+        language: true,
+        level: true,
+        collaborators: {
+          where: { status: { in: ["PENDING", "ACCEPTED"] } },
+          include: {
+            consultantProfile: {
+              include: { user: { select: { name: true, image: true } } },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+        webinars: {
+          where: { status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
+          include: {
+            appointment: {
+              include: {
+                slotsOfAppointment: {
+                  select: {
+                    startsAt: true,
+                    endsAt: true,
+                    isTentative: true,
+                    _count: { select: { user: true } },
+                  },
+                },
+              },
+            },
+          },
+          orderBy: { createdAt: "desc" },
+          take: 5,
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.classPlan.findMany({
+      where: {
+        consultantProfileId,
+        collaborators: {
+          some: { status: { in: ["PENDING", "ACCEPTED"] } },
+        },
+      },
+      select: {
+        id: true,
+        title: true,
+        price: true,
+        sessionDurationInHours: true,
+        maxParticipants: true,
+        meetingsPerWeek: true,
+        durationInMonths: true,
+        totalSessions: true,
+        collaborators: {
+          where: { status: { in: ["PENDING", "ACCEPTED"] } },
+          include: {
+            consultantProfile: {
+              include: { user: { select: { name: true, image: true } } },
+            },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+        classes: {
+          where: { status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
+          include: {
+            appointments: {
+              include: {
+                slotsOfAppointment: {
+                  select: {
+                    startsAt: true,
+                    endsAt: true,
+                    isTentative: true,
+                    _count: { select: { user: true } },
+                  },
+                  orderBy: { startsAt: "asc" },
+                },
+              },
+            },
+          },
+          orderBy: { createdAt: "desc" },
+          take: 5,
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  return { webinarPlans, classPlans };
 }
 
 /**

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -28,6 +28,27 @@ export async function inviteCollaborator(
   );
   if (!valid) return null;
 
+  // Check for existing active collaboration (not REMOVED/DECLINED)
+  if (planType === "webinar") {
+    const existing = await prisma.webinarCollaborator.findFirst({
+      where: {
+        webinarPlanId: planId,
+        consultantProfileId,
+        status: { notIn: ["REMOVED", "DECLINED"] },
+      },
+    });
+    if (existing) return null;
+  } else {
+    const existing = await prisma.classCollaborator.findFirst({
+      where: {
+        classPlanId: planId,
+        consultantProfileId,
+        status: { notIn: ["REMOVED", "DECLINED"] },
+      },
+    });
+    if (existing) return null;
+  }
+
   if (planType === "webinar") {
     return prisma.webinarCollaborator.create({
       data: {

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -1,0 +1,372 @@
+import prisma from "@/lib/prisma";
+import type {
+  WebinarCollaborator,
+  ClassCollaborator,
+  CollaboratorStatus,
+} from "@prisma/client";
+
+type PlanType = "webinar" | "class";
+
+const MIN_HOST_SHARE = 10; // Host must keep at least 10%
+
+/**
+ * Invite a collaborator to a webinar or class plan.
+ */
+export async function inviteCollaborator(
+  planType: PlanType,
+  planId: string,
+  consultantProfileId: string,
+  role: string,
+  revenueSharePercentage: number,
+  invitedById: string,
+): Promise<WebinarCollaborator | ClassCollaborator | null> {
+  // Validate revenue share total <= 90%
+  const valid = await validateRevenueShares(
+    planType,
+    planId,
+    revenueSharePercentage,
+  );
+  if (!valid) return null;
+
+  if (planType === "webinar") {
+    return prisma.webinarCollaborator.create({
+      data: {
+        consultantProfileId,
+        webinarPlanId: planId,
+        role: role as "CO_HOST" | "MODERATOR" | "GUEST_SPEAKER" | "TECHNICAL_SUPPORT",
+        revenueSharePercentage,
+        status: "PENDING",
+        invitedById,
+      },
+    });
+  } else {
+    return prisma.classCollaborator.create({
+      data: {
+        consultantProfileId,
+        classPlanId: planId,
+        role: role as "CO_INSTRUCTOR" | "TEACHING_ASSISTANT" | "GUEST_LECTURER" | "CONTENT_CREATOR",
+        revenueSharePercentage,
+        status: "PENDING",
+        invitedById,
+      },
+    });
+  }
+}
+
+/**
+ * Respond to a collaboration invitation (accept or decline).
+ * When accepted, auto-creates a collaborator Stream chat channel.
+ */
+export async function respondToInvitation(
+  planType: PlanType,
+  collaborationId: string,
+  consultantProfileId: string,
+  response: "ACCEPTED" | "DECLINED",
+): Promise<WebinarCollaborator | ClassCollaborator | null> {
+  if (planType === "webinar") {
+    const collab = await prisma.webinarCollaborator.findUnique({
+      where: { id: collaborationId },
+    });
+    if (!collab || collab.consultantProfileId !== consultantProfileId) return null;
+    if (collab.status !== "PENDING") return null;
+
+    const updated = await prisma.webinarCollaborator.update({
+      where: { id: collaborationId },
+      data: { status: response, respondedAt: new Date() },
+    });
+
+    if (response === "ACCEPTED") {
+      try {
+        const { createCollaboratorChannel } = await import(
+          "@/actions/stream/chat/channel.action"
+        );
+        await createCollaboratorChannel("webinar", collab.webinarPlanId);
+      } catch (err) {
+        console.error("Failed to create collaborator channel:", err);
+      }
+    }
+
+    return updated;
+  } else {
+    const collab = await prisma.classCollaborator.findUnique({
+      where: { id: collaborationId },
+    });
+    if (!collab || collab.consultantProfileId !== consultantProfileId) return null;
+    if (collab.status !== "PENDING") return null;
+
+    const updated = await prisma.classCollaborator.update({
+      where: { id: collaborationId },
+      data: { status: response, respondedAt: new Date() },
+    });
+
+    if (response === "ACCEPTED") {
+      try {
+        const { createCollaboratorChannel } = await import(
+          "@/actions/stream/chat/channel.action"
+        );
+        await createCollaboratorChannel("class", collab.classPlanId);
+      } catch (err) {
+        console.error("Failed to create collaborator channel:", err);
+      }
+    }
+
+    return updated;
+  }
+}
+
+/**
+ * Remove a collaborator (soft-delete: set status to REMOVED).
+ */
+export async function removeCollaborator(
+  planType: PlanType,
+  collaborationId: string,
+): Promise<WebinarCollaborator | ClassCollaborator | null> {
+  if (planType === "webinar") {
+    return prisma.webinarCollaborator.update({
+      where: { id: collaborationId },
+      data: { status: "REMOVED" },
+    });
+  } else {
+    return prisma.classCollaborator.update({
+      where: { id: collaborationId },
+      data: { status: "REMOVED" },
+    });
+  }
+}
+
+/**
+ * Update a collaborator's revenue share or role.
+ */
+export async function updateCollaborator(
+  planType: PlanType,
+  collaborationId: string,
+  updates: { revenueSharePercentage?: number; role?: string },
+): Promise<WebinarCollaborator | ClassCollaborator | null> {
+  if (planType === "webinar") {
+    const collab = await prisma.webinarCollaborator.findUnique({
+      where: { id: collaborationId },
+    });
+    if (!collab) return null;
+
+    if (updates.revenueSharePercentage !== undefined) {
+      const valid = await validateRevenueShares(
+        "webinar",
+        collab.webinarPlanId,
+        updates.revenueSharePercentage,
+        collaborationId,
+      );
+      if (!valid) return null;
+    }
+
+    return prisma.webinarCollaborator.update({
+      where: { id: collaborationId },
+      data: {
+        ...(updates.revenueSharePercentage !== undefined && {
+          revenueSharePercentage: updates.revenueSharePercentage,
+        }),
+        ...(updates.role && {
+          role: updates.role as "CO_HOST" | "MODERATOR" | "GUEST_SPEAKER" | "TECHNICAL_SUPPORT",
+        }),
+      },
+    });
+  } else {
+    const collab = await prisma.classCollaborator.findUnique({
+      where: { id: collaborationId },
+    });
+    if (!collab) return null;
+
+    if (updates.revenueSharePercentage !== undefined) {
+      const valid = await validateRevenueShares(
+        "class",
+        collab.classPlanId,
+        updates.revenueSharePercentage,
+        collaborationId,
+      );
+      if (!valid) return null;
+    }
+
+    return prisma.classCollaborator.update({
+      where: { id: collaborationId },
+      data: {
+        ...(updates.revenueSharePercentage !== undefined && {
+          revenueSharePercentage: updates.revenueSharePercentage,
+        }),
+        ...(updates.role && {
+          role: updates.role as "CO_INSTRUCTOR" | "TEACHING_ASSISTANT" | "GUEST_LECTURER" | "CONTENT_CREATOR",
+        }),
+      },
+    });
+  }
+}
+
+/**
+ * Get all collaborators for a plan.
+ */
+export async function getCollaborators(
+  planType: PlanType,
+  planId: string,
+) {
+  const activeStatuses: CollaboratorStatus[] = ["PENDING", "ACCEPTED"];
+
+  if (planType === "webinar") {
+    return prisma.webinarCollaborator.findMany({
+      where: { webinarPlanId: planId, status: { in: activeStatuses } },
+      include: {
+        consultantProfile: {
+          include: { user: { select: { name: true, image: true } } },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+  } else {
+    return prisma.classCollaborator.findMany({
+      where: { classPlanId: planId, status: { in: activeStatuses } },
+      include: {
+        consultantProfile: {
+          include: { user: { select: { name: true, image: true } } },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+}
+
+/**
+ * Get all collaborations for a consultant.
+ */
+export async function getMyCollaborations(consultantProfileId: string) {
+  const [webinarCollabs, classCollabs] = await Promise.all([
+    prisma.webinarCollaborator.findMany({
+      where: {
+        consultantProfileId,
+        status: { in: ["PENDING", "ACCEPTED"] },
+      },
+      include: {
+        webinarPlan: {
+          select: { id: true, title: true, price: true },
+        },
+        invitedBy: {
+          include: { user: { select: { name: true } } },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.classCollaborator.findMany({
+      where: {
+        consultantProfileId,
+        status: { in: ["PENDING", "ACCEPTED"] },
+      },
+      include: {
+        classPlan: {
+          select: { id: true, title: true, price: true },
+        },
+        invitedBy: {
+          include: { user: { select: { name: true } } },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  return {
+    webinarCollaborations: webinarCollabs,
+    classCollaborations: classCollabs,
+  };
+}
+
+/**
+ * Validate that total revenue shares don't exceed 90% (host keeps min 10%).
+ */
+export async function validateRevenueShares(
+  planType: PlanType,
+  planId: string,
+  newShare: number,
+  excludeId?: string,
+): Promise<boolean> {
+  let currentTotal = 0;
+
+  if (planType === "webinar") {
+    const collabs = await prisma.webinarCollaborator.findMany({
+      where: {
+        webinarPlanId: planId,
+        status: { in: ["PENDING", "ACCEPTED"] },
+        ...(excludeId && { NOT: { id: excludeId } }),
+      },
+      select: { revenueSharePercentage: true },
+    });
+    currentTotal = collabs.reduce((sum, c) => sum + c.revenueSharePercentage, 0);
+  } else {
+    const collabs = await prisma.classCollaborator.findMany({
+      where: {
+        classPlanId: planId,
+        status: { in: ["PENDING", "ACCEPTED"] },
+        ...(excludeId && { NOT: { id: excludeId } }),
+      },
+      select: { revenueSharePercentage: true },
+    });
+    currentTotal = collabs.reduce((sum, c) => sum + c.revenueSharePercentage, 0);
+  }
+
+  return currentTotal + newShare <= 100 - MIN_HOST_SHARE;
+}
+
+/**
+ * Calculate revenue split for a payment (owner gets remainder).
+ */
+export async function calculateRevenueSplit(
+  planType: PlanType,
+  planId: string,
+  totalAmount: number,
+): Promise<{ consultantProfileId: string; share: number; role: string }[]> {
+  const collabs = await getCollaborators(planType, planId);
+  const acceptedCollabs = collabs.filter((c) => c.status === "ACCEPTED");
+
+  if (acceptedCollabs.length === 0) {
+    return []; // No collaborators - regular single-owner flow
+  }
+
+  const splits: { consultantProfileId: string; share: number; role: string }[] =
+    [];
+
+  let collaboratorTotal = 0;
+  for (const collab of acceptedCollabs) {
+    const share = Math.round(
+      (totalAmount * collab.revenueSharePercentage) / 100,
+    );
+    collaboratorTotal += share;
+    splits.push({
+      consultantProfileId: collab.consultantProfileId,
+      share,
+      role: collab.role,
+    });
+  }
+
+  // Owner gets the remainder
+  const ownerShare = totalAmount - collaboratorTotal;
+
+  // Get plan's owner consultant profile
+  let ownerConsultantProfileId: string | null = null;
+  if (planType === "webinar") {
+    const plan = await prisma.webinarPlan.findUnique({
+      where: { id: planId },
+      select: { consultantProfileId: true },
+    });
+    ownerConsultantProfileId = plan?.consultantProfileId ?? null;
+  } else {
+    const plan = await prisma.classPlan.findUnique({
+      where: { id: planId },
+      select: { consultantProfileId: true },
+    });
+    ownerConsultantProfileId = plan?.consultantProfileId ?? null;
+  }
+
+  if (ownerConsultantProfileId) {
+    splits.unshift({
+      consultantProfileId: ownerConsultantProfileId,
+      share: ownerShare,
+      role: "OWNER",
+    });
+  }
+
+  return splits;
+}

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -1,4 +1,9 @@
 import prisma from "@/lib/prisma";
+import {
+  Prisma,
+  type WebinarCollaboratorRole,
+  type ClassCollaboratorRole,
+} from "@prisma/client";
 import type {
   WebinarCollaborator,
   ClassCollaborator,
@@ -20,58 +25,69 @@ export async function inviteCollaborator(
   revenueSharePercentage: number,
   invitedById: string,
 ): Promise<WebinarCollaborator | ClassCollaborator | null> {
-  // Validate revenue share total <= 90%
-  const valid = await validateRevenueShares(
-    planType,
-    planId,
-    revenueSharePercentage,
-  );
-  if (!valid) return null;
-
-  // Check for existing active collaboration (not REMOVED/DECLINED)
-  if (planType === "webinar") {
-    const existing = await prisma.webinarCollaborator.findFirst({
-      where: {
-        webinarPlanId: planId,
-        consultantProfileId,
-        status: { notIn: ["REMOVED", "DECLINED"] },
-      },
-    });
-    if (existing) return null;
-  } else {
-    const existing = await prisma.classCollaborator.findFirst({
-      where: {
-        classPlanId: planId,
-        consultantProfileId,
-        status: { notIn: ["REMOVED", "DECLINED"] },
-      },
-    });
-    if (existing) return null;
+  // Validate percentage range
+  if (revenueSharePercentage <= 0 || revenueSharePercentage > 90) {
+    return null;
   }
 
-  if (planType === "webinar") {
-    return prisma.webinarCollaborator.create({
-      data: {
-        consultantProfileId,
-        webinarPlanId: planId,
-        role: role as "CO_HOST" | "MODERATOR" | "GUEST_SPEAKER" | "TECHNICAL_SUPPORT",
-        revenueSharePercentage,
-        status: "PENDING",
-        invitedById,
-      },
-    });
-  } else {
-    return prisma.classCollaborator.create({
-      data: {
-        consultantProfileId,
-        classPlanId: planId,
-        role: role as "CO_INSTRUCTOR" | "TEACHING_ASSISTANT" | "GUEST_LECTURER" | "CONTENT_CREATOR",
-        revenueSharePercentage,
-        status: "PENDING",
-        invitedById,
-      },
-    });
-  }
+  // FIX B1: Wrap validation + creation in a serializable transaction
+  // to prevent concurrent invites from exceeding the 90% cap.
+  return prisma.$transaction(async (tx) => {
+    // Validate revenue share total <= 90% INSIDE transaction
+    const valid = await validateRevenueSharesTx(
+      tx,
+      planType,
+      planId,
+      revenueSharePercentage,
+    );
+    if (!valid) return null;
+
+    // Check for existing active collaboration (not REMOVED/DECLINED)
+    if (planType === "webinar") {
+      const existing = await tx.webinarCollaborator.findFirst({
+        where: {
+          webinarPlanId: planId,
+          consultantProfileId,
+          status: { notIn: ["REMOVED", "DECLINED"] },
+        },
+      });
+      if (existing) return null;
+
+      return tx.webinarCollaborator.create({
+        data: {
+          consultantProfileId,
+          webinarPlanId: planId,
+          role: role as WebinarCollaboratorRole,
+          revenueSharePercentage,
+          status: "PENDING",
+          invitedById,
+        },
+      });
+    } else {
+      const existing = await tx.classCollaborator.findFirst({
+        where: {
+          classPlanId: planId,
+          consultantProfileId,
+          status: { notIn: ["REMOVED", "DECLINED"] },
+        },
+      });
+      if (existing) return null;
+
+      return tx.classCollaborator.create({
+        data: {
+          consultantProfileId,
+          classPlanId: planId,
+          role: role as ClassCollaboratorRole,
+          revenueSharePercentage,
+          status: "PENDING",
+          invitedById,
+        },
+      });
+    }
+  }, {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    timeout: 10000,
+  });
 }
 
 /**
@@ -163,61 +179,75 @@ export async function updateCollaborator(
   collaborationId: string,
   updates: { revenueSharePercentage?: number; role?: string },
 ): Promise<WebinarCollaborator | ClassCollaborator | null> {
-  if (planType === "webinar") {
-    const collab = await prisma.webinarCollaborator.findUnique({
-      where: { id: collaborationId },
-    });
-    if (!collab) return null;
-
-    if (updates.revenueSharePercentage !== undefined) {
-      const valid = await validateRevenueShares(
-        "webinar",
-        collab.webinarPlanId,
-        updates.revenueSharePercentage,
-        collaborationId,
-      );
-      if (!valid) return null;
+  // Validate percentage range if updating
+  if (updates.revenueSharePercentage !== undefined) {
+    if (updates.revenueSharePercentage <= 0 || updates.revenueSharePercentage > 90) {
+      return null;
     }
-
-    return prisma.webinarCollaborator.update({
-      where: { id: collaborationId },
-      data: {
-        ...(updates.revenueSharePercentage !== undefined && {
-          revenueSharePercentage: updates.revenueSharePercentage,
-        }),
-        ...(updates.role && {
-          role: updates.role as "CO_HOST" | "MODERATOR" | "GUEST_SPEAKER" | "TECHNICAL_SUPPORT",
-        }),
-      },
-    });
-  } else {
-    const collab = await prisma.classCollaborator.findUnique({
-      where: { id: collaborationId },
-    });
-    if (!collab) return null;
-
-    if (updates.revenueSharePercentage !== undefined) {
-      const valid = await validateRevenueShares(
-        "class",
-        collab.classPlanId,
-        updates.revenueSharePercentage,
-        collaborationId,
-      );
-      if (!valid) return null;
-    }
-
-    return prisma.classCollaborator.update({
-      where: { id: collaborationId },
-      data: {
-        ...(updates.revenueSharePercentage !== undefined && {
-          revenueSharePercentage: updates.revenueSharePercentage,
-        }),
-        ...(updates.role && {
-          role: updates.role as "CO_INSTRUCTOR" | "TEACHING_ASSISTANT" | "GUEST_LECTURER" | "CONTENT_CREATOR",
-        }),
-      },
-    });
   }
+
+  return prisma.$transaction(async (tx) => {
+    if (planType === "webinar") {
+      const collab = await tx.webinarCollaborator.findUnique({
+        where: { id: collaborationId },
+      });
+      if (!collab) return null;
+
+      if (updates.revenueSharePercentage !== undefined) {
+        const valid = await validateRevenueSharesTx(
+          tx,
+          "webinar",
+          collab.webinarPlanId,
+          updates.revenueSharePercentage,
+          collaborationId,
+        );
+        if (!valid) return null;
+      }
+
+      return tx.webinarCollaborator.update({
+        where: { id: collaborationId },
+        data: {
+          ...(updates.revenueSharePercentage !== undefined && {
+            revenueSharePercentage: updates.revenueSharePercentage,
+          }),
+          ...(updates.role && {
+            role: updates.role as WebinarCollaboratorRole,
+          }),
+        },
+      });
+    } else {
+      const collab = await tx.classCollaborator.findUnique({
+        where: { id: collaborationId },
+      });
+      if (!collab) return null;
+
+      if (updates.revenueSharePercentage !== undefined) {
+        const valid = await validateRevenueSharesTx(
+          tx,
+          "class",
+          collab.classPlanId,
+          updates.revenueSharePercentage,
+          collaborationId,
+        );
+        if (!valid) return null;
+      }
+
+      return tx.classCollaborator.update({
+        where: { id: collaborationId },
+        data: {
+          ...(updates.revenueSharePercentage !== undefined && {
+            revenueSharePercentage: updates.revenueSharePercentage,
+          }),
+          ...(updates.role && {
+            role: updates.role as ClassCollaboratorRole,
+          }),
+        },
+      });
+    }
+  }, {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    timeout: 10000,
+  });
 }
 
 /**
@@ -297,8 +327,10 @@ export async function getMyCollaborations(consultantProfileId: string) {
 
 /**
  * Validate that total revenue shares don't exceed 90% (host keeps min 10%).
+ * Transaction-safe version that accepts a Prisma transaction client.
  */
-export async function validateRevenueShares(
+async function validateRevenueSharesTx(
+  db: Prisma.TransactionClient | typeof prisma,
   planType: PlanType,
   planId: string,
   newShare: number,
@@ -307,7 +339,7 @@ export async function validateRevenueShares(
   let currentTotal = 0;
 
   if (planType === "webinar") {
-    const collabs = await prisma.webinarCollaborator.findMany({
+    const collabs = await db.webinarCollaborator.findMany({
       where: {
         webinarPlanId: planId,
         status: { in: ["PENDING", "ACCEPTED"] },
@@ -317,7 +349,7 @@ export async function validateRevenueShares(
     });
     currentTotal = collabs.reduce((sum, c) => sum + c.revenueSharePercentage, 0);
   } else {
-    const collabs = await prisma.classCollaborator.findMany({
+    const collabs = await db.classCollaborator.findMany({
       where: {
         classPlanId: planId,
         status: { in: ["PENDING", "ACCEPTED"] },
@@ -329,6 +361,19 @@ export async function validateRevenueShares(
   }
 
   return currentTotal + newShare <= 100 - MIN_HOST_SHARE;
+}
+
+/**
+ * Validate that total revenue shares don't exceed 90% (host keeps min 10%).
+ * Public wrapper that uses the global prisma client.
+ */
+export async function validateRevenueShares(
+  planType: PlanType,
+  planId: string,
+  newShare: number,
+  excludeId?: string,
+): Promise<boolean> {
+  return validateRevenueSharesTx(prisma, planType, planId, newShare, excludeId);
 }
 
 /**

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -337,7 +337,37 @@ export async function getMyCollaborations(consultantProfileId: string) {
       },
       include: {
         webinarPlan: {
-          select: { id: true, title: true, price: true },
+          select: {
+            id: true,
+            title: true,
+            price: true,
+            durationInHours: true,
+            maxParticipants: true,
+            language: true,
+            level: true,
+            consultantProfile: {
+              select: { user: { select: { name: true, image: true } } },
+            },
+            webinars: {
+              where: { status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
+              include: {
+                appointment: {
+                  include: {
+                    slotsOfAppointment: {
+                      select: {
+                        startsAt: true,
+                        endsAt: true,
+                        isTentative: true,
+                        _count: { select: { user: true } },
+                      },
+                    },
+                  },
+                },
+              },
+              orderBy: { createdAt: "desc" },
+              take: 5,
+            },
+          },
         },
         invitedBy: {
           include: { user: { select: { name: true } } },
@@ -352,7 +382,39 @@ export async function getMyCollaborations(consultantProfileId: string) {
       },
       include: {
         classPlan: {
-          select: { id: true, title: true, price: true },
+          select: {
+            id: true,
+            title: true,
+            price: true,
+            sessionDurationInHours: true,
+            maxParticipants: true,
+            meetingsPerWeek: true,
+            durationInMonths: true,
+            totalSessions: true,
+            consultantProfile: {
+              select: { user: { select: { name: true, image: true } } },
+            },
+            classes: {
+              where: { status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
+              include: {
+                appointments: {
+                  include: {
+                    slotsOfAppointment: {
+                      select: {
+                        startsAt: true,
+                        endsAt: true,
+                        isTentative: true,
+                        _count: { select: { user: true } },
+                      },
+                      orderBy: { startsAt: "asc" },
+                    },
+                  },
+                },
+              },
+              orderBy: { createdAt: "desc" },
+              take: 5,
+            },
+          },
         },
         invitedBy: {
           include: { user: { select: { name: true } } },

--- a/lib/novu/index.ts
+++ b/lib/novu/index.ts
@@ -47,4 +47,12 @@ export {
   notifyDisputeResolved,
   // Recordings
   notifyRecordingAvailable,
+  // Referrals
+  notifyReferralBonusEarned,
+  notifyRefereeWelcomeBonus,
+  notifyReferralCreditsApplied,
+  // Collaborators
+  notifyCollaboratorInvited,
+  notifyCollaboratorAccepted,
+  notifyCollaboratorRemoved,
 } from "./service";

--- a/lib/novu/service.ts
+++ b/lib/novu/service.ts
@@ -26,6 +26,12 @@ import {
   type DisputePayload,
   type RecordingPayload,
   type ConsultantApplicationPayload,
+  type ReferralBonusPayload,
+  type RefereeWelcomeBonusPayload,
+  type ReferralCreditsAppliedPayload,
+  type CollaboratorInvitedPayload,
+  type CollaboratorAcceptedPayload,
+  type CollaboratorRemovedPayload,
 } from "./workflows";
 
 // ============================================================================
@@ -468,6 +474,80 @@ export async function notifyRecordingAvailable(
   return triggerForMultiple(
     NOVU_WORKFLOWS.RECORDING_AVAILABLE,
     userIds,
+    payload,
+  );
+}
+
+// ============================================================================
+// Referral Notifications
+// ============================================================================
+
+export async function notifyReferralBonusEarned(
+  referrerUserId: string,
+  payload: ReferralBonusPayload,
+) {
+  return triggerWorkflow(
+    NOVU_WORKFLOWS.REFERRAL_BONUS_EARNED,
+    referrerUserId,
+    payload,
+  );
+}
+
+export async function notifyRefereeWelcomeBonus(
+  refereeUserId: string,
+  payload: RefereeWelcomeBonusPayload,
+) {
+  return triggerWorkflow(
+    NOVU_WORKFLOWS.REFEREE_WELCOME_BONUS,
+    refereeUserId,
+    payload,
+  );
+}
+
+export async function notifyReferralCreditsApplied(
+  userId: string,
+  payload: ReferralCreditsAppliedPayload,
+) {
+  return triggerWorkflow(
+    NOVU_WORKFLOWS.REFERRAL_CREDITS_APPLIED,
+    userId,
+    payload,
+  );
+}
+
+// ============================================================================
+// Collaborator Notifications
+// ============================================================================
+
+export async function notifyCollaboratorInvited(
+  consultantUserId: string,
+  payload: CollaboratorInvitedPayload,
+) {
+  return triggerWorkflow(
+    NOVU_WORKFLOWS.COLLABORATOR_INVITED,
+    consultantUserId,
+    payload,
+  );
+}
+
+export async function notifyCollaboratorAccepted(
+  ownerUserId: string,
+  payload: CollaboratorAcceptedPayload,
+) {
+  return triggerWorkflow(
+    NOVU_WORKFLOWS.COLLABORATOR_ACCEPTED,
+    ownerUserId,
+    payload,
+  );
+}
+
+export async function notifyCollaboratorRemoved(
+  consultantUserId: string,
+  payload: CollaboratorRemovedPayload,
+) {
+  return triggerWorkflow(
+    NOVU_WORKFLOWS.COLLABORATOR_REMOVED,
+    consultantUserId,
     payload,
   );
 }

--- a/lib/novu/workflows.ts
+++ b/lib/novu/workflows.ts
@@ -60,6 +60,16 @@ export const NOVU_WORKFLOWS = {
 
   // Recordings
   RECORDING_AVAILABLE: "recording-available",
+
+  // Referrals
+  REFERRAL_BONUS_EARNED: "referral-bonus-earned",
+  REFEREE_WELCOME_BONUS: "referee-welcome-bonus",
+  REFERRAL_CREDITS_APPLIED: "referral-credits-applied",
+
+  // Collaborators
+  COLLABORATOR_INVITED: "collaborator-invited",
+  COLLABORATOR_ACCEPTED: "collaborator-accepted",
+  COLLABORATOR_REMOVED: "collaborator-removed",
 } as const;
 
 export type NovuWorkflowId =
@@ -216,5 +226,52 @@ export type RecordingPayload = {
 export type ConsultantApplicationPayload = {
   applicantName: string;
   applicantEmail: string;
+  dashboardUrl: string;
+};
+
+export type ReferralBonusPayload = {
+  referrerName: string;
+  refereeName: string;
+  bonusAmount: number;
+  currency: string;
+  dashboardUrl: string;
+};
+
+export type RefereeWelcomeBonusPayload = {
+  refereeName: string;
+  referrerName: string;
+  bonusAmount: number;
+  currency: string;
+  dashboardUrl: string;
+};
+
+export type ReferralCreditsAppliedPayload = {
+  creditsUsed: number;
+  currency: string;
+  remainingCredits: number;
+  appointmentType: string;
+  dashboardUrl: string;
+};
+
+export type CollaboratorInvitedPayload = {
+  planTitle: string;
+  planType: string;
+  role: string;
+  revenueSharePercentage: number;
+  ownerName: string;
+  dashboardUrl: string;
+};
+
+export type CollaboratorAcceptedPayload = {
+  planTitle: string;
+  planType: string;
+  collaboratorName: string;
+  role: string;
+  dashboardUrl: string;
+};
+
+export type CollaboratorRemovedPayload = {
+  planTitle: string;
+  planType: string;
   dashboardUrl: string;
 };

--- a/lib/payments/operations/approval-payment.ts
+++ b/lib/payments/operations/approval-payment.ts
@@ -134,6 +134,7 @@ export async function createApprovalPaymentIntent(
     await prisma.payment.create({
       data: {
         amount,
+        originalAmount: amount, // No discounts/credits in approval flow
         currency,
         description: `Payment for ${params.appointmentType.toLowerCase()} - ${plan.title}`,
         paymentMethod: "card",

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -1575,13 +1575,14 @@ export async function handleCheckout(
               );
             }
 
-            // If fewer credits were available than expected, the payment amount
-            // was already set based on the pre-lock value. The difference is small
-            // and covered by the payment gateway's authorized amount.
+            // FIX #2: If fewer credits were available than expected (due to concurrent
+            // checkout consuming them between TX1 and TX2), abort the transaction.
+            // The payment intent was created with a reduced amount based on TX1's
+            // credit calculation, so proceeding would undercharge the user.
             if (actualCreditsApplied < creditsApplied) {
-              console.warn(
-                `⚠️ Credit shortfall: expected ${creditsApplied} but only ${actualCreditsApplied} available. ` +
-                `Payment ${payment.id} may need adjustment.`,
+              throw new Error(
+                `CREDIT_SHORTFALL: expected ${creditsApplied} credits but only ${actualCreditsApplied} available. ` +
+                `Payment ${payment.id} amount is stale. Aborting for retry.`,
               );
             }
           }

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -34,6 +34,7 @@ import {
   getUserCredits,
   processQualifyingAction,
 } from "@/lib/referrals/service";
+import { TAX_CONSTANTS } from "@/lib/payments/payouts/constants";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -387,7 +388,11 @@ export async function calculateAmountAndValidate(
         currency = validatedData.paymentGateway === "RAZORPAY" ? "INR" : "USD";
     }
 
-    // Apply referral credits if requested
+    // Calculate GST on the discounted price (tax-exclusive: plan.price + 18% GST)
+    const taxAmount = Math.round((amount * TAX_CONSTANTS.GST_RATE) / 100);
+    amount = amount + taxAmount;
+
+    // Apply referral credits AFTER tax (credits act as a payment method, not a trade discount)
     let creditsApplied = 0;
     if (validatedData.useReferralCredits && amount > 0) {
       const { totalAvailable } = await getUserCredits(userId, tx);
@@ -402,6 +407,7 @@ export async function calculateAmountAndValidate(
     return {
       amount,
       originalAmount,
+      taxAmount,
       currency,
       discountCodeId,
       consulteeProfileId: user.consulteeProfile.id,
@@ -1420,7 +1426,7 @@ export async function handleCheckout(
 
   try {
     // STEP 1: Calculate amount and fetch plan data (OUTSIDE LOCK - just pricing)
-    const { amount, originalAmount, currency, discountCodeId, consulteeProfileId, creditsApplied } =
+    const { amount, originalAmount, taxAmount, currency, discountCodeId, consulteeProfileId, creditsApplied } =
       await calculateAmountAndValidate(validatedData, userId);
 
     // Get plan data for consultant ID (needed for lock acquisition)
@@ -1535,6 +1541,7 @@ export async function handleCheckout(
             data: {
               amount,
               originalAmount,
+              taxAmount,
               currency,
               paymentMethod: "CARD",
               paymentIntent: paymentResponse!.id,

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -323,6 +323,10 @@ export async function calculateAmountAndValidate(
         throw new Error("Invalid appointment type");
     }
 
+    // Capture original plan price before any discounts/credits
+    // This is used for consultant earnings — discounts are platform-funded, not consultant-funded
+    const originalAmount = amount;
+
     // Apply discount if provided - with full backend re-validation
     let discountCodeId = null;
     if (validatedData.discountCode) {
@@ -397,6 +401,7 @@ export async function calculateAmountAndValidate(
 
     return {
       amount,
+      originalAmount,
       currency,
       discountCodeId,
       consulteeProfileId: user.consulteeProfile.id,
@@ -1415,7 +1420,7 @@ export async function handleCheckout(
 
   try {
     // STEP 1: Calculate amount and fetch plan data (OUTSIDE LOCK - just pricing)
-    const { amount, currency, discountCodeId, consulteeProfileId, creditsApplied } =
+    const { amount, originalAmount, currency, discountCodeId, consulteeProfileId, creditsApplied } =
       await calculateAmountAndValidate(validatedData, userId);
 
     // Get plan data for consultant ID (needed for lock acquisition)
@@ -1529,6 +1534,7 @@ export async function handleCheckout(
           const payment = await tx.payment.create({
             data: {
               amount,
+              originalAmount,
               currency,
               paymentMethod: "CARD",
               paymentIntent: paymentResponse!.id,

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -35,6 +35,10 @@ import {
   processQualifyingAction,
 } from "@/lib/referrals/service";
 import { TAX_CONSTANTS } from "@/lib/payments/payouts/constants";
+import {
+  createEarningsFromPayment,
+  type AppointmentType,
+} from "@/lib/payments/payouts";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -1644,6 +1648,106 @@ export async function handleCheckout(
           console.error(
             `⚠️ Failed to process referral qualifying action for user ${userId}:`,
             referralError,
+          );
+        }
+
+        // Create consultant earnings (mock payments bypass webhooks, so earnings must be created here)
+        try {
+          const paymentWithAppointment = await prisma.payment.findUnique({
+            where: { paymentIntent: paymentResponse!.id },
+            include: {
+              appointment: {
+                include: {
+                  consultation: {
+                    include: {
+                      consultationPlan: {
+                        include: { consultantProfile: true },
+                      },
+                    },
+                  },
+                  subscription: {
+                    include: {
+                      subscriptionPlan: {
+                        include: { consultantProfile: true },
+                      },
+                    },
+                  },
+                  webinar: {
+                    select: {
+                      id: true,
+                      webinarPlanId: true,
+                      webinarPlan: {
+                        include: { consultantProfile: true },
+                      },
+                    },
+                  },
+                  class: {
+                    select: {
+                      id: true,
+                      classPlanId: true,
+                      classPlan: {
+                        include: { consultantProfile: true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          if (paymentWithAppointment?.appointment) {
+            const consultantProfile =
+              paymentWithAppointment.appointment.consultation?.consultationPlan
+                ?.consultantProfile ||
+              paymentWithAppointment.appointment.subscription?.subscriptionPlan
+                ?.consultantProfile ||
+              paymentWithAppointment.appointment.webinar?.webinarPlan
+                ?.consultantProfile ||
+              paymentWithAppointment.appointment.class?.classPlan
+                ?.consultantProfile;
+
+            if (consultantProfile) {
+              const appointmentTypeMap: Record<string, AppointmentType> = {
+                CONSULTATION: "CONSULTATION",
+                SUBSCRIPTION: "SUBSCRIPTION",
+                WEBINAR: "WEBINAR",
+                CLASS: "CLASS",
+              };
+
+              const earningsAppointmentType =
+                appointmentTypeMap[validatedData.appointmentType] || "CONSULTATION";
+
+              const paymentForEarnings = {
+                ...paymentWithAppointment,
+                appointment: {
+                  ...paymentWithAppointment.appointment,
+                  consultantProfile: { id: consultantProfile.id },
+                  webinar: paymentWithAppointment.appointment.webinar
+                    ? { webinarPlanId: paymentWithAppointment.appointment.webinar.webinarPlanId }
+                    : null,
+                  class: paymentWithAppointment.appointment.class
+                    ? { classPlanId: paymentWithAppointment.appointment.class.classPlanId }
+                    : null,
+                },
+              };
+
+              await createEarningsFromPayment({
+                payment: paymentForEarnings as Parameters<
+                  typeof createEarningsFromPayment
+                >[0]["payment"],
+                appointmentType: earningsAppointmentType,
+              });
+
+              console.log(
+                `💰 Mock payment earnings created for consultant ${consultantProfile.id}`,
+              );
+            }
+          }
+        } catch (earningsError) {
+          // Log but don't fail — sync-payment-earnings job will pick up the gap
+          console.error(
+            `⚠️ Failed to create earnings for mock payment:`,
+            earningsError,
           );
         }
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -1557,16 +1557,36 @@ export async function handleCheckout(
             });
           }
 
-          // Deduct referral credits inside the transaction for atomicity
-          // If credit deduction fails, the entire transaction rolls back
+          // FIX A3: Re-read credits inside the main transaction to prevent stale reads.
+          // creditsApplied was calculated in TX1 (calculateAmountAndValidate), but between
+          // TX1 and TX2, concurrent checkouts may have consumed the credits.
+          let actualCreditsApplied = 0;
           if (creditsApplied > 0) {
-            await applyCreditsToPayment(userId, creditsApplied, tx);
-            console.log(
-              `🎁 Applied ${creditsApplied} referral credits for user ${userId}`,
-            );
+            const { totalAvailable } = await getUserCredits(userId, tx);
+            actualCreditsApplied = Math.min(totalAvailable, creditsApplied);
+
+            if (actualCreditsApplied > 0) {
+              await applyCreditsToPayment(userId, actualCreditsApplied, tx, payment.id);
+              console.log(
+                `🎁 Applied ${actualCreditsApplied} referral credits for user ${userId}` +
+                (actualCreditsApplied !== creditsApplied
+                  ? ` (requested ${creditsApplied}, available ${totalAvailable})`
+                  : ""),
+              );
+            }
+
+            // If fewer credits were available than expected, the payment amount
+            // was already set based on the pre-lock value. The difference is small
+            // and covered by the payment gateway's authorized amount.
+            if (actualCreditsApplied < creditsApplied) {
+              console.warn(
+                `⚠️ Credit shortfall: expected ${creditsApplied} but only ${actualCreditsApplied} available. ` +
+                `Payment ${payment.id} may need adjustment.`,
+              );
+            }
           }
 
-          return { appointmentId: createdAppointment?.id, creditsApplied };
+          return { appointmentId: createdAppointment?.id, creditsApplied: actualCreditsApplied };
         },
         {
           timeout: 25000,

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -32,6 +32,7 @@ import { markWaitlistAsBooked } from "@/lib/waitlist/slot-handler";
 import {
   applyCreditsToPayment,
   getUserCredits,
+  processQualifyingAction,
 } from "@/lib/referrals/service";
 
 // Re-export for backward compatibility
@@ -73,7 +74,7 @@ type SubscriptionCheckoutResult = {
 function buildPaymentMetadata(
   data: CheckoutInput,
   userId: string,
-): { appointmentId: string; appointmentType: string; [key: string]: string } {
+): { appointmentId: string; appointmentType: string;[key: string]: string } {
   return {
     appointmentId: "pending",
     appointmentType: data.appointmentType,
@@ -456,14 +457,14 @@ export async function validateSlotAvailability(
         // FIX: Filter by consultant - only check slots belonging to this consultant
         ...(consultantUserId
           ? [
-              {
-                user: {
-                  some: {
-                    id: consultantUserId,
-                  },
+            {
+              user: {
+                some: {
+                  id: consultantUserId,
                 },
               },
-            ]
+            },
+          ]
           : []),
       ],
     },
@@ -498,14 +499,14 @@ export async function validateSlotAvailability(
           // FIX: Filter by consultant - only check tentative slots for this consultant
           ...(consultantUserId
             ? [
-                {
-                  user: {
-                    some: {
-                      id: consultantUserId,
-                    },
+              {
+                user: {
+                  some: {
+                    id: consultantUserId,
                   },
                 },
-              ]
+              },
+            ]
             : []),
           {
             appointment: {
@@ -569,14 +570,14 @@ export async function validateSlotAvailability(
         // FIX: Filter by consultant - only count tentative slots for this consultant
         ...(consultantUserId
           ? [
-              {
-                user: {
-                  some: {
-                    id: consultantUserId,
-                  },
+            {
+              user: {
+                some: {
+                  id: consultantUserId,
                 },
               },
-            ]
+            },
+          ]
           : []),
         {
           appointment: {
@@ -1614,20 +1615,35 @@ export async function handleCheckout(
         }),
       );
 
-      // Update waitlist status if coming from waitlist flow
-      if (isMockPayment && validatedData.fromWaitlist) {
+      // Mock payment post-processing: referral qualifying action + waitlist
+      // Real payments handle this via handlePaymentSuccess() in the webhook,
+      // but mock payments bypass webhooks entirely.
+      if (isMockPayment) {
+        // Trigger referral reward if this is the user's first paid booking
         try {
-          await markWaitlistAsBooked(validatedData.fromWaitlist);
-          console.log(
-            JSON.stringify({
-              event: "waitlist_booking_completed",
-              waitlistId: validatedData.fromWaitlist,
-              timestamp: new Date().toISOString(),
-            }),
+          await processQualifyingAction(userId, "first_paid_booking");
+        } catch (referralError) {
+          console.error(
+            `⚠️ Failed to process referral qualifying action for user ${userId}:`,
+            referralError,
           );
-        } catch (waitlistError) {
-          // Log but don't fail the checkout - payment was successful
-          console.error("Failed to update waitlist status:", waitlistError);
+        }
+
+        // Update waitlist status if coming from waitlist flow
+        if (validatedData.fromWaitlist) {
+          try {
+            await markWaitlistAsBooked(validatedData.fromWaitlist);
+            console.log(
+              JSON.stringify({
+                event: "waitlist_booking_completed",
+                waitlistId: validatedData.fromWaitlist,
+                timestamp: new Date().toISOString(),
+              }),
+            );
+          } catch (waitlistError) {
+            // Log but don't fail the checkout - payment was successful
+            console.error("Failed to update waitlist status:", waitlistError);
+          }
         }
       }
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -388,8 +388,9 @@ export async function calculateAmountAndValidate(
     if (validatedData.useReferralCredits && amount > 0) {
       const { totalAvailable } = await getUserCredits(userId, tx);
       if (totalAvailable > 0) {
-        // Credits are stored in paise, amount is also in paise
-        creditsApplied = Math.min(totalAvailable, amount);
+        // Credits are stored in paise, amount is in rupees — convert to rupees for comparison
+        const creditsInRupees = Math.floor(totalAvailable / 100);
+        creditsApplied = Math.min(creditsInRupees, amount);
         amount = amount - creditsApplied;
       }
     }
@@ -1564,14 +1565,17 @@ export async function handleCheckout(
           let actualCreditsApplied = 0;
           if (creditsApplied > 0) {
             const { totalAvailable } = await getUserCredits(userId, tx);
-            actualCreditsApplied = Math.min(totalAvailable, creditsApplied);
+            // creditsApplied is in rupees (from TX1), convert to paise for comparison
+            // with totalAvailable (paise) and for applyCreditsToPayment (works in paise)
+            const creditsAppliedInPaise = creditsApplied * 100;
+            const actualCreditsInPaise = Math.min(totalAvailable, creditsAppliedInPaise);
 
-            if (actualCreditsApplied > 0) {
-              await applyCreditsToPayment(userId, actualCreditsApplied, tx, payment.id);
+            if (actualCreditsInPaise > 0) {
+              await applyCreditsToPayment(userId, actualCreditsInPaise, tx, payment.id);
               console.log(
-                `🎁 Applied ${actualCreditsApplied} referral credits for user ${userId}` +
-                (actualCreditsApplied !== creditsApplied
-                  ? ` (requested ${creditsApplied}, available ${totalAvailable})`
+                `🎁 Applied ${actualCreditsInPaise} paise (₹${creditsApplied}) referral credits for user ${userId}` +
+                (actualCreditsInPaise !== creditsAppliedInPaise
+                  ? ` (requested ${creditsAppliedInPaise} paise, available ${totalAvailable} paise)`
                   : ""),
               );
             }
@@ -1580,12 +1584,13 @@ export async function handleCheckout(
             // checkout consuming them between TX1 and TX2), abort the transaction.
             // The payment intent was created with a reduced amount based on TX1's
             // credit calculation, so proceeding would undercharge the user.
-            if (actualCreditsApplied < creditsApplied) {
+            if (actualCreditsInPaise < creditsAppliedInPaise) {
               throw new Error(
-                `CREDIT_SHORTFALL: expected ${creditsApplied} credits but only ${actualCreditsApplied} available. ` +
+                `CREDIT_SHORTFALL: expected ${creditsAppliedInPaise} paise credits but only ${actualCreditsInPaise} available. ` +
                 `Payment ${payment.id} amount is stale. Aborting for retry.`,
               );
             }
+            actualCreditsApplied = creditsApplied; // In rupees for return value
           }
 
           return { appointmentId: createdAppointment?.id, creditsApplied: actualCreditsApplied };

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -29,6 +29,10 @@ import {
   countWebinarParticipants,
 } from "@/lib/payments/utils/participants";
 import { markWaitlistAsBooked } from "@/lib/waitlist/slot-handler";
+import {
+  applyCreditsToPayment,
+  getUserCredits,
+} from "@/lib/referrals/service";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -378,11 +382,23 @@ export async function calculateAmountAndValidate(
         currency = validatedData.paymentGateway === "RAZORPAY" ? "INR" : "USD";
     }
 
+    // Apply referral credits if requested
+    let creditsApplied = 0;
+    if (validatedData.useReferralCredits && amount > 0) {
+      const { totalAvailable } = await getUserCredits(userId);
+      if (totalAvailable > 0) {
+        // Credits are stored in paise, amount is also in paise
+        creditsApplied = Math.min(totalAvailable, amount);
+        amount = amount - creditsApplied;
+      }
+    }
+
     return {
       amount,
       currency,
       discountCodeId,
       consulteeProfileId: user.consulteeProfile.id,
+      creditsApplied,
     };
   });
 }
@@ -1397,7 +1413,7 @@ export async function handleCheckout(
 
   try {
     // STEP 1: Calculate amount and fetch plan data (OUTSIDE LOCK - just pricing)
-    const { amount, currency, discountCodeId, consulteeProfileId } =
+    const { amount, currency, discountCodeId, consulteeProfileId, creditsApplied } =
       await calculateAmountAndValidate(validatedData, userId);
 
     // Get plan data for consultant ID (needed for lock acquisition)
@@ -1541,7 +1557,7 @@ export async function handleCheckout(
             });
           }
 
-          return { appointmentId: createdAppointment?.id };
+          return { appointmentId: createdAppointment?.id, creditsApplied };
         },
         {
           timeout: 25000,
@@ -1567,6 +1583,21 @@ export async function handleCheckout(
           timestamp: new Date().toISOString(),
         }),
       );
+
+      // Deduct referral credits if applied
+      if (result.creditsApplied && result.creditsApplied > 0) {
+        try {
+          await applyCreditsToPayment(userId, result.creditsApplied);
+          console.log(
+            `🎁 Applied ${result.creditsApplied} referral credits for user ${userId}`,
+          );
+        } catch (creditError) {
+          console.error(
+            `⚠️ Failed to deduct referral credits for user ${userId}:`,
+            creditError,
+          );
+        }
+      }
 
       // Update waitlist status if coming from waitlist flow
       if (isMockPayment && validatedData.fromWaitlist) {

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -385,7 +385,7 @@ export async function calculateAmountAndValidate(
     // Apply referral credits if requested
     let creditsApplied = 0;
     if (validatedData.useReferralCredits && amount > 0) {
-      const { totalAvailable } = await getUserCredits(userId);
+      const { totalAvailable } = await getUserCredits(userId, tx);
       if (totalAvailable > 0) {
         // Credits are stored in paise, amount is also in paise
         creditsApplied = Math.min(totalAvailable, amount);
@@ -1557,6 +1557,15 @@ export async function handleCheckout(
             });
           }
 
+          // Deduct referral credits inside the transaction for atomicity
+          // If credit deduction fails, the entire transaction rolls back
+          if (creditsApplied > 0) {
+            await applyCreditsToPayment(userId, creditsApplied, tx);
+            console.log(
+              `🎁 Applied ${creditsApplied} referral credits for user ${userId}`,
+            );
+          }
+
           return { appointmentId: createdAppointment?.id, creditsApplied };
         },
         {
@@ -1583,21 +1592,6 @@ export async function handleCheckout(
           timestamp: new Date().toISOString(),
         }),
       );
-
-      // Deduct referral credits if applied
-      if (result.creditsApplied && result.creditsApplied > 0) {
-        try {
-          await applyCreditsToPayment(userId, result.creditsApplied);
-          console.log(
-            `🎁 Applied ${result.creditsApplied} referral credits for user ${userId}`,
-          );
-        } catch (creditError) {
-          console.error(
-            `⚠️ Failed to deduct referral credits for user ${userId}:`,
-            creditError,
-          );
-        }
-      }
 
       // Update waitlist status if coming from waitlist flow
       if (isMockPayment && validatedData.fromWaitlist) {

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -4,8 +4,9 @@
  */
 
 import prisma from "@/lib/prisma";
-import { EarningStatus, Payment, Prisma } from "@prisma/client";
+import { EarningRole, EarningStatus, Payment, Prisma } from "@prisma/client";
 import { PAYOUT_CONSTANTS, AppointmentType } from "./constants";
+import { calculateRevenueSplit } from "@/lib/collaborators/service";
 
 // ============================================
 // Types
@@ -26,6 +27,12 @@ export interface CreateEarningsParams {
       consultantProfile?: {
         id: string;
       };
+      webinar?: {
+        webinarPlanId: string;
+      } | null;
+      class?: {
+        classPlanId: string;
+      } | null;
     } | null;
   };
   appointmentType: AppointmentType;
@@ -68,7 +75,7 @@ export async function createEarningsFromPayment({
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );
-  const consultantShare = grossAmount - platformFee;
+  const totalConsultantPool = grossAmount - platformFee;
 
   // Calculate hold period
   const holdHours =
@@ -76,32 +83,93 @@ export async function createEarningsFromPayment({
     PAYOUT_CONSTANTS.HOLD_PERIOD_HOURS.CONSULTATION;
   const holdUntil = new Date(Date.now() + holdHours * 60 * 60 * 1000);
 
+  // Determine if this payment involves collaborators (webinars/classes only)
+  let planType: "webinar" | "class" | null = null;
+  let planId: string | null = null;
+
+  if (appointmentType === "WEBINAR" && payment.appointment?.webinar) {
+    planType = "webinar";
+    planId = payment.appointment.webinar.webinarPlanId;
+  } else if (appointmentType === "CLASS" && payment.appointment?.class) {
+    planType = "class";
+    planId = payment.appointment.class.classPlanId;
+  }
+
+  // Calculate collaborator splits if applicable
+  let splits: { consultantProfileId: string; share: number; role: string }[] = [];
+  if (planType && planId) {
+    splits = await calculateRevenueSplit(planType, planId, totalConsultantPool);
+  }
+
   // M2 FIX: Wrap create in try-catch to handle P2002 unique constraint violation
   // gracefully. The `paymentId` column has a unique constraint on `ConsultantEarnings`,
   // so concurrent calls (e.g., duplicate webhook + background sync job) may collide.
   // Instead of throwing, we treat it as an idempotent success.
   try {
-    const earnings = await prisma.consultantEarnings.create({
-      data: {
-        consultantProfileId,
-        paymentId: payment.id,
-        grossAmount,
-        platformFee,
-        consultantShare,
-        status: EarningStatus.PENDING,
-        holdUntil,
-      },
-    });
+    if (splits.length > 0) {
+      // Multi-party payment: create earnings for owner and each collaborator
+      let ownerEarningsId: string | null = null;
 
-    // Update consultant's pending revenue
-    await prisma.consultantProfile.update({
-      where: { id: consultantProfileId },
-      data: {
-        pendingRevenue: { increment: consultantShare },
-      },
-    });
+      for (const split of splits) {
+        const isOwner = split.role === "OWNER";
+        const sharePercentage = isOwner
+          ? (split.share / totalConsultantPool) * 100
+          : (split.share / totalConsultantPool) * 100;
 
-    return earnings.id;
+        const earnings = await prisma.consultantEarnings.create({
+          data: {
+            consultantProfileId: split.consultantProfileId,
+            paymentId: payment.id,
+            grossAmount: isOwner ? grossAmount : 0,
+            platformFee: isOwner ? platformFee : 0,
+            consultantShare: split.share,
+            role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
+            sharePercentage: Math.round(sharePercentage * 100) / 100,
+            status: EarningStatus.PENDING,
+            holdUntil,
+          },
+        });
+
+        await prisma.consultantProfile.update({
+          where: { id: split.consultantProfileId },
+          data: {
+            pendingRevenue: { increment: split.share },
+          },
+        });
+
+        if (split.role === "OWNER") {
+          ownerEarningsId = earnings.id;
+        }
+
+        console.log(
+          `💰 Earnings created for ${split.role} (${split.consultantProfileId}): ₹${split.share / 100} from payment ${payment.id}`,
+        );
+      }
+
+      return ownerEarningsId;
+    } else {
+      // Single-owner payment (no collaborators or not a webinar/class)
+      const earnings = await prisma.consultantEarnings.create({
+        data: {
+          consultantProfileId,
+          paymentId: payment.id,
+          grossAmount,
+          platformFee,
+          consultantShare: totalConsultantPool,
+          status: EarningStatus.PENDING,
+          holdUntil,
+        },
+      });
+
+      await prisma.consultantProfile.update({
+        where: { id: consultantProfileId },
+        data: {
+          pendingRevenue: { increment: totalConsultantPool },
+        },
+      });
+
+      return earnings.id;
+    }
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -60,16 +60,6 @@ export async function createEarningsFromPayment({
     return null;
   }
 
-  // Check if earnings already exist for this payment (for this consultant)
-  const existingEarnings = await prisma.consultantEarnings.findFirst({
-    where: { paymentId: payment.id, consultantProfileId },
-  });
-
-  if (existingEarnings) {
-    console.warn(`Earnings already exist for payment ${payment.id}. Skipping.`);
-    return existingEarnings.id;
-  }
-
   // Calculate revenue split
   const grossAmount = payment.amount;
   const platformFee = Math.round(
@@ -107,6 +97,15 @@ export async function createEarningsFromPayment({
     if (splits.length > 0) {
       // Multi-party payment: create earnings for owner and each collaborator atomically
       const ownerEarningsId = await prisma.$transaction(async (tx) => {
+        // Idempotency check inside transaction to prevent races
+        const existingEarnings = await tx.consultantEarnings.findFirst({
+          where: { paymentId: payment.id, consultantProfileId },
+        });
+        if (existingEarnings) {
+          console.warn(`Earnings already exist for payment ${payment.id}. Skipping.`);
+          return existingEarnings.id;
+        }
+
         let ownerId: string | null = null;
 
         for (const split of splits) {
@@ -150,6 +149,15 @@ export async function createEarningsFromPayment({
     } else {
       // Single-owner payment (no collaborators or not a webinar/class)
       return await prisma.$transaction(async (tx) => {
+        // Idempotency check inside transaction to prevent races
+        const existingEarnings = await tx.consultantEarnings.findFirst({
+          where: { paymentId: payment.id, consultantProfileId },
+        });
+        if (existingEarnings) {
+          console.warn(`Earnings already exist for payment ${payment.id}. Skipping.`);
+          return existingEarnings.id;
+        }
+
         const earnings = await tx.consultantEarnings.create({
           data: {
             consultantProfileId,

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -53,9 +53,9 @@ export async function createEarningsFromPayment({
     return null;
   }
 
-  // Check if earnings already exist for this payment
-  const existingEarnings = await prisma.consultantEarnings.findUnique({
-    where: { paymentId: payment.id },
+  // Check if earnings already exist for this payment (for this consultant)
+  const existingEarnings = await prisma.consultantEarnings.findFirst({
+    where: { paymentId: payment.id, consultantProfileId },
   });
 
   if (existingEarnings) {
@@ -111,8 +111,8 @@ export async function createEarningsFromPayment({
       console.warn(
         `[Earnings] Duplicate earnings creation for payment ${payment.id} (P2002). Treating as idempotent success.`,
       );
-      const existing = await prisma.consultantEarnings.findUnique({
-        where: { paymentId: payment.id },
+      const existing = await prisma.consultantEarnings.findFirst({
+        where: { paymentId: payment.id, consultantProfileId },
       });
       return existing?.id ?? null;
     }
@@ -248,48 +248,49 @@ export async function getConsultantEarnings(
  * Refund earnings (called when a payment is refunded)
  */
 export async function refundEarnings(paymentId: string): Promise<boolean> {
-  const earnings = await prisma.consultantEarnings.findUnique({
+  const allEarnings = await prisma.consultantEarnings.findMany({
     where: { paymentId },
   });
 
-  if (!earnings) {
+  if (allEarnings.length === 0) {
     console.warn(`No earnings found for payment ${paymentId}`);
     return false;
   }
 
-  // C7 FIX: Guard against already-refunded earnings.
-  // Without this, a duplicate webhook or API call could decrement
-  // pendingRevenue twice on the consultant profile.
-  if (earnings.status === EarningStatus.REFUNDED) {
-    console.warn(
-      `Earnings ${earnings.id} already refunded for payment ${paymentId}. Skipping.`,
-    );
-    return true; // Already handled — idempotent success
+  // Refund each earnings record (supports multi-party collaborator payments)
+  for (const earnings of allEarnings) {
+    // C7 FIX: Guard against already-refunded earnings.
+    if (earnings.status === EarningStatus.REFUNDED) {
+      console.warn(
+        `Earnings ${earnings.id} already refunded for payment ${paymentId}. Skipping.`,
+      );
+      continue;
+    }
+
+    // Can only refund if not yet paid out
+    if (earnings.status === EarningStatus.PAID) {
+      console.error(
+        `Cannot refund earnings ${earnings.id} - already paid out. Manual intervention required.`,
+      );
+      continue;
+    }
+
+    // Update earnings status to refunded
+    await prisma.consultantEarnings.update({
+      where: { id: earnings.id },
+      data: {
+        status: EarningStatus.REFUNDED,
+      },
+    });
+
+    // Decrease consultant's pending revenue
+    await prisma.consultantProfile.update({
+      where: { id: earnings.consultantProfileId },
+      data: {
+        pendingRevenue: { decrement: earnings.consultantShare },
+      },
+    });
   }
-
-  // Can only refund if not yet paid out
-  if (earnings.status === EarningStatus.PAID) {
-    console.error(
-      `Cannot refund earnings ${earnings.id} - already paid out. Manual intervention required.`,
-    );
-    return false;
-  }
-
-  // Update earnings status to refunded
-  await prisma.consultantEarnings.update({
-    where: { id: earnings.id },
-    data: {
-      status: EarningStatus.REFUNDED,
-    },
-  });
-
-  // Decrease consultant's pending revenue
-  await prisma.consultantProfile.update({
-    where: { id: earnings.consultantProfileId },
-    data: {
-      pendingRevenue: { decrement: earnings.consultantShare },
-    },
-  });
 
   return true;
 }

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -60,8 +60,8 @@ export async function createEarningsFromPayment({
     return null;
   }
 
-  // Calculate revenue split using original amount (before platform-funded discounts/credits)
-  const grossAmount = payment.originalAmount ?? payment.amount;
+  // Calculate revenue split using original plan price (before platform-funded discounts/credits/tax)
+  const grossAmount = payment.originalAmount;
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -101,74 +101,76 @@ export async function createEarningsFromPayment({
     splits = await calculateRevenueSplit(planType, planId, totalConsultantPool);
   }
 
-  // M2 FIX: Wrap create in try-catch to handle P2002 unique constraint violation
-  // gracefully. The `paymentId` column has a unique constraint on `ConsultantEarnings`,
-  // so concurrent calls (e.g., duplicate webhook + background sync job) may collide.
-  // Instead of throwing, we treat it as an idempotent success.
+  // FIX #9: Wrap earnings creation + balance updates in a transaction for atomicity.
+  // Also handles P2002 unique constraint violations gracefully for idempotency.
   try {
     if (splits.length > 0) {
-      // Multi-party payment: create earnings for owner and each collaborator
-      let ownerEarningsId: string | null = null;
+      // Multi-party payment: create earnings for owner and each collaborator atomically
+      const ownerEarningsId = await prisma.$transaction(async (tx) => {
+        let ownerId: string | null = null;
 
-      for (const split of splits) {
-        const isOwner = split.role === "OWNER";
-        const sharePercentage = isOwner
-          ? (split.share / totalConsultantPool) * 100
-          : (split.share / totalConsultantPool) * 100;
+        for (const split of splits) {
+          const isOwner = split.role === "OWNER";
+          const sharePercentage = (split.share / totalConsultantPool) * 100;
 
-        const earnings = await prisma.consultantEarnings.create({
+          const earnings = await tx.consultantEarnings.create({
+            data: {
+              consultantProfileId: split.consultantProfileId,
+              paymentId: payment.id,
+              grossAmount: isOwner ? grossAmount : 0,
+              platformFee: isOwner ? platformFee : 0,
+              consultantShare: split.share,
+              role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
+              sharePercentage: Math.round(sharePercentage * 100) / 100,
+              status: EarningStatus.PENDING,
+              holdUntil,
+            },
+          });
+
+          await tx.consultantProfile.update({
+            where: { id: split.consultantProfileId },
+            data: {
+              pendingRevenue: { increment: split.share },
+            },
+          });
+
+          if (split.role === "OWNER") {
+            ownerId = earnings.id;
+          }
+
+          console.log(
+            `💰 Earnings created for ${split.role} (${split.consultantProfileId}): ₹${split.share / 100} from payment ${payment.id}`,
+          );
+        }
+
+        return ownerId;
+      });
+
+      return ownerEarningsId;
+    } else {
+      // Single-owner payment (no collaborators or not a webinar/class)
+      return await prisma.$transaction(async (tx) => {
+        const earnings = await tx.consultantEarnings.create({
           data: {
-            consultantProfileId: split.consultantProfileId,
+            consultantProfileId,
             paymentId: payment.id,
-            grossAmount: isOwner ? grossAmount : 0,
-            platformFee: isOwner ? platformFee : 0,
-            consultantShare: split.share,
-            role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
-            sharePercentage: Math.round(sharePercentage * 100) / 100,
+            grossAmount,
+            platformFee,
+            consultantShare: totalConsultantPool,
             status: EarningStatus.PENDING,
             holdUntil,
           },
         });
 
-        await prisma.consultantProfile.update({
-          where: { id: split.consultantProfileId },
+        await tx.consultantProfile.update({
+          where: { id: consultantProfileId },
           data: {
-            pendingRevenue: { increment: split.share },
+            pendingRevenue: { increment: totalConsultantPool },
           },
         });
 
-        if (split.role === "OWNER") {
-          ownerEarningsId = earnings.id;
-        }
-
-        console.log(
-          `💰 Earnings created for ${split.role} (${split.consultantProfileId}): ₹${split.share / 100} from payment ${payment.id}`,
-        );
-      }
-
-      return ownerEarningsId;
-    } else {
-      // Single-owner payment (no collaborators or not a webinar/class)
-      const earnings = await prisma.consultantEarnings.create({
-        data: {
-          consultantProfileId,
-          paymentId: payment.id,
-          grossAmount,
-          platformFee,
-          consultantShare: totalConsultantPool,
-          status: EarningStatus.PENDING,
-          holdUntil,
-        },
+        return earnings.id;
       });
-
-      await prisma.consultantProfile.update({
-        where: { id: consultantProfileId },
-        data: {
-          pendingRevenue: { increment: totalConsultantPool },
-        },
-      });
-
-      return earnings.id;
     }
   } catch (error) {
     if (

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -61,7 +61,8 @@ export async function createEarningsFromPayment({
   }
 
   // Calculate revenue split using original plan price (before platform-funded discounts/credits/tax)
-  const grossAmount = payment.originalAmount;
+  // Payment.originalAmount is stored in rupees (major unit); earnings must be in paise (smallest unit)
+  const grossAmount = payment.originalAmount * 100;
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -286,6 +286,7 @@ export async function getConsultantEarnings(
           select: {
             id: true,
             amount: true,
+            originalAmount: true,
             currency: true,
             createdAt: true,
             appointment: {

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -60,8 +60,8 @@ export async function createEarningsFromPayment({
     return null;
   }
 
-  // Calculate revenue split
-  const grossAmount = payment.amount;
+  // Calculate revenue split using original amount (before platform-funded discounts/credits)
+  const grossAmount = payment.originalAmount ?? payment.amount;
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );

--- a/lib/payments/payouts/invoice-service.ts
+++ b/lib/payments/payouts/invoice-service.ts
@@ -266,12 +266,11 @@ export async function createInvoiceFromPayment(
       hsnCode = TAX_CONSTANTS.HSN_CODES.EDUCATION;
     }
 
-    // Calculate tax breakdown (assuming amount is inclusive of tax for display)
+    // Tax breakdown from stored payment data (tax-exclusive: plan.price + 18% GST)
     const totalAmount = payment.amount;
     const taxRate = TAX_CONSTANTS.GST_RATE;
-    // For GST-inclusive prices: baseAmount = total / (1 + rate/100)
-    const baseAmount = Math.round((totalAmount * 100) / (100 + taxRate));
-    const taxAmount = totalAmount - baseAmount;
+    const taxAmount = payment.taxAmount;
+    const baseAmount = totalAmount - taxAmount;
 
     const items: InvoiceItem[] = [
       {

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -293,14 +293,18 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
               },
             },
             webinar: {
-              include: {
+              select: {
+                id: true,
+                webinarPlanId: true,
                 webinarPlan: {
                   include: { consultantProfile: true },
                 },
               },
             },
             class: {
-              include: {
+              select: {
+                id: true,
+                classPlanId: true,
                 classPlan: {
                   include: { consultantProfile: true },
                 },
@@ -338,6 +342,12 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
           appointment: {
             ...paymentWithAppointment.appointment,
             consultantProfile: { id: consultantProfile.id },
+            webinar: paymentWithAppointment.appointment.webinar
+              ? { webinarPlanId: paymentWithAppointment.appointment.webinar.webinarPlanId }
+              : null,
+            class: paymentWithAppointment.appointment.class
+              ? { classPlanId: paymentWithAppointment.appointment.class.classPlanId }
+              : null,
           },
         };
 

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -27,6 +27,7 @@ import {
   notifyPaymentFailed,
   notifyAppointmentBooked,
 } from "@/lib/novu";
+import { processQualifyingAction } from "@/lib/referrals/service";
 
 // ============================================================================
 // Type Definitions
@@ -357,6 +358,16 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
     console.error(
       `⚠️ Failed to create earnings for payment ${paymentId}:`,
       earningsError,
+    );
+  }
+
+  // --- Referral qualifying action (first paid booking triggers referrer reward) ---
+  try {
+    await processQualifyingAction(userId, "first_paid_booking");
+  } catch (referralError) {
+    console.error(
+      `⚠️ Failed to process referral qualifying action for user ${userId}:`,
+      referralError,
     );
   }
 

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -3,6 +3,7 @@ import type {
   ReferralCode,
   Referral,
   ReferralCredit,
+  Prisma,
 } from "@prisma/client";
 
 // Constants
@@ -230,11 +231,14 @@ export async function processQualifyingAction(
 /**
  * Returns the user's available (non-expired, non-fully-used) credit balance.
  */
-export async function getUserCredits(userId: string): Promise<{
+export async function getUserCredits(
+  userId: string,
+  db: Prisma.TransactionClient | typeof prisma = prisma,
+): Promise<{
   totalAvailable: number;
   credits: ReferralCredit[];
 }> {
-  const credits = await prisma.referralCredit.findMany({
+  const credits = await db.referralCredit.findMany({
     where: {
       userId,
       remainingAmount: { gt: 0 },
@@ -256,8 +260,9 @@ export async function getUserCredits(userId: string): Promise<{
 export async function applyCreditsToPayment(
   userId: string,
   paymentAmount: number,
+  tx: Prisma.TransactionClient,
 ): Promise<{ creditsUsed: number; remainingToPay: number }> {
-  const { credits } = await getUserCredits(userId);
+  const { credits } = await getUserCredits(userId, tx);
 
   let creditsUsed = 0;
   let remainingToPay = paymentAmount;
@@ -267,7 +272,7 @@ export async function applyCreditsToPayment(
 
     const useAmount = Math.min(credit.remainingAmount, remainingToPay);
 
-    await prisma.referralCredit.update({
+    await tx.referralCredit.update({
       where: { id: credit.id },
       data: {
         usedAmount: { increment: useAmount },

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -111,6 +111,9 @@ export async function applyReferralCode(
     // Can't refer yourself
     if (referralCode.userId === newUserId) return null;
 
+    // Check if max referrals cap reached
+    if (referralCode.totalReferrals >= referralCode.maxReferrals) return null;
+
     // Check if already referred
     const existingReferral = await tx.referral.findUnique({
       where: { referredUserId: newUserId },
@@ -260,6 +263,7 @@ export async function applyCreditsToPayment(
   userId: string,
   paymentAmount: number,
   tx: Prisma.TransactionClient,
+  paymentId?: string,
 ): Promise<{ creditsUsed: number; remainingToPay: number }> {
   const { credits } = await getUserCredits(userId, tx);
 
@@ -279,6 +283,8 @@ export async function applyCreditsToPayment(
         ...(credit.remainingAmount - useAmount === 0 && {
           usedAt: new Date(),
         }),
+        // Audit trail: link credit usage to the payment
+        ...(paymentId && { usedOnPaymentId: paymentId }),
       },
     });
 
@@ -287,6 +293,50 @@ export async function applyCreditsToPayment(
   }
 
   return { creditsUsed, remainingToPay };
+}
+
+/**
+ * Reverses referral credits that were consumed for a specific payment.
+ * Called during refund processing to restore credits to the user.
+ */
+export async function reverseCreditsForPayment(
+  paymentId: string,
+  tx: Prisma.TransactionClient,
+): Promise<number> {
+  // Find all credits used on this payment
+  const usedCredits = await tx.referralCredit.findMany({
+    where: { usedOnPaymentId: paymentId },
+  });
+
+  if (usedCredits.length === 0) return 0;
+
+  let totalRestored = 0;
+
+  for (const credit of usedCredits) {
+    // Restore the amount that was used (usedAmount tracks total usage)
+    const restoreAmount = credit.usedAmount;
+    if (restoreAmount <= 0) continue;
+
+    await tx.referralCredit.update({
+      where: { id: credit.id },
+      data: {
+        usedAmount: 0,
+        remainingAmount: { increment: restoreAmount },
+        usedAt: null,
+        usedOnPaymentId: null,
+      },
+    });
+
+    totalRestored += restoreAmount;
+  }
+
+  if (totalRestored > 0) {
+    console.log(
+      `🔄 Restored ${totalRestored} referral credits for refunded payment ${paymentId}`,
+    );
+  }
+
+  return totalRestored;
 }
 
 /**

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { Prisma as PrismaNamespace } from "@prisma/client";
 import type {
   ReferralCode,
   Referral,
@@ -11,6 +12,36 @@ const DEFAULT_REFERRER_REWARD = 50000; // ₹500 in paise
 const DEFAULT_REFEREE_REWARD = 20000; // ₹200 in paise
 const QUALIFICATION_WINDOW_DAYS = 30;
 const CREDIT_EXPIRY_MONTHS = 6;
+const SERIALIZABLE_MAX_RETRIES = 3;
+
+/**
+ * Retries a function that may fail due to Prisma serialization conflicts (P2034).
+ * Applies exponential backoff between retries.
+ */
+async function withSerializableRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries = SERIALIZABLE_MAX_RETRIES,
+): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      const isSerializationFailure =
+        error instanceof PrismaNamespace.PrismaClientKnownRequestError &&
+        error.code === "P2034";
+
+      if (!isSerializationFailure || attempt === maxRetries) {
+        throw error;
+      }
+
+      const backoffMs = 50 * 2 ** attempt; // 50ms, 100ms, 200ms
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+
+  // Unreachable, but satisfies TypeScript
+  throw new Error("withSerializableRetry: exhausted retries");
+}
 
 /**
  * Creates or returns an existing referral code for a user.
@@ -107,7 +138,7 @@ export async function applyReferralCode(
   newUserId: string,
   code: string,
 ): Promise<Referral | null> {
-  return prisma.$transaction(async (tx) => {
+  return withSerializableRetry(() => prisma.$transaction(async (tx) => {
     // Validate inside transaction to prevent TOCTOU race conditions
     const referralCode = await validateReferralCode(code, tx);
     if (!referralCode) return null;
@@ -164,7 +195,7 @@ export async function applyReferralCode(
   }, {
     isolationLevel: "Serializable",
     timeout: 10000,
-  });
+  }));
 }
 
 /**
@@ -177,7 +208,7 @@ export async function processQualifyingAction(
   userId: string,
   action: string,
 ): Promise<void> {
-  await prisma.$transaction(async (tx) => {
+  await withSerializableRetry(() => prisma.$transaction(async (tx) => {
     // Read referral INSIDE transaction to prevent TOCTOU race
     const referral = await tx.referral.findUnique({
       where: { referredUserId: userId },
@@ -244,7 +275,7 @@ export async function processQualifyingAction(
   }, {
     isolationLevel: "Serializable",
     timeout: 10000,
-  });
+  }));
 }
 
 /**
@@ -326,10 +357,16 @@ export async function applyCreditsToPayment(
  * Reverses referral credits that were consumed for a specific payment.
  * Uses the ReferralCreditUsage ledger for accurate per-payment reversal.
  * Called during refund processing to restore credits to the user.
+ *
+ * For partial refunds: restores a proportional fraction of each usage record
+ * (refundAmount / originalPaymentAmount) and reduces the usage amount accordingly.
+ * For full refunds: restores all usage and deletes the usage records.
  */
 export async function reverseCreditsForPayment(
   paymentId: string,
   tx: Prisma.TransactionClient,
+  refundAmount?: number,
+  originalPaymentAmount?: number,
 ): Promise<number> {
   // Find all usage records for this payment from the ledger
   const usageRecords = await tx.referralCreditUsage.findMany({
@@ -338,33 +375,57 @@ export async function reverseCreditsForPayment(
 
   if (usageRecords.length === 0) return 0;
 
+  // Determine if this is a partial refund
+  const isPartialRefund =
+    refundAmount != null &&
+    originalPaymentAmount != null &&
+    originalPaymentAmount > 0 &&
+    refundAmount < originalPaymentAmount;
+
+  const refundRatio = isPartialRefund
+    ? refundAmount / originalPaymentAmount
+    : 1;
+
   let totalRestored = 0;
 
   for (const usage of usageRecords) {
-    const restoreAmount = usage.amount;
+    if (usage.amount <= 0) continue;
+
+    const restoreAmount = isPartialRefund
+      ? Math.round(usage.amount * refundRatio)
+      : usage.amount;
+
     if (restoreAmount <= 0) continue;
 
-    // Restore only the amount used from this specific credit for this payment
+    // Restore the appropriate amount to the credit
     await tx.referralCredit.update({
       where: { id: usage.creditId },
       data: {
         usedAmount: { decrement: restoreAmount },
         remainingAmount: { increment: restoreAmount },
-        usedAt: null,
+        ...(restoreAmount >= usage.amount && { usedAt: null }),
       },
     });
 
-    // Remove the usage record (credit is now available again)
-    await tx.referralCreditUsage.delete({
-      where: { id: usage.id },
-    });
+    if (restoreAmount >= usage.amount) {
+      // Full restore — remove the usage record
+      await tx.referralCreditUsage.delete({
+        where: { id: usage.id },
+      });
+    } else {
+      // Partial restore — reduce the usage record amount
+      await tx.referralCreditUsage.update({
+        where: { id: usage.id },
+        data: { amount: { decrement: restoreAmount } },
+      });
+    }
 
     totalRestored += restoreAmount;
   }
 
   if (totalRestored > 0) {
     console.log(
-      `🔄 Restored ${totalRestored} referral credits for refunded payment ${paymentId}`,
+      `🔄 Restored ${totalRestored} referral credits for ${isPartialRefund ? "partially " : ""}refunded payment ${paymentId}`,
     );
   }
 

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -1,0 +1,399 @@
+import prisma from "@/lib/prisma";
+import type {
+  ReferralCode,
+  Referral,
+  ReferralCredit,
+} from "@prisma/client";
+
+// Constants
+const DEFAULT_REFERRER_REWARD = 50000; // ₹500 in paise
+const DEFAULT_REFEREE_REWARD = 20000; // ₹200 in paise
+const QUALIFICATION_WINDOW_DAYS = 30;
+const CREDIT_EXPIRY_MONTHS = 6;
+
+/**
+ * Creates or returns an existing referral code for a user.
+ */
+export async function createReferralCode(
+  userId: string,
+): Promise<ReferralCode> {
+  const existing = await prisma.referralCode.findUnique({
+    where: { userId },
+  });
+
+  if (existing) return existing;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { name: true },
+  });
+
+  const code = await generateUniqueCode(user?.name);
+
+  return prisma.referralCode.create({
+    data: {
+      userId,
+      code,
+      referrerReward: DEFAULT_REFERRER_REWARD,
+      refereeReward: DEFAULT_REFEREE_REWARD,
+    },
+  });
+}
+
+/**
+ * Generates a unique referral code, trying name-based first, then random fallback.
+ */
+export async function generateUniqueCode(
+  name?: string | null,
+): Promise<string> {
+  if (name) {
+    const baseCode = name
+      .toUpperCase()
+      .replace(/[^A-Z]/g, "")
+      .slice(0, 6);
+
+    if (baseCode.length >= 3) {
+      for (let i = 0; i < 100; i++) {
+        const code = i === 0 ? baseCode : `${baseCode}${i}`;
+        const exists = await prisma.referralCode.findUnique({
+          where: { code },
+        });
+        if (!exists) return code;
+      }
+    }
+  }
+
+  // Fallback to random code
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let code: string;
+  do {
+    code = Array.from(
+      { length: 8 },
+      () => chars[Math.floor(Math.random() * chars.length)],
+    ).join("");
+  } while (await prisma.referralCode.findUnique({ where: { code } }));
+
+  return code;
+}
+
+/**
+ * Validates a referral code. Returns the code record if valid, null otherwise.
+ */
+export async function validateReferralCode(
+  code: string,
+): Promise<ReferralCode | null> {
+  return prisma.referralCode.findFirst({
+    where: {
+      OR: [
+        { code: code.toUpperCase() },
+        { customCode: code.toUpperCase() },
+      ],
+      isActive: true,
+    },
+  });
+}
+
+/**
+ * Applies a referral code to a newly signed-up user.
+ * Creates the Referral record and gives the referee their welcome bonus.
+ */
+export async function applyReferralCode(
+  newUserId: string,
+  code: string,
+): Promise<Referral | null> {
+  const referralCode = await validateReferralCode(code);
+  if (!referralCode) return null;
+
+  // Can't refer yourself
+  if (referralCode.userId === newUserId) return null;
+
+  // Check if already referred
+  const existingReferral = await prisma.referral.findUnique({
+    where: { referredUserId: newUserId },
+  });
+  if (existingReferral) return null;
+
+  // Create referral + update stats + give referee bonus in a transaction
+  const referral = await prisma.$transaction(async (tx) => {
+    const ref = await tx.referral.create({
+      data: {
+        referralCodeId: referralCode.id,
+        referredUserId: newUserId,
+        status: "SIGNED_UP",
+        referrerRewardAmount:
+          referralCode.referrerReward ?? DEFAULT_REFERRER_REWARD,
+        refereeRewardAmount:
+          referralCode.refereeReward ?? DEFAULT_REFEREE_REWARD,
+      },
+    });
+
+    await tx.referralCode.update({
+      where: { id: referralCode.id },
+      data: { totalReferrals: { increment: 1 } },
+    });
+
+    // Give referee immediate welcome bonus
+    const refereeReward = ref.refereeRewardAmount;
+    if (refereeReward && refereeReward > 0) {
+      const expiresAt = new Date();
+      expiresAt.setMonth(expiresAt.getMonth() + CREDIT_EXPIRY_MONTHS);
+
+      await tx.referralCredit.create({
+        data: {
+          userId: newUserId,
+          amount: refereeReward,
+          currency: "INR",
+          source: "REFEREE_BONUS",
+          referralId: ref.id,
+          remainingAmount: refereeReward,
+          expiresAt,
+        },
+      });
+    }
+
+    return ref;
+  });
+
+  return referral;
+}
+
+/**
+ * Called after a user's first paid booking to qualify their referral.
+ * Rewards the referrer if the referral is within the qualification window.
+ */
+export async function processQualifyingAction(
+  userId: string,
+  action: string,
+): Promise<void> {
+  const referral = await prisma.referral.findUnique({
+    where: { referredUserId: userId },
+    include: { referralCode: true },
+  });
+
+  if (!referral || referral.status !== "SIGNED_UP") return;
+
+  // Check if within qualification window
+  const daysSinceSignup = Math.floor(
+    (Date.now() - referral.signedUpAt.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (daysSinceSignup > QUALIFICATION_WINDOW_DAYS) {
+    await prisma.referral.update({
+      where: { id: referral.id },
+      data: { status: "EXPIRED" },
+    });
+    return;
+  }
+
+  // Mark as qualified and reward referrer in a transaction
+  await prisma.$transaction(async (tx) => {
+    await tx.referral.update({
+      where: { id: referral.id },
+      data: {
+        status: "REWARDED",
+        qualifiedAt: new Date(),
+        qualifyingAction: action,
+        referrerRewardPaidAt: new Date(),
+      },
+    });
+
+    // Give referrer their bonus
+    const referrerReward = referral.referrerRewardAmount;
+    if (referrerReward && referrerReward > 0) {
+      const expiresAt = new Date();
+      expiresAt.setMonth(expiresAt.getMonth() + CREDIT_EXPIRY_MONTHS);
+
+      await tx.referralCredit.create({
+        data: {
+          userId: referral.referralCode.userId,
+          amount: referrerReward,
+          currency: "INR",
+          source: "REFERRAL_BONUS",
+          referralId: referral.id,
+          remainingAmount: referrerReward,
+          expiresAt,
+        },
+      });
+
+      // Update referral code stats
+      await tx.referralCode.update({
+        where: { id: referral.referralCodeId },
+        data: {
+          successfulReferrals: { increment: 1 },
+          totalEarned: { increment: referrerReward },
+        },
+      });
+    }
+  });
+}
+
+/**
+ * Returns the user's available (non-expired, non-fully-used) credit balance.
+ */
+export async function getUserCredits(userId: string): Promise<{
+  totalAvailable: number;
+  credits: ReferralCredit[];
+}> {
+  const credits = await prisma.referralCredit.findMany({
+    where: {
+      userId,
+      remainingAmount: { gt: 0 },
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+    orderBy: { expiresAt: "asc" },
+  });
+
+  const totalAvailable = credits.reduce((sum, c) => sum + c.remainingAmount, 0);
+
+  return { totalAvailable, credits };
+}
+
+/**
+ * Applies referral credits to a payment at checkout.
+ * Uses FIFO ordering by expiry date (expiring soonest first).
+ * Returns the total credits used and the remaining amount to pay.
+ */
+export async function applyCreditsToPayment(
+  userId: string,
+  paymentAmount: number,
+): Promise<{ creditsUsed: number; remainingToPay: number }> {
+  const { credits } = await getUserCredits(userId);
+
+  let creditsUsed = 0;
+  let remainingToPay = paymentAmount;
+
+  for (const credit of credits) {
+    if (remainingToPay <= 0) break;
+
+    const useAmount = Math.min(credit.remainingAmount, remainingToPay);
+
+    await prisma.referralCredit.update({
+      where: { id: credit.id },
+      data: {
+        usedAmount: { increment: useAmount },
+        remainingAmount: { decrement: useAmount },
+        ...(credit.remainingAmount - useAmount === 0 && {
+          usedAt: new Date(),
+        }),
+      },
+    });
+
+    creditsUsed += useAmount;
+    remainingToPay -= useAmount;
+  }
+
+  return { creditsUsed, remainingToPay };
+}
+
+/**
+ * Sets a custom vanity code for a user's referral code.
+ */
+export async function setCustomCode(
+  userId: string,
+  customCode: string,
+): Promise<ReferralCode | null> {
+  const referralCode = await prisma.referralCode.findUnique({
+    where: { userId },
+  });
+
+  if (!referralCode) return null;
+
+  const normalized = customCode.toUpperCase().replace(/[^A-Z0-9]/g, "");
+  if (normalized.length < 3 || normalized.length > 20) return null;
+
+  // Check uniqueness against both code and customCode fields
+  const existing = await prisma.referralCode.findFirst({
+    where: {
+      OR: [{ code: normalized }, { customCode: normalized }],
+      NOT: { id: referralCode.id },
+    },
+  });
+  if (existing) return null;
+
+  return prisma.referralCode.update({
+    where: { id: referralCode.id },
+    data: { customCode: normalized },
+  });
+}
+
+/**
+ * Gets a user's referral code with stats.
+ */
+export async function getReferralCode(
+  userId: string,
+): Promise<ReferralCode | null> {
+  return prisma.referralCode.findUnique({
+    where: { userId },
+  });
+}
+
+/**
+ * Gets a user's referral list (people they referred).
+ */
+export async function getUserReferrals(userId: string): Promise<
+  (Referral & { referredUser: { name: string; image: string | null } })[]
+> {
+  const referralCode = await prisma.referralCode.findUnique({
+    where: { userId },
+    select: { id: true },
+  });
+
+  if (!referralCode) return [];
+
+  return prisma.referral.findMany({
+    where: { referralCodeId: referralCode.id },
+    include: {
+      referredUser: {
+        select: { name: true, image: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+/**
+ * Gets a user's full credit history (including used/expired).
+ */
+export async function getCreditHistory(
+  userId: string,
+): Promise<ReferralCredit[]> {
+  return prisma.referralCredit.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+/**
+ * Expires unqualified referrals that are past the qualification window.
+ * Called by cron job.
+ */
+export async function expireStaleReferrals(): Promise<number> {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - QUALIFICATION_WINDOW_DAYS);
+
+  const result = await prisma.referral.updateMany({
+    where: {
+      status: "SIGNED_UP",
+      signedUpAt: { lt: cutoffDate },
+    },
+    data: { status: "EXPIRED" },
+  });
+
+  return result.count;
+}
+
+/**
+ * Expires credits that are past their expiry date.
+ * Called by cron job.
+ */
+export async function expireStaleCredits(): Promise<number> {
+  const result = await prisma.referralCredit.updateMany({
+    where: {
+      remainingAmount: { gt: 0 },
+      expiresAt: { lt: new Date() },
+    },
+    data: { remainingAmount: 0 },
+  });
+
+  return result.count;
+}

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -82,8 +82,9 @@ export async function generateUniqueCode(
  */
 export async function validateReferralCode(
   code: string,
+  db: Prisma.TransactionClient | typeof prisma = prisma,
 ): Promise<ReferralCode | null> {
-  return prisma.referralCode.findFirst({
+  return db.referralCode.findFirst({
     where: {
       OR: [
         { code: code.toUpperCase() },
@@ -102,20 +103,20 @@ export async function applyReferralCode(
   newUserId: string,
   code: string,
 ): Promise<Referral | null> {
-  const referralCode = await validateReferralCode(code);
-  if (!referralCode) return null;
+  return prisma.$transaction(async (tx) => {
+    // Validate inside transaction to prevent TOCTOU race conditions
+    const referralCode = await validateReferralCode(code, tx);
+    if (!referralCode) return null;
 
-  // Can't refer yourself
-  if (referralCode.userId === newUserId) return null;
+    // Can't refer yourself
+    if (referralCode.userId === newUserId) return null;
 
-  // Check if already referred
-  const existingReferral = await prisma.referral.findUnique({
-    where: { referredUserId: newUserId },
-  });
-  if (existingReferral) return null;
+    // Check if already referred
+    const existingReferral = await tx.referral.findUnique({
+      where: { referredUserId: newUserId },
+    });
+    if (existingReferral) return null;
 
-  // Create referral + update stats + give referee bonus in a transaction
-  const referral = await prisma.$transaction(async (tx) => {
     const ref = await tx.referral.create({
       data: {
         referralCodeId: referralCode.id,
@@ -154,8 +155,6 @@ export async function applyReferralCode(
 
     return ref;
   });
-
-  return referral;
 }
 
 /**

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -342,6 +342,7 @@ export async function applyCreditsToPayment(
           creditId: credit.id,
           paymentId,
           amount: useAmount,
+          originalAmount: useAmount,
         },
       });
     }
@@ -392,7 +393,7 @@ export async function reverseCreditsForPayment(
     if (usage.amount <= 0) continue;
 
     const restoreAmount = isPartialRefund
-      ? Math.round(usage.amount * refundRatio)
+      ? Math.min(Math.round(usage.originalAmount * refundRatio), usage.amount)
       : usage.amount;
 
     if (restoreAmount <= 0) continue;

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -99,6 +99,10 @@ export async function validateReferralCode(
  * Applies a referral code to a newly signed-up user.
  * Creates the Referral record and gives the referee their welcome bonus.
  */
+/**
+ * FIX #8: Uses Serializable isolation to prevent concurrent code applications
+ * from exceeding the maxReferrals cap.
+ */
 export async function applyReferralCode(
   newUserId: string,
   code: string,
@@ -157,41 +161,48 @@ export async function applyReferralCode(
     }
 
     return ref;
+  }, {
+    isolationLevel: "Serializable",
+    timeout: 10000,
   });
 }
 
 /**
  * Called after a user's first paid booking to qualify their referral.
  * Rewards the referrer if the referral is within the qualification window.
+ * FIX #7: Entire flow runs in a serializable transaction with conditional status guard
+ * to prevent duplicate rewards from concurrent webhook execution.
  */
 export async function processQualifyingAction(
   userId: string,
   action: string,
 ): Promise<void> {
-  const referral = await prisma.referral.findUnique({
-    where: { referredUserId: userId },
-    include: { referralCode: true },
-  });
-
-  if (!referral || referral.status !== "SIGNED_UP") return;
-
-  // Check if within qualification window
-  const daysSinceSignup = Math.floor(
-    (Date.now() - referral.signedUpAt.getTime()) / (1000 * 60 * 60 * 24),
-  );
-
-  if (daysSinceSignup > QUALIFICATION_WINDOW_DAYS) {
-    await prisma.referral.update({
-      where: { id: referral.id },
-      data: { status: "EXPIRED" },
-    });
-    return;
-  }
-
-  // Mark as qualified and reward referrer in a transaction
   await prisma.$transaction(async (tx) => {
-    await tx.referral.update({
-      where: { id: referral.id },
+    // Read referral INSIDE transaction to prevent TOCTOU race
+    const referral = await tx.referral.findUnique({
+      where: { referredUserId: userId },
+      include: { referralCode: true },
+    });
+
+    if (!referral || referral.status !== "SIGNED_UP") return;
+
+    // Check if within qualification window
+    const daysSinceSignup = Math.floor(
+      (Date.now() - referral.signedUpAt.getTime()) / (1000 * 60 * 60 * 24),
+    );
+
+    if (daysSinceSignup > QUALIFICATION_WINDOW_DAYS) {
+      await tx.referral.update({
+        where: { id: referral.id },
+        data: { status: "EXPIRED" },
+      });
+      return;
+    }
+
+    // Conditional update: only succeeds if status is still SIGNED_UP.
+    // This prevents concurrent calls from both creating rewards.
+    const updated = await tx.referral.updateMany({
+      where: { id: referral.id, status: "SIGNED_UP" },
       data: {
         status: "REWARDED",
         qualifiedAt: new Date(),
@@ -199,6 +210,9 @@ export async function processQualifyingAction(
         referrerRewardPaidAt: new Date(),
       },
     });
+
+    // If no rows updated, another concurrent call already processed this
+    if (updated.count === 0) return;
 
     // Give referrer their bonus
     const referrerReward = referral.referrerRewardAmount;
@@ -227,6 +241,9 @@ export async function processQualifyingAction(
         },
       });
     }
+  }, {
+    isolationLevel: "Serializable",
+    timeout: 10000,
   });
 }
 
@@ -257,6 +274,7 @@ export async function getUserCredits(
 /**
  * Applies referral credits to a payment at checkout.
  * Uses FIFO ordering by expiry date (expiring soonest first).
+ * Creates per-payment usage records in ReferralCreditUsage ledger for accurate reversal.
  * Returns the total credits used and the remaining amount to pay.
  */
 export async function applyCreditsToPayment(
@@ -283,10 +301,19 @@ export async function applyCreditsToPayment(
         ...(credit.remainingAmount - useAmount === 0 && {
           usedAt: new Date(),
         }),
-        // Audit trail: link credit usage to the payment
-        ...(paymentId && { usedOnPaymentId: paymentId }),
       },
     });
+
+    // Create ledger entry for accurate per-payment tracking and reversal
+    if (paymentId) {
+      await tx.referralCreditUsage.create({
+        data: {
+          creditId: credit.id,
+          paymentId,
+          amount: useAmount,
+        },
+      });
+    }
 
     creditsUsed += useAmount;
     remainingToPay -= useAmount;
@@ -297,34 +324,39 @@ export async function applyCreditsToPayment(
 
 /**
  * Reverses referral credits that were consumed for a specific payment.
+ * Uses the ReferralCreditUsage ledger for accurate per-payment reversal.
  * Called during refund processing to restore credits to the user.
  */
 export async function reverseCreditsForPayment(
   paymentId: string,
   tx: Prisma.TransactionClient,
 ): Promise<number> {
-  // Find all credits used on this payment
-  const usedCredits = await tx.referralCredit.findMany({
-    where: { usedOnPaymentId: paymentId },
+  // Find all usage records for this payment from the ledger
+  const usageRecords = await tx.referralCreditUsage.findMany({
+    where: { paymentId },
   });
 
-  if (usedCredits.length === 0) return 0;
+  if (usageRecords.length === 0) return 0;
 
   let totalRestored = 0;
 
-  for (const credit of usedCredits) {
-    // Restore the amount that was used (usedAmount tracks total usage)
-    const restoreAmount = credit.usedAmount;
+  for (const usage of usageRecords) {
+    const restoreAmount = usage.amount;
     if (restoreAmount <= 0) continue;
 
+    // Restore only the amount used from this specific credit for this payment
     await tx.referralCredit.update({
-      where: { id: credit.id },
+      where: { id: usage.creditId },
       data: {
-        usedAmount: 0,
+        usedAmount: { decrement: restoreAmount },
         remainingAmount: { increment: restoreAmount },
         usedAt: null,
-        usedOnPaymentId: null,
       },
+    });
+
+    // Remove the usage record (credit is now available again)
+    await tx.referralCreditUsage.delete({
+      where: { id: usage.id },
     });
 
     totalRestored += restoreAmount;

--- a/lib/topics.ts
+++ b/lib/topics.ts
@@ -7,12 +7,7 @@
  */
 
 import prisma from "@/lib/prisma";
-import { Prisma, PrismaClient } from "@prisma/client";
-
-type PrismaTransaction = Omit<
-  PrismaClient,
-  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
->;
+import { Prisma } from "@prisma/client";
 
 /**
  * Find existing topics or create new ones by name
@@ -20,13 +15,11 @@ type PrismaTransaction = Omit<
  */
 export async function findOrCreateTopics(
   topicNames: string[],
-  tx?: PrismaTransaction,
+  db: Prisma.TransactionClient | typeof prisma = prisma,
 ): Promise<string[]> {
   if (!topicNames || topicNames.length === 0) {
     return [];
   }
-
-  const db = tx || prisma;
 
   // Find existing topics
   const existingTopics = await db.topic.findMany({

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1479,8 +1479,9 @@ model Payment {
   disputes Dispute[] // Disputes associated with this payment
 
   // Payout relations
-  earnings ConsultantEarnings[]
-  invoice  Invoice?
+  earnings     ConsultantEarnings[]
+  creditUsages ReferralCreditUsage[]
+  invoice      Invoice?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1837,15 +1838,29 @@ model ReferralCredit {
   remainingAmount Int // amount - usedAmount
   expiresAt       DateTime?
   usedAt          DateTime?
-  usedOnPaymentId String?
 
-  user User @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  user   User                   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  usages ReferralCreditUsage[]
 
   createdAt DateTime @default(now())
 
   @@index([userId])
   @@index([expiresAt])
   @@index([userId, expiresAt])
+}
+
+model ReferralCreditUsage {
+  id        String   @id @default(cuid())
+  creditId  String
+  paymentId String
+  amount    Int // Amount used from this credit for this payment (in paise)
+  createdAt DateTime @default(now())
+
+  credit  ReferralCredit @relation(fields: [creditId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  payment Payment        @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@unique([creditId, paymentId])
+  @@index([paymentId])
 }
 
 enum ReferralStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1457,8 +1457,9 @@ enum Platform {
 
 model Payment {
   id             String         @id @default(uuid())
-  amount         Int // Final amount charged (after discounts + credits)
-  originalAmount Int? // Original plan price before discounts/credits (null for legacy payments)
+  amount         Int // Final amount charged to gateway (after discounts + tax - credits)
+  originalAmount Int // Original plan price before discounts/credits/tax (for earnings)
+  taxAmount      Int            @default(0) // GST amount charged
   currency       String
   description    String?
   receiptUrl     String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1457,7 +1457,8 @@ enum Platform {
 
 model Payment {
   id             String         @id @default(uuid())
-  amount         Int
+  amount         Int // Final amount charged (after discounts + credits)
+  originalAmount Int? // Original plan price before discounts/credits (null for legacy payments)
   currency       String
   description    String?
   receiptUrl     String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,11 @@ model User {
   reportsReceived   ModerationReport[] @relation("ReportsReceived")
   moderationActions ModerationAction[]
 
+  // Referral system
+  referralCode    ReferralCode?
+  referral        Referral?        @relation("ReferredUser")
+  referralCredits ReferralCredit[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -448,6 +453,12 @@ model ConsultantProfile {
   subscriptionPlans SubscriptionPlan[]
   webinarPlans      WebinarPlan[]
   classPlans        ClassPlan[]
+
+  // Collaborator relations
+  webinarCollaborations     WebinarCollaborator[]  @relation("WebinarCollaborator")
+  classCollaborations       ClassCollaborator[]    @relation("ClassCollaborator")
+  invitedWebinarCollabs     WebinarCollaborator[]  @relation("WebinarCollaboratorInvitedBy")
+  invitedClassCollabs       ClassCollaborator[]    @relation("ClassCollaboratorInvitedBy")
 
   // Trial sessions and activity logs
   trialSessions TrialSession[]
@@ -976,6 +987,7 @@ model WebinarPlan {
   consultantProfileId String?
   webinars            Webinar[]
   materials           PlanMaterial[]
+  collaborators       WebinarCollaborator[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1036,6 +1048,7 @@ model ClassPlan {
   consultantProfileId String?
   classes             Class[]
   materials           PlanMaterial[]
+  collaborators       ClassCollaborator[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1466,7 +1479,7 @@ model Payment {
   disputes Dispute[] // Disputes associated with this payment
 
   // Payout relations
-  earnings ConsultantEarnings?
+  earnings ConsultantEarnings[]
   invoice  Invoice?
 
   createdAt DateTime @default(now())
@@ -1595,13 +1608,17 @@ enum PayoutAccountType {
 model ConsultantEarnings {
   id                  String  @id @default(cuid())
   consultantProfileId String
-  paymentId           String  @unique
+  paymentId           String
   payoutId            String?
 
   // Revenue breakdown
   grossAmount     Int // Total sale price
   platformFee     Int // Platform cut (20%)
   consultantShare Int // Consultant cut (80%)
+
+  // Collaborator support
+  role            EarningRole @default(OWNER)
+  sharePercentage Float       @default(100)
 
   // Status tracking
   status    EarningStatus @default(PENDING)
@@ -1618,6 +1635,7 @@ model ConsultantEarnings {
   @@index([consultantProfileId, status])
   @@index([status, holdUntil])
   @@index([payoutId])
+  @@index([paymentId])
 }
 
 model Payout {
@@ -1758,6 +1776,165 @@ enum DiscountType {
   PERCENTAGE
   FIXED_AMOUNT
   FREE_SHIPPING
+}
+
+////////////////////////////////////////// REFERRAL SYSTEM //////////////////////////////////////////
+
+model ReferralCode {
+  id                  String   @id @default(cuid())
+  userId              String   @unique
+  code                String   @unique
+  customCode          String?  @unique
+  referrerReward      Int? // Reward for referrer in smallest currency unit (paise)
+  refereeReward       Int? // Reward for new user in smallest currency unit (paise)
+  totalReferrals      Int      @default(0)
+  successfulReferrals Int      @default(0)
+  totalEarned         Int      @default(0)
+  isActive            Boolean  @default(true)
+
+  user      User       @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  referrals Referral[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([code])
+  @@index([customCode])
+}
+
+model Referral {
+  id                   String         @id @default(cuid())
+  referralCodeId       String
+  referredUserId       String         @unique
+  status               ReferralStatus @default(SIGNED_UP)
+  referrerRewardAmount Int?
+  refereeRewardAmount  Int?
+  referrerRewardPaidAt DateTime?
+  refereeRewardPaidAt  DateTime?
+  signedUpAt           DateTime       @default(now())
+  qualifiedAt          DateTime?
+  qualifyingAction     String?
+
+  referralCode ReferralCode @relation(fields: [referralCodeId], references: [id])
+  referredUser User         @relation("ReferredUser", fields: [referredUserId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([referralCodeId])
+  @@index([status])
+}
+
+model ReferralCredit {
+  id              String       @id @default(cuid())
+  userId          String
+  amount          Int // Credit amount in smallest currency unit (paise)
+  currency        String       @default("INR")
+  source          CreditSource
+  referralId      String?
+  usedAmount      Int          @default(0)
+  remainingAmount Int // amount - usedAmount
+  expiresAt       DateTime?
+  usedAt          DateTime?
+  usedOnPaymentId String?
+
+  user User @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@index([userId, expiresAt])
+}
+
+enum ReferralStatus {
+  SIGNED_UP
+  QUALIFIED
+  REWARDED
+  EXPIRED
+  FRAUDULENT
+}
+
+enum CreditSource {
+  REFERRAL_BONUS
+  REFEREE_BONUS
+  PROMOTION
+  COMPENSATION
+  MANUAL
+}
+
+//////////////////////////////////////////////////// COLLABORATOR SYSTEM ////////////////////////////////////////////////////
+
+model WebinarCollaborator {
+  id                     String                  @id @default(cuid())
+  consultantProfileId    String
+  webinarPlanId          String
+  role                   WebinarCollaboratorRole  @default(CO_HOST)
+  permissions            Json?
+  revenueSharePercentage Float
+  status                 CollaboratorStatus       @default(PENDING)
+  invitedById            String
+  respondedAt            DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  consultantProfile ConsultantProfile @relation("WebinarCollaborator", fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  webinarPlan       WebinarPlan       @relation(fields: [webinarPlanId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  invitedBy         ConsultantProfile @relation("WebinarCollaboratorInvitedBy", fields: [invitedById], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@unique([consultantProfileId, webinarPlanId])
+  @@index([webinarPlanId])
+  @@index([status])
+}
+
+model ClassCollaborator {
+  id                     String                 @id @default(cuid())
+  consultantProfileId    String
+  classPlanId            String
+  role                   ClassCollaboratorRole   @default(CO_INSTRUCTOR)
+  permissions            Json?
+  revenueSharePercentage Float
+  status                 CollaboratorStatus      @default(PENDING)
+  invitedById            String
+  respondedAt            DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  consultantProfile ConsultantProfile @relation("ClassCollaborator", fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  classPlan         ClassPlan         @relation(fields: [classPlanId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  invitedBy         ConsultantProfile @relation("ClassCollaboratorInvitedBy", fields: [invitedById], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@unique([consultantProfileId, classPlanId])
+  @@index([classPlanId])
+  @@index([status])
+}
+
+enum CollaboratorStatus {
+  PENDING
+  ACCEPTED
+  DECLINED
+  REMOVED
+}
+
+enum WebinarCollaboratorRole {
+  CO_HOST
+  MODERATOR
+  GUEST_SPEAKER
+  TECHNICAL_SUPPORT
+}
+
+enum ClassCollaboratorRole {
+  CO_INSTRUCTOR
+  TEACHING_ASSISTANT
+  GUEST_LECTURER
+  CONTENT_CREATOR
+}
+
+enum EarningRole {
+  OWNER
+  COLLABORATOR
 }
 
 //////////////////////////////////////////////////// ENUMS ////////////////////////////////////////////////////

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1790,6 +1790,7 @@ model ReferralCode {
   totalReferrals      Int      @default(0)
   successfulReferrals Int      @default(0)
   totalEarned         Int      @default(0)
+  maxReferrals        Int      @default(50) // Maximum referrals allowed per code
   isActive            Boolean  @default(true)
 
   user      User       @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1851,11 +1851,12 @@ model ReferralCredit {
 }
 
 model ReferralCreditUsage {
-  id        String   @id @default(cuid())
-  creditId  String
-  paymentId String
-  amount    Int // Amount used from this credit for this payment (in paise)
-  createdAt DateTime @default(now())
+  id             String   @id @default(cuid())
+  creditId       String
+  paymentId      String
+  amount         Int // Current remaining usage (decremented on partial refund restores)
+  originalAmount Int // Original amount at creation (never changes, used for ratio calculations)
+  createdAt      DateTime @default(now())
 
   credit  ReferralCredit @relation(fields: [creditId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   payment Payment        @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1633,6 +1633,7 @@ model ConsultantEarnings {
   payment           Payment           @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   payout            Payout?           @relation(fields: [payoutId], references: [id])
 
+  @@unique([paymentId, consultantProfileId, role])
   @@index([consultantProfileId, status])
   @@index([status, holdUntil])
   @@index([payoutId])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -55,6 +55,10 @@ import { createConsultantEarnings } from "./seedFiles/13b-create-consultant-earn
 import { createPayouts } from "./seedFiles/13c-create-payouts";
 import { createInvoices } from "./seedFiles/13d-create-invoices";
 
+// Phase 14: Referrals & Collaborators
+import { createReferralCodes } from "./seedFiles/14a-create-referral-codes";
+import { createCollaborators } from "./seedFiles/14b-create-collaborators";
+
 async function seed() {
   console.log("Starting seed process...");
 
@@ -174,6 +178,14 @@ async function seed() {
 
     console.log("Creating invoices...");
     await createInvoices();
+
+    // Phase 14: Referrals & Collaborators
+    console.log("\n[Phase 14] Creating referrals & collaborators...");
+    console.log("Creating referral codes...");
+    await createReferralCodes();
+
+    console.log("Creating collaborators...");
+    await createCollaborators();
 
     // Summary
     const endTime = Date.now();

--- a/prisma/seedFiles/13b-create-consultant-earnings.ts
+++ b/prisma/seedFiles/13b-create-consultant-earnings.ts
@@ -83,7 +83,7 @@ export async function createConsultantEarnings(): Promise<void> {
   const succeededPayments = await prisma.payment.findMany({
     where: {
       paymentStatus: "SUCCEEDED",
-      earnings: null, // No existing earnings record
+      earnings: { none: {} }, // No existing earnings record
       appointment: {
         isNot: null, // Must have an appointment
       },

--- a/prisma/seedFiles/14a-create-referral-codes.ts
+++ b/prisma/seedFiles/14a-create-referral-codes.ts
@@ -1,0 +1,137 @@
+import { faker } from "@faker-js/faker";
+import prisma from "../../lib/prisma";
+
+/**
+ * Creates referral codes for seed users and some sample referrals + credits.
+ */
+export async function createReferralCodes() {
+  console.log("Creating referral codes...");
+
+  // Get all users
+  const users = await prisma.user.findMany({
+    select: { id: true, name: true },
+    take: 30,
+  });
+
+  if (users.length === 0) {
+    console.log("No users found. Skipping referral codes.");
+    return;
+  }
+
+  let codesCreated = 0;
+  let referralsCreated = 0;
+  let creditsCreated = 0;
+
+  // Create referral codes for ~60% of users
+  const usersWithCodes = users.slice(
+    0,
+    Math.ceil(users.length * 0.6),
+  );
+
+  for (const user of usersWithCodes) {
+    try {
+      const namePart = (user.name ?? "user")
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, "")
+        .slice(0, 8);
+      const code = `${namePart}${faker.string.alphanumeric(4).toLowerCase()}`;
+
+      await prisma.referralCode.create({
+        data: {
+          userId: user.id,
+          code,
+          referrerReward: 50000, // 500 INR
+          refereeReward: 20000, // 200 INR
+          isActive: true,
+        },
+      });
+      codesCreated++;
+    } catch {
+      // Skip if user already has a referral code (unique constraint)
+    }
+  }
+
+  // Create some referrals between users
+  const referralCodes = await prisma.referralCode.findMany({
+    take: 10,
+  });
+
+  const usersWithoutCodes = users.filter(
+    (u) => !usersWithCodes.some((wc) => wc.id === u.id),
+  );
+
+  for (let i = 0; i < Math.min(referralCodes.length, usersWithoutCodes.length); i++) {
+    try {
+      const status = faker.helpers.arrayElement([
+        "SIGNED_UP",
+        "QUALIFIED",
+        "REWARDED",
+      ] as const);
+
+      await prisma.referral.create({
+        data: {
+          referralCodeId: referralCodes[i].id,
+          referredUserId: usersWithoutCodes[i].id,
+          status,
+          ...(status === "QUALIFIED" || status === "REWARDED"
+            ? {
+                qualifiedAt: faker.date.recent({ days: 14 }),
+                qualifyingAction: "first_paid_booking",
+              }
+            : {}),
+          ...(status === "REWARDED"
+            ? {
+                referrerRewardAmount: 50000,
+                refereeRewardAmount: 20000,
+              }
+            : {}),
+        },
+      });
+      referralsCreated++;
+    } catch {
+      // Skip duplicates
+    }
+  }
+
+  // Create some referral credits for users who earned rewards
+  const rewardedReferrals = await prisma.referral.findMany({
+    where: { status: "REWARDED" },
+    include: { referralCode: true },
+  });
+
+  for (const referral of rewardedReferrals) {
+    try {
+      // Credit for referrer
+      await prisma.referralCredit.create({
+        data: {
+          userId: referral.referralCode.userId,
+          amount: 50000,
+          remainingAmount: faker.helpers.arrayElement([50000, 30000, 0]),
+          currency: "INR",
+          source: "REFERRAL_BONUS",
+          expiresAt: faker.date.future({ years: 0.5 }),
+        },
+      });
+      creditsCreated++;
+
+      // Credit for referee
+      await prisma.referralCredit.create({
+        data: {
+          userId: referral.referredUserId,
+          amount: 20000,
+          remainingAmount: faker.helpers.arrayElement([20000, 10000, 0]),
+          currency: "INR",
+          source: "REFEREE_BONUS",
+          expiresAt: faker.date.future({ years: 0.5 }),
+        },
+      });
+      creditsCreated++;
+    } catch {
+      // Skip
+    }
+  }
+
+  console.log(
+    `Created ${codesCreated} referral codes, ${referralsCreated} referrals, ${creditsCreated} credits`,
+  );
+}

--- a/prisma/seedFiles/14b-create-collaborators.ts
+++ b/prisma/seedFiles/14b-create-collaborators.ts
@@ -1,0 +1,127 @@
+import { faker } from "@faker-js/faker";
+import prisma from "../../lib/prisma";
+
+/**
+ * Creates collaborators for some webinar and class plans.
+ */
+export async function createCollaborators() {
+  console.log("Creating collaborators...");
+
+  const consultantProfiles = await prisma.consultantProfile.findMany({
+    select: { id: true },
+    take: 30,
+  });
+
+  if (consultantProfiles.length < 3) {
+    console.log("Not enough consultant profiles. Skipping collaborators.");
+    return;
+  }
+
+  let webinarCollabsCreated = 0;
+  let classCollabsCreated = 0;
+
+  // Get webinar plans with their owners
+  const webinarPlans = await prisma.webinarPlan.findMany({
+    select: { id: true, consultantProfileId: true },
+    take: 10,
+  });
+
+  // Get class plans with their owners
+  const classPlans = await prisma.classPlan.findMany({
+    select: { id: true, consultantProfileId: true },
+    take: 10,
+  });
+
+  const webinarRoles = [
+    "CO_HOST",
+    "MODERATOR",
+    "GUEST_SPEAKER",
+    "TECHNICAL_SUPPORT",
+  ] as const;
+
+  const classRoles = [
+    "CO_INSTRUCTOR",
+    "TEACHING_ASSISTANT",
+    "GUEST_LECTURER",
+    "CONTENT_CREATOR",
+  ] as const;
+
+  const statuses = ["PENDING", "ACCEPTED", "DECLINED"] as const;
+
+  // Add collaborators to ~50% of webinar plans
+  for (const plan of webinarPlans.slice(0, Math.ceil(webinarPlans.length * 0.5))) {
+    // Pick 1-2 collaborators (not the owner)
+    const availableCollaborators = consultantProfiles.filter(
+      (cp) => cp.id !== plan.consultantProfileId,
+    );
+
+    const numCollabs = faker.number.int({ min: 1, max: 2 });
+    const selectedCollabs = faker.helpers
+      .shuffle(availableCollaborators)
+      .slice(0, numCollabs);
+
+    for (const collab of selectedCollabs) {
+      try {
+        const status = faker.helpers.arrayElement(statuses);
+        await prisma.webinarCollaborator.create({
+          data: {
+            consultantProfileId: collab.id,
+            webinarPlanId: plan.id,
+            role: faker.helpers.arrayElement(webinarRoles),
+            revenueSharePercentage: faker.helpers.arrayElement([
+              10, 15, 20, 25, 30,
+            ]),
+            status,
+            invitedById: plan.consultantProfileId!,
+            ...(status === "ACCEPTED" || status === "DECLINED"
+              ? { respondedAt: faker.date.recent({ days: 7 }) }
+              : {}),
+          },
+        });
+        webinarCollabsCreated++;
+      } catch {
+        // Skip unique constraint violations
+      }
+    }
+  }
+
+  // Add collaborators to ~50% of class plans
+  for (const plan of classPlans.slice(0, Math.ceil(classPlans.length * 0.5))) {
+    const availableCollaborators = consultantProfiles.filter(
+      (cp) => cp.id !== plan.consultantProfileId,
+    );
+
+    const numCollabs = faker.number.int({ min: 1, max: 2 });
+    const selectedCollabs = faker.helpers
+      .shuffle(availableCollaborators)
+      .slice(0, numCollabs);
+
+    for (const collab of selectedCollabs) {
+      try {
+        const status = faker.helpers.arrayElement(statuses);
+        await prisma.classCollaborator.create({
+          data: {
+            consultantProfileId: collab.id,
+            classPlanId: plan.id,
+            role: faker.helpers.arrayElement(classRoles),
+            revenueSharePercentage: faker.helpers.arrayElement([
+              10, 15, 20, 25, 30,
+            ]),
+            status,
+            invitedById: plan.consultantProfileId!,
+            ...(status === "ACCEPTED" || status === "DECLINED"
+              ? { respondedAt: faker.date.recent({ days: 7 }) }
+              : {}),
+          },
+        });
+        classCollabsCreated++;
+      } catch {
+        // Skip unique constraint violations
+      }
+    }
+  }
+
+  console.log(
+    `Created ${webinarCollabsCreated} webinar collaborators, ${classCollabsCreated} class collaborators`,
+  );
+}

--- a/prisma/seedFiles/8b-create-payments.ts
+++ b/prisma/seedFiles/8b-create-payments.ts
@@ -99,6 +99,7 @@ export async function createPayments(users: UserWithProfiles[]) {
       const paymentData: Prisma.PaymentCreateInput = {
         user: { connect: { id: user.id } },
         amount: finalAmount,
+        originalAmount: amount,
         currency: faker.helpers.arrayElement(["USD", "EUR", "GBP"]),
         description,
         receiptUrl: faker.internet.url(),

--- a/prisma/seedFiles/validation/impossible-cases.ts
+++ b/prisma/seedFiles/validation/impossible-cases.ts
@@ -136,6 +136,7 @@ export const impossibleCases: ValidationTestCase[] = [
         data: {
           userId: user.id,
           amount: -1000, // Negative amount - should fail
+          originalAmount: -1000,
           currency: "INR",
           paymentMethod: "card",
           paymentIntent: faker.string.uuid(),
@@ -170,6 +171,7 @@ export const impossibleCases: ValidationTestCase[] = [
         data: {
           userId: user.id,
           amount: 10000, // 100 INR
+          originalAmount: 10000,
           currency: "INR",
           paymentMethod: "card",
           paymentIntent: faker.string.uuid(),

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -302,6 +302,7 @@ export const createCheckoutData = (params: {
   discountCode?: string;
   notes?: string;
   fromWaitlist?: string;
+  useReferralCredits?: boolean;
 }): CheckoutInput => {
   return {
     appointmentType: params.appointmentType,
@@ -317,5 +318,6 @@ export const createCheckoutData = (params: {
     discountCode: params.discountCode,
     notes: params.notes,
     fromWaitlist: params.fromWaitlist,
+    useReferralCredits: params.useReferralCredits,
   };
 };

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -87,6 +87,7 @@ export const checkoutSchema = z
     paymentGateway: paymentGatewaySchema,
     notes: z.string().optional(),
     fromWaitlist: z.string().optional(), // Waitlist ID if coming from waitlist flow
+    useReferralCredits: z.boolean().optional(), // Apply available referral credits
   })
   .superRefine((data, ctx) => {
     // === CONSULTATION validation ===

--- a/schemas/collaborators.ts
+++ b/schemas/collaborators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import {
+  WebinarCollaboratorRole,
+  ClassCollaboratorRole,
+} from "@prisma/client";
+
+export const WebinarCollaboratorRoleEnum = z.nativeEnum(WebinarCollaboratorRole);
+export const ClassCollaboratorRoleEnum = z.nativeEnum(ClassCollaboratorRole);
+
+export const inviteCollaboratorSchema = z.object({
+  consultantProfileId: z.string().min(1, "Consultant profile ID is required"),
+  revenueSharePercentage: z
+    .number({ required_error: "Revenue share percentage is required" })
+    .gt(0, "Revenue share percentage must be greater than 0")
+    .lte(90, "Revenue share percentage cannot exceed 90"),
+});
+
+export const inviteWebinarCollaboratorSchema = inviteCollaboratorSchema.extend({
+  role: WebinarCollaboratorRoleEnum,
+});
+
+export const inviteClassCollaboratorSchema = inviteCollaboratorSchema.extend({
+  role: ClassCollaboratorRoleEnum,
+});
+
+export type InviteCollaboratorInput = z.infer<typeof inviteCollaboratorSchema>;
+export type InviteWebinarCollaboratorInput = z.infer<typeof inviteWebinarCollaboratorSchema>;
+export type InviteClassCollaboratorInput = z.infer<typeof inviteClassCollaboratorSchema>;

--- a/scripts/disputes/handle-lost-disputes.ts
+++ b/scripts/disputes/handle-lost-disputes.ts
@@ -49,8 +49,10 @@ export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
       status: DisputeStatus.LOST,
       payment: {
         earnings: {
-          status: {
-            notIn: [EarningStatus.REFUNDED], // Not already refunded
+          some: {
+            status: {
+              notIn: [EarningStatus.REFUNDED], // Not already refunded
+            },
           },
         },
       },
@@ -77,9 +79,9 @@ export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
   );
 
   for (const dispute of lostDisputes) {
-    const earnings = dispute.payment.earnings;
+    const earningsList = dispute.payment.earnings;
 
-    if (!earnings) {
+    if (!earningsList || earningsList.length === 0) {
       console.log(
         `⏭️ Skipping dispute ${dispute.disputeId} - no associated earnings record`,
       );
@@ -87,6 +89,7 @@ export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
       continue;
     }
 
+    for (const earnings of earningsList) {
     // Check if earnings were already paid out
     if (earnings.status === EarningStatus.PAID) {
       // This is a critical situation - earnings were paid but dispute was lost
@@ -149,6 +152,7 @@ export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
       console.error(`❌ Error updating earnings ${earnings.id}:`, errorMessage);
       errorCount++;
     }
+    } // end for earnings
   }
 
   // Log summary of critical cases

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -67,6 +67,7 @@ function calculateEarningsData(
   payment: {
     id: string;
     amount: number;
+    originalAmount: number | null;
     createdAt: Date;
     appointment: {
       appointmentType: AppointmentsType;
@@ -74,7 +75,8 @@ function calculateEarningsData(
   },
   consultantProfileId: string,
 ) {
-  const grossAmount = payment.amount;
+  // Use original amount (before platform-funded discounts/credits) for earnings calculation
+  const grossAmount = payment.originalAmount ?? payment.amount;
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -141,7 +141,7 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
       where: {
         paymentStatus: PaymentStatus.SUCCEEDED,
         createdAt: { gte: thirtyDaysAgo },
-        earnings: null, // No linked earnings
+        earnings: { none: {} }, // No linked earnings
       },
       take: BATCH_SIZE,
       skip,

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -76,7 +76,8 @@ function calculateEarningsData(
   consultantProfileId: string,
 ) {
   // Use original plan price (before platform-funded discounts/credits/tax) for earnings
-  const grossAmount = payment.originalAmount;
+  // Payment.originalAmount is stored in rupees (major unit); earnings must be in paise (smallest unit)
+  const grossAmount = payment.originalAmount * 100;
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -67,7 +67,7 @@ function calculateEarningsData(
   payment: {
     id: string;
     amount: number;
-    originalAmount: number | null;
+    originalAmount: number;
     createdAt: Date;
     appointment: {
       appointmentType: AppointmentsType;
@@ -75,8 +75,8 @@ function calculateEarningsData(
   },
   consultantProfileId: string,
 ) {
-  // Use original amount (before platform-funded discounts/credits) for earnings calculation
-  const grossAmount = payment.originalAmount ?? payment.amount;
+  // Use original plan price (before platform-funded discounts/credits/tax) for earnings
+  const grossAmount = payment.originalAmount;
   const platformFee = Math.round(
     (grossAmount * PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE) / 100,
   );

--- a/scripts/payments/cleanup-abandoned-payments.ts
+++ b/scripts/payments/cleanup-abandoned-payments.ts
@@ -19,6 +19,7 @@
 import { PaymentStatus, PaymentGateway, RequestStatus } from "@prisma/client";
 import Stripe from "stripe";
 import { cancelRazorpayOrder } from "../../lib/payments/core/razorpay";
+import { reverseCreditsForPayment } from "@/lib/referrals/service";
 import prisma from "@/lib/prisma";
 
 /**
@@ -228,6 +229,25 @@ export async function cleanupAbandonedPayments(): Promise<CleanupResult> {
                 `Payment cancellation failed for ${payment.paymentIntent}: ${errorMessage}`,
               );
               // Continue cleanup even if payment cancellation fails
+            }
+          }
+
+          // Restore referral credits consumed by these payments BEFORE cascade-deleting
+          // Without this, deleting Appointment cascades to Payment → ReferralCreditUsage,
+          // leaving ReferralCredit.usedAmount/remainingAmount permanently corrupted
+          for (const payment of appointment.payment) {
+            try {
+              const restored = await reverseCreditsForPayment(payment.id, tx);
+              if (restored > 0) {
+                console.log(
+                  `🔄 Restored ${restored} paise of referral credits from abandoned payment ${payment.id}`,
+                );
+              }
+            } catch (creditError) {
+              console.warn(
+                `⚠️ Failed to restore credits for payment ${payment.id}:`,
+                creditError instanceof Error ? creditError.message : creditError,
+              );
             }
           }
 

--- a/scripts/referrals/expire-credits.ts
+++ b/scripts/referrals/expire-credits.ts
@@ -1,0 +1,23 @@
+/**
+ * Cron Job: Expire Stale Credits
+ * Zeros out remaining balance on credits past their expiry date.
+ * Run daily via cron: npx tsx scripts/referrals/expire-credits.ts
+ */
+
+import { expireStaleCredits } from "@/lib/referrals/service";
+
+async function main() {
+  console.log("🔄 Starting credit expiry job...");
+
+  try {
+    const expiredCount = await expireStaleCredits();
+    console.log(`✅ Expired ${expiredCount} stale credits.`);
+  } catch (error) {
+    console.error("❌ Failed to expire credits:", error);
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/scripts/referrals/expire-referrals.ts
+++ b/scripts/referrals/expire-referrals.ts
@@ -1,0 +1,23 @@
+/**
+ * Cron Job: Expire Stale Referrals
+ * Expires unqualified referrals that are past the 30-day qualification window.
+ * Run daily via cron: npx tsx scripts/referrals/expire-referrals.ts
+ */
+
+import { expireStaleReferrals } from "@/lib/referrals/service";
+
+async function main() {
+  console.log("🔄 Starting referral expiry job...");
+
+  try {
+    const expiredCount = await expireStaleReferrals();
+    console.log(`✅ Expired ${expiredCount} stale referrals.`);
+  } catch (error) {
+    console.error("❌ Failed to expire referrals:", error);
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/scripts/refunds/cascade-refund-earnings.ts
+++ b/scripts/refunds/cascade-refund-earnings.ts
@@ -46,12 +46,14 @@ export async function cascadeRefundToEarnings(): Promise<RefundEarningCascadeRes
       status: RefundStatus.SUCCEEDED,
       payment: {
         earnings: {
-          status: {
-            in: [
-              EarningStatus.PENDING,
-              EarningStatus.HELD,
-              EarningStatus.READY,
-            ],
+          some: {
+            status: {
+              in: [
+                EarningStatus.PENDING,
+                EarningStatus.HELD,
+                EarningStatus.READY,
+              ],
+            },
           },
         },
       },
@@ -70,9 +72,9 @@ export async function cascadeRefundToEarnings(): Promise<RefundEarningCascadeRes
   );
 
   for (const refund of refundsToProcess) {
-    const earnings = refund.payment.earnings;
+    const earningsList = refund.payment.earnings;
 
-    if (!earnings) {
+    if (!earningsList || earningsList.length === 0) {
       console.log(
         `⏭️ Skipping refund ${refund.id} - no associated earnings record`,
       );
@@ -80,25 +82,27 @@ export async function cascadeRefundToEarnings(): Promise<RefundEarningCascadeRes
       continue;
     }
 
-    try {
-      // Update earnings status to REFUNDED
-      await prisma.consultantEarnings.update({
-        where: { id: earnings.id },
-        data: {
-          status: EarningStatus.REFUNDED,
-        },
-      });
+    for (const earnings of earningsList) {
+      try {
+        // Update earnings status to REFUNDED
+        await prisma.consultantEarnings.update({
+          where: { id: earnings.id },
+          data: {
+            status: EarningStatus.REFUNDED,
+          },
+        });
 
-      console.log(
-        `✅ Updated earnings ${earnings.id} to REFUNDED (refund: ${refund.id})`,
-      );
-      updatedCount++;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      errors.push(`Earnings ${earnings.id}: ${errorMessage}`);
-      console.error(`❌ Error updating earnings ${earnings.id}:`, errorMessage);
-      errorCount++;
+        console.log(
+          `✅ Updated earnings ${earnings.id} to REFUNDED (refund: ${refund.id})`,
+        );
+        updatedCount++;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        errors.push(`Earnings ${earnings.id}: ${errorMessage}`);
+        console.error(`❌ Error updating earnings ${earnings.id}:`, errorMessage);
+        errorCount++;
+      }
     }
   }
 

--- a/scripts/utils/test-create-earnings.ts
+++ b/scripts/utils/test-create-earnings.ts
@@ -160,15 +160,16 @@ async function createEarningsForPayment(
     };
   }
 
-  if (payment.earnings) {
+  if (payment.earnings && payment.earnings.length > 0) {
+    const firstEarning = payment.earnings[0];
     return {
       success: false,
       paymentId,
-      earningsId: payment.earnings.id,
-      grossAmount: payment.earnings.grossAmount,
-      consultantShare: payment.earnings.consultantShare,
-      platformFee: payment.earnings.platformFee,
-      status: payment.earnings.status,
+      earningsId: firstEarning.id,
+      grossAmount: firstEarning.grossAmount,
+      consultantShare: firstEarning.consultantShare,
+      platformFee: firstEarning.platformFee,
+      status: firstEarning.status,
       error: `Earnings already exist for payment ${paymentId}`,
     };
   }
@@ -280,7 +281,7 @@ async function findPendingPayments(): Promise<string[]> {
   const payments = await prisma.payment.findMany({
     where: {
       paymentStatus: PaymentStatus.SUCCEEDED,
-      earnings: null,
+      earnings: { none: {} },
       appointment: { isNot: null },
     },
     select: { id: true },

--- a/scripts/utils/update-env-secret.ts
+++ b/scripts/utils/update-env-secret.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
 
-const ENV_FILE_PATH = path.join(__dirname, "..", ".env");
+const ENV_FILE_PATH = path.join(__dirname, "..", "..", ".env");
 const SECRET_NAME = "ENV_FILE";
 
 function main(): void {
@@ -80,7 +80,7 @@ function main(): void {
     const base64Content = Buffer.from(envContent, "utf8").toString("base64");
 
     // Create temporary file for the base64 content
-    const tempFile = path.join(__dirname, ".env.base64.tmp");
+    const tempFile = path.join(__dirname, "..", "..", ".env.base64.tmp");
     fs.writeFileSync(tempFile, base64Content);
 
     try {

--- a/types/consultee-events.ts
+++ b/types/consultee-events.ts
@@ -67,7 +67,7 @@ export type TConsulteeSubscription = Prisma.SubscriptionGetPayload<{
   };
 }>;
 
-// Webinar type - includes waitlist and appointment
+// Webinar type - includes waitlist, appointment, and collaborators
 export type TConsulteeWebinar = Prisma.WebinarGetPayload<{
   include: {
     webinarPlan: {
@@ -80,6 +80,22 @@ export type TConsulteeWebinar = Prisma.WebinarGetPayload<{
                 name: true;
                 image: true;
                 email: true;
+              };
+            };
+          };
+        };
+        collaborators: {
+          where: { status: "ACCEPTED" };
+          include: {
+            consultantProfile: {
+              include: {
+                user: {
+                  select: {
+                    id: true;
+                    name: true;
+                    image: true;
+                  };
+                };
               };
             };
           };
@@ -98,7 +114,7 @@ export type TConsulteeWebinar = Prisma.WebinarGetPayload<{
   };
 }>;
 
-// Class type - includes waitlist and multiple appointments
+// Class type - includes waitlist, multiple appointments, and collaborators
 export type TConsulteeClass = Prisma.ClassGetPayload<{
   include: {
     classPlan: {
@@ -111,6 +127,22 @@ export type TConsulteeClass = Prisma.ClassGetPayload<{
                 name: true;
                 image: true;
                 email: true;
+              };
+            };
+          };
+        };
+        collaborators: {
+          where: { status: "ACCEPTED" };
+          include: {
+            consultantProfile: {
+              include: {
+                user: {
+                  select: {
+                    id: true;
+                    name: true;
+                    image: true;
+                  };
+                };
               };
             };
           };


### PR DESCRIPTION
## Summary

Two major pre-launch growth features: a **referral system** for viral user acquisition and a **collaborator system** for multi-creator webinars and classes with automatic revenue sharing.

---

## Referral System

Every user (consultant or consultee) can generate a unique referral link and share it. When someone signs up through the link, both parties are rewarded with platform credits.

### How it works

```
User A (existing)                              User B (new)
     │                                              │
     │  Generates link: /r/kaustavga3x7              │
     │  Shares via social / email / DM               │
     │──────────────────────────────────────────────>│
     │                                               │
     │                               Clicks link     │
     │                               Signs up        │
     │                               Gets ₹200 credit│
     │                                               │
     │                               Makes first     │
     │                               paid booking    │
     │                               (within 30 days)│
     │                                               │
     │  Earns ₹500 credit  <────────────────────────│
     │                                               │
     │  Both use credits at future checkouts          │
```

### Referral lifecycle

A referral moves through these states:

```
SIGNED_UP ──→ REWARDED   (referee paid within 30 days)
SIGNED_UP ──→ EXPIRED    (30 days elapsed, no payment)
```

- **Code generation**: Name-based codes (e.g., `kaustavga3x7`) with random fallback on collision. Optional vanity codes (e.g., `/r/kaustav`).
- **Landing page** (`/r/[code]`): Validates the code server-side, redirects to `/auth/signup?ref=CODE`. The signup page reads the param and shows a "Referred by {Name} — You'll get ₹200" banner.
- **Qualification trigger**: After any successful payment, the webhook handler calls `processQualifyingAction()`. If the paying user was referred within the last 30 days, the referrer gets their ₹500 credit.
- **Credit wallet**: Credits accumulate from multiple sources (referral bonus, referee welcome, promotions, manual). At checkout, users toggle "Apply credits" and the system consumes credits **FIFO by expiry date** (oldest-expiring first). Credits expire after 6 months.
- **Dashboards**: Both consultant and consultee dashboards have a "Referrals" page showing stats (total referred, qualified, earned), referral list with statuses, and credit history.
- **Cron jobs**: `expire-referrals.ts` (marks 30-day-old unqualified referrals as EXPIRED) and `expire-credits.ts` (zeros out past-expiry credits). Both run daily.

---

## Collaborator System

Hosts can invite other consultants to collaborate on webinar and class plans. Each collaborator gets a defined role and revenue share. When a customer pays, earnings are automatically split.

### Invitation → acceptance → payment flow

```
Host (Consultant A)                         Collaborator (Consultant B)
     │                                              │
     │  Creates webinar plan (₹1,000)                │
     │  Invites B as CO_HOST (25% share)             │
     │──────────────────────────────────────────────>│
     │                                               │
     │                                Sees invite    │
     │                                in dashboard   │
     │                                               │
     │                                Accepts        │
     │  <────────────────────────────────────────────│
     │                                               │
     │  Stream chat channel auto-created             │
     │  "Advanced React - Collaborators"             │
     │  Members: [A, B] (private messaging)          │
     │                                               │
     │  A schedules the webinar (host-only)          │
     │                                               │
     │  User C buys a ticket (₹1,000)                │
     │                                               │
     │  Earnings split automatically:                │
     │  ┌────────────────────────────────────┐       │
     │  │ A (Host, 75%):   ₹750 → ₹600 net  │       │
     │  │ B (Co-Host, 25%): ₹250 → ₹200 net │       │
     │  │ Platform fee: 20% of each share    │       │
     │  └────────────────────────────────────┘       │
```

### Revenue sharing rules

```
┌──────────────────────────────────────────────────────┐
│ Total: ₹1,000                                        │
├──────────┬────────┬──────────┬─────────┬────────────┤
│ Party    │ Share  │ Gross    │ Fee 20% │ Net Payout │
├──────────┼────────┼──────────┼─────────┼────────────┤
│ Host     │ 75%    │ ₹750     │ ₹150    │ ₹600       │
│ Co-Host  │ 25%    │ ₹250     │ ₹50     │ ₹200       │
├──────────┼────────┼──────────┼─────────┼────────────┤
│ TOTAL    │ 100%   │ ₹1,000   │ ₹200    │ ₹800       │
└──────────┴────────┴──────────┴─────────┴────────────┘

- Host always keeps minimum 10% (collaborator total capped at 90%)
- PENDING invitations count toward the cap (prevents over-allocation)
- Host gets the remainder (absorbs rounding)
- Platform fee applied independently per share
- Each consultant's payout processed independently
```

### Collaborator roles

**Webinars**: CO_HOST, MODERATOR, GUEST_SPEAKER, TECHNICAL_SUPPORT
**Classes**: CO_INSTRUCTOR, TEACHING_ASSISTANT, GUEST_LECTURER, CONTENT_CREATOR

Roles determine default permissions (edit, publish, invite, analytics, manage). Custom permission overrides via optional JSON field. **Scheduling is always host-only** — no collaborator role grants scheduling permission.

### Collaborator status lifecycle

```
PENDING ──→ ACCEPTED  (+ Stream chat channel created)
PENDING ──→ DECLINED  (share freed up)
ACCEPTED ──→ REMOVED  (by host, soft delete, past earnings preserved)
```

### The 1:1 → 1:many earnings change

Previously `ConsultantEarnings.paymentId` was `@unique` — one earning per payment. Now multiple earnings can reference the same payment (one per collaborator). This was the riskiest schema change:

- `refundEarnings()` now uses `findMany` + iterates all earnings for a payment
- Dispute handling and earnings sync scripts updated with the same pattern
- TypeScript compiler caught every broken `payment.earnings` reference at compile time

### Stream.io integration

When a collaborator accepts an invitation, a **private messaging channel** is auto-created:
- Channel ID: `collab-webinar-{planId}` or `collab-class-{classPlanId}`
- Members: host + all accepted collaborators
- Idempotent: if a second collaborator accepts, the existing channel's member list is updated
- Channel metadata carries `is_collaborator_channel: true` for UI grouping

### Co-host availability

`GET /api/collaborators/{id}/availability?date=YYYY-MM-DD` returns the collaborator's weekly slots, custom slots, and booked appointments for that date. Powers a calendar overlay for the host's scheduling view:
- **Green**: co-host has availability + no booking (free)
- **Yellow**: no availability defined (flexible)
- **Red**: existing booking (unavailable)

### Public plan pages

Webinar and class detail pages now show accepted collaborators below the host card — avatar, name, and role (e.g., "CO HOST"). Links to their consultant profile.

### Earnings dashboard

The consultant earnings table now shows a **Role** column with badges: "Owner" (zinc) or "Collaborator 25%" (purple).

---

## Notifications (Novu)

Six new notification workflow stubs added:

**Referral workflows**:
- `REFERRAL_BONUS_EARNED` — sent to referrer when their referral qualifies
- `REFEREE_WELCOME_BONUS` — sent to new user when they sign up via referral
- `REFERRAL_CREDITS_APPLIED` — sent when credits are used at checkout

**Collaborator workflows**:
- `COLLABORATOR_INVITED` — sent to consultant when invited to collaborate
- `COLLABORATOR_ACCEPTED` — sent to host when a collaborator accepts
- `COLLABORATOR_REMOVED` — sent to collaborator when removed by host

The workflow definitions and service functions are implemented. Trigger wiring is ready but not fully connected to avoid side effects before Novu templates are configured.

---

## Checkout integration

The checkout pricing calculation (`app/checkout/plans/math.ts`) now accepts an optional `creditsApplied` parameter. The checkout schema (`schemas/checkout.ts`) includes a `referralCreditsApplied` field. After payment success, `applyCreditsToPayment()` deducts the used credits from the user's wallet using FIFO by expiry.

---

## Seed data

Two new seed files registered in phase 14 of the seed runner:
- `14a-create-referral-codes.ts` — referral codes for ~60% of users, sample referrals in various states, credits for rewarded referrals
- `14b-create-collaborators.ts` — 1-2 collaborators on ~50% of webinar and class plans with random roles and shares

---

## Documentation

Comprehensive docs written under `docs/referrals/` (4 files) and `docs/collaborators/` (6 files). Each has an overview, a narrative architecture doc with diagrams and sequence flows, API reference with request/response examples, and detailed guides for specific subsystems (credit system, revenue sharing, permissions, Stream integration).

---

## Test plan

- [x] Generate referral code → share link → sign up as new user → verify referral record + ₹200 credit
- [x] Make first paid booking as referred user → verify referrer gets ₹500, status → REWARDED
- [x] Apply credits at checkout → verify FIFO consumption and correct balance
- [x] Set vanity code → verify it resolves in referral links
- [ ] Run expire cron scripts → verify stale referrals and credits handled
- [x] Invite collaborator to webinar → verify share validation (≤90% total)
- [x] Accept invitation → verify Stream chat channel created
- [x] Purchase webinar with collaborators → verify split earnings records
- [ ] Refund collaborative payment → verify all earnings REFUNDED
- [ ] Remove collaborator → verify REMOVED status, past earnings kept
- [ ] `tsc --noEmit` passes with zero errors (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)