### PR TITLE
fix(meetings): connect consultee user to consultation slots for meeting access (#422)

### DIFF
--- a/app/api/meetings/[meetingId]/validate-access/route.ts
+++ b/app/api/meetings/[meetingId]/validate-access/route.ts
@@ -55,18 +55,12 @@ export async function GET(
                     consultationPlan: {
                       select: { consultantProfileId: true },
                     },
-                    requestedBy: {
-                      include: { user: { select: { id: true } } },
-                    },
                   },
                 },
                 subscription: {
                   include: {
                     subscriptionPlan: {
                       select: { consultantProfileId: true },
-                    },
-                    requestedBy: {
-                      include: { user: { select: { id: true } } },
                     },
                   },
                 },
@@ -140,21 +134,6 @@ export async function GET(
     }
 
     if (isParticipant) {
-      return NextResponse.json({
-        hasAccess: true,
-        role: "participant",
-        message: "Access granted as participant",
-      });
-    }
-
-    // Fallback: Check if user is the consultee who requested this appointment
-    // This covers existing consultations/subscriptions where the user was not
-    // connected to the slot via SlotOfAppointmentToUser during creation
-    const isConsultee =
-      appointment.consultation?.requestedBy?.user?.id === userId ||
-      appointment.subscription?.requestedBy?.user?.id === userId;
-
-    if (isConsultee) {
       return NextResponse.json({
         hasAccess: true,
         role: "participant",

--- a/app/api/meetings/[meetingId]/validate-access/route.ts
+++ b/app/api/meetings/[meetingId]/validate-access/route.ts
@@ -99,7 +99,7 @@ export async function GET(
     });
 
     // Check if user is a participant in this slot
-    const isParticipant = meetingSession.slotOfAppointment.user.some(
+    let isParticipant = meetingSession.slotOfAppointment.user.some(
       (u: { id: string }) => u.id === userId,
     );
 
@@ -131,6 +131,27 @@ export async function GET(
         role: "host",
         message: "Access granted as meeting host",
       });
+    }
+
+    // For classes/webinars, the meeting is created on the consultant's allocation
+    // slot, but the consultee is connected to a separate enrollment slot under the
+    // same appointment. Check all appointment slots if the direct slot check fails.
+    if (!isParticipant && (appointment.class || appointment.webinar)) {
+      const appointmentWithSlots = await prisma.appointment.findUnique({
+        where: { id: appointment.id },
+        include: {
+          slotsOfAppointment: {
+            include: {
+              user: { select: { id: true } },
+            },
+          },
+        },
+      });
+
+      isParticipant =
+        appointmentWithSlots?.slotsOfAppointment.some((slot) =>
+          slot.user.some((u) => u.id === userId),
+        ) ?? false;
     }
 
     if (isParticipant) {

--- a/app/api/meetings/[meetingId]/validate-access/route.ts
+++ b/app/api/meetings/[meetingId]/validate-access/route.ts
@@ -55,12 +55,18 @@ export async function GET(
                     consultationPlan: {
                       select: { consultantProfileId: true },
                     },
+                    requestedBy: {
+                      include: { user: { select: { id: true } } },
+                    },
                   },
                 },
                 subscription: {
                   include: {
                     subscriptionPlan: {
                       select: { consultantProfileId: true },
+                    },
+                    requestedBy: {
+                      include: { user: { select: { id: true } } },
                     },
                   },
                 },
@@ -134,6 +140,21 @@ export async function GET(
     }
 
     if (isParticipant) {
+      return NextResponse.json({
+        hasAccess: true,
+        role: "participant",
+        message: "Access granted as participant",
+      });
+    }
+
+    // Fallback: Check if user is the consultee who requested this appointment
+    // This covers existing consultations/subscriptions where the user was not
+    // connected to the slot via SlotOfAppointmentToUser during creation
+    const isConsultee =
+      appointment.consultation?.requestedBy?.user?.id === userId ||
+      appointment.subscription?.requestedBy?.user?.id === userId;
+
+    if (isConsultee) {
       return NextResponse.json({
         hasAccess: true,
         role: "participant",

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -941,6 +941,7 @@ export async function handleConsultationCheckout(
   tx: Prisma.TransactionClient,
   data: CheckoutInput,
   consulteeProfileId: string,
+  userId: string,
   skipPayment: boolean,
 ) {
   const plan = await tx.consultationPlan.findUnique({
@@ -988,6 +989,7 @@ export async function handleConsultationCheckout(
           startsAt: new Date(data.slotStartTimeInUTC!),
           endsAt: new Date(data.slotEndTimeInUTC!),
           isTentative: !skipPayment,
+          user: { connect: { id: userId } },
         },
       },
     },
@@ -1457,6 +1459,7 @@ export async function handleCheckout(
                 tx,
                 validatedData,
                 consulteeProfileId,
+                userId,
                 isMockPayment, // skipPayment = isMockPayment
               );
               createdAppointment = consultationResult.appointment;

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -68,6 +68,7 @@ interface SubscriptionData {
   schedulingPeriodEndsAt?: string;
   notes?: string;
   consulteeProfileId: string;
+  userId: string;
 }
 
 /**
@@ -677,6 +678,7 @@ async function createAppointmentFromWebhook(
         schedulingPeriodEndsAt,
         notes,
         consulteeProfileId,
+        userId,
       });
       break;
     case AppointmentsType.WEBINAR:
@@ -789,6 +791,7 @@ async function createSubscription(
         startsAt: new Date(data.slotStartTimeInUTC),
         endsAt: new Date(data.slotEndTimeInUTC),
         isTentative: false,
+        user: { connect: { id: data.userId } },
       },
     };
   }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -53,6 +53,7 @@ interface ConsultationData {
   slotEndTimeInUTC: string;
   notes?: string;
   consulteeProfileId: string;
+  userId: string;
 }
 
 /**
@@ -631,6 +632,7 @@ async function createAppointmentFromWebhook(
         slotEndTimeInUTC,
         notes,
         consulteeProfileId,
+        userId,
       });
       break;
     case AppointmentsType.SUBSCRIPTION:
@@ -701,6 +703,7 @@ async function createConsultation(
           startsAt: new Date(data.slotStartTimeInUTC),
           endsAt: new Date(data.slotEndTimeInUTC),
           isTentative: false,
+          user: { connect: { id: data.userId } },
         },
       },
     },


### PR DESCRIPTION
## Description 

- Consultees were getting "You are not authorized to join this meeting" errors for consultation appointments because the SlotOfAppointmentToUser relationship was never populated during slot creation — unlike webinars and classes which already connected users correctly.


### Ref: https://github.com/Practitionist/familiarise_web/issues/422    

## Changes:
- Add user connection when creating consultation slots during checkout (checkout.ts) and legacy webhook flow (handlers.ts)
- Add fallback consultee check in validate-access route to grant access for existing consultations where the user link was never created