### PR TITLE
fix: allow camera and microphone access in Permissions-Policy header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,7 +22,7 @@ const securityHeaders = [
   // Restrict access to browser features not used by this app
   {
     key: "Permissions-Policy",
-    value: "camera=(), microphone=(), geolocation=()",
+    value: "camera=(self), microphone=(self), geolocation=()",
   },
 ];
 


### PR DESCRIPTION
- The Permissions-Policy HTTP header was set to camera=() and microphone=(), which completely blocks all camera and microphone access at the browser level — even for the site's own origin. This prevented the browser from ever showing a permission prompt, causing Stream.io video meetings to be entirely non-functional on production.

- Users were unable to enable audio or video when joining meetings, with the console showing: "Permission was not granted previously, and prompting again is not allowed" and "Failed to get audio stream".

- Changed the policy to camera=(self) and microphone=(self), which allows the site's own origin (familiarisenow.com) to request camera/microphone permissions while still blocking third-party iframes from accessing them.