### PR TITLE
fix: repair 5 failing GitHub Actions cron workflows

### DIFF
--- a/.github/workflows/alert-dispute-deadlines.yml
+++ b/.github/workflows/alert-dispute-deadlines.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/alert-orphaned-payments.yml
+++ b/.github/workflows/alert-orphaned-payments.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/archive-webhook-events.yml
+++ b/.github/workflows/archive-webhook-events.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/auto-complete-appointments.yml
+++ b/.github/workflows/auto-complete-appointments.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cascade-refund-earnings.yml
+++ b/.github/workflows/cascade-refund-earnings.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cleanup-abandoned-payments.yml
+++ b/.github/workflows/cleanup-abandoned-payments.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cleanup-auth-tokens.yml
+++ b/.github/workflows/cleanup-auth-tokens.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cleanup-empty-folders.yml
+++ b/.github/workflows/cleanup-empty-folders.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cleanup-invalid-appointments.yml
+++ b/.github/workflows/cleanup-invalid-appointments.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cleanup-stale-pending-consultations.yml
+++ b/.github/workflows/cleanup-stale-pending-consultations.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/cleanup-tentative-slots.yml
+++ b/.github/workflows/cleanup-tentative-slots.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/create-payout-batch.yml
+++ b/.github/workflows/create-payout-batch.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/deactivate-expired-discounts.yml
+++ b/.github/workflows/deactivate-expired-discounts.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/expire-stale-requests.yml
+++ b/.github/workflows/expire-stale-requests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/handle-lost-disputes.yml
+++ b/.github/workflows/handle-lost-disputes.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/handle-stuck-payouts.yml
+++ b/.github/workflows/handle-stuck-payouts.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/process-payouts.yml
+++ b/.github/workflows/process-payouts.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/process-waitlist-expirations.yml
+++ b/.github/workflows/process-waitlist-expirations.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/process-waitlist-expirations.yml
+++ b/.github/workflows/process-waitlist-expirations.yml
@@ -21,6 +21,9 @@ jobs:
     name: Process Expired Notifications
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -39,7 +42,7 @@ jobs:
         run: npx prisma generate
 
       - name: Run expiration processor
-        run: npx ts-node scripts/waitlist/process-expired-notifications.ts
+        run: npx tsx scripts/waitlist/process-expired-notifications.ts
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
 

--- a/.github/workflows/process-waitlist-expirations.yml
+++ b/.github/workflows/process-waitlist-expirations.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/race-condition-tests.yml
+++ b/.github/workflows/race-condition-tests.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/reconcile-disputes.yml
+++ b/.github/workflows/reconcile-disputes.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/reconcile-document-storage.yml
+++ b/.github/workflows/reconcile-document-storage.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/reconcile-payment-status.yml
+++ b/.github/workflows/reconcile-payment-status.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/reconcile-payout-status.yml
+++ b/.github/workflows/reconcile-payout-status.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/reconcile-pending-refunds.yml
+++ b/.github/workflows/reconcile-pending-refunds.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/reconcile-slot-availability.yml
+++ b/.github/workflows/reconcile-slot-availability.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/release-earnings.yml
+++ b/.github/workflows/release-earnings.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/send-waitlist-reminders.yml
+++ b/.github/workflows/send-waitlist-reminders.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/send-waitlist-reminders.yml
+++ b/.github/workflows/send-waitlist-reminders.yml
@@ -21,6 +21,9 @@ jobs:
     name: Send Expiration Reminders
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -39,7 +42,7 @@ jobs:
         run: npx prisma generate
 
       - name: Run reminder sender
-        run: npx ts-node scripts/waitlist/send-expiration-reminders.ts
+        run: npx tsx scripts/waitlist/send-expiration-reminders.ts
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
 

--- a/.github/workflows/send-waitlist-reminders.yml
+++ b/.github/workflows/send-waitlist-reminders.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/stream-sync.yml
+++ b/.github/workflows/stream-sync.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/sync-payment-earnings.yml
+++ b/.github/workflows/sync-payment-earnings.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/testing-stuff.yml
+++ b/.github/workflows/testing-stuff.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/jobs/payments/reconcile-payment-status.ts
+++ b/jobs/payments/reconcile-payment-status.ts
@@ -36,6 +36,12 @@ function outputToGitHubActions(result: PaymentReconciliationResult): void {
     fs.appendFileSync(outputFile, outputs + "\n");
   }
 
