### PR TITLE
feat: API security audit — auth, IDOR protection & rate limiting

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/errors/classification/payment-error-classification";
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
+import { checkoutLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,6 +15,10 @@ export async function POST(req: NextRequest) {
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    // Rate limit: 5 checkouts per minute per user
+    const rl = await applyRateLimit(checkoutLimiter, session.user.id);
+    if (rl) return rl;
 
     // Validate request body
     const body = await req.json();

--- a/app/api/consultants/search/route.ts
+++ b/app/api/consultants/search/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import prisma from "@/lib/prisma";
+import { searchLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   try {
+    // Rate limit: 60 requests per minute per IP
+    const rl = await applyRateLimit(searchLimiter, getClientIp(req));
+    if (rl) return rl;
+
     const session = await getSession();
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { transformNestedPlanTopics } from "@/lib/topics";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 // =============================================================================
 // Prisma Query Types - Derived from actual query shape for type safety
@@ -157,8 +162,19 @@ export async function GET(
   // Note: request parameter kept for Next.js API route signature compatibility
   void request;
 
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consultantId } = await params;
+
+    if (
+      !isPrivileged(session.user.role) &&
+      session.user.consultantProfileId !== consultantId
+    ) {
+      return forbiddenResponse("You can only access your own planner");
+    }
 
     if (!consultantId) {
       return NextResponse.json(

--- a/app/api/dashboard/consultant/[consultantId]/requests/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/requests/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 // =============================================================================
 // Prisma Query Types - Derived from actual query shape for type safety
@@ -263,9 +268,20 @@ export async function GET(
   // Note: request parameter kept for Next.js API route signature compatibility
   void request;
 
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consultantId } = await params;
     const consultantProfileId = consultantId;
+
+    if (
+      !isPrivileged(session.user.role) &&
+      session.user.consultantProfileId !== consultantId
+    ) {
+      return forbiddenResponse("You can only access your own requests");
+    }
 
     if (!consultantId) {
       return NextResponse.json(

--- a/app/api/dashboard/consultee/[consulteeId]/events/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/events/route.ts
@@ -1,12 +1,28 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ consulteeId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consulteeId } = await params;
+
+    if (
+      !isPrivileged(session.user.role) &&
+      session.user.consulteeProfileId !== consulteeId
+    ) {
+      return forbiddenResponse("You can only access your own events");
+    }
 
     if (!consulteeId) {
       return NextResponse.json(

--- a/app/api/dashboard/consultee/[consulteeId]/payments/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/payments/route.ts
@@ -1,12 +1,28 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ consulteeId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consulteeId } = await params;
+
+    if (
+      !isPrivileged(session.user.role) &&
+      session.user.consulteeProfileId !== consulteeId
+    ) {
+      return forbiddenResponse("You can only access your own payment history");
+    }
 
     if (!consulteeId) {
       return NextResponse.json(

--- a/app/api/dashboard/consultee/[consulteeId]/pending-payments/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/pending-payments/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { RequestStatus } from "@prisma/client";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 /**
  * GET /api/dashboard/consultee/[consulteeId]/pending-payments
@@ -10,8 +15,19 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ consulteeId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consulteeId } = await params;
+
+    if (
+      !isPrivileged(session.user.role) &&
+      session.user.consulteeProfileId !== consulteeId
+    ) {
+      return forbiddenResponse("You can only access your own pending payments");
+    }
 
     // Fetch consultee profile to get their ID
     const consulteeProfile = await prisma.consulteeProfile.findUnique({

--- a/app/api/dashboard/consultee/[consulteeId]/resources/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/resources/route.ts
@@ -3,6 +3,11 @@ import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 import { RecordingService } from "@/lib/stream/recording-service";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 const planMaterialSelect = {
   id: true,
@@ -129,8 +134,19 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ consulteeId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consulteeId } = await params;
+
+    if (
+      !isPrivileged(session.user.role) &&
+      session.user.consulteeProfileId !== consulteeId
+    ) {
+      return forbiddenResponse("You can only access your own resources");
+    }
 
     if (!consulteeId) {
       return NextResponse.json(

--- a/app/api/events/classes/[classId]/route.ts
+++ b/app/api/events/classes/[classId]/route.ts
@@ -5,14 +5,23 @@ import {
   requireApiAuth,
   isPrivileged,
   forbiddenResponse,
+  authorizeEventAccess,
 } from "@/lib/auth-helpers";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ classId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { classId } = await params;
+
+    const authz = await authorizeEventAccess(session, "class", classId);
+    if (authz) return authz;
+
     const classData = await prisma.class.findUniqueOrThrow({
       where: { id: classId },
       include: {
@@ -121,6 +130,12 @@ export async function PUT(
 
     return NextResponse.json({ data: classData }, { status: 200 });
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json({ error: "Class not found" }, { status: 404 });
+    }
     console.error(error);
     return NextResponse.json(
       { error: "Internal Server Error" },
@@ -183,6 +198,12 @@ export async function DELETE(
 
     return NextResponse.json({ data: classData }, { status: 200 });
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json({ error: "Class not found" }, { status: 404 });
+    }
     console.error(error);
     return NextResponse.json(
       { error: "Internal Server Error" },

--- a/app/api/events/classes/[classId]/route.ts
+++ b/app/api/events/classes/[classId]/route.ts
@@ -1,6 +1,11 @@
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: NextRequest,
@@ -58,12 +63,27 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ classId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { classId } = await params;
     const body = await request.json();
 
+    // Only the owning consultant or ADMIN/STAFF can update a class instance
     const classData = await prisma.class.update({
-      where: { id: classId },
+      where: {
+        id: classId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              classPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       data: {
         schedulingPeriodStartsAt: body.schedulingPeriodStartsAt,
         schedulingPeriodEndsAt: body.schedulingPeriodEndsAt,
@@ -113,11 +133,26 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ classId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { classId } = await params;
 
+    // Only the owning consultant or ADMIN/STAFF can delete a class instance
     const classData = await prisma.class.delete({
-      where: { id: classId },
+      where: {
+        id: classId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              classPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       include: {
         classPlan: {
           include: {

--- a/app/api/events/classes/route.ts
+++ b/app/api/events/classes/route.ts
@@ -1,12 +1,32 @@
 import prisma from "@/lib/prisma";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { transformNestedPlanTopics } from "@/lib/topics";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
+  // Require authentication (middleware already enforces cookie presence for /api/events/)
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { searchParams } = new URL(request.url);
     const consulteeProfileId = searchParams.get("consulteeProfileId");
     const consultantProfileId = searchParams.get("consultantProfileId");
+
+    // IDOR protection: non-privileged users can only request their own profile's data
+    if (!isPrivileged(session.user.role)) {
+      if (consulteeProfileId && session.user.consulteeProfileId !== consulteeProfileId) {
+        return forbiddenResponse("You can only view your own enrolled classes");
+      }
+      if (consultantProfileId && session.user.consultantProfileId !== consultantProfileId) {
+        return forbiddenResponse("You can only view your own classes");
+      }
+    }
     const startDateStr = searchParams.get("startDate");
     const endDateStr = searchParams.get("endDate");
 

--- a/app/api/events/classes/route.ts
+++ b/app/api/events/classes/route.ts
@@ -15,8 +15,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const consulteeProfileId = searchParams.get("consulteeProfileId");
-    const consultantProfileId = searchParams.get("consultantProfileId");
+    let consulteeProfileId = searchParams.get("consulteeProfileId");
+    let consultantProfileId = searchParams.get("consultantProfileId");
 
     // IDOR protection: non-privileged users can only request their own profile's data
     if (!isPrivileged(session.user.role)) {
@@ -25,6 +25,15 @@ export async function GET(request: NextRequest) {
       }
       if (consultantProfileId && session.user.consultantProfileId !== consultantProfileId) {
         return forbiddenResponse("You can only view your own classes");
+      }
+      // No-filter fallthrough guard: auto-fill from session so the unfiltered else
+      // branch is never reached by non-privileged users with no params supplied.
+      if (!consulteeProfileId && !consultantProfileId) {
+        if (session.user.consulteeProfileId) {
+          consulteeProfileId = session.user.consulteeProfileId;
+        } else if (session.user.consultantProfileId) {
+          consultantProfileId = session.user.consultantProfileId;
+        }
       }
     }
     const startDateStr = searchParams.get("startDate");

--- a/app/api/events/classes/route.ts
+++ b/app/api/events/classes/route.ts
@@ -33,6 +33,9 @@ export async function GET(request: NextRequest) {
           consulteeProfileId = session.user.consulteeProfileId;
         } else if (session.user.consultantProfileId) {
           consultantProfileId = session.user.consultantProfileId;
+        } else {
+          // User has no profile (e.g. incomplete onboarding) — must not reach unfiltered query
+          return forbiddenResponse("You are not authorized to view classes without a profile");
         }
       }
     }

--- a/app/api/events/webinars/[webinarId]/route.ts
+++ b/app/api/events/webinars/[webinarId]/route.ts
@@ -5,14 +5,23 @@ import {
   requireApiAuth,
   isPrivileged,
   forbiddenResponse,
+  authorizeEventAccess,
 } from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ webinarId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { webinarId } = await params;
+
+    const authz = await authorizeEventAccess(session, "webinar", webinarId);
+    if (authz) return authz;
+
     const webinarData = await prisma.webinar.findUniqueOrThrow({
       where: { id: webinarId },
       include: {
@@ -83,16 +92,14 @@ export async function PUT(
       data: {
         status: body.status,
         feedbackSummary: body.feedbackSummary,
-        webinarPlan: body.webinarPlanId
-          ? {
-              connect: { id: body.webinarPlanId },
-            }
-          : undefined,
-        appointment: body.appointmentId
-          ? {
-              connect: { id: body.appointmentId },
-            }
-          : undefined,
+        webinarPlan:
+          isPrivileged(session.user.role) && body.webinarPlanId
+            ? { connect: { id: body.webinarPlanId } }
+            : undefined,
+        appointment:
+          isPrivileged(session.user.role) && body.appointmentId
+            ? { connect: { id: body.appointmentId } }
+            : undefined,
       },
       include: {
         webinarPlan: {
@@ -120,6 +127,15 @@ export async function PUT(
 
     return NextResponse.json({ data: webinarData }, { status: 200 });
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json(
+        { error: "Webinar not found" },
+        { status: 404 },
+      );
+    }
     console.error("Error updating webinar:", error);
     return NextResponse.json(
       { error: "An error occurred while updating the webinar" },
@@ -178,6 +194,15 @@ export async function DELETE(
 
     return NextResponse.json({ data: webinarData }, { status: 200 });
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json(
+        { error: "Webinar not found" },
+        { status: 404 },
+      );
+    }
     console.error("Error deleting webinar:", error);
     return NextResponse.json(
       { error: "An error occurred while deleting the webinar" },

--- a/app/api/events/webinars/[webinarId]/route.ts
+++ b/app/api/events/webinars/[webinarId]/route.ts
@@ -1,6 +1,11 @@
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
@@ -51,15 +56,30 @@ export async function GET(
 }
 
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ webinarId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { webinarId } = await params;
     const body = await request.json();
 
+    // Only the owning consultant or ADMIN/STAFF can update a webinar instance
     const webinarData = await prisma.webinar.update({
-      where: { id: webinarId },
+      where: {
+        id: webinarId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              webinarPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       data: {
         status: body.status,
         feedbackSummary: body.feedbackSummary,
@@ -109,14 +129,29 @@ export async function PUT(
 }
 
 export async function DELETE(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ webinarId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { webinarId } = await params;
 
+    // Only the owning consultant or ADMIN/STAFF can delete a webinar instance
     const webinarData = await prisma.webinar.delete({
-      where: { id: webinarId },
+      where: {
+        id: webinarId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              webinarPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       include: {
         webinarPlan: {
           include: {

--- a/app/api/events/webinars/route.ts
+++ b/app/api/events/webinars/route.ts
@@ -16,8 +16,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const consulteeProfileId = searchParams.get("consulteeProfileId");
-    const consultantProfileId = searchParams.get("consultantProfileId");
+    let consulteeProfileId = searchParams.get("consulteeProfileId");
+    let consultantProfileId = searchParams.get("consultantProfileId");
 
     // IDOR protection: non-privileged users can only request their own profile's data
     if (!isPrivileged(session.user.role)) {
@@ -26,6 +26,15 @@ export async function GET(request: NextRequest) {
       }
       if (consultantProfileId && session.user.consultantProfileId !== consultantProfileId) {
         return forbiddenResponse("You can only view your own webinars");
+      }
+      // No-filter fallthrough guard: auto-fill from session so the unfiltered else
+      // branch is never reached by non-privileged users with no params supplied.
+      if (!consulteeProfileId && !consultantProfileId) {
+        if (session.user.consulteeProfileId) {
+          consulteeProfileId = session.user.consulteeProfileId;
+        } else if (session.user.consultantProfileId) {
+          consultantProfileId = session.user.consultantProfileId;
+        }
       }
     }
     const startDateStr = searchParams.get("startDate");

--- a/app/api/events/webinars/route.ts
+++ b/app/api/events/webinars/route.ts
@@ -34,6 +34,9 @@ export async function GET(request: NextRequest) {
           consulteeProfileId = session.user.consulteeProfileId;
         } else if (session.user.consultantProfileId) {
           consultantProfileId = session.user.consultantProfileId;
+        } else {
+          // User has no profile (e.g. incomplete onboarding) — must not reach unfiltered query
+          return forbiddenResponse("You are not authorized to view webinars without a profile");
         }
       }
     }
@@ -235,6 +238,10 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: Request) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const body = await request.json();
 
@@ -247,6 +254,17 @@ export async function POST(request: Request) {
         },
         { status: 400 },
       );
+    }
+
+    // Ownership check: only the owning consultant or privileged users can schedule a webinar
+    if (!isPrivileged(session.user.role)) {
+      const plan = await prisma.webinarPlan.findUnique({
+        where: { id: body.webinarPlanId },
+        select: { consultantProfileId: true },
+      });
+      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
+        return forbiddenResponse("You can only create webinars for your own plans");
+      }
     }
 
     const webinar = await prisma.webinar.create({

--- a/app/api/events/webinars/route.ts
+++ b/app/api/events/webinars/route.ts
@@ -1,13 +1,33 @@
 import prisma from "@/lib/prisma";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { WebinarStatus } from "@prisma/client";
 import { transformNestedPlanTopics } from "@/lib/topics";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
+  // Require authentication (middleware already enforces cookie presence for /api/events/)
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { searchParams } = new URL(request.url);
     const consulteeProfileId = searchParams.get("consulteeProfileId");
     const consultantProfileId = searchParams.get("consultantProfileId");
+
+    // IDOR protection: non-privileged users can only request their own profile's data
+    if (!isPrivileged(session.user.role)) {
+      if (consulteeProfileId && session.user.consulteeProfileId !== consulteeProfileId) {
+        return forbiddenResponse("You can only view your own enrolled webinars");
+      }
+      if (consultantProfileId && session.user.consultantProfileId !== consultantProfileId) {
+        return forbiddenResponse("You can only view your own webinars");
+      }
+    }
     const startDateStr = searchParams.get("startDate");
     const endDateStr = searchParams.get("endDate");
 

--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { z } from "zod";
+import { newsletterLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 const subscribeSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -15,6 +16,10 @@ const subscribeSchema = z.object({
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
+    // Rate limit: 3 subscriptions per hour per IP
+    const rl = await applyRateLimit(newsletterLimiter, getClientIp(req));
+    if (rl) return rl;
+
     const body = await req.json();
     const parsed = subscribeSchema.safeParse(body);
 

--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -8,7 +8,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { z } from "zod";
-import { newsletterLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 const subscribeSchema = z.object({
   email: z.string().email("Invalid email address"),
@@ -16,10 +15,6 @@ const subscribeSchema = z.object({
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
-    // Rate limit: 3 subscriptions per hour per IP
-    const rl = await applyRateLimit(newsletterLimiter, getClientIp(req));
-    if (rl) return rl;
-
     const body = await req.json();
     const parsed = subscribeSchema.safeParse(body);
 

--- a/app/api/participants/class/[classId]/route.ts
+++ b/app/api/participants/class/[classId]/route.ts
@@ -1,16 +1,34 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { handleSlotOpening } from "@/lib/waitlist/slot-handler";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ classId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { classId } = await params;
+    // Non-privileged users can only view participants for classes they own as consultant
     const classEvent = await prisma.class.findUnique({
       where: {
         id: classId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              classPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
       },
       include: {
         classPlan: true,
@@ -75,6 +93,17 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ classId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  if (
+    !isPrivileged(session.user.role) &&
+    !session.user.consultantProfileId
+  ) {
+    return forbiddenResponse("Only consultants can remove participants");
+  }
+
   try {
     const { classId } = await params;
 
@@ -86,8 +115,19 @@ export async function DELETE(
     }
 
     // Remove user from all slots in all appointments for this class
+    // Non-privileged users can only modify classes they own as consultant
     const classEvent = await prisma.class.findUnique({
-      where: { id: classId },
+      where: {
+        id: classId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              classPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       include: {
         appointments: {
           include: {

--- a/app/api/participants/consultations/[consultationId]/route.ts
+++ b/app/api/participants/consultations/[consultationId]/route.ts
@@ -1,15 +1,33 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ consultationId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { consultationId } = await params;
+    // Non-privileged users can only view participants for consultations they own as consultant
     const consultation = await prisma.consultation.findUnique({
       where: {
         id: consultationId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              consultationPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
       },
       include: {
         consultationPlan: true,
@@ -76,6 +94,17 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ consultationId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  if (
+    !isPrivileged(session.user.role) &&
+    !session.user.consultantProfileId
+  ) {
+    return forbiddenResponse("Only consultants can remove participants");
+  }
+
   try {
     const { consultationId } = await params;
 
@@ -87,8 +116,19 @@ export async function DELETE(
     }
 
     // Find the consultation
+    // Non-privileged users can only modify consultations they own as consultant
     const consultation = await prisma.consultation.findUnique({
-      where: { id: consultationId },
+      where: {
+        id: consultationId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              consultationPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       include: {
         appointment: {
           include: {

--- a/app/api/participants/subscriptions/[subscriptionId]/route.ts
+++ b/app/api/participants/subscriptions/[subscriptionId]/route.ts
@@ -1,15 +1,33 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ subscriptionId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { subscriptionId } = await params;
+    // Non-privileged users can only view participants for subscriptions they own as consultant
     const subscription = await prisma.subscription.findUnique({
       where: {
         id: subscriptionId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              subscriptionPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
       },
       include: {
         subscriptionPlan: true,
@@ -71,6 +89,17 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ subscriptionId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  if (
+    !isPrivileged(session.user.role) &&
+    !session.user.consultantProfileId
+  ) {
+    return forbiddenResponse("Only consultants can remove participants");
+  }
+
   try {
     const { subscriptionId } = await params;
 
@@ -82,8 +111,19 @@ export async function DELETE(
     }
 
     // Find the subscription
+    // Non-privileged users can only modify subscriptions they own as consultant
     const subscription = await prisma.subscription.findUnique({
-      where: { id: subscriptionId },
+      where: {
+        id: subscriptionId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              subscriptionPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       include: {
         appointments: {
           include: {

--- a/app/api/participants/webinar/[webinarId]/route.ts
+++ b/app/api/participants/webinar/[webinarId]/route.ts
@@ -1,16 +1,34 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { handleSlotOpening } from "@/lib/waitlist/slot-handler";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ webinarId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { webinarId } = await params;
+    // Non-privileged users can only view participants for webinars they own as consultant
     const webinarEvent = await prisma.webinar.findUnique({
       where: {
         id: webinarId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              webinarPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
       },
       include: {
         webinarPlan: true,
@@ -70,6 +88,17 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ webinarId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  if (
+    !isPrivileged(session.user.role) &&
+    !session.user.consultantProfileId
+  ) {
+    return forbiddenResponse("Only consultants can remove participants");
+  }
+
   try {
     const { webinarId } = await params;
 
@@ -81,8 +110,19 @@ export async function DELETE(
     }
 
     // Remove user from all slots in the appointment
+    // Non-privileged users can only modify webinars they own as consultant
     const webinarEvent = await prisma.webinar.findUnique({
-      where: { id: webinarId },
+      where: {
+        id: webinarId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              webinarPlan: {
+                consultantProfileId:
+                  session.user.consultantProfileId ?? "__none__",
+              },
+            }),
+      },
       include: {
         appointment: {
           include: {

--- a/app/api/payments/discounts/validate/route.ts
+++ b/app/api/payments/discounts/validate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { DiscountType } from "@prisma/client";
 import { getSession } from "@/lib/auth-server";
+import { discountLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 interface ValidateDiscountRequest {
   code: string;
@@ -32,6 +33,10 @@ export async function POST(request: NextRequest) {
         { status: 401 },
       );
     }
+
+    // Rate limit: 10 discount validations per minute per user
+    const rl = await applyRateLimit(discountLimiter, session.user.id);
+    if (rl) return rl;
 
     const body: ValidateDiscountRequest = await request.json();
     const { code, amount } = body;

--- a/app/api/plans/classes/[classPlanId]/route.ts
+++ b/app/api/plans/classes/[classPlanId]/route.ts
@@ -108,11 +108,10 @@ export async function PUT(
         prerequisites: body.prerequisites,
         materialProvided: body.materialProvided,
         learningOutcomes: body.learningOutcomes,
-        consultantProfile: body.consultantProfileId
-          ? {
-              connect: { id: body.consultantProfileId },
-            }
-          : undefined,
+        consultantProfile:
+          isPrivileged(session.user.role) && body.consultantProfileId
+            ? { connect: { id: body.consultantProfileId } }
+            : undefined,
         topics: body.topicIds
           ? {
               set: body.topicIds.map((id: string) => ({ id })),

--- a/app/api/plans/classes/[classPlanId]/route.ts
+++ b/app/api/plans/classes/[classPlanId]/route.ts
@@ -3,6 +3,11 @@ import { Prisma, PlanEmailSupport } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { fetchClassPlanDetail } from "@/lib/data/plan-details";
 import { apiError } from "@/lib/errors";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: NextRequest,
@@ -37,9 +42,24 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ classPlanId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { classPlanId } = await params;
     const body = await request.json();
+
+    // Only the owning consultant or ADMIN/STAFF can update a class plan
+    if (!isPrivileged(session.user.role)) {
+      const plan = await prisma.classPlan.findUnique({
+        where: { id: classPlanId },
+        select: { consultantProfileId: true },
+      });
+      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
+        return forbiddenResponse("You can only update your own class plans");
+      }
+    }
 
     // Input validation
     if (body.durationInMonths && body.durationInMonths <= 0) {
@@ -160,8 +180,23 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ classPlanId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { classPlanId } = await params;
+
+    // Only the owning consultant or ADMIN/STAFF can delete a class plan
+    if (!isPrivileged(session.user.role)) {
+      const plan = await prisma.classPlan.findUnique({
+        where: { id: classPlanId },
+        select: { consultantProfileId: true },
+      });
+      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
+        return forbiddenResponse("You can only delete your own class plans");
+      }
+    }
 
     // Check if there are any associated classes
     const associatedClasses = await prisma.class.findMany({

--- a/app/api/plans/classes/[classPlanId]/route.ts
+++ b/app/api/plans/classes/[classPlanId]/route.ts
@@ -3,11 +3,7 @@ import { Prisma, PlanEmailSupport } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { fetchClassPlanDetail } from "@/lib/data/plan-details";
 import { apiError } from "@/lib/errors";
-import {
-  requireApiAuth,
-  isPrivileged,
-  forbiddenResponse,
-} from "@/lib/auth-helpers";
+import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 
 export async function GET(
   request: NextRequest,
@@ -50,17 +46,6 @@ export async function PUT(
     const { classPlanId } = await params;
     const body = await request.json();
 
-    // Only the owning consultant or ADMIN/STAFF can update a class plan
-    if (!isPrivileged(session.user.role)) {
-      const plan = await prisma.classPlan.findUnique({
-        where: { id: classPlanId },
-        select: { consultantProfileId: true },
-      });
-      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
-        return forbiddenResponse("You can only update your own class plans");
-      }
-    }
-
     // Input validation
     if (body.durationInMonths && body.durationInMonths <= 0) {
       return NextResponse.json(
@@ -101,7 +86,15 @@ export async function PUT(
     }
 
     const classPlan = await prisma.classPlan.update({
-      where: { id: classPlanId },
+      where: {
+        id: classPlanId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              consultantProfileId:
+                session.user.consultantProfileId ?? "__none__",
+            }),
+      },
       data: {
         title: body.title,
         description: body.description,
@@ -187,15 +180,24 @@ export async function DELETE(
   try {
     const { classPlanId } = await params;
 
-    // Only the owning consultant or ADMIN/STAFF can delete a class plan
-    if (!isPrivileged(session.user.role)) {
-      const plan = await prisma.classPlan.findUnique({
-        where: { id: classPlanId },
-        select: { consultantProfileId: true },
-      });
-      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
-        return forbiddenResponse("You can only delete your own class plans");
-      }
+    // Verify existence + ownership in one query (non-owners get 404, not 403)
+    const existingPlan = await prisma.classPlan.findUnique({
+      where: {
+        id: classPlanId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              consultantProfileId:
+                session.user.consultantProfileId ?? "__none__",
+            }),
+      },
+      select: { id: true },
+    });
+    if (!existingPlan) {
+      return NextResponse.json(
+        { error: "Class plan not found" },
+        { status: 404 },
+      );
     }
 
     // Check if there are any associated classes

--- a/app/api/plans/webinars/[webinarPlanId]/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/route.ts
@@ -3,6 +3,11 @@ import { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { fetchWebinarPlanDetail } from "@/lib/data/plan-details";
 import { apiError } from "@/lib/errors";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(
   request: NextRequest,
@@ -37,9 +42,24 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ webinarPlanId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { webinarPlanId } = await params;
     const body = await request.json();
+
+    // Only the owning consultant or ADMIN/STAFF can update a webinar plan
+    if (!isPrivileged(session.user.role)) {
+      const plan = await prisma.webinarPlan.findUnique({
+        where: { id: webinarPlanId },
+        select: { consultantProfileId: true },
+      });
+      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
+        return forbiddenResponse("You can only update your own webinar plans");
+      }
+    }
 
     // Input validation
     if (body.durationInHours && body.durationInHours <= 0) {
@@ -127,8 +147,23 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ webinarPlanId: string }> },
 ) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const { webinarPlanId } = await params;
+
+    // Only the owning consultant or ADMIN/STAFF can delete a webinar plan
+    if (!isPrivileged(session.user.role)) {
+      const plan = await prisma.webinarPlan.findUnique({
+        where: { id: webinarPlanId },
+        select: { consultantProfileId: true },
+      });
+      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
+        return forbiddenResponse("You can only delete your own webinar plans");
+      }
+    }
 
     // Check if there are any associated webinars
     const associatedWebinars = await prisma.webinar.findMany({

--- a/app/api/plans/webinars/[webinarPlanId]/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/route.ts
@@ -89,11 +89,10 @@ export async function PUT(
         prerequisites: body.prerequisites,
         materialProvided: body.materialProvided,
         learningOutcomes: body.learningOutcomes,
-        consultantProfile: body.consultantProfileId
-          ? {
-              connect: { id: body.consultantProfileId },
-            }
-          : undefined,
+        consultantProfile:
+          isPrivileged(session.user.role) && body.consultantProfileId
+            ? { connect: { id: body.consultantProfileId } }
+            : undefined,
         topics: body.topicIds
           ? {
               set: body.topicIds.map((id: string) => ({ id })),

--- a/app/api/plans/webinars/[webinarPlanId]/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/route.ts
@@ -3,11 +3,7 @@ import { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { fetchWebinarPlanDetail } from "@/lib/data/plan-details";
 import { apiError } from "@/lib/errors";
-import {
-  requireApiAuth,
-  isPrivileged,
-  forbiddenResponse,
-} from "@/lib/auth-helpers";
+import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 
 export async function GET(
   request: NextRequest,
@@ -50,17 +46,6 @@ export async function PUT(
     const { webinarPlanId } = await params;
     const body = await request.json();
 
-    // Only the owning consultant or ADMIN/STAFF can update a webinar plan
-    if (!isPrivileged(session.user.role)) {
-      const plan = await prisma.webinarPlan.findUnique({
-        where: { id: webinarPlanId },
-        select: { consultantProfileId: true },
-      });
-      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
-        return forbiddenResponse("You can only update your own webinar plans");
-      }
-    }
-
     // Input validation
     if (body.durationInHours && body.durationInHours <= 0) {
       return NextResponse.json(
@@ -84,7 +69,15 @@ export async function PUT(
     }
 
     const webinarPlan = await prisma.webinarPlan.update({
-      where: { id: webinarPlanId },
+      where: {
+        id: webinarPlanId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              consultantProfileId:
+                session.user.consultantProfileId ?? "__none__",
+            }),
+      },
       data: {
         title: body.title,
         description: body.description,
@@ -154,15 +147,24 @@ export async function DELETE(
   try {
     const { webinarPlanId } = await params;
 
-    // Only the owning consultant or ADMIN/STAFF can delete a webinar plan
-    if (!isPrivileged(session.user.role)) {
-      const plan = await prisma.webinarPlan.findUnique({
-        where: { id: webinarPlanId },
-        select: { consultantProfileId: true },
-      });
-      if (!plan || plan.consultantProfileId !== session.user.consultantProfileId) {
-        return forbiddenResponse("You can only delete your own webinar plans");
-      }
+    // Verify existence + ownership in one query (non-owners get 404, not 403)
+    const existingPlan = await prisma.webinarPlan.findUnique({
+      where: {
+        id: webinarPlanId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              consultantProfileId:
+                session.user.consultantProfileId ?? "__none__",
+            }),
+      },
+      select: { id: true },
+    });
+    if (!existingPlan) {
+      return NextResponse.json(
+        { error: "Webinar plan not found" },
+        { status: 404 },
+      );
     }
 
     // Check if there are any associated webinars

--- a/app/api/plans/webinars/route.ts
+++ b/app/api/plans/webinars/route.ts
@@ -8,6 +8,11 @@ import {
   paginatedResponse,
   rankAndPaginate,
 } from "../shared/plan-filters";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 export async function GET(request: NextRequest) {
   try {
@@ -115,6 +120,10 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   try {
     const body = await request.json();
     const {
@@ -128,18 +137,22 @@ export async function POST(request: NextRequest) {
       prerequisites,
       materialProvided,
       learningOutcomes,
-      consultantProfileId,
       topicIds,
     } = body;
 
+    // Ownership: non-privileged users can only create plans for themselves
+    const consultantProfileId = isPrivileged(session.user.role)
+      ? body.consultantProfileId
+      : session.user.consultantProfileId;
+
+    if (!consultantProfileId) {
+      return forbiddenResponse(
+        "You must have a consultant profile to create a webinar plan",
+      );
+    }
+
     // Input validation
-    if (
-      !title ||
-      !durationInHours ||
-      !price ||
-      !maxParticipants ||
-      !consultantProfileId
-    ) {
+    if (!title || !durationInHours || !price || !maxParticipants) {
       return NextResponse.json(
         { error: "Missing required fields" },
         { status: 400 },

--- a/app/api/referrals/apply/route.ts
+++ b/app/api/referrals/apply/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import { applyReferralCode } from "@/lib/referrals/service";
+import { referralApplyLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
   try {
@@ -8,6 +9,10 @@ export async function POST(req: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    // Rate limit: 3 referral applications per 24 hours per user
+    const rl = await applyRateLimit(referralApplyLimiter, session.user.id);
+    if (rl) return rl;
 
     const body = await req.json();
     const { code } = body;

--- a/app/api/report/route.ts
+++ b/app/api/report/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { ModerationReportType } from "@prisma/client";
+import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
 /**
@@ -18,6 +19,10 @@ export async function POST(req: NextRequest) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    // Rate limit: 5 reports per hour per user
+    const rl = await applyRateLimit(spamLimiter, `report:${session.user.id}`);
+    if (rl) return rl;
 
     const body = await req.json();
     const {

--- a/app/api/slots/request-for-approval/route.ts
+++ b/app/api/slots/request-for-approval/route.ts
@@ -6,6 +6,7 @@ import { SlotLockError } from "@/utils/errors/SlotLockError";
 import { SlotValidationService } from "@/utils/slotAllocation/SlotValidationService";
 import { notifyNewBookingRequest } from "@/lib/novu";
 import { RequestForApprovalSchema } from "@/schemas/slots";
+import { requestApprovalLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
 export async function POST(req: NextRequest) {
@@ -18,6 +19,10 @@ export async function POST(req: NextRequest) {
         { status: 401 },
       );
     }
+
+    // Rate limit: 10 approval requests per hour per user
+    const rl = await applyRateLimit(requestApprovalLimiter, session.user.id);
+    if (rl) return rl;
 
     const body = await req.json();
     const parseResult = RequestForApprovalSchema.safeParse(body);

--- a/app/api/test-race-condition/route.ts
+++ b/app/api/test-race-condition/route.ts
@@ -5,6 +5,10 @@ import { NextRequest, NextResponse } from "next/server";
  * This helps verify the race condition fix works correctly
  */
 export async function POST(req: NextRequest) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not available" }, { status: 403 });
+  }
+
   try {
     const body = await req.json();
     const {

--- a/app/api/test-redis/route.ts
+++ b/app/api/test-redis/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import redisClient from "../../../lib/redis";
 
 export async function GET() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not available" }, { status: 403 });
+  }
+
   try {
     // Test basic SET operation
     const testKey = `test-${Date.now()}`;

--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -16,11 +16,7 @@ import {
   notifyTrialSessionCancelled,
 } from "@/lib/novu";
 import { UpdateTrialSchema } from "@/schemas/trials";
-import {
-  requireApiAuth,
-  isPrivileged,
-  forbiddenResponse,
-} from "@/lib/auth-helpers";
+import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 
 interface RouteContext {
   params: Promise<{ trialId: string }>;
@@ -39,7 +35,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
   try {
     const trialSession = await prisma.trialSession.findUnique({
-      where: { id: trialId },
+      where: {
+        id: trialId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              OR: [
+                { consulteeProfileId: session.user.consulteeProfileId ?? "__none__" },
+                { consultantProfileId: session.user.consultantProfileId ?? "__none__" },
+              ],
+            }),
+      },
       include: {
         consulteeProfile: {
           include: {
@@ -84,17 +90,6 @@ export async function GET(request: NextRequest, context: RouteContext) {
         { error: "Trial session not found" },
         { status: 404 },
       );
-    }
-
-    // Non-privileged users can only view trials they are a participant of
-    if (!isPrivileged(session.user.role)) {
-      const isConsultee =
-        session.user.consulteeProfileId === trialSession.consulteeProfileId;
-      const isConsultant =
-        session.user.consultantProfileId === trialSession.consultantProfileId;
-      if (!isConsultee && !isConsultant) {
-        return forbiddenResponse("You can only view your own trial sessions");
-      }
     }
 
     return NextResponse.json({ data: trialSession });
@@ -192,7 +187,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     // Fetch the existing trial session
     const existingTrial = await prisma.trialSession.findUnique({
-      where: { id: trialId },
+      where: {
+        id: trialId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              OR: [
+                { consulteeProfileId: session.user.consulteeProfileId ?? "__none__" },
+                { consultantProfileId: session.user.consultantProfileId ?? "__none__" },
+              ],
+            }),
+      },
       include: {
         consulteeProfile: {
           include: {
@@ -214,17 +219,6 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         { error: "Trial session not found" },
         { status: 404 },
       );
-    }
-
-    // Non-privileged users can only update trials they are a participant of
-    if (!isPrivileged(session.user.role)) {
-      const isConsultee =
-        session.user.consulteeProfileId === existingTrial.consulteeProfileId;
-      const isConsultant =
-        session.user.consultantProfileId === existingTrial.consultantProfileId;
-      if (!isConsultee && !isConsultant) {
-        return forbiddenResponse("You can only update your own trial sessions");
-      }
     }
 
     const updateData: Prisma.TrialSessionUpdateInput = {};
@@ -549,7 +543,17 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 
   try {
     const existingTrial = await prisma.trialSession.findUnique({
-      where: { id: trialId },
+      where: {
+        id: trialId,
+        ...(isPrivileged(session.user.role)
+          ? {}
+          : {
+              OR: [
+                { consulteeProfileId: session.user.consulteeProfileId ?? "__none__" },
+                { consultantProfileId: session.user.consultantProfileId ?? "__none__" },
+              ],
+            }),
+      },
     });
 
     if (!existingTrial) {
@@ -557,17 +561,6 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
         { error: "Trial session not found" },
         { status: 404 },
       );
-    }
-
-    // Non-privileged users can only cancel trials they are a participant of
-    if (!isPrivileged(session.user.role)) {
-      const isConsultee =
-        session.user.consulteeProfileId === existingTrial.consulteeProfileId;
-      const isConsultant =
-        session.user.consultantProfileId === existingTrial.consultantProfileId;
-      if (!isConsultee && !isConsultant) {
-        return forbiddenResponse("You can only cancel your own trial sessions");
-      }
     }
 
     // Only allow cancellation of PENDING or SCHEDULED trials

--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -16,6 +16,11 @@ import {
   notifyTrialSessionCancelled,
 } from "@/lib/novu";
 import { UpdateTrialSchema } from "@/schemas/trials";
+import {
+  requireApiAuth,
+  isPrivileged,
+  forbiddenResponse,
+} from "@/lib/auth-helpers";
 
 interface RouteContext {
   params: Promise<{ trialId: string }>;
@@ -26,6 +31,10 @@ interface RouteContext {
  * Get a specific trial session
  */
 export async function GET(request: NextRequest, context: RouteContext) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   const { trialId } = await context.params;
 
   try {
@@ -75,6 +84,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
         { error: "Trial session not found" },
         { status: 404 },
       );
+    }
+
+    // Non-privileged users can only view trials they are a participant of
+    if (!isPrivileged(session.user.role)) {
+      const isConsultee =
+        session.user.consulteeProfileId === trialSession.consulteeProfileId;
+      const isConsultant =
+        session.user.consultantProfileId === trialSession.consultantProfileId;
+      if (!isConsultee && !isConsultant) {
+        return forbiddenResponse("You can only view your own trial sessions");
+      }
     }
 
     return NextResponse.json({ data: trialSession });
@@ -153,6 +173,10 @@ async function validateSlotAvailability(
  * Update a trial session (approve, reject, schedule, complete, etc.)
  */
 export async function PATCH(request: NextRequest, context: RouteContext) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   const { trialId } = await context.params;
 
   try {
@@ -190,6 +214,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         { error: "Trial session not found" },
         { status: 404 },
       );
+    }
+
+    // Non-privileged users can only update trials they are a participant of
+    if (!isPrivileged(session.user.role)) {
+      const isConsultee =
+        session.user.consulteeProfileId === existingTrial.consulteeProfileId;
+      const isConsultant =
+        session.user.consultantProfileId === existingTrial.consultantProfileId;
+      if (!isConsultee && !isConsultant) {
+        return forbiddenResponse("You can only update your own trial sessions");
+      }
     }
 
     const updateData: Prisma.TrialSessionUpdateInput = {};
@@ -506,6 +541,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
  * Cancel a trial session
  */
 export async function DELETE(request: NextRequest, context: RouteContext) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
   const { trialId } = await context.params;
 
   try {
@@ -518,6 +557,17 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
         { error: "Trial session not found" },
         { status: 404 },
       );
+    }
+
+    // Non-privileged users can only cancel trials they are a participant of
+    if (!isPrivileged(session.user.role)) {
+      const isConsultee =
+        session.user.consulteeProfileId === existingTrial.consulteeProfileId;
+      const isConsultant =
+        session.user.consultantProfileId === existingTrial.consultantProfileId;
+      if (!isConsultee && !isConsultant) {
+        return forbiddenResponse("You can only cancel your own trial sessions");
+      }
     }
 
     // Only allow cancellation of PENDING or SCHEDULED trials

--- a/app/api/trials/check-eligibility/route.ts
+++ b/app/api/trials/check-eligibility/route.ts
@@ -1,6 +1,5 @@
 import prisma from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
-import { eligibilityLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 /**
  * GET /api/trials/check-eligibility
@@ -12,10 +11,6 @@ import { eligibilityLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limi
  * - subscriptionPlanId: Optional - check if specific plan has trial enabled
  */
 export async function GET(request: NextRequest) {
-  // Rate limit: 20 eligibility checks per minute per IP
-  const rl = await applyRateLimit(eligibilityLimiter, getClientIp(request));
-  if (rl) return rl;
-
   const { searchParams } = new URL(request.url);
   const consulteeProfileId = searchParams.get("consulteeProfileId");
   const consultantProfileId = searchParams.get("consultantProfileId");

--- a/app/api/trials/check-eligibility/route.ts
+++ b/app/api/trials/check-eligibility/route.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
+import { eligibilityLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 /**
  * GET /api/trials/check-eligibility
@@ -11,6 +12,10 @@ import { NextRequest, NextResponse } from "next/server";
  * - subscriptionPlanId: Optional - check if specific plan has trial enabled
  */
 export async function GET(request: NextRequest) {
+  // Rate limit: 20 eligibility checks per minute per IP
+  const rl = await applyRateLimit(eligibilityLimiter, getClientIp(request));
+  if (rl) return rl;
+
   const { searchParams } = new URL(request.url);
   const consulteeProfileId = searchParams.get("consulteeProfileId");
   const consultantProfileId = searchParams.get("consultantProfileId");

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -6,8 +6,8 @@ import { apiError } from "@/lib/errors";
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const page = parseInt(searchParams.get("page") || "1");
-    const limit = parseInt(searchParams.get("limit") || "10");
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1"));
+    const limit = Math.min(Math.max(1, parseInt(searchParams.get("limit") || "10")), 100);
     const domain = searchParams.get("domain");
     const subdomain = searchParams.get("subdomain");
     const tags = searchParams.get("tags")?.split(",");

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -2,9 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { consultantListInclude } from "@/lib/data/explore-experts";
 import { apiError } from "@/lib/errors";
+import { searchLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function GET(request: NextRequest) {
   try {
+    // Rate limit: 60 requests per minute per IP
+    const rl = await applyRateLimit(searchLimiter, getClientIp(request));
+    if (rl) return rl;
+
     const searchParams = request.nextUrl.searchParams;
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "10");

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -2,14 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { consultantListInclude } from "@/lib/data/explore-experts";
 import { apiError } from "@/lib/errors";
-import { searchLimiter, applyRateLimit, getClientIp } from "@/lib/rate-limit";
 
 export async function GET(request: NextRequest) {
   try {
-    // Rate limit: 60 requests per minute per IP
-    const rl = await applyRateLimit(searchLimiter, getClientIp(request));
-    if (rl) return rl;
-
     const searchParams = request.nextUrl.searchParams;
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "10");

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -6,8 +6,8 @@ import { apiError } from "@/lib/errors";
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const page = Math.max(1, parseInt(searchParams.get("page") || "1"));
-    const limit = Math.min(Math.max(1, parseInt(searchParams.get("limit") || "10")), 100);
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1") || 1);
+    const limit = Math.min(Math.max(1, parseInt(searchParams.get("limit") || "10") || 10), 100);
     const domain = searchParams.get("domain");
     const subdomain = searchParams.get("subdomain");
     const tags = searchParams.get("tags")?.split(",");

--- a/app/api/user/feedbacks/route.ts
+++ b/app/api/user/feedbacks/route.ts
@@ -2,6 +2,7 @@ import prisma from "lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { notifyFeedbackReceived } from "@/lib/novu";
 import { CreateFeedbackSchema } from "@/schemas/feedbacks";
+import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
 export async function GET() {
@@ -45,6 +46,13 @@ export async function POST(req: NextRequest) {
         { status: 401 },
       );
     }
+
+    // Rate limit: 5 feedbacks per hour per user
+    const rl = await applyRateLimit(
+      spamLimiter,
+      `feedbacks:${session.user.id}`,
+    );
+    if (rl) return rl;
 
     const body = await req.json();
     const result = CreateFeedbackSchema.safeParse(body);

--- a/app/api/user/reviews/route.ts
+++ b/app/api/user/reviews/route.ts
@@ -3,6 +3,8 @@ import prisma from "@/lib/prisma";
 import { notifyNewReview } from "@/lib/novu";
 import { CreateReviewSchema } from "@/schemas/feedbacks";
 import { apiError } from "@/lib/errors";
+import { getSession } from "@/lib/auth-server";
+import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 export async function GET(req: NextRequest) {
   try {
@@ -80,6 +82,15 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Rate limit: 5 reviews per hour per user
+    const rl = await applyRateLimit(spamLimiter, `reviews:${session.user.id}`);
+    if (rl) return rl;
+
     const body = await req.json();
     const result = CreateReviewSchema.safeParse(body);
     if (!result.success) {

--- a/app/api/user/support-tickets/route.ts
+++ b/app/api/user/support-tickets/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "lib/prisma";
 import { notifySupportTicketCreated } from "@/lib/novu";
 import { CreateSupportTicketSchema } from "@/schemas/support";
+import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
 export async function GET() {
@@ -69,6 +70,10 @@ export async function POST(req: NextRequest) {
         { status: 401 },
       );
     }
+
+    // Rate limit: 5 support tickets per hour per user
+    const rl = await applyRateLimit(spamLimiter, `tickets:${session.user.id}`);
+    if (rl) return rl;
 
     const body = await req.json();
     const result = CreateSupportTicketSchema.safeParse(body);

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { joinWaitlist, getUserWaitlistEntries } from "@/lib/waitlist";
 import { sendWaitlistJoinedEmail } from "@/lib/waitlist/notifications";
 import prisma from "@/lib/prisma";
+import { waitlistLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
 /**
@@ -23,6 +24,10 @@ export async function POST(request: NextRequest) {
         { status: 401 },
       );
     }
+
+    // Rate limit: 5 waitlist joins per hour per user
+    const rl = await applyRateLimit(waitlistLimiter, session.user.id);
+    if (rl) return rl;
 
     const body = await request.json();
     const { webinarId, classId, preferences } = body;

--- a/docs/finances/06-saas-expenditures.md
+++ b/docs/finances/06-saas-expenditures.md
@@ -41,7 +41,7 @@ This document details all SaaS and infrastructure costs for Familiarise. Updated
 | [Globe.dev](https://globe.dev/)                                  | Free tier (Flutter deployment)           | ₹0                   | Not publicly listed      | Unknown                                          |
 | [Novu](https://novu.co/pricing)                                  | 10K workflow runs/mo, 20 workflows       | ₹0                   | $30/mo (~₹2,721) Pro     | ~500-1K bookings/month (~5-8 events each)        |
 | [Resend](https://resend.com/pricing)                             | 100 emails/day, 3K/month                 | ₹0                   | $20/mo (~₹1,814)         | ~100 bookings/day                                |
-| [Upstash Redis](https://upstash.com/pricing)                     | Free tier                                | ₹0                   | $10/mo (~₹907)           | Heavy rate-limiting                              |
+| [Upstash Redis](https://upstash.com/pricing)                     | 500K cmds/mo, 256 MB data, 50 GB bw     | ₹0                   | $0.20/100K cmds PAYG (₹18/mo at 10K MAU) | ~8,300 MAU — see [cost model](../upstash/redis/04-pricing-and-cost-model.md) |
 | [PostHog](https://posthog.com/pricing)                           | 1M events/month                          | ₹0                   | Usage-based              | Scale stage                                      |
 | [Sentry](https://sentry.io/pricing)                              | 5K errors/month                          | ₹0                   | $26/mo (~₹2,200) Team    | Paid features needed                             |
 | [Cloudflare](https://www.cloudflare.com/plans/)                  | CDN, DDoS protection                     | ₹0                   | $20/mo Pro               | Enterprise features                              |
@@ -228,6 +228,7 @@ You lose access when ANY of these happen:
 | **Vercel**          | Need team features or bandwidth         | LOW        | ₹0 → ₹1,814/seat        | Can stay on hobby plan for a long time with single developer     |
 | **PostHog**         | 1M events/month                         | LOW        | ₹0 → usage-based        | Very generous free tier; unlikely to hit in Year 1               |
 | **Sentry**          | 5K errors/month                         | LOW        | ₹0 → ₹2,358/mo          | If hitting 5K errors, you have bigger problems                   |
+| **Upstash Redis**   | ~8,300 MAU (~500K Redis cmds/mo)        | LOW        | ₹0 → ₹18/mo PAYG        | Stays free through Year 1; see [cost model](../upstash/redis/04-pricing-and-cost-model.md) |
 
 ---
 
@@ -306,6 +307,7 @@ When GST-registered, you must pay 18% IGST on all imported services (foreign Saa
 | Stream.io | Dashboard → Usage           | 1,500 MAU (75% of 2K limit)     |
 | Novu      | Dashboard → Usage           | 7,000 runs/month (70% of limit) |
 | Resend    | Dashboard → Usage           | 70 emails/day (70% of limit)    |
+| Upstash   | Dashboard → Usage           | 400K commands/month (80% of free tier) |
 | Razorpay  | Dashboard → Settlements     | Refund rate > 5%                |
 | Claude    | Subscription page           | Before renewal each month       |
 
@@ -319,3 +321,4 @@ When GST-registered, you must pay 18% IGST on all imported services (foreign Saa
 - [09-tax-compliance-india.md](./09-tax-compliance-india.md) - Tax compliance (GST, TDS, TCS)
 - [10-profitability-minimum-pricing.md](./10-profitability-minimum-pricing.md) - Profitability analysis
 - `temp/11-cfo-master-plan.md` - Comprehensive CFO financial blueprint (private, not in git)
+- [../upstash/redis/04-pricing-and-cost-model.md](../upstash/redis/04-pricing-and-cost-model.md) - Upstash Redis command budget, growth projections, and plan decision guide

--- a/docs/upstash/redis/04-pricing-and-cost-model.md
+++ b/docs/upstash/redis/04-pricing-and-cost-model.md
@@ -1,0 +1,130 @@
+# Upstash Redis — Pricing & Cost Model
+
+Covers the full command budget for the current Redis usage (rate limiting, distributed locks, maintenance mode), growth projections by MAU, data size analysis, and guidance on when to leave the free tier.
+
+---
+
+## What Redis Is Used For
+
+Three distinct use cases with very different command profiles:
+
+| Use case | Where | Commands per event | Frequency |
+|---|---|---|---|
+| **Rate limiting** | `lib/rate-limit.ts` (11 limiters) | ~2 per `limit()` call | Every rate-limited request |
+| **Maintenance state** | `lib/maintenance-edge.ts` | 2 GETs per cache miss | Once per 30s per edge instance |
+| **Distributed locks** | `lib/redis.ts` (payouts, approval-payments, appointments) | ~3 (SET NX + Lua eval) | Per payment/booking only |
+
+### Rate limiters at a glance
+
+| Limiter | Endpoint | Window | Key | Layer |
+|---|---|---|---|---|
+| `authLimiter` | POST `/api/auth/sign-in,sign-up,forget-password` | 10/15 min | IP | Edge |
+| `searchLimiter` | GET `/api/user/consultants` | 60/min | IP | Edge |
+| `eligibilityLimiter` | GET `/api/trials/check-eligibility` | 20/min | IP | Edge |
+| `newsletterLimiter` | POST `/api/newsletter/subscribe` | 3/hr | IP | Edge |
+| `availabilityLimiter` | GET `/api/slots/availability/[id]` | 30/min | IP | Edge |
+| `checkoutLimiter` | POST `/api/checkout` | 5/min | user ID | Handler |
+| `discountLimiter` | POST `/api/payments/discounts/validate` | 10/min | user ID | Handler |
+| `referralApplyLimiter` | POST `/api/referrals/apply` | 3/24 hr | user ID | Handler |
+| `spamLimiter` | support tickets, feedbacks, reviews, report | 5/hr | user ID | Handler |
+| `waitlistLimiter` | POST `/api/waitlist` | 5/hr | user ID | Handler |
+| `requestApprovalLimiter` | POST `/api/slots/request-for-approval` | 10/hr | user ID | Handler |
+
+### Maintenance mode — the 30-second cache
+
+`getMaintenanceState()` in `lib/maintenance-edge.ts` fires 2 Redis GETs per call but is **cached in-memory for 30 seconds per edge instance**. In the normal `OFF` state (always the case unless you explicitly trigger maintenance), the result is cached and the vast majority of requests never touch Redis for maintenance. Actual Redis hits: roughly 1 call per 10–20 middleware invocations at moderate traffic.
+
+---
+
+## Commands per User per Month
+
+### Active consultee (visits 7×/month, books 1–2 sessions)
+
+| Action | Commands |
+|---|---|
+| 7 browse sessions × 3 search pages × 2 cmds | 42 |
+| 7 sessions × 2 availability checks × 2 cmds | 28 |
+| 1 login × 2 cmds | 2 |
+| 1 booking: checkout (2) + lock acquire/release (3) | 5 |
+| Maintenance amortized (7 sessions × 3 req × 0.1 cmd) | ~2 |
+| **Total** | **~80 cmds/month** |
+
+### Active consultant (visits 4–5×/month, no booking)
+
+| Action | Commands |
+|---|---|
+| 4 sessions × 2 searches × 2 cmds | 16 |
+| 4 logins × 2 cmds | 8 |
+| Maintenance amortized | ~2 |
+| **Total** | **~26 cmds/month** |
+
+**Blended average across all user types:** ~55–60 commands/MAU/month
+
+---
+
+## Growth Projections
+
+Exchange rate: ₹90.7/$1. Free tier: 500K commands/month. Pay-as-you-go: $0.20 per 100K commands after the free allowance.
+
+| Stage | MAU | Commands/month | Free tier used | PAYG cost | Monthly cost (₹) |
+|---|---|---|---|---|---|
+| Launch (M1) | 50 | ~3K | 0.6% | $0 | ₹0 |
+| Early traction (M3) | 200 | ~12K | 2.4% | $0 | ₹0 |
+| Growing (M6) | 700 | ~42K | 8% | $0 | ₹0 |
+| Scale (M12) | 1,500 | ~90K | 18% | $0 | ₹0 |
+| Strong growth (M18) | 5,000 | ~300K | 60% | $0 | ₹0 |
+| **Free tier ceiling** | **~8,300 MAU** | **~500K** | 100% | $0 | **₹0** |
+| Post-ceiling | 10,000 | ~600K | — | $0.20 | ₹18 |
+| | 20,000 | ~1.2M | — | $1.40 | ₹127 |
+| | 50,000 | ~3M | — | $5.00 | ₹454 |
+| | 100,000 | ~6M | — | $11.00 | ₹998 |
+
+**Bottom line:** Redis is effectively free through all of Year 1 and most of Year 2. Even at 10K MAU the cost is ₹18/month — well below the noise floor compared to the Stream.io cliff (₹36K/month).
+
+---
+
+## Data Size
+
+Rate limit keys are sorted sets with short TTLs (1 min – 24 hr). At 100 concurrent users, all live rate limit keys together occupy ~200 KB. At 10,000 concurrent users: ~15–20 MB. The free tier's 256 MB data limit is not the binding constraint — the 500K command ceiling is hit first, and even that is at ~8,300 MAU.
+
+| Concurrent users | Est. live Redis data |
+|---|---|
+| 100 | ~200 KB |
+| 1,000 | ~2 MB |
+| 10,000 | ~15–20 MB |
+| Free tier limit | 256 MB |
+
+---
+
+## Plan Decision Guide
+
+| Plan | Price | When it makes sense |
+|---|---|---|
+| **Free** | $0 | Up to ~8,300 MAU. Stay here. |
+| **Pay-as-you-go** | $0.20/100K cmds | 8,300–165,000 MAU. Cheapest option beyond free. |
+| **Fixed 1 GB** | $20/mo (₹1,814) | Only rational at ~10M cmds/month ≈ 165K MAU, where PAYG also costs ~$20. |
+| **Fixed 5 GB** | $100/mo (₹9,070) | ~50M cmds/month ≈ 830K MAU. |
+
+**Stay on Pay-as-you-go until Fixed becomes cheaper.** At current usage patterns, the crossover to Fixed 1 GB happens at ~165K MAU — a scale unlikely to be reached before a Series A.
+
+> **Note on future caching:** If query caching (consultant profiles, availability, search results) is ever added on top of rate limiting, the command budget per user will increase significantly and these projections will need updating. See `docs/roadmap/infrastructure/12-caching-upstash-redis.md`.
+
+---
+
+## Monitoring
+
+Set an alert at **400K commands/month (80% of the free tier)** in the Upstash dashboard to get advance warning before the free tier expires.
+
+| Metric | Where | Alert threshold |
+|---|---|---|
+| Monthly commands | Upstash Dashboard → Usage | 400K/month |
+| Data size | Upstash Dashboard → Usage | 200 MB |
+| Daily commands spike | Dashboard → Daily Commands chart | >20K/day (sudden traffic or abuse) |
+
+---
+
+## Related Documents
+
+- [`docs/finances/06-saas-expenditures.md`](../../finances/06-saas-expenditures.md) — Full SaaS cost breakdown by growth stage
+- [`docs/upstash/redis/locking/00_README.md`](./locking/00_README.md) — Distributed locking implementation (the other Redis use case)
+- [`docs/roadmap/infrastructure/12-caching-upstash-redis.md`](../../roadmap/infrastructure/12-caching-upstash-redis.md) — Future query caching roadmap (different command budget)

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -21,12 +21,12 @@ type RatelimitRedis = ConstructorParameters<typeof Ratelimit>[0]["redis"];
 
 function makeLimiter(
   requests: number,
-  window: string,
+  window: `${number} ${"ms" | "s" | "m" | "h" | "d"}`,
   prefix: string,
 ): Ratelimit {
   return new Ratelimit({
     redis: redis as RatelimitRedis,
-    limiter: Ratelimit.slidingWindow(requests, window as "1 m"),
+    limiter: Ratelimit.slidingWindow(requests, window),
     prefix,
   });
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -16,7 +16,7 @@
  */
 
 import { Ratelimit } from "@upstash/ratelimit";
-import redis from "@/lib/redis";
+import redis from "@/lib/redis-edge";
 import { NextResponse } from "next/server";
 
 type RatelimitRedis = ConstructorParameters<typeof Ratelimit>[0]["redis"];

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared rate limiters for API routes.
+ *
+ * Rate limit profiles:
+ * - checkoutLimiter:        5/min per user   — POST /api/checkout (fraud)
+ * - discountLimiter:        10/min per user  — POST /api/payments/discounts/validate (brute-force)
+ * - newsletterLimiter:      3/hr per IP      — POST /api/newsletter/subscribe (spam)
+ * - referralApplyLimiter:   3/24h per user   — POST /api/referrals/apply (farming)
+ * - spamLimiter:            5/hr per user    — support-tickets, feedbacks, reviews, report
+ * - waitlistLimiter:        5/hr per user    — POST /api/waitlist
+ * - requestApprovalLimiter: 10/hr per user   — POST /api/slots/request-for-approval
+ * - searchLimiter:          60/min per IP    — GET /api/user/consultants, /api/consultants/search
+ * - eligibilityLimiter:     20/min per IP    — GET /api/trials/check-eligibility
+ */
+
+import { Ratelimit } from "@upstash/ratelimit";
+import redis from "@/lib/redis";
+import { NextResponse } from "next/server";
+
+type RatelimitRedis = ConstructorParameters<typeof Ratelimit>[0]["redis"];
+
+function makeLimiter(
+  requests: number,
+  window: string,
+  prefix: string,
+): Ratelimit {
+  return new Ratelimit({
+    redis: redis as RatelimitRedis,
+    limiter: Ratelimit.slidingWindow(requests, window as "1 m"),
+    prefix,
+  });
+}
+
+/** 5 per minute — POST /api/checkout */
+export const checkoutLimiter = makeLimiter(5, "1 m", "rl:checkout");
+
+/** 10 per minute — POST /api/payments/discounts/validate */
+export const discountLimiter = makeLimiter(10, "1 m", "rl:discount");
+
+/** 3 per hour — POST /api/newsletter/subscribe (IP-based) */
+export const newsletterLimiter = makeLimiter(3, "1 h", "rl:newsletter");
+
+/** 3 per 24 hours — POST /api/referrals/apply */
+export const referralApplyLimiter = makeLimiter(3, "24 h", "rl:referral-apply");
+
+/** 5 per hour — support-tickets, feedbacks, reviews, report (scope key by route) */
+export const spamLimiter = makeLimiter(5, "1 h", "rl:spam");
+
+/** 5 per hour — POST /api/waitlist */
+export const waitlistLimiter = makeLimiter(5, "1 h", "rl:waitlist");
+
+/** 10 per hour — POST /api/slots/request-for-approval */
+export const requestApprovalLimiter = makeLimiter(
+  10,
+  "1 h",
+  "rl:request-approval",
+);
+
+/** 60 per minute — GET /api/user/consultants, GET /api/consultants/search */
+export const searchLimiter = makeLimiter(60, "1 m", "rl:search");
+
+/** 20 per minute — GET /api/trials/check-eligibility */
+export const eligibilityLimiter = makeLimiter(20, "1 m", "rl:eligibility");
+
+/**
+ * Apply rate limit to a request.
+ * Returns a 429 NextResponse if exceeded, otherwise null.
+ *
+ * @param limiter    - Named Ratelimit instance from this module
+ * @param identifier - Rate limit key: userId for auth'd routes, IP for public routes.
+ *                     Prefix with a route slug when reusing the same limiter across
+ *                     multiple endpoints (e.g. `tickets:${userId}`).
+ */
+export async function applyRateLimit(
+  limiter: Ratelimit,
+  identifier: string,
+): Promise<NextResponse | null> {
+  const { success, remaining } = await limiter.limit(identifier);
+  if (!success) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again later." },
+      { status: 429, headers: { "X-RateLimit-Remaining": String(remaining) } },
+    );
+  }
+  return null;
+}
+
+/**
+ * Extract the client IP from request headers.
+ * Use for IP-based rate limiting on public endpoints.
+ */
+export function getClientIp(
+  req: { headers: { get(name: string): string | null } },
+): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
+  );
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -16,6 +16,7 @@
  */
 
 import { Ratelimit } from "@upstash/ratelimit";
+import { randomUUID } from "crypto";
 import redis from "@/lib/redis";
 import { NextResponse } from "next/server";
 
@@ -83,14 +84,18 @@ export async function applyRateLimit(
   limiter: Ratelimit,
   identifier: string,
 ): Promise<NextResponse | null> {
-  const { success, remaining } = await limiter.limit(identifier);
-  if (!success) {
-    return NextResponse.json(
-      { error: "Too many requests. Please try again later." },
-      { status: 429, headers: { "X-RateLimit-Remaining": String(remaining) } },
-    );
+  try {
+    const { success, remaining } = await limiter.limit(identifier);
+    if (!success) {
+      return NextResponse.json(
+        { error: "Too many requests. Please try again later." },
+        { status: 429, headers: { "X-RateLimit-Remaining": String(remaining) } },
+      );
+    }
+    return null;
+  } catch {
+    return null; // Redis down — fail open
   }
-  return null;
 }
 
 /**
@@ -98,9 +103,9 @@ export async function applyRateLimit(
  * Use for IP-based rate limiting on public endpoints.
  */
 export function getClientIp(
-  req: { headers: { get(name: string): string | null } },
+  req: { ip?: string; headers: { get(name: string): string | null } },
 ): string {
-  return (
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
-  );
+  const ip =
+    req.ip ?? req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  return ip ?? randomUUID();
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -16,7 +16,6 @@
  */
 
 import { Ratelimit } from "@upstash/ratelimit";
-import { randomUUID } from "crypto";
 import redis from "@/lib/redis";
 import { NextResponse } from "next/server";
 
@@ -107,5 +106,5 @@ export function getClientIp(
 ): string {
   const ip =
     req.ip ?? req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  return ip ?? randomUUID();
+  return ip ?? "unknown_ip";
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -2,6 +2,7 @@
  * Shared rate limiters for API routes.
  *
  * Rate limit profiles:
+ * - authLimiter:            10/15min per IP  — POST /api/auth/sign-in, sign-up, forget-password (brute-force)
  * - checkoutLimiter:        5/min per user   — POST /api/checkout (fraud)
  * - discountLimiter:        10/min per user  — POST /api/payments/discounts/validate (brute-force)
  * - newsletterLimiter:      3/hr per IP      — POST /api/newsletter/subscribe (spam)
@@ -11,6 +12,7 @@
  * - requestApprovalLimiter: 10/hr per user   — POST /api/slots/request-for-approval
  * - searchLimiter:          60/min per IP    — GET /api/user/consultants, /api/consultants/search
  * - eligibilityLimiter:     20/min per IP    — GET /api/trials/check-eligibility
+ * - availabilityLimiter:    30/min per IP    — GET /api/slots/availability/[consultantId]
  */
 
 import { Ratelimit } from "@upstash/ratelimit";
@@ -30,6 +32,9 @@ function makeLimiter(
     prefix,
   });
 }
+
+/** 10 per 15 minutes — auth endpoints (sign-in, sign-up, forget-password) */
+export const authLimiter = makeLimiter(10, "15 m", "rl:auth");
 
 /** 5 per minute — POST /api/checkout */
 export const checkoutLimiter = makeLimiter(5, "1 m", "rl:checkout");
@@ -61,6 +66,9 @@ export const searchLimiter = makeLimiter(60, "1 m", "rl:search");
 
 /** 20 per minute — GET /api/trials/check-eligibility */
 export const eligibilityLimiter = makeLimiter(20, "1 m", "rl:eligibility");
+
+/** 30 per minute — GET /api/slots/availability/[consultantId] (IP-based, public booking flow) */
+export const availabilityLimiter = makeLimiter(30, "1 m", "rl:availability");
 
 /**
  * Apply rate limit to a request.

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -106,5 +106,5 @@ export function getClientIp(
 ): string {
   const ip =
     req.ip ?? req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  return ip ?? "unknown_ip";
+  return ip || "unknown_ip";
 }

--- a/lib/redis-edge.ts
+++ b/lib/redis-edge.ts
@@ -1,0 +1,18 @@
+/**
+ * Edge-compatible Upstash Redis client.
+ *
+ * Used exclusively by lib/rate-limit.ts which runs in Next.js Edge middleware.
+ * Does NOT import Node.js `crypto` or MockRedis — both are incompatible with
+ * the Edge runtime. @upstash/redis uses the REST API and is safe for Edge.
+ *
+ * For server-side Redis (distributed locking, circuit breaker, etc.) use lib/redis.ts.
+ */
+
+import { Redis } from "@upstash/redis";
+
+const redisEdge = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+export default redisEdge;

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,9 +8,11 @@ import {
   isWriteBlockedInDegraded,
 } from "@/lib/maintenance-edge";
 import {
+  authLimiter,
   searchLimiter,
   eligibilityLimiter,
   newsletterLimiter,
+  availabilityLimiter,
   applyRateLimit,
   getClientIp,
 } from "@/lib/rate-limit";
@@ -169,6 +171,17 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   // Edge rate limiting for high-traffic public endpoints (IP-based).
   // Runs before any serverless function is invoked — prevents cost amplification
   // under DDoS even when every request would otherwise return 429.
+
+  // Auth brute-force protection — must be checked before PUBLIC_API_PREFIXES pass-through
+  if (
+    pathname.startsWith("/api/auth/sign-in") ||
+    pathname.startsWith("/api/auth/sign-up") ||
+    pathname.startsWith("/api/auth/forget-password")
+  ) {
+    const rl = await applyRateLimit(authLimiter, getClientIp(req));
+    if (rl) return rl;
+  }
+
   if (
     pathname.startsWith("/api/user/consultants") ||
     pathname.startsWith("/api/consultants/search")
@@ -182,6 +195,10 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   }
   if (pathname.startsWith("/api/newsletter/subscribe") && req.method === "POST") {
     const rl = await applyRateLimit(newsletterLimiter, getClientIp(req));
+    if (rl) return rl;
+  }
+  if (pathname.startsWith("/api/slots/availability/")) {
+    const rl = await applyRateLimit(availabilityLimiter, getClientIp(req));
     if (rl) return rl;
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -33,12 +33,16 @@ const ROUTE_PATTERNS = {
     "/api/user/",
     "/api/events/",
     "/api/plans/",
+    "/api/participants/", // Private: participant management for classes/webinars/etc.
+    "/api/dashboard/", // Private: dashboard data routes
+    "/api/trials/", // Private: trial session routes (public sub-routes exempted below)
   ],
   // Note: /api/auth/ must remain public for BetterAuth to work
   // /api/user/consultants routes are public for explore page (verification filter enforced in API)
   // /api/user/reviews is public for displaying reviews on consultant profiles
   // /api/plans/classes and /api/plans/webinars are public for browse/detail pages;
   //   their sub-routes (recordings, materials) enforce auth in their own handlers
+  // /api/trials/check-eligibility and /api/trials/stats are public (no private data)
   PUBLIC_API_PREFIXES: [
     "/api/auth/",
     "/api/health/",
@@ -46,6 +50,8 @@ const ROUTE_PATTERNS = {
     "/api/user/reviews", // Public: consultant reviews
     "/api/plans/classes", // Public: browse and view class plans (sub-routes enforce their own auth)
     "/api/plans/webinars", // Public: browse and view webinar plans (sub-routes enforce their own auth)
+    "/api/trials/check-eligibility", // Public: eligibility check (no private data returned)
+    "/api/trials/stats", // Public: aggregate trial stats
   ],
 };
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -172,11 +172,12 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   // Runs before any serverless function is invoked — prevents cost amplification
   // under DDoS even when every request would otherwise return 429.
 
-  // Auth brute-force protection — must be checked before PUBLIC_API_PREFIXES pass-through
+  // Auth brute-force protection — POST only (credential submission); GET/OPTIONS must not consume quota
   if (
-    pathname.startsWith("/api/auth/sign-in") ||
-    pathname.startsWith("/api/auth/sign-up") ||
-    pathname.startsWith("/api/auth/forget-password")
+    req.method === "POST" &&
+    (pathname.startsWith("/api/auth/sign-in") ||
+      pathname.startsWith("/api/auth/sign-up") ||
+      pathname.startsWith("/api/auth/forget-password"))
   ) {
     const rl = await applyRateLimit(authLimiter, getClientIp(req));
     if (rl) return rl;

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,13 @@ import {
   validateBypass,
   isWriteBlockedInDegraded,
 } from "@/lib/maintenance-edge";
+import {
+  searchLimiter,
+  eligibilityLimiter,
+  newsletterLimiter,
+  applyRateLimit,
+  getClientIp,
+} from "@/lib/rate-limit";
 
 // Constants for common URLs and route patterns
 const URLS = {
@@ -157,6 +164,25 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
       );
       return response;
     }
+  }
+
+  // Edge rate limiting for high-traffic public endpoints (IP-based).
+  // Runs before any serverless function is invoked — prevents cost amplification
+  // under DDoS even when every request would otherwise return 429.
+  if (
+    pathname.startsWith("/api/user/consultants") ||
+    pathname.startsWith("/api/consultants/search")
+  ) {
+    const rl = await applyRateLimit(searchLimiter, getClientIp(req));
+    if (rl) return rl;
+  }
+  if (pathname.startsWith("/api/trials/check-eligibility")) {
+    const rl = await applyRateLimit(eligibilityLimiter, getClientIp(req));
+    if (rl) return rl;
+  }
+  if (pathname.startsWith("/api/newsletter/subscribe") && req.method === "POST") {
+    const rl = await applyRateLimit(newsletterLimiter, getClientIp(req));
+    if (rl) return rl;
   }
 
   // Handle public API routes first (most common, no auth needed)

--- a/middleware.ts
+++ b/middleware.ts
@@ -182,10 +182,7 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     if (rl) return rl;
   }
 
-  if (
-    pathname.startsWith("/api/user/consultants") ||
-    pathname.startsWith("/api/consultants/search")
-  ) {
+  if (pathname.startsWith("/api/user/consultants")) {
     const rl = await applyRateLimit(searchLimiter, getClientIp(req));
     if (rl) return rl;
   }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const withBundleAnalyzer =
       })
     : (config) => config;
 
-/** @type {import('next').NextConfig['headers']} */
+/** @type {Array<{ key: string; value: string }>} */
 const securityHeaders = [
   // Prevent the page from being embedded in an iframe (clickjacking)
   { key: "X-Frame-Options", value: "DENY" },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,20 @@ const withBundleAnalyzer =
       })
     : (config) => config;
 
+/** @type {import('next').NextConfig['headers']} */
+const securityHeaders = [
+  // Prevent the page from being embedded in an iframe (clickjacking)
+  { key: "X-Frame-Options", value: "DENY" },
+  // Prevent browsers from MIME-sniffing a response away from the declared content-type
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // Disable DNS prefetching to reduce information leakage
+  { key: "X-DNS-Prefetch-Control", value: "off" },
+  // Only send origin when navigating to same origin; send nothing for cross-origin
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Restrict access to browser features not used by this app
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig = {
   // This tells Next.js to explicitly process these packages during the build, which should resolve the module format conflict.
   transpilePackages: ["react-day-picker", "date-fns"],
@@ -54,6 +68,15 @@ const nextConfig = {
   // Reduce JavaScript bundle size by removing console statements in production
   compiler: {
     removeConsole: process.env.NODE_ENV === "production",
+  },
+
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Closes #459

## Summary

Full security audit of the API surface, covering missing authentication, IDOR vulnerabilities, rate limiting, security headers, and input validation across ~34 files. Three rounds of automated review (Copilot, Gemini, GPT-5.3 Codex) were incorporated after the initial pass.

---

## 🔴 Critical — Missing Authentication

Routes that had zero protection (no middleware guard and no handler-level auth):

### Middleware coverage gaps (`middleware.ts`)
- Added `/api/participants/`, `/api/dashboard/`, `/api/trials/` to `AUTHENTICATED_API_PREFIXES`
- Added `/api/trials/check-eligibility` and `/api/trials/stats` to `PUBLIC_API_PREFIXES` (legitimately public)

### Participant routes (4 routes)
`GET /api/participants/class`, `/consultations`, `/subscriptions`, `/webinar`
- `requireApiAuth()` + ownership enforced via Prisma `WHERE` clause scoping on `consultantProfileId` — non-owners get 404, not 403, to avoid leaking resource existence

### Dashboard routes (6 routes)
`/api/dashboard/consultant/planner`, `/requests`, `/consultee/events`, `/payments`, `/pending-payments`, `/resources`
- `requireApiAuth()` + profile ID ownership check; ADMIN/STAFF bypass via `isPrivileged()`

### Trials (`/api/trials/[trialId]` — GET, PATCH, DELETE)
- `requireApiAuth()` + participant check (must be the consultee or the consultant of that trial)
- Ownership embedded directly in `findUnique`/`update`/`delete` `WHERE` clause — non-participants receive 404 to avoid trial ID existence leakage

### Event creation
- `POST /api/events/webinars`: was completely unauthenticated — added `requireApiAuth()` + consultant ownership check
- `POST /api/plans/webinars`: was completely unauthenticated — added `requireApiAuth()`; non-privileged users have `consultantProfileId` resolved from session rather than request body

### Reviews
- `POST /api/user/reviews`: was missing auth entirely — added `requireApiAuth()`

### Dev/test endpoints
- `GET /api/test-race-condition` and `GET /api/test-redis`: added `NODE_ENV === 'production'` guard returning 403

---

## 🟠 High — IDOR Vulnerabilities

Routes that required a session cookie but performed no ownership validation, allowing any authenticated user to read or modify another user's data:

### Event list routes
- `GET /api/events/classes` and `GET /api/events/webinars`: IDOR guard on `consulteeProfileId` and `consultantProfileId` query params; non-privileged users without matching profile IDs get 403 (previously fell through to an unfiltered query returning all records)

### Event instance routes (`[classId]` / `[webinarId]`)
- **GET**: Added `requireApiAuth()` + `authorizeEventAccess()` — stale/fake cookies previously passed middleware cookie presence check and reached data-returning handlers that exposed emails, slots, and payment data
- **PUT / DELETE**: Ownership enforced via `classPlan`/`webinarPlan.consultantProfileId` in the Prisma `WHERE` clause

### Plan routes (`[classPlanId]` / `[webinarPlanId]`)
- **PUT / DELETE**: Ownership pre-check using `findUnique` with ownership in `WHERE`; DELETE returns 404 for both not-found and unauthorized (avoids leaking plan existence to non-owners)
- **PUT**: `consultantProfileId` connect in update data now gated on `isPrivileged()` — previously any authenticated consultant could reassign a plan to another consultant's profile

### Webinar instance PUT
- `webinarPlanId` and `appointmentId` connects in PUT data now gated on `isPrivileged()` — previously any authenticated user could reassign a webinar to a different plan or appointment

---

## 🟡 Medium — Rate Limiting

Created **`lib/rate-limit.ts`** — shared module with 11 named [Upstash](https://upstash.com/) `Ratelimit` instances using sliding windows, plus `applyRateLimit()` and `getClientIp()` helpers.

Created **`lib/redis-edge.ts`** — minimal Upstash REST client compatible with the Vercel Edge runtime (the standard Node.js Redis client uses `crypto` and `MockRedis` which break Edge).

IP-based limiters run in **`middleware.ts`** at the Vercel Edge so they block before any serverless function is invoked — prevents cost-amplification DDoS and avoids cold-start overhead. Auth limiter scoped to `POST` only (GET/OPTIONS must not consume quota). User ID-based limiters run in route handlers where the session is available.

| Route | Limit | Key | Layer |
|---|---|---|---|
| `POST /api/auth/sign-in` | 10 / 15 min | IP | Edge |
| `POST /api/auth/sign-up` | 10 / 15 min | IP | Edge |
| `POST /api/auth/forget-password` | 10 / 15 min | IP | Edge |
| `GET /api/user/consultants` | 60 / min | IP | Edge |
| `GET /api/trials/check-eligibility` | 20 / min | IP | Edge |
| `POST /api/newsletter/subscribe` | 3 / hr | IP | Edge |
| `GET /api/slots/availability/[consultantId]` | 30 / min | IP | Edge |
| `POST /api/checkout` | 5 / min | user ID | Handler |
| `POST /api/payments/discounts/validate` | 10 / min | user ID | Handler |
| `POST /api/referrals/apply` | 3 / 24 hr | user ID | Handler |
| `POST /api/user/support-tickets` | 5 / hr | user ID | Handler |
| `POST /api/user/feedbacks` | 5 / hr | user ID | Handler |
| `POST /api/user/reviews` | 5 / hr | user ID | Handler |
| `POST /api/report` | 5 / hr | user ID | Handler |
| `POST /api/waitlist` | 5 / hr | user ID | Handler |
| `POST /api/slots/request-for-approval` | 10 / hr | user ID | Handler |
| `GET /api/consultants/search` | 60 / min | IP | Handler (auth-gated) |

**Implementation notes:**
- `applyRateLimit()` wraps `limiter.limit()` in `try/catch` and returns `null` on Redis error (fail-open / circuit-breaker pattern — a Redis outage degrades rate limiting gracefully rather than returning 500s to all users)
- `getClientIp()` checks `req.ip` first (set by Vercel Edge from a trusted internal header), then falls back to the first hop of `x-forwarded-for`, then `"unknown_ip"` — uses `||` (not `??`) so empty strings also fall through to the static fallback
- `/api/consultants/search` removed from the edge `searchLimiter` block to avoid double-consuming tokens (edge + handler = effective cap halved to 30/min instead of 60)

---

## 🛡️ Security Headers

Added to `next.config.mjs` via `headers()`, applied to all routes (`source: "/(.*)"`)：

| Header | Value | Protection |
|---|---|---|
| `X-Frame-Options` | `DENY` | Clickjacking |
| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
| `X-DNS-Prefetch-Control` | `off` | DNS info leakage |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer URL leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Feature abuse |

---

## 🔢 Input Validation

- `GET /api/user/consultants`: `limit` param clamped to `[1, 100]` and `page` to `>= 1` — previously `?limit=99999` issued a `take: 99999` Prisma query on the most-trafficked public endpoint. Also fixed `parseInt` NaN fallback (`Math.max(1, NaN) === NaN`, causing Prisma `skip` errors on malformed input).

---

## 🔧 Error Handling

- `PUT` and `DELETE` handlers in `events/classes/[classId]` and `events/webinars/[webinarId]` now catch Prisma `P2025` (record not found when ownership `WHERE` clause eliminates the row) and return 404 — previously surfaced as a 500.

---

## Disputed / Won't Fix

**[P3] Rate limiting fail-open on Redis errors** — intentional circuit-breaker pattern. A Redis outage should degrade rate limiting gracefully, not take all protected endpoints offline with 500s.

**[P3] `x-forwarded-for` first-hop spoofing** — moot on Vercel: the edge runtime sets `req.ip` from a trusted internal header that clients cannot influence. The `x-forwarded-for` fallback is only reached when `req.ip` is `undefined` (i.e., local dev), where IP spoofing is irrelevant.

---

## Test plan

- [ ] `GET /api/participants/class/[id]` without auth → 401; with auth as non-owner → 404; as ADMIN → 200
- [ ] `GET /api/dashboard/consultee/[otherId]/payments` as a different authenticated user → 403
- [ ] `GET /api/events/classes?consulteeProfileId=[otherId]` as a different authenticated user → 403
- [ ] `GET /api/events/classes/[id]` with no cookie → 401; as unrelated user → 403; as owner → 200
- [ ] `GET /api/events/webinars/[id]` with no cookie → 401; as unrelated user → 403; as owner → 200
- [ ] `PATCH /api/trials/[id]` without auth → 401; as unrelated user → 404
- [ ] `POST /api/plans/webinars` without auth → 401; with auth but wrong `consultantProfileId` in body (non-privileged) → 403 (body ID ignored, session ID used); with no consultant profile → 403
- [ ] `POST /api/events/webinars` without auth → 401
- [ ] `PUT /api/plans/classes/[id]` with `consultantProfileId` in body as non-privileged user → ownership unchanged, other fields updated normally
- [ ] `PUT /api/events/webinars/[id]` with `webinarPlanId` in body as non-privileged user → plan not reassigned
- [ ] `PUT /api/events/classes/[id]` as wrong owner → 404 (not 500)
- [ ] `POST /api/auth/sign-in` — send 11 requests in 15 minutes from same IP → 11th returns 429
- [ ] `POST /api/checkout` — send 6 requests in 1 minute → 6th returns 429
- [ ] `POST /api/newsletter/subscribe` — send 4 requests in 1 hour → 4th returns 429
- [ ] `GET /api/user/consultants?limit=99999` → responds with max 100 results
- [ ] `GET /api/user/consultants?limit=abc` → no Prisma skip error (NaN fallback fixed)
- [ ] Response headers include `X-Frame-Options: DENY` on all routes
- [ ] `GET /api/test-redis` in production env → 403
- [ ] All existing dashboard, participant management, and trial flows work normally for authorized users (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)