### PR TITLE
fix: slot deletion guard, migration, and auto-allocate for in-progress classes

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -709,6 +709,21 @@ export function UnifiedCalendar({
         return;
       }
 
+      // Imminent "This Event" slots (<24h away): block deselection
+      if (isCurrentEventSlot && !status.isInPast) {
+        const now = new Date();
+        const imminentCutoff = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+        if (slot.startTime < imminentCutoff) {
+          toast({
+            variant: "destructive",
+            title: "Session too soon",
+            description:
+              "This session starts within 24 hours and cannot be rescheduled.",
+          });
+          return;
+        }
+      }
+
       // Block selection of unavailable, booked, or past non-event slots
       if (status.isInPast) {
         toast({

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -1959,6 +1959,7 @@ export function useEventSlotAllocation(
           startDate: options.startDate,
           endDate: options.endDate,
           totalSessions: options.maxTotalCalls, // maxTotalCalls is already totalSessions-aware
+          pastConfirmedSlotCount: options.pastConfirmedSlotCount,
         };
 
         // For recurring events (subscription/class), the calendar UI only

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -224,7 +224,7 @@ export class AllocationAlgorithms {
     try {
       // Calculate required slots based on event type
       // Pass durationInHours for consultations/webinars, sessionDurationInHours for subscriptions/classes
-      const requiredSlots = calculateRequiredSlots(
+      const rawRequired = calculateRequiredSlots(
         options.eventType,
         options.durationInMonths,
         options.callsPerWeek,
@@ -233,6 +233,13 @@ export class AllocationAlgorithms {
         options.endDate,
         options.totalSessions,
       );
+
+      // For in-progress recurring events, subtract past confirmed slots
+      const pastCount = options.pastConfirmedSlotCount || 0;
+      const requiredSlots =
+        options.eventType === "class" && pastCount > 0
+          ? Math.max(0, rawRequired - pastCount)
+          : rawRequired;
 
       let selectedSlots: TimeSlot[] = [];
       let strategy = "";

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -1500,13 +1500,17 @@ export class SlotAllocationService {
         where: whereClause,
         include: {
           slotsOfAppointment: {
-            include: { user: { select: { id: true } } },
+            include: {
+              user: { select: { id: true } },
+              meetingSession: { select: { id: true, endedAt: true } },
+            },
           },
         },
       });
 
       let preservedSlotCount = 0;
       const enrolledUserIdSet = new Set<string>();
+      const imminentCutoff = new Date(now.getTime() + 24 * 60 * 60 * 1000); // 24h buffer
 
       for (const appointment of appointments) {
         const pastSlots = appointment.slotsOfAppointment.filter(
@@ -1516,27 +1520,38 @@ export class SlotAllocationService {
           (slot) => new Date(slot.endsAt) > now,
         );
 
-        preservedSlotCount += pastSlots.length;
+        // Guard: preserve slots that are imminent (<24h) or have active sessions
+        const protectedFutureSlots = futureSlots.filter(
+          (slot) =>
+            new Date(slot.startsAt) < imminentCutoff ||
+            (slot.meetingSession && !slot.meetingSession.endedAt),
+        );
+        const deletableFutureSlots = futureSlots.filter(
+          (slot) =>
+            new Date(slot.startsAt) >= imminentCutoff &&
+            (!slot.meetingSession || slot.meetingSession.endedAt !== null),
+        );
 
-        // Capture enrolled user IDs from future slots before deletion
-        for (const slot of futureSlots) {
+        preservedSlotCount += pastSlots.length + protectedFutureSlots.length;
+
+        // Capture enrolled user IDs from deletable future slots before deletion
+        for (const slot of deletableFutureSlots) {
           for (const user of (slot as any).user || []) {
             enrolledUserIdSet.add(user.id);
           }
         }
 
-        if (futureSlots.length > 0) {
-          // Delete only future slots
+        if (deletableFutureSlots.length > 0) {
           await tx.slotOfAppointment.deleteMany({
             where: {
               appointmentId: appointment.id,
-              id: { in: futureSlots.map((s) => s.id) },
+              id: { in: deletableFutureSlots.map((s) => s.id) },
             },
           });
         }
 
-        // If no past slots remain, delete the now-empty appointment
-        if (pastSlots.length === 0) {
+        // Only delete the appointment if no slots remain at all
+        if (pastSlots.length === 0 && protectedFutureSlots.length === 0) {
           await tx.appointment.delete({ where: { id: appointment.id } });
         }
       }


### PR DESCRIPTION
 ## Summary
  - Add Prisma migration for `SlotCompletionStatus` enum, `completionStatus`/`completedAt` columns,
   and composite index on `SlotOfAppointment`
  - Guard imminent slots (<24h) and active meeting sessions from deletion during in-progress       
  reallocation (backend + frontend)
  - Fix auto-allocate failing for in-progress classes by accounting for past confirmed slots in    
  required slot calculation

  ## Changes

  ### Migration (`prisma/migrations/add_slot_completion_status/migration.sql`)
  - CREATE TYPE `SlotCompletionStatus` (SCHEDULED, COMPLETED, UNVERIFIED, CANCELLED, RESCHEDULED)  
  - ADD COLUMN `completionStatus` with default SCHEDULED
  - ADD COLUMN `completedAt` as nullable TIMESTAMPTZ
  - CREATE INDEX on (completionStatus, endsAt)

  ### Backend slot deletion guard (`SlotAllocationService.ts`)
  - Include `meetingSession` relation in preservePastSlots query
  - 3-way slot categorization: past, protected future (imminent <24h or active session), deletable 
  future
  - Only delete safe future slots; preserve imminent and active session slots

  ### Frontend 24h guard (`UnifiedCalendar.tsx`)
  - Block deselection of "this event" slots starting within 24 hours
  - Show toast: "Session too soon — cannot be rescheduled"

  ### Auto-allocate fix (`useSlotAllocation.ts`, `allocationAlgorithms.ts`)
  - Pass `pastConfirmedSlotCount` in auto-allocate options
  - Subtract past confirmed slots from required count for class events
  - Without this, auto-allocate sends too many slots and backend rejects

## Test plan
  - [x] `npx tsc --noEmit` passes
  - [x] 674/674 tests pass
  - [x] Manually verified: auto-allocate works for in-progress class (1 past session, 7 remaining) 
  - [ ] Verify migration runs cleanly on staging DB