+  if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
+    console.log(
+      `::warning::Razorpay credentials not configured — Razorpay records were skipped`,
+    );
+  }
+
   if (result.succeededCount > 0) {
     console.log(
       `::warning::${result.succeededCount} payments found succeeded - may need manual appointment creation!`,

--- a/jobs/payouts/handle-stuck-payouts.ts
+++ b/jobs/payouts/handle-stuck-payouts.ts
@@ -28,6 +28,7 @@ function outputToGitHubActions(result: StuckPayoutsResult): void {
       `reconciled_count=${result.reconciledCount}`,
       `retried_count=${result.retriedCount}`,
       `failed_count=${result.failedCount}`,
+      `skipped_count=${result.skippedCount}`,
       `success=${result.success}`,
     ].join("\n");
 
@@ -69,6 +70,7 @@ async function main(): Promise<void> {
     console.log(`   Reconciled: ${result.reconciledCount}`);
     console.log(`   Retried: ${result.retriedCount}`);
     console.log(`   Failed: ${result.failedCount}`);
+    console.log(`   Skipped: ${result.skippedCount}`);
     console.log(`   Success: ${result.success}`);
 
     if (result.errors.length > 0) {

--- a/jobs/payouts/handle-stuck-payouts.ts
+++ b/jobs/payouts/handle-stuck-payouts.ts
@@ -34,6 +34,12 @@ function outputToGitHubActions(result: StuckPayoutsResult): void {
     fs.appendFileSync(outputFile, outputs + "\n");
   }
 
+  if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
+    console.log(
+      `::warning::Razorpay credentials not configured — Razorpay records were skipped`,
+    );
+  }
+
   if (result.failedCount > 0) {
     console.log(
       `::warning::${result.failedCount} payouts permanently failed after max retries`,

--- a/jobs/payouts/reconcile-payout-status.ts
+++ b/jobs/payouts/reconcile-payout-status.ts
@@ -36,6 +36,12 @@ function outputToGitHubActions(result: PayoutReconciliationResult): void {
     fs.appendFileSync(outputFile, outputs + "\n");
   }
 
+  if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
+    console.log(
+      `::warning::Razorpay credentials not configured — Razorpay records were skipped`,
+    );
+  }
+
   if (result.discrepancies.length > 0) {
     console.log(
       `::warning::${result.discrepancies.length} payout status discrepancies found and reconciled!`,

--- a/scripts/payments/reconcile-payment-status.ts
+++ b/scripts/payments/reconcile-payment-status.ts
@@ -206,6 +206,11 @@ export async function reconcilePaymentStatus(): Promise<PaymentReconciliationRes
     orderBy: { createdAt: "asc" },
   });
 
+  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID && process.env.RAZORPAY_KEY_SECRET);
+  if (!razorpayConfigured) {
+    console.warn("⚠️ Razorpay credentials not configured — Razorpay records will be skipped");
+  }
+
   console.log(
     `Found ${stalePendingPayments.length} stale PENDING payments to reconcile`,
   );
@@ -234,6 +239,11 @@ export async function reconcilePaymentStatus(): Promise<PaymentReconciliationRes
     if (payment.paymentGateway === PaymentGateway.STRIPE) {
       gatewayStatus = await getStripePaymentStatus(payment.paymentIntent);
     } else if (payment.paymentGateway === PaymentGateway.RAZORPAY) {
+      if (!razorpayConfigured) {
+        console.log(`   Skipping - Razorpay credentials not configured`);
+        skippedCount++;
+        continue;
+      }
       // For Razorpay, paymentIntent might be orderId
       gatewayStatus = await getRazorpayPaymentStatus(payment.paymentIntent);
     } else {

--- a/scripts/payouts/handle-stuck-payouts.ts
+++ b/scripts/payouts/handle-stuck-payouts.ts
@@ -33,6 +33,7 @@ export interface StuckPayoutsResult {
   reconciledCount: number;
   retriedCount: number;
   failedCount: number;
+  skippedCount: number;
   errors: string[];
   timestamp: string;
 }
@@ -171,6 +172,7 @@ export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
   let reconciledCount = 0;
   let retriedCount = 0;
   let failedCount = 0;
+  let skippedCount = 0;
 
   const stuckThreshold = new Date(
     Date.now() - STUCK_THRESHOLD_HOURS * 60 * 60 * 1000,
@@ -256,6 +258,7 @@ export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
     } else if (payout.provider === PaymentGateway.RAZORPAY) {
       if (!razorpayConfigured) {
         console.log(`   Skipping - Razorpay credentials not configured`);
+        skippedCount++;
         continue;
       }
       gatewayStatus = await getRazorpayPayoutStatus(payout.providerPayoutId);
@@ -322,6 +325,7 @@ export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
   console.log(`   Reconciled: ${reconciledCount}`);
   console.log(`   Reset for retry: ${retriedCount}`);
   console.log(`   Permanently failed: ${failedCount}`);
+  console.log(`   Skipped: ${skippedCount}`);
 
   return {
     success: errors.length === 0,
@@ -329,6 +333,7 @@ export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
     reconciledCount,
     retriedCount,
     failedCount,
+    skippedCount,
     errors,
     timestamp: new Date().toISOString(),
   };

--- a/scripts/payouts/handle-stuck-payouts.ts
+++ b/scripts/payouts/handle-stuck-payouts.ts
@@ -191,6 +191,11 @@ export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
     },
   });
 
+  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID && process.env.RAZORPAY_KEY_SECRET);
+  if (!razorpayConfigured) {
+    console.warn("⚠️ Razorpay credentials not configured — Razorpay records will be skipped");
+  }
+
   console.log(
     `Found ${stuckPayouts.length} payouts stuck in PROCESSING for >${STUCK_THRESHOLD_HOURS}h`,
   );
@@ -249,6 +254,10 @@ export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
     if (payout.provider === PaymentGateway.STRIPE) {
       gatewayStatus = await getStripePayoutStatus(payout.providerPayoutId);
     } else if (payout.provider === PaymentGateway.RAZORPAY) {
+      if (!razorpayConfigured) {
+        console.log(`   Skipping - Razorpay credentials not configured`);
+        continue;
+      }
       gatewayStatus = await getRazorpayPayoutStatus(payout.providerPayoutId);
     }
 

--- a/scripts/payouts/reconcile-payout-status.ts
+++ b/scripts/payouts/reconcile-payout-status.ts
@@ -199,6 +199,11 @@ export async function reconcilePayoutStatus(): Promise<PayoutReconciliationResul
     orderBy: { updatedAt: "asc" },
   });
 
