### PR TITLE
fix: add status guards to Timings buttons and extend in-progress reallocation to subscriptions (#482)

### DIFF
--- a/__tests__/booking-algorithm/allocationAlgorithms.test.ts
+++ b/__tests__/booking-algorithm/allocationAlgorithms.test.ts
@@ -224,6 +224,50 @@ describe("AllocationAlgorithms.manualAllocate", () => {
     expect(result.error).toContain("Expected 4 slots but received 8");
   });
 
+  it("should adjust required slots for in-progress subscription with past slots", async () => {
+    // Subscription: 2 calls/week × 4 weeks = 8 total required (1hr = 2 slots each)
+    // Past: 4 slots (2 sessions completed)
+    // Expected: 4 future slots needed
+    const futureSlots = makeFutureConsecutiveSlots("2025-06-02T09:00:00Z", 4);
+    const result = await AllocationAlgorithms.manualAllocate(
+      futureSlots as any,
+      {
+        eventType: "subscription",
+        eventId: "sub-1",
+        sessionDurationInHours: 1,
+        callsPerWeek: 2,
+        durationInMonths: 1,
+        startDate: new Date("2025-05-01"),
+        endDate: new Date("2025-06-30"),
+        totalSessions: 4,
+        pastConfirmedSlotCount: 4,
+      },
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject wrong slot count for in-progress subscription", async () => {
+    // Subscription: 4 total sessions × 2 slots = 8 total required
+    // Past: 4 slots → need 4 future, but providing 8
+    const futureSlots = makeFutureConsecutiveSlots("2025-06-02T09:00:00Z", 8);
+    const result = await AllocationAlgorithms.manualAllocate(
+      futureSlots as any,
+      {
+        eventType: "subscription",
+        eventId: "sub-1",
+        sessionDurationInHours: 1,
+        callsPerWeek: 2,
+        durationInMonths: 1,
+        startDate: new Date("2025-05-01"),
+        endDate: new Date("2025-06-30"),
+        totalSessions: 4,
+        pastConfirmedSlotCount: 4,
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Expected 4 slots but received 8");
+  });
+
   it("should not adjust required slots for non-recurring events", async () => {
     // Consultation: pastConfirmedSlotCount should be ignored
     const slots = makeFutureConsecutiveSlots("2025-06-01T09:00:00Z", 2);

--- a/__tests__/booking-algorithm/slotAllocationService.test.ts
+++ b/__tests__/booking-algorithm/slotAllocationService.test.ts
@@ -14,6 +14,7 @@
  */
 
 import "./setup";
+import { isRecurringEventType } from "@/utils/slotAllocation/types";
 
 // ─── Module Mocks ───────────────────────────────────────────────────────────
 
@@ -1476,8 +1477,7 @@ describe("Edge cases", () => {
         eventFactories[eventType](),
       );
 
-      const slots =
-        eventType === "subscription" || eventType === "class"
+      const slots = isRecurringEventType(eventType)
           ? ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"]
           : ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"];
 

--- a/__tests__/booking-algorithm/slotAllocationService.test.ts
+++ b/__tests__/booking-algorithm/slotAllocationService.test.ts
@@ -14,7 +14,6 @@
  */
 
 import "./setup";
-import { isRecurringEventType } from "@/utils/slotAllocation/types";
 
 // ─── Module Mocks ───────────────────────────────────────────────────────────
 
@@ -1477,9 +1476,7 @@ describe("Edge cases", () => {
         eventFactories[eventType](),
       );
 
-      const slots = isRecurringEventType(eventType)
-          ? ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"]
-          : ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"];
+      const slots = ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"];
 
       await SlotAllocationService.allocate({
         eventType,

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -569,6 +569,7 @@ export function AppointmentsTab({
                               {/* Management buttons inline with user name */}
                               <div className="flex items-center gap-2 ml-4">
                                 {groupStatus !== "Completed" &&
+                                  groupStatus !== "Cancelled" &&
                                   canManageGroupTimings(groupAppointments) && (
                                   <Button
                                     variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -77,6 +77,10 @@ export function AppointmentsTab({
   const searchParams = useSearchParams();
   const [selectedAppointment, setSelectedAppointment] =
     useState<TAppointment | null>(null);
+  const [selectedGroupProgress, setSelectedGroupProgress] = useState<{
+    completedSessions: number;
+    totalSessions: number;
+  } | null>(null);
   const [groupPagination, setGroupPagination] = useState<
     Map<string, { currentPage: number; showAll: boolean }>
   >(new Map());
@@ -461,11 +465,12 @@ export function AppointmentsTab({
                             key={classEvent.id}
                             title={classEvent.classPlan.title}
                             subtitle={`${classEvent.classPlan.meetingsPerWeek} meeting${classEvent.classPlan.meetingsPerWeek !== 1 ? "s" : ""}/week · ${classEvent.classPlan.totalSessions} sessions · ${classEvent.classPlan.sessionDurationInHours}h each`}
-                            onSetSchedule={() =>
+                            onSetSchedule={() => {
                               setSelectedAppointment(
                                 buildSyntheticClassAppointment(classEvent),
-                              )
-                            }
+                              );
+                              setSelectedGroupProgress(null);
+                            }}
                           />
                         ))}
                       </div>
@@ -479,11 +484,12 @@ export function AppointmentsTab({
                             key={webinarEvent.id}
                             title={webinarEvent.webinarPlan.title}
                             subtitle={`Single session · ${webinarEvent.webinarPlan.durationInHours}h`}
-                            onSetSchedule={() =>
+                            onSetSchedule={() => {
                               setSelectedAppointment(
                                 buildSyntheticWebinarAppointment(webinarEvent),
-                              )
-                            }
+                              );
+                              setSelectedGroupProgress(null);
+                            }}
                           />
                         ))}
                       </div>
@@ -568,9 +574,14 @@ export function AppointmentsTab({
                                     variant="outline"
                                     size="sm"
                                     className="h-8 text-xs px-3"
-                                    onClick={() =>
-                                      setSelectedAppointment(firstAppointment)
-                                    }
+                                    onClick={() => {
+                                      setSelectedAppointment(firstAppointment);
+                                      setSelectedGroupProgress(
+                                        completedSessions > 0
+                                          ? { completedSessions, totalSessions }
+                                          : null,
+                                      );
+                                    }}
                                   >
                                     <Clock className="w-3 h-3 mr-1" />
                                     Timings
@@ -771,11 +782,12 @@ export function AppointmentsTab({
                                                 variant="outline"
                                                 size="sm"
                                                 className="h-8 text-xs px-3"
-                                                onClick={() =>
+                                                onClick={() => {
                                                   setSelectedAppointment(
                                                     appointment,
-                                                  )
-                                                }
+                                                  );
+                                                  setSelectedGroupProgress(null);
+                                                }}
                                               >
                                                 <Clock className="w-3 h-3 mr-1" />
                                                 Timings
@@ -944,8 +956,13 @@ export function AppointmentsTab({
       {selectedAppointment && (
         <EventTimingsCalendar
           isOpen={!!selectedAppointment}
-          onClose={() => setSelectedAppointment(null)}
+          onClose={() => {
+            setSelectedAppointment(null);
+            setSelectedGroupProgress(null);
+          }}
           appointment={selectedAppointment}
+          completedSessions={selectedGroupProgress?.completedSessions}
+          groupTotalSessions={selectedGroupProgress?.totalSessions}
         />
       )}
     </div>

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -562,7 +562,8 @@ export function AppointmentsTab({
 
                               {/* Management buttons inline with user name */}
                               <div className="flex items-center gap-2 ml-4">
-                                {canManageGroupTimings(groupAppointments) && (
+                                {groupStatus !== "Completed" &&
+                                  canManageGroupTimings(groupAppointments) && (
                                   <Button
                                     variant="outline"
                                     size="sm"
@@ -761,6 +762,8 @@ export function AppointmentsTab({
                                         {/* Management buttons right after user info */}
                                         <div className="flex items-center gap-2 ml-4">
                                           {!isRecurring &&
+                                            status !== "Completed" &&
+                                            status !== "Cancelled" &&
                                             canManageAppointmentTimings(
                                               appointment,
                                             ) && (

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/EventTimingsCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/EventTimingsCalendar.tsx
@@ -30,12 +30,16 @@ interface EventTimingsCalendarProps {
   isOpen: boolean;
   onClose: () => void;
   appointment: TAppointment;
+  completedSessions?: number;
+  groupTotalSessions?: number;
 }
 
 export function EventTimingsCalendar({
   isOpen,
   onClose,
   appointment,
+  completedSessions,
+  groupTotalSessions,
 }: EventTimingsCalendarProps) {
   const params = useParams();
 
@@ -125,8 +129,14 @@ export function EventTimingsCalendar({
     switch (appointment.appointmentType) {
       case "CONSULTATION":
         return "Select consecutive time slots for your consultation. All slots must be on the same day.";
-      case "SUBSCRIPTION":
-        return `Schedule ${eventDetails.callsPerWeek} call${eventDetails.callsPerWeek !== 1 ? "s" : ""} per week for ${eventDetails.durationInMonths} month${eventDetails.durationInMonths !== 1 ? "s" : ""}. Each call is ${eventDetails.sessionDurationInHours || 1} hour${(eventDetails.sessionDurationInHours || 1) > 1 ? "s" : ""}.`;
+      case "SUBSCRIPTION": {
+        const baseText = `Schedule ${eventDetails.callsPerWeek} call${eventDetails.callsPerWeek !== 1 ? "s" : ""} per week for ${eventDetails.durationInMonths} month${eventDetails.durationInMonths !== 1 ? "s" : ""}. Each call is ${eventDetails.sessionDurationInHours || 1} hour${(eventDetails.sessionDurationInHours || 1) > 1 ? "s" : ""}.`;
+        if (completedSessions && completedSessions > 0 && groupTotalSessions) {
+          const remaining = groupTotalSessions - completedSessions;
+          return `${baseText} ${completedSessions} of ${groupTotalSessions} sessions completed — select times for the remaining ${remaining}.`;
+        }
+        return baseText;
+      }
       case "WEBINAR":
         return "Select consecutive time slots for your webinar session.";
       case "CLASS": {
@@ -134,7 +144,12 @@ export function EventTimingsCalendar({
         const durationText =
           sessionDuration === 1 ? "1 hour" : `${sessionDuration} hours`;
         const meetingsPerWeek = eventDetails.meetingsPerWeek || 1;
-        return `Schedule ${meetingsPerWeek} meeting${meetingsPerWeek !== 1 ? "s" : ""} per week. Each session is ${durationText}.`;
+        const classBaseText = `Schedule ${meetingsPerWeek} meeting${meetingsPerWeek !== 1 ? "s" : ""} per week. Each session is ${durationText}.`;
+        if (completedSessions && completedSessions > 0 && groupTotalSessions) {
+          const remaining = groupTotalSessions - completedSessions;
+          return `${classBaseText} ${completedSessions} of ${groupTotalSessions} sessions completed — select times for the remaining ${remaining}.`;
+        }
+        return classBaseText;
       }
       default:
         return "Select time slots for your event.";

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/EventTimingsCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/EventTimingsCalendar.tsx
@@ -125,17 +125,25 @@ export function EventTimingsCalendar({
     onClose();
   };
 
+  const appendProgressText = (
+    baseText: string,
+    completed?: number,
+    total?: number,
+  ): string => {
+    if (completed && completed > 0 && total) {
+      const remaining = total - completed;
+      return `${baseText} ${completed} of ${total} sessions completed — select times for the remaining ${remaining}.`;
+    }
+    return baseText;
+  };
+
   const getDescriptionText = () => {
     switch (appointment.appointmentType) {
       case "CONSULTATION":
         return "Select consecutive time slots for your consultation. All slots must be on the same day.";
       case "SUBSCRIPTION": {
         const baseText = `Schedule ${eventDetails.callsPerWeek} call${eventDetails.callsPerWeek !== 1 ? "s" : ""} per week for ${eventDetails.durationInMonths} month${eventDetails.durationInMonths !== 1 ? "s" : ""}. Each call is ${eventDetails.sessionDurationInHours || 1} hour${(eventDetails.sessionDurationInHours || 1) > 1 ? "s" : ""}.`;
-        if (completedSessions && completedSessions > 0 && groupTotalSessions) {
-          const remaining = groupTotalSessions - completedSessions;
-          return `${baseText} ${completedSessions} of ${groupTotalSessions} sessions completed — select times for the remaining ${remaining}.`;
-        }
-        return baseText;
+        return appendProgressText(baseText, completedSessions, groupTotalSessions);
       }
       case "WEBINAR":
         return "Select consecutive time slots for your webinar session.";
@@ -145,11 +153,7 @@ export function EventTimingsCalendar({
           sessionDuration === 1 ? "1 hour" : `${sessionDuration} hours`;
         const meetingsPerWeek = eventDetails.meetingsPerWeek || 1;
         const classBaseText = `Schedule ${meetingsPerWeek} meeting${meetingsPerWeek !== 1 ? "s" : ""} per week. Each session is ${durationText}.`;
-        if (completedSessions && completedSessions > 0 && groupTotalSessions) {
-          const remaining = groupTotalSessions - completedSessions;
-          return `${classBaseText} ${completedSessions} of ${groupTotalSessions} sessions completed — select times for the remaining ${remaining}.`;
-        }
-        return classBaseText;
+        return appendProgressText(classBaseText, completedSessions, groupTotalSessions);
       }
       default:
         return "Select time slots for your event.";

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
@@ -16,6 +16,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { cn } from "@/utils/tailwind";
+import { isRecurringEventType } from "@/utils/slotAllocation/types";
 import { WebinarStatus, ClassStatus } from "@prisma/client";
 import {
   Event,
@@ -263,7 +264,7 @@ export function EventCard({
 
   const isLiveSession = eventType === "webinar" || eventType === "class";
   const durationSuffix =
-    eventType === "subscription" || eventType === "class" ? "/mo" : "";
+    isRecurringEventType(eventType) ? "/mo" : "";
 
   // Check if subscription plan has free trial enabled
   const hasFreeTrialEnabled =

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/tooltip";
 import { DAYS, INTERVALS } from "@/utils/timeSlotsMeta";
 import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/slotAllocation/slotTimeUtils";
+import { isRecurringEventType } from "@/utils/slotAllocation/types";
 import {
   format,
   addDays,
@@ -450,8 +451,7 @@ export function UnifiedCalendar({
     endDate: allowedEnd,
     // Provide dynamic maxTotalCalls so validation/toasts show the real limit.
     // Prefer totalSessions from plan (authoritative) over calendar-week calculation.
-    maxTotalCalls:
-      eventType === "subscription" || eventType === "class"
+    maxTotalCalls: isRecurringEventType(eventType)
         ? totalSessions && totalSessions > 0
           ? totalSessions
           : allowedStart && allowedEnd && callsPerWeek
@@ -459,8 +459,7 @@ export function UnifiedCalendar({
               (callsPerWeek || 1)
             : undefined
         : undefined,
-    pastConfirmedSlotCount:
-      eventType === "class" || eventType === "subscription"
+    pastConfirmedSlotCount: isRecurringEventType(eventType)
         ? pastEventSlotCount
         : undefined,
     onSuccess: handleAllocationSuccess,
@@ -503,7 +502,7 @@ export function UnifiedCalendar({
       } else {
         setConfigWarning(null);
       }
-    } else if (eventType === "subscription" || eventType === "class") {
+    } else if (isRecurringEventType(eventType)) {
       if (!sessionDurationInHours || sessionDurationInHours <= 0) {
         setConfigWarning(
           `${eventType === "subscription" ? "Session" : "Class"} duration not configured. Using 1-hour default.`,

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -199,6 +199,7 @@ function computeSubscriptionFooter(
     callsPerWeek?: number;
     sessionDurationInHours?: number;
     totalSessions?: number;
+    pastCompletedSessions?: number;
   }>,
 ): string | null {
   const {
@@ -208,6 +209,7 @@ function computeSubscriptionFooter(
     callsPerWeek,
     sessionDurationInHours,
     totalSessions,
+    pastCompletedSessions = 0,
   } = params;
 
   // Use totalSessions from plan (authoritative) to avoid calendar-week edge cases
@@ -221,13 +223,18 @@ function computeSubscriptionFooter(
   }
   const slotsPerCall = getSlotsPerCall(sessionDurationInHours);
   const scheduled = Math.floor(selectedSlots.length / slotsPerCall);
-  const remaining = maxTotalCalls - scheduled;
+  const totalScheduled = scheduled + pastCompletedSessions;
+  const remaining = maxTotalCalls - totalScheduled;
 
   const duration = sessionDurationInHours || 1;
   const durationText = duration === 1 ? "1 hour" : `${duration} hours`;
 
   // Clear, user-friendly text based on progress
-  if (scheduled === 0) {
+  if (pastCompletedSessions > 0 && scheduled === 0) {
+    return `${pastCompletedSessions} past session${pastCompletedSessions !== 1 ? "s" : ""} completed | Schedule ${remaining} more (${durationText} each)`;
+  } else if (pastCompletedSessions > 0 && remaining > 0) {
+    return `✅ ${totalScheduled} of ${maxTotalCalls} (${pastCompletedSessions} past + ${scheduled} new) | ⏳ ${remaining} remaining`;
+  } else if (scheduled === 0) {
     return `📅 Choose times for ${maxTotalCalls} sessions (${durationText} each)`;
   } else if (remaining > 0) {
     return `✅ ${scheduled} of ${maxTotalCalls} sessions scheduled • ${remaining} more to go`;
@@ -1267,6 +1274,7 @@ export function UnifiedCalendar({
             {(() => {
               try {
                 if (eventType === "subscription") {
+                  const slotsPerCall = getSlotsPerCall(sessionDurationInHours);
                   const computed = computeSubscriptionFooter({
                     selectedSlots,
                     allowedStart,
@@ -1274,6 +1282,10 @@ export function UnifiedCalendar({
                     callsPerWeek,
                     sessionDurationInHours,
                     totalSessions,
+                    pastCompletedSessions:
+                      pastEventSlotCount > 0
+                        ? Math.floor(pastEventSlotCount / slotsPerCall)
+                        : 0,
                   });
                   if (computed) return computed;
                   // Fallback to existing text if boundaries not provided

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -9,6 +9,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { DAYS, INTERVALS } from "@/utils/timeSlotsMeta";
+import { TWENTY_FOUR_HOURS_IN_MS } from "@/utils/slotAllocation/slotTimeUtils";
 import {
   format,
   addDays,
@@ -712,7 +713,7 @@ export function UnifiedCalendar({
       // Imminent "This Event" slots (<24h away): block deselection
       if (isCurrentEventSlot && !status.isInPast) {
         const now = new Date();
-        const imminentCutoff = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+        const imminentCutoff = new Date(now.getTime() + TWENTY_FOUR_HOURS_IN_MS);
         if (slot.startTime < imminentCutoff) {
           toast({
             variant: "destructive",

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -439,9 +439,14 @@ function getSlotLimits(
       );
       // FIXED: Calculate actual call count for maxSlots (not slot count)
       const totalCalls = Math.ceil(requiredSlots / subscriptionSessionSlots);
+      const rawMaxCalls = options.maxTotalCalls || totalCalls;
+      // Subtract past completed sessions so the interactive guard caps at remaining sessions
+      const pastSessions = Math.floor(
+        (options.pastConfirmedSlotCount || 0) / subscriptionSessionSlots,
+      );
       return {
         minSlots: requiredSlots,
-        maxSlots: options.maxTotalCalls || totalCalls, // ✅ Use call count, not slot count
+        maxSlots: rawMaxCalls - pastSessions, // ✅ Cap at remaining sessions for in-progress events
         slotsPerSession: subscriptionSessionSlots,
         totalSessions: totalCalls, // ✅ Also use call count for sessions
       };

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -7,6 +7,7 @@ import {
   AllocationResult,
 } from "../utils/allocationAlgorithms";
 import { AllocationService } from "../utils/allocationService";
+import { isRecurringEventType } from "@/utils/slotAllocation/types";
 
 /**
  * ENHANCED EVENT SLOT ALLOCATION HOOK
@@ -1252,10 +1253,7 @@ export function useEventSlotAllocation(
 
     // For subscriptions and classes, maxTotalCalls is set to the plan's totalSessions (authoritative).
     // Derive requiredSlots from it to stay consistent with backend validation.
-    if (
-      (eventType === "subscription" || eventType === "class") &&
-      options.maxTotalCalls
-    ) {
+    if (isRecurringEventType(eventType) && options.maxTotalCalls) {
       const slotsPerSession = Math.ceil(
         (options.sessionDurationInHours || 1) / 0.5,
       );
@@ -1280,7 +1278,7 @@ export function useEventSlotAllocation(
     // For in-progress classes/subscriptions, subtract past confirmed slots so
     // the consultant only needs to select FUTURE slots.
     const pastCount = options.pastConfirmedSlotCount || 0;
-    if ((eventType === "class" || eventType === "subscription") && pastCount > 0) {
+    if (isRecurringEventType(eventType) && pastCount > 0) {
       return Math.max(0, rawRequired - pastCount);
     }
 
@@ -1967,7 +1965,7 @@ export function useEventSlotAllocation(
         // needs slots spanning the entire scheduling period. Fetch them.
         let slotsForAllocation = availableSlots;
         if (
-          (eventType === "subscription" || eventType === "class") &&
+          isRecurringEventType(eventType) &&
           options.startDate &&
           options.endDate &&
           options.consultantId

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -1272,12 +1272,10 @@ export function useEventSlotAllocation(
       );
     }
 
-    // For in-progress classes, subtract past confirmed slots so the consultant
-    // only needs to select FUTURE slots. Subscriptions don't need this because
-    // totalSessions from RequestSlotAllocationTab already accounts for
-    // rescheduling (only counting tentative sessions that need new times).
+    // For in-progress classes/subscriptions, subtract past confirmed slots so
+    // the consultant only needs to select FUTURE slots.
     const pastCount = options.pastConfirmedSlotCount || 0;
-    if (eventType === "class" && pastCount > 0) {
+    if ((eventType === "class" || eventType === "subscription") && pastCount > 0) {
       return Math.max(0, rawRequired - pastCount);
     }
 

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -97,7 +97,7 @@ export class AllocationAlgorithms {
       // For in-progress recurring events, subtract past confirmed slots
       const pastCount = options.pastConfirmedSlotCount || 0;
       const requiredSlots =
-        options.eventType === "class" && pastCount > 0
+        (options.eventType === "class" || options.eventType === "subscription") && pastCount > 0
           ? Math.max(0, rawRequired - pastCount)
           : rawRequired;
 
@@ -237,7 +237,7 @@ export class AllocationAlgorithms {
       // For in-progress recurring events, subtract past confirmed slots
       const pastCount = options.pastConfirmedSlotCount || 0;
       const requiredSlots =
-        options.eventType === "class" && pastCount > 0
+        (options.eventType === "class" || options.eventType === "subscription") && pastCount > 0
           ? Math.max(0, rawRequired - pastCount)
           : rawRequired;
 

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -5,6 +5,7 @@ import {
   validateSlotDistribution,
 } from "./calendarUtils";
 import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+import { isRecurringEventType } from "@/utils/slotAllocation/types";
 import { AllocationService } from "./allocationService";
 
 /**
@@ -97,7 +98,7 @@ export class AllocationAlgorithms {
       // For in-progress recurring events, subtract past confirmed slots
       const pastCount = options.pastConfirmedSlotCount || 0;
       const requiredSlots =
-        (options.eventType === "class" || options.eventType === "subscription") && pastCount > 0
+        isRecurringEventType(options.eventType) && pastCount > 0
           ? Math.max(0, rawRequired - pastCount)
           : rawRequired;
 
@@ -237,7 +238,7 @@ export class AllocationAlgorithms {
       // For in-progress recurring events, subtract past confirmed slots
       const pastCount = options.pastConfirmedSlotCount || 0;
       const requiredSlots =
-        (options.eventType === "class" || options.eventType === "subscription") && pastCount > 0
+        isRecurringEventType(options.eventType) && pastCount > 0
           ? Math.max(0, rawRequired - pastCount)
           : rawRequired;
 

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -598,8 +598,9 @@ export const getGroupStatus = (appointments: TAppointment[]): string => {
   const type = firstAppointment.appointmentType;
 
   if (type === "SUBSCRIPTION" && firstAppointment.subscription) {
-    if (firstAppointment.subscription.requestStatus === "CANCELLED")
+    if (firstAppointment.subscription.requestStatus === "CANCELLED") {
       return "Cancelled";
+    }
 
     const now = new Date();
     const startDate = new Date(

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -598,6 +598,9 @@ export const getGroupStatus = (appointments: TAppointment[]): string => {
   const type = firstAppointment.appointmentType;
 
   if (type === "SUBSCRIPTION" && firstAppointment.subscription) {
+    if (firstAppointment.subscription.requestStatus === "CANCELLED")
+      return "Cancelled";
+
     const now = new Date();
     const startDate = new Date(
       firstAppointment.subscription.schedulingPeriodStartsAt,
@@ -618,6 +621,8 @@ export const getGroupStatus = (appointments: TAppointment[]): string => {
   }
 
   if (type === "CLASS" && firstAppointment.class) {
+    if (firstAppointment.class.status === "CANCELLED") return "Cancelled";
+
     const now = new Date();
 
     // Check if any sessions are completed, same as subscription

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -622,7 +622,7 @@ export const getGroupStatus = (appointments: TAppointment[]): string => {
   }
 
   if (type === "CLASS" && firstAppointment.class) {
-    if (firstAppointment.class.status === "CANCELLED") return "Cancelled";
+    if (firstAppointment.class.status === "CANCELLED") { return "Cancelled"; }
 
     const now = new Date();
 

--- a/components/dashboard/DashboardNavbar.tsx
+++ b/components/dashboard/DashboardNavbar.tsx
@@ -31,8 +31,8 @@ export function DashboardNavbar({
 }: DashboardNavbarProps) {
   return (
     <div
-      className="flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl"
-      style={{ zIndex: 9999, overflow: "visible" }}
+      className="flex h-16 items-center justify-end gap-2 px-6 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl"
+      style={{ overflow: "visible" }}
     >
       {/* Left spacer - future home for breadcrumbs */}
       <div className="flex-1" />

--- a/components/dashboard/DashboardShell.tsx
+++ b/components/dashboard/DashboardShell.tsx
@@ -98,7 +98,7 @@ export function DashboardShell({
         {/* Main Content */}
         <main className="flex-1 lg:ml-64 min-h-screen bg-zinc-100">
           {/* Mobile Header Bar */}
-          <div className="sticky top-maintenance z-[9999] overflow-visible flex items-center gap-3 px-4 py-3 bg-white border-b border-zinc-200 lg:hidden">
+          <div className="sticky top-maintenance z-50 overflow-visible flex items-center gap-3 px-4 py-3 bg-white border-b border-zinc-200 lg:hidden">
             <Button
               variant="ghost"
               size="icon"
@@ -123,11 +123,11 @@ export function DashboardShell({
 
           {/* Desktop header - full navbar or simple header actions */}
           {navbar ? (
-            <div className="hidden lg:block relative z-[9999] overflow-visible">
+            <div className="hidden lg:block sticky top-0 z-50 overflow-visible">
               {navbar}
             </div>
           ) : headerActions ? (
-            <div className="hidden lg:flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl relative z-[9999] overflow-visible">
+            <div className="hidden lg:flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 backdrop-blur-xl relative z-50 overflow-visible">
               {headerActions}
             </div>
           ) : null}

--- a/components/dashboard/DashboardSidebar.tsx
+++ b/components/dashboard/DashboardSidebar.tsx
@@ -204,7 +204,7 @@ export function DashboardSidebar({
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto p-3">
+      <nav className="flex-1 overflow-y-auto scrollbar-hide p-3">
         {/* Render sectioned navigation if navSections is provided */}
         {navSections.length > 0 ? (
           <div className="space-y-4">

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -31,6 +31,7 @@ import { lockAutoAllocate, unlockAutoAllocate } from "@/utils/appointmentlock";
 import {
   DAY_OF_WEEK_TO_INDEX,
   isMinuteWithinWeeklySlot,
+  TWENTY_FOUR_HOURS_IN_MS,
 } from "./slotTimeUtils";
 import {
   AllocationValidationError,
@@ -1511,7 +1512,7 @@ export class SlotAllocationService {
 
       let preservedSlotCount = 0;
       const enrolledUserIdSet = new Set<string>();
-      const imminentCutoff = new Date(now.getTime() + 24 * 60 * 60 * 1000); // 24h buffer
+      const imminentCutoff = new Date(now.getTime() + TWENTY_FOUR_HOURS_IN_MS);
 
       for (const appointment of appointments) {
         const pastSlots = appointment.slotsOfAppointment.filter(
@@ -1537,7 +1538,7 @@ export class SlotAllocationService {
 
         // Capture enrolled user IDs from deletable future slots before deletion
         for (const slot of deletableFutureSlots) {
-          for (const user of (slot as any).user || []) {
+          for (const user of slot.user) {
             enrolledUserIdSet.add(user.id);
           }
         }

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -275,15 +275,15 @@ export class SlotAllocationService {
           const isInProgressReallocation =
             !isReschedule &&
             pastConfirmedSlotCount > 0 &&
-            eventType === "class";
+            (eventType === "class" || eventType === "subscription");
 
-          // Guard: for classes, reject re-allocation when already fully scheduled.
+          // Guard: for classes/subscriptions, reject re-allocation when already fully scheduled.
           // Webinars are handled by the DB unique constraint on webinarId (P2002 → 409).
-          // Classes have no such constraint, so we enforce it here to prevent
+          // Classes/subscriptions have no such constraint, so we enforce it here to prevent
           // concurrent auto-allocate calls from creating duplicate session sets.
           // For in-progress reallocation, only count FUTURE confirmed slots.
           if (
-            eventType === "class" &&
+            (eventType === "class" || eventType === "subscription") &&
             !isReschedule &&
             existingNonTentativeSlotCount > 0
           ) {
@@ -571,7 +571,7 @@ export class SlotAllocationService {
           const isInProgressReallocation =
             !isReschedule &&
             pastConfirmedSlotCount > 0 &&
-            eventType === "class";
+            (eventType === "class" || eventType === "subscription");
 
           // Collect appointment IDs to exclude from conflict detection and weekly limits.
           // For reschedule: exclude tentative appointments (they'll be deleted)

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -23,6 +23,7 @@ import {
   PrismaTransaction,
   ConsultantAllocationData,
   EventConfig,
+  isRecurringEventType,
 } from "./types";
 import { SlotCalculationService } from "./SlotCalculationService";
 import { SlotValidationService } from "./SlotValidationService";
@@ -276,7 +277,7 @@ export class SlotAllocationService {
           const isInProgressReallocation =
             !isReschedule &&
             pastConfirmedSlotCount > 0 &&
-            (eventType === "class" || eventType === "subscription");
+            isRecurringEventType(eventType);
 
           // Guard: for classes/subscriptions, reject re-allocation when already fully scheduled.
           // Webinars are handled by the DB unique constraint on webinarId (P2002 → 409).
@@ -284,7 +285,7 @@ export class SlotAllocationService {
           // concurrent auto-allocate calls from creating duplicate session sets.
           // For in-progress reallocation, only count FUTURE confirmed slots.
           if (
-            (eventType === "class" || eventType === "subscription") &&
+            isRecurringEventType(eventType) &&
             !isReschedule &&
             existingNonTentativeSlotCount > 0
           ) {
@@ -572,7 +573,7 @@ export class SlotAllocationService {
           const isInProgressReallocation =
             !isReschedule &&
             pastConfirmedSlotCount > 0 &&
-            (eventType === "class" || eventType === "subscription");
+            isRecurringEventType(eventType);
 
           // Collect appointment IDs to exclude from conflict detection and weekly limits.
           // For reschedule: exclude tentative appointments (they'll be deleted)
@@ -584,7 +585,7 @@ export class SlotAllocationService {
             : existingAppointments.map((a) => a.id);
 
           // Validate total slot count for recurring event types
-          if (eventType === "subscription" || eventType === "class") {
+          if (isRecurringEventType(eventType)) {
             if (isReschedule) {
               // Use calculateRequiredSlots instead of tentativeSlotCount.
               // Class creation creates 1 full-duration slot per appointment,

--- a/utils/slotAllocation/slotTimeUtils.ts
+++ b/utils/slotAllocation/slotTimeUtils.ts
@@ -13,6 +13,9 @@
 
 import { DayOfWeek, Prisma } from "@prisma/client";
 
+/** 24 hours expressed in milliseconds */
+export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Convert minutes-since-midnight-UTC to "HH:MM" string
  * @param minutes - Minutes since midnight (0-1439)

--- a/utils/slotAllocation/types.ts
+++ b/utils/slotAllocation/types.ts
@@ -18,6 +18,20 @@ export type AllocationMode = "auto" | "manual" | "requested";
 export type EventType = "consultation" | "subscription" | "webinar" | "class";
 
 /**
+ * Event types that are recurring (have multiple sessions over time).
+ * Used to guard past-session subtraction, reallocation logic, etc.
+ */
+export const RECURRING_EVENT_TYPES: ReadonlyArray<EventType> = [
+  "class",
+  "subscription",
+] as const;
+
+/** Type-safe check for whether an event type is recurring */
+export function isRecurringEventType(eventType: string): boolean {
+  return (RECURRING_EVENT_TYPES as ReadonlyArray<string>).includes(eventType);
+}
+
+/**
  * Request structure for slot allocation
  */
 export interface AllocationRequest {


### PR DESCRIPTION
## Summary

- **Status guards**: Hide the "Timings" button on completed groups and completed/cancelled individual appointments, preventing slot reallocation on finished services

- **Subscription reallocation parity**: Extend in-progress reallocation protections (past slot preservation, required slot count adjustment, duplicate allocation guard) from classes to subscriptions across 6 locations

- **Tests**: Add 2 new test cases mirroring existing class tests for subscription in-progress reallocation 


#482 