+  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID && process.env.RAZORPAY_KEY_SECRET);
+  if (!razorpayConfigured) {
+    console.warn("⚠️ Razorpay credentials not configured — Razorpay records will be skipped");
+  }
+
   console.log(
     `Found ${stalePayouts.length} stale PENDING/PROCESSING payouts to reconcile`,
   );
@@ -233,6 +238,11 @@ export async function reconcilePayoutStatus(): Promise<PayoutReconciliationResul
     if (payout.provider === PaymentGateway.STRIPE) {
       gatewayStatus = await getStripePayoutStatus(payout.providerPayoutId);
     } else if (payout.provider === PaymentGateway.RAZORPAY) {
+      if (!razorpayConfigured) {
+        console.log(`   Skipping - Razorpay credentials not configured`);
+        skippedCount++;
+        continue;
+      }
       gatewayStatus = await getRazorpayPayoutStatus(payout.providerPayoutId);
     } else {
       console.log(`   Skipping - unsupported gateway: ${payout.provider}`);


### PR DESCRIPTION
## Summary

- **Waitlist workflows** (`process-waitlist-expirations`, `send-waitlist-reminders`): replaced `npx ts-node` with `npx tsx` (consistent with all other workflows), bumped Node.js 20 → 22, and added `permissions: contents: read, issues: write` so the `github-script` failure notification step can create issues
- **Razorpay reconciliation** (`reconcile-payment-status`, `reconcile-payout-status`, `handle-stuck-payouts`): gracefully skip Razorpay records when credentials aren't configured instead of erroring out. Adds `::warning::` annotations in job wrappers so skipped records are visible on the GitHub Actions run summary page
- **All 30 workflows**: bumped `actions/setup-node` v4 → v5 and `actions/checkout` v4 → v5 to resolve Node.js 20 deprecation warnings (forced to Node.js 24 after June 2, 2026)

## How Razorpay skip works

| Scenario | GitHub Actions UI |
|---|---|
| Razorpay creds missing (expected for now) | Yellow warning banner, job succeeds ✅ |
| Razorpay creds present, API fails | Red error + exit(1) ❌ |
| Everything works | Green check, no annotations ✅ |

When Razorpay KYC completes and the secret is added to GitHub Actions, the skip logic becomes a no-op automatically — no code changes needed.

## Files changed

**Waitlist workflow fixes:**
- `.github/workflows/process-waitlist-expirations.yml` — tsx, Node 22, permissions, action bumps
- `.github/workflows/send-waitlist-reminders.yml` — tsx, Node 22, permissions, action bumps

**Razorpay graceful skip (core scripts):**
- `scripts/payments/reconcile-payment-status.ts` — skip logic + skippedCount
- `scripts/payouts/reconcile-payout-status.ts` — skip logic + skippedCount
- `scripts/payouts/handle-stuck-payouts.ts` — skip logic + skippedCount added to interface & result

**Razorpay warning annotations (job wrappers):**
- `jobs/payments/reconcile-payment-status.ts` — `::warning::` annotation
- `jobs/payouts/reconcile-payout-status.ts` — `::warning::` annotation
- `jobs/payouts/handle-stuck-payouts.ts` — `::warning::` annotation + skippedCount output

**Action version bumps (all 30 workflows):**
- `actions/setup-node` v4 → v5
- `actions/checkout` v4 → v5 (2 waitlist files that were still on v4)

## Not fixed (by design)

`alert-dispute-deadlines` — intentionally exits with code 1 when critical disputes are found. This is correct behavior, not a bug.

## Test plan

- [ ] Monitor next hourly cron trigger for waitlist workflows — should see green runs
- [ ] Re-run Razorpay jobs via `gh workflow run` — should see yellow warning + exit code 0
- [ ] If a waitlist job fails legitimately, the `github-script` step should successfully create a GitHub issue
- [ ] Verify no Node.js 20 deprecation warnings on any workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)