### PR TITLE
feat: multi-currency guardrails — tax engine, TDS, gateway auto-routing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -83,3 +83,7 @@ DEV_BYPASS_AUTH="false"
 
 # Logo.dev API - company logo stickers for work experience (https://logo.dev)
 NEXT_PUBLIC_LOGO_DEV_TOKEN=""
+
+# PAN encryption key for consultant tax info (AES-256-GCM)
+# Generate with: openssl rand -hex 32
+PAN_ENCRYPTION_KEY=""

--- a/app/api/admin/tds/route.ts
+++ b/app/api/admin/tds/route.ts
@@ -41,6 +41,43 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ financialYear: fy, consultants: breakdown });
     }
 
+    // Form 26Q filing view — ADMIN only (exposes decrypted PAN)
+    if (view === "form26q") {
+      if (user?.role !== "ADMIN") {
+        return NextResponse.json(
+          { error: "Forbidden — Admin only for PAN access" },
+          { status: 403 },
+        );
+      }
+
+      const records = await prisma.tDSRecord.findMany({
+        where: { financialYear: fy, reportedInForm26Q: false },
+        include: {
+          consultantProfile: {
+            include: { taxInfo: true },
+          },
+        },
+      });
+
+      const { decryptPAN } = await import("@/lib/payments/tax/pan-crypto");
+      const form26qData = records.map((r) => ({
+        id: r.id,
+        consultantProfileId: r.consultantProfileId,
+        financialYear: r.financialYear,
+        quarter: r.quarter,
+        tdsDeducted: r.tdsDeducted,
+        tdsRate: r.tdsRate,
+        cumulativeAmountCredited: r.cumulativeAmountCredited,
+        isReversal: r.isReversal,
+        consultantPAN: r.consultantProfile.taxInfo?.panEncrypted
+          ? decryptPAN(Buffer.from(r.consultantProfile.taxInfo.panEncrypted))
+          : null,
+        createdAt: r.createdAt,
+      }));
+
+      return NextResponse.json({ financialYear: fy, records: form26qData });
+    }
+
     const summary = await getTDSSummary(fy);
     return NextResponse.json(summary);
   } catch (error) {

--- a/app/api/admin/tds/route.ts
+++ b/app/api/admin/tds/route.ts
@@ -1,0 +1,112 @@
+/**
+ * Admin TDS API
+ * View TDS deduction summaries and manage Form 26Q filing status
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import {
+  getTDSSummary,
+  getConsultantTDSBreakdown,
+  markTDSAsFiled,
+  getIndianFinancialYear,
+} from "@/lib/payments/tax/tds-service";
+
+/**
+ * GET /api/admin/tds?fy=2026-27&view=summary|consultants
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== "ADMIN" && user?.role !== "STAFF") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const fy = searchParams.get("fy") || getIndianFinancialYear();
+    const view = searchParams.get("view") || "summary";
+
+    if (view === "consultants") {
+      const breakdown = await getConsultantTDSBreakdown(fy);
+      return NextResponse.json({ financialYear: fy, consultants: breakdown });
+    }
+
+    const summary = await getTDSSummary(fy);
+    return NextResponse.json(summary);
+  } catch (error) {
+    console.error("Admin TDS API error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch TDS data" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/admin/tds
+ * Mark TDS records as filed in Form 26Q
+ * Body: { financialYear: string, quarter: number, filingDate: string }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true },
+    });
+
+    if (user?.role !== "ADMIN") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { financialYear, quarter, filingDate } = body;
+
+    if (!financialYear || !quarter || !filingDate) {
+      return NextResponse.json(
+        { error: "financialYear, quarter, and filingDate are required" },
+        { status: 400 },
+      );
+    }
+
+    if (quarter < 1 || quarter > 4) {
+      return NextResponse.json(
+        { error: "quarter must be 1-4" },
+        { status: 400 },
+      );
+    }
+
+    const result = await markTDSAsFiled({
+      financialYear,
+      quarter,
+      filingDate: new Date(filingDate),
+    });
+
+    return NextResponse.json({
+      message: `Marked ${result.count} TDS records as filed`,
+      financialYear,
+      quarter,
+      recordsUpdated: result.count,
+    });
+  } catch (error) {
+    console.error("Admin TDS filing error:", error);
+    return NextResponse.json(
+      { error: "Failed to update TDS filing status" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/checkout/context/route.ts
+++ b/app/api/checkout/context/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { resolveCheckoutTaxContext } from "@/lib/payments/tax/checkout-context";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const taxContext = await resolveCheckoutTaxContext({
+      userId: session.user.id,
+      headers: req.headers,
+    });
+
+    return NextResponse.json(taxContext);
+  } catch (error) {
+    console.error("Checkout context error:", error);
+    return NextResponse.json(
+      { error: "Failed to resolve checkout tax context" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -50,7 +50,6 @@ export async function POST(req: NextRequest) {
     const gatewayRouting = routeGateway({
       buyerCountry,
       requestedGateway: validatedData.paymentGateway,
-      amount: 0, // Amount not yet known; routing is country-based
     });
 
     // Override gateway with auto-routed selection

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -8,6 +8,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import { checkoutLimiter, applyRateLimit } from "@/lib/rate-limit";
 import { ZodError } from "zod";
+import prisma from "@/lib/prisma";
+import {
+  detectBuyerCountry,
+  extractBuyerCountryParams,
+} from "@/lib/payments/tax/buyer-country";
+import { routeGateway } from "@/lib/payments/gateway-router";
 
 export async function POST(req: NextRequest) {
   try {
@@ -28,12 +34,46 @@ export async function POST(req: NextRequest) {
     const isMockPayment =
       body.isMockPayment === true && process.env.NODE_ENV === "development";
 
+    // Detect buyer country for tax jurisdiction and gateway routing
+    // Fetch user.country from DB (not on session type) for highest-confidence detection
+    const userRecord = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { country: true },
+    });
+    const headerParams = extractBuyerCountryParams(req.headers);
+    const buyerCountry = detectBuyerCountry({
+      userCountry: userRecord?.country,
+      ...headerParams,
+    });
+
+    // Auto-route to optimal gateway (Razorpay domestic/IBT, Stripe fallback)
+    const gatewayRouting = routeGateway({
+      buyerCountry,
+      requestedGateway: validatedData.paymentGateway,
+      amount: 0, // Amount not yet known; routing is country-based
+    });
+
+    // Override gateway with auto-routed selection
+    validatedData.paymentGateway = gatewayRouting.gateway;
+
+    console.log(
+      JSON.stringify({
+        event: "checkout_gateway_routed",
+        buyerCountry,
+        gateway: gatewayRouting.gateway,
+        isIBT: gatewayRouting.isIBT,
+        reason: gatewayRouting.reason,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
     // Unified checkout flow: Create payment first, then appointment via webhook
     // Supports both real and mock payments via isMockPayment flag
     const result = await handleCheckout(
       validatedData,
       session.user.id,
       isMockPayment,
+      buyerCountry,
     );
     return NextResponse.json(result);
   } catch (error) {

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -8,12 +8,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import { checkoutLimiter, applyRateLimit } from "@/lib/rate-limit";
 import { ZodError } from "zod";
-import prisma from "@/lib/prisma";
-import {
-  detectBuyerCountry,
-  extractBuyerCountryParams,
-} from "@/lib/payments/tax/buyer-country";
 import { routeGateway } from "@/lib/payments/gateway-router";
+import { resolveCheckoutTaxContext } from "@/lib/payments/tax/checkout-context";
 
 export async function POST(req: NextRequest) {
   try {
@@ -34,16 +30,9 @@ export async function POST(req: NextRequest) {
     const isMockPayment =
       body.isMockPayment === true && process.env.NODE_ENV === "development";
 
-    // Detect buyer country for tax jurisdiction and gateway routing
-    // Fetch user.country from DB (not on session type) for highest-confidence detection
-    const userRecord = await prisma.user.findUnique({
-      where: { id: session.user.id },
-      select: { country: true },
-    });
-    const headerParams = extractBuyerCountryParams(req.headers);
-    const buyerCountry = detectBuyerCountry({
-      userCountry: userRecord?.country,
-      ...headerParams,
+    const { buyerCountry } = await resolveCheckoutTaxContext({
+      userId: session.user.id,
+      headers: req.headers,
     });
 
     // Auto-route to optimal gateway (Razorpay domestic/IBT, Stripe fallback)

--- a/app/api/consultant/tax-info/route.ts
+++ b/app/api/consultant/tax-info/route.ts
@@ -1,0 +1,138 @@
+/**
+ * Consultant Tax Info API
+ * Manage PAN, GSTIN, and other tax-related info for consultants
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { z } from "zod";
+
+const updateTaxInfoSchema = z.object({
+  panNumber: z.string().length(10).optional(),
+  gstin: z.string().length(15).optional(),
+  country: z.string().length(2).optional(),
+});
+
+/**
+ * GET /api/consultant/tax-info
+ * Get the authenticated consultant's tax info
+ */
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const consultantProfile = await prisma.consultantProfile.findUnique({
+      where: { userId: session.user.id },
+      include: { taxInfo: true },
+    });
+
+    if (!consultantProfile) {
+      return NextResponse.json(
+        { error: "Consultant profile not found" },
+        { status: 404 },
+      );
+    }
+
+    // Mask PAN: show only last 4 chars (e.g., "XXXXXX1234")
+    const taxInfo = consultantProfile.taxInfo;
+    return NextResponse.json({
+      hasTaxInfo: !!taxInfo,
+      panNumber: taxInfo?.panNumber
+        ? `XXXXXX${taxInfo.panNumber.slice(-4)}`
+        : null,
+      panVerified: taxInfo?.panVerified ?? false,
+      gstin: taxInfo?.gstin ?? null,
+      gstinVerified: taxInfo?.gstinVerified ?? false,
+      country: taxInfo?.country ?? "IN",
+      isIndianResident: taxInfo?.isIndianResident ?? true,
+    });
+  } catch (error) {
+    console.error("Tax info GET error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch tax info" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * PUT /api/consultant/tax-info
+ * Create or update the authenticated consultant's tax info
+ */
+export async function PUT(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const consultantProfile = await prisma.consultantProfile.findUnique({
+      where: { userId: session.user.id },
+      select: { id: true },
+    });
+
+    if (!consultantProfile) {
+      return NextResponse.json(
+        { error: "Consultant profile not found" },
+        { status: 404 },
+      );
+    }
+
+    const body = await req.json();
+    const validated = updateTaxInfoSchema.parse(body);
+
+    const isIndianResident = (validated.country || "IN") === "IN";
+
+    const taxInfo = await prisma.consultantTaxInfo.upsert({
+      where: { consultantProfileId: consultantProfile.id },
+      create: {
+        consultantProfileId: consultantProfile.id,
+        panNumber: validated.panNumber,
+        gstin: validated.gstin,
+        country: validated.country || "IN",
+        isIndianResident,
+      },
+      update: {
+        ...(validated.panNumber !== undefined && {
+          panNumber: validated.panNumber,
+          panVerified: false, // Reset verification on change
+        }),
+        ...(validated.gstin !== undefined && {
+          gstin: validated.gstin,
+          gstinVerified: false,
+        }),
+        ...(validated.country !== undefined && {
+          country: validated.country,
+          isIndianResident,
+        }),
+      },
+    });
+
+    return NextResponse.json({
+      message: "Tax info updated",
+      panNumber: taxInfo.panNumber
+        ? `XXXXXX${taxInfo.panNumber.slice(-4)}`
+        : null,
+      panVerified: taxInfo.panVerified,
+      gstin: taxInfo.gstin,
+      gstinVerified: taxInfo.gstinVerified,
+      country: taxInfo.country,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.issues[0]?.message ?? "Invalid input" },
+        { status: 400 },
+      );
+    }
+    console.error("Tax info PUT error:", error);
+    return NextResponse.json(
+      { error: "Failed to update tax info" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/consultant/tax-info/route.ts
+++ b/app/api/consultant/tax-info/route.ts
@@ -87,6 +87,9 @@ export async function PUT(req: NextRequest) {
 
     const isIndianResident = (validated.country || "IN") === "IN";
 
+    // TODO: Encrypt PAN before persistence (requires KMS infrastructure).
+    // PAN is high-sensitivity identity data — should be encrypted at rest
+    // with only masked last-4 stored in cleartext for lookup/display.
     const taxInfo = await prisma.consultantTaxInfo.upsert({
       where: { consultantProfileId: consultantProfile.id },
       create: {

--- a/app/api/consultant/tax-info/route.ts
+++ b/app/api/consultant/tax-info/route.ts
@@ -86,7 +86,9 @@ export async function PUT(req: NextRequest) {
     const isIndianResident = (validated.country || "IN") === "IN";
 
     // Encrypt PAN if provided
-    let panFields: { panEncrypted: Buffer; panLast4: string } | undefined;
+    let panFields:
+      | { panEncrypted: Uint8Array<ArrayBuffer>; panLast4: string }
+      | undefined;
     if (validated.panNumber) {
       const { encrypted, last4 } = encryptPAN(validated.panNumber);
       panFields = { panEncrypted: encrypted, panLast4: last4 };

--- a/app/api/consultant/tax-info/route.ts
+++ b/app/api/consultant/tax-info/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
 import { z } from "zod";
+import { encryptPAN } from "@/lib/payments/tax/pan-crypto";
 
 const updateTaxInfoSchema = z.object({
   panNumber: z.string().length(10).optional(),
@@ -37,13 +38,10 @@ export async function GET() {
       );
     }
 
-    // Mask PAN: show only last 4 chars (e.g., "XXXXXX1234")
     const taxInfo = consultantProfile.taxInfo;
     return NextResponse.json({
       hasTaxInfo: !!taxInfo,
-      panNumber: taxInfo?.panNumber
-        ? `XXXXXX${taxInfo.panNumber.slice(-4)}`
-        : null,
+      panMasked: taxInfo?.panLast4 ? `XXXXXX${taxInfo.panLast4}` : null,
       panVerified: taxInfo?.panVerified ?? false,
       gstin: taxInfo?.gstin ?? null,
       gstinVerified: taxInfo?.gstinVerified ?? false,
@@ -87,21 +85,27 @@ export async function PUT(req: NextRequest) {
 
     const isIndianResident = (validated.country || "IN") === "IN";
 
-    // TODO: Encrypt PAN before persistence (requires KMS infrastructure).
-    // PAN is high-sensitivity identity data — should be encrypted at rest
-    // with only masked last-4 stored in cleartext for lookup/display.
+    // Encrypt PAN if provided
+    let panFields: { panEncrypted: Buffer; panLast4: string } | undefined;
+    if (validated.panNumber) {
+      const { encrypted, last4 } = encryptPAN(validated.panNumber);
+      panFields = { panEncrypted: encrypted, panLast4: last4 };
+    }
+
     const taxInfo = await prisma.consultantTaxInfo.upsert({
       where: { consultantProfileId: consultantProfile.id },
       create: {
         consultantProfileId: consultantProfile.id,
-        panNumber: validated.panNumber,
+        panEncrypted: panFields?.panEncrypted ?? null,
+        panLast4: panFields?.panLast4 ?? null,
         gstin: validated.gstin,
         country: validated.country || "IN",
         isIndianResident,
       },
       update: {
         ...(validated.panNumber !== undefined && {
-          panNumber: validated.panNumber,
+          panEncrypted: panFields?.panEncrypted ?? null,
+          panLast4: panFields?.panLast4 ?? null,
           panVerified: false, // Reset verification on change
         }),
         ...(validated.gstin !== undefined && {
@@ -117,9 +121,7 @@ export async function PUT(req: NextRequest) {
 
     return NextResponse.json({
       message: "Tax info updated",
-      panNumber: taxInfo.panNumber
-        ? `XXXXXX${taxInfo.panNumber.slice(-4)}`
-        : null,
+      panMasked: taxInfo.panLast4 ? `XXXXXX${taxInfo.panLast4}` : null,
       panVerified: taxInfo.panVerified,
       gstin: taxInfo.gstin,
       gstinVerified: taxInfo.gstinVerified,

--- a/app/api/payments/refunds/route.ts
+++ b/app/api/payments/refunds/route.ts
@@ -62,6 +62,29 @@ export async function POST(req: NextRequest) {
     const { paymentId, amount, reason, forceRefund } =
       createRefundSchema.parse(body);
 
+    // Fetch exchange rate for international payment audit (before transaction)
+    let refundExchangeRate: number | null = null;
+    let refundDisplayCurrency: string | null = null;
+
+    const paymentForRateCheck = await prisma.payment.findUnique({
+      where: { id: paymentId },
+      select: { isInternational: true, displayCurrencyAtCheckout: true },
+    });
+
+    if (
+      paymentForRateCheck?.isInternational &&
+      paymentForRateCheck.displayCurrencyAtCheckout
+    ) {
+      refundDisplayCurrency = paymentForRateCheck.displayCurrencyAtCheckout;
+      try {
+        const { getExchangeRates } = await import("@/lib/currency");
+        const rates = await getExchangeRates();
+        refundExchangeRate = rates[refundDisplayCurrency] ?? null;
+      } catch {
+        console.warn("Failed to fetch exchange rate for refund audit");
+      }
+    }
+
     // ==========================================================================
     // TWO-PHASE REFUND PATTERN
     // ==========================================================================
@@ -139,7 +162,9 @@ export async function POST(req: NextRequest) {
           status: "PENDING",
           refundId: `pending_${crypto.randomUUID()}`,
           paymentGateway: payment.paymentGateway,
-          metadata: {},
+          metadata: { forceRefund: forceRefund ?? false },
+          exchangeRateAtRefund: refundExchangeRate,
+          displayCurrency: refundDisplayCurrency,
           paymentId: payment.id,
         },
       });

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -119,7 +119,19 @@ export async function handleRefundCreated(
       if (mapRefundStatus(refundStatus) !== "SUCCEEDED") return;
 
       try {
-        await refundEarnings(paymentId);
+        // Check if any refund for this payment has forceRefund in metadata
+        const refunds = await prisma.refund.findMany({
+          where: { paymentId },
+          select: { metadata: true },
+        });
+        const hasForceRefund = refunds.some(
+          (r) =>
+            r.metadata &&
+            typeof r.metadata === "object" &&
+            (r.metadata as Record<string, unknown>).forceRefund === true,
+        );
+
+        await refundEarnings(paymentId, { forceRefund: hasForceRefund });
         console.log(`💰 Earnings refunded for payment ${paymentId}`);
       } catch (earningsError) {
         // Log but don't fail - earnings can be manually updated
@@ -580,8 +592,22 @@ export async function handleRefundForEarnings(
     return;
   }
 
+  // Check if any refund for this payment has forceRefund in metadata
+  const refunds = await prisma.refund.findMany({
+    where: { paymentId: payment.id },
+    select: { metadata: true },
+  });
+  const hasForceRefund = refunds.some(
+    (r) =>
+      r.metadata &&
+      typeof r.metadata === "object" &&
+      (r.metadata as Record<string, unknown>).forceRefund === true,
+  );
+
   // Refund the earnings (will mark as REFUNDED and update consultant balance)
-  const success = await refundEarnings(payment.id);
+  const success = await refundEarnings(payment.id, {
+    forceRefund: hasForceRefund,
+  });
 
   if (success) {
     console.log(`✅ Earnings refunded for payment ${payment.id}`);

--- a/app/checkout/components/RazorpayCheckout.tsx
+++ b/app/checkout/components/RazorpayCheckout.tsx
@@ -17,6 +17,10 @@ interface RazorpayCheckoutProps {
   onPaymentSuccess: (response: any) => void;
   onPaymentError: (error: any) => void;
   disabled?: boolean;
+  userName?: string;
+  userEmail?: string;
+  userPhone?: string;
+  description?: string;
 }
 
 export default function RazorpayCheckout({
@@ -24,6 +28,10 @@ export default function RazorpayCheckout({
   onPaymentSuccess,
   onPaymentError,
   disabled,
+  userName,
+  userEmail,
+  userPhone,
+  description,
 }: RazorpayCheckoutProps) {
   const { toast } = useToast();
   const [isProcessing, setIsProcessing] = useState(false);
@@ -75,22 +83,23 @@ export default function RazorpayCheckout({
         key: process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID,
         amount: data.paymentIntent.amount,
         currency: data.paymentIntent.currency,
-        name: "Your App Name",
-        description: "Test Transaction",
+        name: "Familiarise",
+        description: description || "Service Payment",
         order_id: data.paymentIntent.id,
         handler: function (response: any) {
           onPaymentSuccess(response);
         },
-        prefill: {
-          name: "Test User",
-          email: "test.user@example.com",
-          contact: "9999999999",
-        },
-        notes: {
-          address: "Test Address",
-        },
+        ...(userName || userEmail || userPhone
+          ? {
+              prefill: {
+                ...(userName && { name: userName }),
+                ...(userEmail && { email: userEmail }),
+                ...(userPhone && { contact: userPhone }),
+              },
+            }
+          : {}),
         theme: {
-          color: "#3399cc",
+          color: "#2563EB", // Familiarise brand blue
         },
       };
 

--- a/app/checkout/plans/class/[classPlanId]/page.tsx
+++ b/app/checkout/plans/class/[classPlanId]/page.tsx
@@ -26,6 +26,7 @@ import {
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
 import type { AppliedDiscount } from "@/types/checkout";
+import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
 
 import type {
   Appointment,
@@ -85,6 +86,7 @@ export default function ClassCheckoutPage({
   const resolvedSearchParams = use(searchParams);
 
   const { formatPrice, currency } = useCurrency();
+  const checkoutTaxContext = useCheckoutTaxContext();
   const [planData, setPlanData] = useState<PlanResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -234,6 +236,7 @@ export default function ClassCheckoutPage({
           planId: planData.data.id,
           eventId: firstClassId,
           discountCode: appliedDiscount?.code,
+          displayCurrency: currency,
           paymentGateway: gateway,
           fromWaitlist,
           useReferralCredits,
@@ -358,14 +361,14 @@ export default function ClassCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
-      isInternational: currency !== "INR",
+      isInternational: checkoutTaxContext.isInternational,
     });
   }, [
     planData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
-    currency,
+    checkoutTaxContext.isInternational,
   ]);
 
   if (isLoading) {
@@ -718,17 +721,16 @@ export default function ClassCheckoutPage({
           {[
             {
               name: "Stripe",
-              description: "International payments in USD",
+              description: "Card payments (international)",
               gateway: "STRIPE" as const,
               isActive: true,
             },
             {
               name: "Razorpay",
-              description: "Indian payments in INR",
+              description: "UPI, cards & bank transfer",
               gateway: "RAZORPAY" as const,
               isActive: true,
             },
-            // TODO: Add Lemon Squeezy and XFlow when webhook appointment creation is implemented
           ].map((gateway) => (
             <Card key={gateway.name} className="border-zinc-200">
               <CardHeader>
@@ -757,6 +759,7 @@ export default function ClassCheckoutPage({
                             eventId: planDetails.classes[0]?.id,
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             useReferralCredits,
                           })}
                           onPaymentSuccess={razorpayHandlers.onPaymentSuccess}
@@ -771,6 +774,7 @@ export default function ClassCheckoutPage({
                             eventId: planDetails.classes[0]?.id,
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             useReferralCredits,
                           })}
                           onPaymentSuccess={stripeHandlers.onPaymentSuccess}

--- a/app/checkout/plans/class/[classPlanId]/page.tsx
+++ b/app/checkout/plans/class/[classPlanId]/page.tsx
@@ -46,7 +46,11 @@ export type CheckoutClassPlanData = ClassPlan & {
   consultantProfile:
     | (ConsultantProfile & {
         user: User & {
-          workExperiences?: Array<{ company: string; companyDomain: string | null; isCurrent: boolean }>;
+          workExperiences?: Array<{
+            company: string;
+            companyDomain: string | null;
+            isCurrent: boolean;
+          }>;
         };
         domain: Domain | null;
         subDomains: SubDomain[];
@@ -80,7 +84,7 @@ export default function ClassCheckoutPage({
   const resolvedParams = use(params);
   const resolvedSearchParams = use(searchParams);
 
-  const { formatPrice } = useCurrency();
+  const { formatPrice, currency } = useCurrency();
   const [planData, setPlanData] = useState<PlanResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -354,12 +358,14 @@ export default function ClassCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
+      isInternational: currency !== "INR",
     });
   }, [
     planData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
+    currency,
   ]);
 
   if (isLoading) {
@@ -443,19 +449,20 @@ export default function ClassCheckoutPage({
                   consultantDetails?.domain?.name ||
                   "Consultant"}
               </div>
-              {userDetails?.workExperiences && userDetails.workExperiences.length > 0 && (
-                <div className="flex items-center gap-1.5 mt-1">
-                  {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
-                    <CompanyLogo
-                      key={`checkout-class-company-${i}`}
-                      companyName={exp.company}
-                      companyDomain={exp.companyDomain ?? undefined}
-                      size={20}
-                      className="border-zinc-200"
-                    />
-                  ))}
-                </div>
-              )}
+              {userDetails?.workExperiences &&
+                userDetails.workExperiences.length > 0 && (
+                  <div className="flex items-center gap-1.5 mt-1">
+                    {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
+                      <CompanyLogo
+                        key={`checkout-class-company-${i}`}
+                        companyName={exp.company}
+                        companyDomain={exp.companyDomain ?? undefined}
+                        size={20}
+                        className="border-zinc-200"
+                      />
+                    ))}
+                  </div>
+                )}
             </div>
           </div>
           <div className="text-right">

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -22,7 +22,6 @@ import {
   ConsultationPlan,
   PaymentGateway,
 } from "@prisma/client";
-import { loadStripe } from "@stripe/stripe-js";
 import { CreditCard as CreditCardIcon } from "lucide-react";
 import { CompanyLogo } from "@/components/ui/company-logo";
 import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -30,6 +29,7 @@ import RazorpayCheckout from "../../../components/RazorpayCheckout";
 import StripeCheckout from "../../../components/StripeCheckout";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
+import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
 
 type ConsultationPlanWithConsultant = ConsultationPlan & {
   consultantProfile: ConsultantProfile & {
@@ -65,6 +65,7 @@ export default function ConsultationCheckoutPage({
   const resolvedSearchParams = use(searchParams);
 
   const { formatPrice, currency } = useCurrency();
+  const checkoutTaxContext = useCheckoutTaxContext();
   const [eventData, setEventData] = useState<ConsultationResponse | null>(null);
   const [slotData, setSlotData] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -257,7 +258,7 @@ export default function ConsultationCheckoutPage({
   };
 
   const handleCheckout = useCallback(
-    async (gateway: "STRIPE" | "RAZORPAY", isMockPayment: boolean = false) => {
+    async (gateway: PaymentGateway, isMockPayment: boolean = false) => {
       // Block checkout during maintenance mode
       if (isMaintenanceBlocked) {
         toast({
@@ -305,6 +306,7 @@ export default function ConsultationCheckoutPage({
           slotOfAvailabilityCustomId:
             searchParamsValidation.data.slotOfAvailabilityCustomId,
           discountCode: appliedDiscount?.code, // Use state instead of URL params
+          displayCurrency: currency,
           notes: searchParamsValidation.data.notes,
           useReferralCredits,
         });
@@ -357,26 +359,8 @@ export default function ConsultationCheckoutPage({
           // Small delay to let user see the toast before redirect
           setTimeout(async () => {
             try {
-              // Handle gateway-specific responses
-              switch (gateway) {
-                case "STRIPE":
-                  const stripe = await loadStripe(
-                    process.env.NEXT_PUBLIC_STRIPE_KEY!,
-                  );
-                  await stripe?.confirmPayment({
-                    clientSecret: data.paymentIntent.client_secret,
-                    confirmParams: {
-                      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/checkout-success`,
-                    },
-                  });
-                  break;
-
-                case "RAZORPAY":
-                  // Razorpay is handled by the RazorpayCheckout component
-                  // This case shouldn't be reached since Razorpay has its own component
-                  break;
-
-                // TODO: Add Lemon Squeezy and XFlow cases when webhook handlers are implemented
+              if (gateway !== "RAZORPAY") {
+                throw new Error("Unsupported payment gateway");
               }
             } catch (paymentError) {
               console.error("Payment confirmation error:", paymentError);
@@ -495,14 +479,14 @@ export default function ConsultationCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent, // Don't use percent if we have a fixed amount
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
-      isInternational: currency !== "INR",
+      isInternational: checkoutTaxContext.isInternational,
     });
   }, [
     eventData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
-    currency,
+    checkoutTaxContext.isInternational,
   ]);
 
   if (isLoading) {
@@ -799,22 +783,19 @@ export default function ConsultationCheckoutPage({
               Select your preferred payment method
             </div>
           </div>
-          {/* Payment Gateway Cards */}
-          {/* Priority Gateways: Stripe and Razorpay with Real + Mock Payment */}
           {[
             {
               name: "Stripe",
-              description: "International payments in USD",
+              description: "Card payments (international)",
               gateway: "STRIPE" as const,
               isActive: true,
             },
             {
               name: "Razorpay",
-              description: "Indian payments in INR",
+              description: "UPI, cards & bank transfer",
               gateway: "RAZORPAY" as const,
               isActive: true,
             },
-            // TODO: Add Lemon Squeezy and XFlow when webhook appointment creation is implemented
           ].map((gateway) => (
             <Card key={gateway.name} className="border-zinc-200">
               <CardHeader>
@@ -835,7 +816,6 @@ export default function ConsultationCheckoutPage({
                   </div>
                   {gateway.isActive ? (
                     <div className="flex gap-2">
-                      {/* Real Payment Button */}
                       {gateway.gateway === "RAZORPAY" ? (
                         <RazorpayCheckout
                           checkoutData={createCheckoutData({
@@ -865,6 +845,7 @@ export default function ConsultationCheckoutPage({
                                   .slotOfAvailabilityCustomId[0]
                               : resolvedSearchParams.slotOfAvailabilityCustomId,
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             notes: Array.isArray(resolvedSearchParams.notes)
                               ? resolvedSearchParams.notes[0]
                               : resolvedSearchParams.notes,
@@ -919,6 +900,7 @@ export default function ConsultationCheckoutPage({
                                   .slotOfAvailabilityCustomId[0]
                               : resolvedSearchParams.slotOfAvailabilityCustomId,
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             notes: Array.isArray(resolvedSearchParams.notes)
                               ? resolvedSearchParams.notes[0]
                               : resolvedSearchParams.notes,

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -38,7 +38,11 @@ type ConsultationPlanWithConsultant = ConsultationPlan & {
       name: string;
       email: string;
       image: string;
-      workExperiences?: Array<{ company: string; companyDomain: string | null; isCurrent: boolean }>;
+      workExperiences?: Array<{
+        company: string;
+        companyDomain: string | null;
+        isCurrent: boolean;
+      }>;
     };
   };
 };
@@ -60,7 +64,7 @@ export default function ConsultationCheckoutPage({
   const resolvedParams = use(params);
   const resolvedSearchParams = use(searchParams);
 
-  const { formatPrice } = useCurrency();
+  const { formatPrice, currency } = useCurrency();
   const [eventData, setEventData] = useState<ConsultationResponse | null>(null);
   const [slotData, setSlotData] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -491,12 +495,14 @@ export default function ConsultationCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent, // Don't use percent if we have a fixed amount
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
+      isInternational: currency !== "INR",
     });
   }, [
     eventData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
+    currency,
   ]);
 
   if (isLoading) {
@@ -566,19 +572,20 @@ export default function ConsultationCheckoutPage({
               <div className="text-sm text-muted-foreground">
                 {consultantDetails?.headline || "Consultant"}
               </div>
-              {userDetails?.workExperiences && userDetails.workExperiences.length > 0 && (
-                <div className="flex items-center gap-1.5 mt-1">
-                  {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
-                    <CompanyLogo
-                      key={`checkout-consult-company-${i}`}
-                      companyName={exp.company}
-                      companyDomain={exp.companyDomain ?? undefined}
-                      size={20}
-                      className="border-zinc-200"
-                    />
-                  ))}
-                </div>
-              )}
+              {userDetails?.workExperiences &&
+                userDetails.workExperiences.length > 0 && (
+                  <div className="flex items-center gap-1.5 mt-1">
+                    {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
+                      <CompanyLogo
+                        key={`checkout-consult-company-${i}`}
+                        companyName={exp.company}
+                        companyDomain={exp.companyDomain ?? undefined}
+                        size={20}
+                        className="border-zinc-200"
+                      />
+                    ))}
+                  </div>
+                )}
             </div>
           </div>
           <div className="text-right">

--- a/app/checkout/plans/math.ts
+++ b/app/checkout/plans/math.ts
@@ -93,7 +93,9 @@ export function calculatePricing(
   baseAmount: number,
   config: PricingConfig = {},
 ): PricingBreakdown {
-  const taxRate = config.isInternational ? 0 : (config.taxRate ?? DEFAULT_TAX_RATE);
+  const taxRate = config.isInternational
+    ? 0
+    : (config.taxRate ?? DEFAULT_TAX_RATE);
   const discountPercent = config.discountPercent ?? 0;
 
   const subtotal = calculateSubtotal(baseAmount);

--- a/app/checkout/plans/math.ts
+++ b/app/checkout/plans/math.ts
@@ -12,6 +12,7 @@ const DEFAULT_TAX_RATE = parseFloat(
 
 export interface PricingConfig {
   taxRate?: number; // Override tax rate (0.18 = 18%)
+  isInternational?: boolean; // If true, zero-rate tax (export of services)
   discountPercent?: number; // Applied discount percentage (0.10 = 10%)
   discountAmount?: number; // Fixed discount amount
   creditsApplied?: number; // Referral credits applied (in major currency unit)
@@ -92,7 +93,7 @@ export function calculatePricing(
   baseAmount: number,
   config: PricingConfig = {},
 ): PricingBreakdown {
-  const taxRate = config.taxRate ?? DEFAULT_TAX_RATE;
+  const taxRate = config.isInternational ? 0 : (config.taxRate ?? DEFAULT_TAX_RATE);
   const discountPercent = config.discountPercent ?? 0;
 
   const subtotal = calculateSubtotal(baseAmount);

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -22,6 +22,19 @@ import {
   SubscriptionPlan,
   PaymentGateway,
 } from "@prisma/client";
+import { CreditCard as CreditCardIcon } from "lucide-react";
+import { CompanyLogo } from "@/components/ui/company-logo";
+import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import RazorpayCheckout from "../../../components/RazorpayCheckout";
+import StripeCheckout from "../../../components/StripeCheckout";
+import {
+  createHandleApiError,
+  createRazorpayCheckoutHandlers,
+  createStripeCheckoutHandlers,
+} from "../../utils";
+import { calculatePricing, formatPercentage } from "../../math";
+import { useCurrency } from "@/hooks/useCurrency";
+import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
 
 type SubscriptionPlanWithConsultant = SubscriptionPlan & {
   consultantProfile: ConsultantProfile & {
@@ -42,19 +55,6 @@ type SubscriptionPlanWithConsultant = SubscriptionPlan & {
 type SubscriptionResponse = {
   data: SubscriptionPlanWithConsultant;
 };
-import { loadStripe } from "@stripe/stripe-js";
-import { CreditCard as CreditCardIcon } from "lucide-react";
-import { CompanyLogo } from "@/components/ui/company-logo";
-import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import RazorpayCheckout from "../../../components/RazorpayCheckout";
-import StripeCheckout from "../../../components/StripeCheckout";
-import {
-  createHandleApiError,
-  createStripeCheckoutHandlers,
-  createRazorpayCheckoutHandlers,
-} from "../../utils";
-import { calculatePricing, formatPercentage } from "../../math";
-import { useCurrency } from "@/hooks/useCurrency";
 
 type PageProps = {
   params: Promise<{ planId: string }>;
@@ -70,6 +70,7 @@ export default function SubscriptionCheckoutPage({
   const resolvedSearchParams = use(searchParams);
 
   const { formatPrice, currency } = useCurrency();
+  const checkoutTaxContext = useCheckoutTaxContext();
   const [planData, setPlanData] = useState<SubscriptionResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -233,6 +234,7 @@ export default function SubscriptionCheckoutPage({
             searchParamsValidation.data.schedulingPeriodEndsAt,
           discountCode: appliedDiscount?.code,
           paymentGateway: gateway,
+          displayCurrency: currency,
           useReferralCredits,
         });
 
@@ -284,21 +286,8 @@ export default function SubscriptionCheckoutPage({
             // Small delay to let user see the toast before redirect
             setTimeout(async () => {
               try {
-                // Handle gateway-specific responses
-                switch (gateway) {
-                  case "STRIPE":
-                    const stripe = await loadStripe(
-                      process.env.NEXT_PUBLIC_STRIPE_KEY!,
-                    );
-                    await stripe?.confirmPayment({
-                      clientSecret: data.clientSecret!,
-                      confirmParams: {
-                        return_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/checkout-success`,
-                      },
-                    });
-                    break;
-
-                  // TODO: Add Lemon Squeezy and XFlow cases when webhook handlers are implemented
+                if (gateway !== "RAZORPAY") {
+                  throw new Error("Unsupported payment gateway");
                 }
               } catch (paymentError) {
                 console.error("Payment confirmation error:", paymentError);
@@ -401,14 +390,14 @@ export default function SubscriptionCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
-      isInternational: currency !== "INR",
+      isInternational: checkoutTaxContext.isInternational,
     });
   }, [
     planData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
-    currency,
+    checkoutTaxContext.isInternational,
   ]);
 
   if (isLoading) {
@@ -767,22 +756,19 @@ export default function SubscriptionCheckoutPage({
               Select your preferred payment method
             </div>
           </div>
-          {/* Payment Gateway Cards */}
-          {/* Priority Gateways: Stripe and Razorpay with Real + Mock Payment */}
           {[
             {
               name: "Stripe",
-              description: "International payments in USD",
+              description: "Card payments (international)",
               gateway: "STRIPE" as const,
               isActive: true,
             },
             {
               name: "Razorpay",
-              description: "Indian payments in INR",
+              description: "UPI, cards & bank transfer",
               gateway: "RAZORPAY" as const,
               isActive: true,
             },
-            // TODO: Add Lemon Squeezy and XFlow when webhook appointment creation is implemented
           ].map((gateway) => (
             <Card key={gateway.gateway} className="border-zinc-200">
               <CardHeader>
@@ -803,35 +789,35 @@ export default function SubscriptionCheckoutPage({
                   </div>
                   {gateway.isActive ? (
                     <div className="flex gap-2">
-                      {/* Real Payment Button */}
-                      {gateway.gateway === "STRIPE" ? (
-                        <StripeCheckout
-                          checkoutData={createCheckoutData({
-                            appointmentType: "SUBSCRIPTION",
-                            planId: planData?.data?.id || "",
-                            paymentGateway: "STRIPE",
-                            discountCode: appliedDiscount?.code,
-                            useReferralCredits,
-                          })}
-                          onPaymentSuccess={stripeHandlers.onPaymentSuccess}
-                          onPaymentError={stripeHandlers.onPaymentError}
-                          disabled={isMaintenanceBlocked}
-                        />
-                      ) : gateway.gateway === "RAZORPAY" ? (
+                      {gateway.gateway === "RAZORPAY" ? (
                         <RazorpayCheckout
                           checkoutData={createCheckoutData({
                             appointmentType: "SUBSCRIPTION",
                             planId: planData?.data?.id || "",
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             useReferralCredits,
                           })}
                           onPaymentSuccess={razorpayHandlers.onPaymentSuccess}
                           onPaymentError={razorpayHandlers.onPaymentError}
                           disabled={isMaintenanceBlocked}
                         />
+                      ) : gateway.gateway === "STRIPE" ? (
+                        <StripeCheckout
+                          checkoutData={createCheckoutData({
+                            appointmentType: "SUBSCRIPTION",
+                            planId: planData?.data?.id || "",
+                            paymentGateway: "STRIPE",
+                            discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
+                            useReferralCredits,
+                          })}
+                          onPaymentSuccess={stripeHandlers.onPaymentSuccess}
+                          onPaymentError={stripeHandlers.onPaymentError}
+                          disabled={isMaintenanceBlocked}
+                        />
                       ) : null}
-                      {/* Mock Payment Button */}
                       <Button
                         variant="secondary"
                         onClick={() => handleCheckout(gateway.gateway, true)}

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -30,7 +30,11 @@ type SubscriptionPlanWithConsultant = SubscriptionPlan & {
       name: string;
       email: string;
       image: string;
-      workExperiences?: Array<{ company: string; companyDomain: string | null; isCurrent: boolean }>;
+      workExperiences?: Array<{
+        company: string;
+        companyDomain: string | null;
+        isCurrent: boolean;
+      }>;
     };
   };
 };
@@ -65,7 +69,7 @@ export default function SubscriptionCheckoutPage({
   const resolvedParams = use(params);
   const resolvedSearchParams = use(searchParams);
 
-  const { formatPrice } = useCurrency();
+  const { formatPrice, currency } = useCurrency();
   const [planData, setPlanData] = useState<SubscriptionResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -397,12 +401,14 @@ export default function SubscriptionCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
+      isInternational: currency !== "INR",
     });
   }, [
     planData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
+    currency,
   ]);
 
   if (isLoading) {
@@ -472,19 +478,20 @@ export default function SubscriptionCheckoutPage({
               <div className="text-sm text-muted-foreground">
                 {consultantDetails?.headline || "Consultant"}
               </div>
-              {userDetails?.workExperiences && userDetails.workExperiences.length > 0 && (
-                <div className="flex items-center gap-1.5 mt-1">
-                  {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
-                    <CompanyLogo
-                      key={`checkout-sub-company-${i}`}
-                      companyName={exp.company}
-                      companyDomain={exp.companyDomain ?? undefined}
-                      size={20}
-                      className="border-zinc-200"
-                    />
-                  ))}
-                </div>
-              )}
+              {userDetails?.workExperiences &&
+                userDetails.workExperiences.length > 0 && (
+                  <div className="flex items-center gap-1.5 mt-1">
+                    {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
+                      <CompanyLogo
+                        key={`checkout-sub-company-${i}`}
+                        companyName={exp.company}
+                        companyDomain={exp.companyDomain ?? undefined}
+                        size={20}
+                        className="border-zinc-200"
+                      />
+                    ))}
+                  </div>
+                )}
             </div>
           </div>
           <div className="text-right">

--- a/app/checkout/plans/useCheckoutTaxContext.ts
+++ b/app/checkout/plans/useCheckoutTaxContext.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type CheckoutTaxContext = {
+  buyerCountry: string;
+  isInternational: boolean;
+};
+
+const DEFAULT_CONTEXT: CheckoutTaxContext = {
+  buyerCountry: "IN",
+  isInternational: false,
+};
+
+export function useCheckoutTaxContext() {
+  const [taxContext, setTaxContext] =
+    useState<CheckoutTaxContext>(DEFAULT_CONTEXT);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTaxContext() {
+      try {
+        const response = await fetch("/api/checkout/context", {
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch checkout tax context");
+        }
+
+        const data = (await response.json()) as CheckoutTaxContext;
+        if (!cancelled) {
+          setTaxContext(data);
+        }
+      } catch {
+        if (!cancelled) {
+          setTaxContext(DEFAULT_CONTEXT);
+        }
+      }
+    }
+
+    loadTaxContext();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return taxContext;
+}

--- a/app/checkout/plans/utils.ts
+++ b/app/checkout/plans/utils.ts
@@ -195,12 +195,12 @@ export async function handleUnifiedCheckout(
 export const paymentGateways = [
   {
     name: "Stripe",
-    description: "International payments in USD",
+    description: "Card payments (international)",
     gateway: "STRIPE" as const,
   },
   {
     name: "Razorpay",
-    description: "Indian payments in INR",
+    description: "UPI, cards & bank transfer",
     gateway: "RAZORPAY" as const,
   },
   // TODO: Add Lemon Squeezy and XFlow when webhook appointment creation is implemented

--- a/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
+++ b/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
@@ -49,7 +49,11 @@ export type CheckoutWebinarPlanData = WebinarPlan & {
   consultantProfile:
     | (ConsultantProfile & {
         user: User & {
-          workExperiences?: Array<{ company: string; companyDomain: string | null; isCurrent: boolean }>;
+          workExperiences?: Array<{
+            company: string;
+            companyDomain: string | null;
+            isCurrent: boolean;
+          }>;
         };
         domain: Domain | null;
         subDomains: SubDomain[];
@@ -85,7 +89,7 @@ export default function WebinarCheckoutPage({
   const resolvedParams = use(params);
   const resolvedSearchParams = use(searchParams);
 
-  const { formatPrice } = useCurrency();
+  const { formatPrice, currency } = useCurrency();
   const [planData, setPlanData] = useState<PlanResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -351,12 +355,14 @@ export default function WebinarCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
+      isInternational: currency !== "INR",
     });
   }, [
     planData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
+    currency,
   ]);
 
   if (isLoading) {
@@ -440,19 +446,20 @@ export default function WebinarCheckoutPage({
                   consultantDetails?.domain?.name ||
                   "Consultant"}
               </div>
-              {userDetails?.workExperiences && userDetails.workExperiences.length > 0 && (
-                <div className="flex items-center gap-1.5 mt-1">
-                  {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
-                    <CompanyLogo
-                      key={`checkout-webinar-company-${i}`}
-                      companyName={exp.company}
-                      companyDomain={exp.companyDomain ?? undefined}
-                      size={20}
-                      className="border-zinc-200"
-                    />
-                  ))}
-                </div>
-              )}
+              {userDetails?.workExperiences &&
+                userDetails.workExperiences.length > 0 && (
+                  <div className="flex items-center gap-1.5 mt-1">
+                    {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
+                      <CompanyLogo
+                        key={`checkout-webinar-company-${i}`}
+                        companyName={exp.company}
+                        companyDomain={exp.companyDomain ?? undefined}
+                        size={20}
+                        className="border-zinc-200"
+                      />
+                    ))}
+                  </div>
+                )}
             </div>
           </div>
           <div className="text-right">

--- a/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
+++ b/app/checkout/plans/webinar/[webinarPlanId]/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../utils";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
+import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
 import type { AppliedDiscount } from "@/types/checkout";
 
 import type {
@@ -90,6 +91,7 @@ export default function WebinarCheckoutPage({
   const resolvedSearchParams = use(searchParams);
 
   const { formatPrice, currency } = useCurrency();
+  const checkoutTaxContext = useCheckoutTaxContext();
   const [planData, setPlanData] = useState<PlanResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -231,6 +233,7 @@ export default function WebinarCheckoutPage({
           eventId: searchParamsValidation.data.eventId,
           discountCode: appliedDiscount?.code,
           paymentGateway: gateway,
+          displayCurrency: currency,
           fromWaitlist,
           useReferralCredits,
         });
@@ -355,14 +358,14 @@ export default function WebinarCheckoutPage({
       discountPercent: discountAmount > 0 ? 0 : discountPercent,
       discountAmount,
       creditsApplied: useReferralCredits ? availableCredits : 0,
-      isInternational: currency !== "INR",
+      isInternational: checkoutTaxContext.isInternational,
     });
   }, [
     planData?.data?.price,
     appliedDiscount,
     useReferralCredits,
     availableCredits,
-    currency,
+    checkoutTaxContext.isInternational,
   ]);
 
   if (isLoading) {
@@ -689,21 +692,19 @@ export default function WebinarCheckoutPage({
               Select your preferred payment method
             </div>
           </div>
-          {/* Payment Gateway Cards */}
           {[
             {
               name: "Stripe",
-              description: "International payments in USD",
+              description: "Card payments (international)",
               gateway: "STRIPE" as const,
               isActive: true,
             },
             {
               name: "Razorpay",
-              description: "Indian payments in INR",
+              description: "UPI, cards & bank transfer",
               gateway: "RAZORPAY" as const,
               isActive: true,
             },
-            // TODO: Add Lemon Squeezy and XFlow when webhook appointment creation is implemented
           ].map((gateway) => (
             <Card key={gateway.name} className="border-zinc-200">
               <CardHeader>
@@ -724,7 +725,6 @@ export default function WebinarCheckoutPage({
                   </div>
                   {gateway.isActive ? (
                     <div className="flex gap-2">
-                      {/* Real Payment Button */}
                       {gateway.gateway === "RAZORPAY" ? (
                         <RazorpayCheckout
                           checkoutData={createCheckoutData({
@@ -733,6 +733,7 @@ export default function WebinarCheckoutPage({
                             eventId: planDetails.webinars[0]?.id,
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             useReferralCredits,
                           })}
                           onPaymentSuccess={razorpayHandlers.onPaymentSuccess}
@@ -747,6 +748,7 @@ export default function WebinarCheckoutPage({
                             eventId: planDetails.webinars[0]?.id,
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
+                            displayCurrency: currency,
                             useReferralCredits,
                           })}
                           onPaymentSuccess={stripeHandlers.onPaymentSuccess}
@@ -754,7 +756,6 @@ export default function WebinarCheckoutPage({
                           disabled={isMaintenanceBlocked}
                         />
                       ) : null}
-                      {/* Mock Payment Button */}
                       <Button
                         variant="secondary"
                         onClick={() => handleCheckout(gateway.gateway, true)}

--- a/docs/finances/07-tax-compliance-india.md
+++ b/docs/finances/07-tax-compliance-india.md
@@ -198,8 +198,7 @@ Export of services is zero-rated under GST (IGST Act Section 16). Conditions:
 - Recipient located outside India
 - Payment received in convertible foreign exchange
 
-**Current implementation:** GST is zero-rated when `currency !== "INR"` in checkout.
-For full compliance, buyer location verification via billing address should be added.
+**Current implementation:** GST is zero-rated when `buyerCountry !== "IN"` in checkout (using server-side buyer country detection via DB user.country → CF-IPCountry header → Accept-Language fallback). For full compliance, additional evidence (billing address, FIRC reference, LUT state) should be captured per payment — see `docs/payments/multi-currency/03-tds-compliance.md` launch blockers.
 
 ---
 
@@ -349,7 +348,7 @@ Consultants can claim TDS deducted by platform:
 
 ### Implemented
 
-- **TDS calculation + auto-deduction**: `lib/payments/tax/tds-service.ts` — calculates TDS at payout time, deducts before sending to gateway
+- **TDS calculation + auto-deduction**: `lib/payments/tax/tds-service.ts` — calculates TDS at payout time, deducts before sending to gateway. TDS records are created only on confirmed (COMPLETED) payouts; failed payouts clean up all TDS data.
 - **ConsultantTaxInfo model**: PAN, GSTIN, country tracking in `prisma/schema.prisma`
 - **TDSRecord model**: Per-deduction audit trail for Form 26Q filing
 - **Admin TDS API**: `GET/POST /api/admin/tds` — FY summary, per-consultant breakdown, filing status

--- a/docs/finances/07-tax-compliance-india.md
+++ b/docs/finances/07-tax-compliance-india.md
@@ -140,8 +140,8 @@ The `math.ts` checkout utilities calculate tax for **display and invoicing purpo
 
 The 56th GST Council meeting introduced a simplified two-rate framework:
 
-| Old Structure         | New Structure (GST 2.0, effective Sep 2025)                    |
-| --------------------- | -------------------------------------------------------------- |
+| Old Structure         | New Structure (GST 2.0, effective Sep 2025)                        |
+| --------------------- | ------------------------------------------------------------------ |
 | 0%, 5%, 12%, 18%, 28% | 5% (merit, no ITC), 18% (standard, with ITC), 40% (demerit/luxury) |
 
 **Impact**: Most platform services remain at 18% with Input Tax Credit (ITC) available.
@@ -193,6 +193,7 @@ As Familiarise collects payments on behalf of consultants (suppliers), you may b
 ### International Buyers (Export of Services)
 
 Export of services is zero-rated under GST (IGST Act Section 16). Conditions:
+
 - Supplier located in India
 - Recipient located outside India
 - Payment received in convertible foreign exchange

--- a/docs/finances/07-tax-compliance-india.md
+++ b/docs/finances/07-tax-compliance-india.md
@@ -344,7 +344,33 @@ Consultants can claim TDS deducted by platform:
 
 ---
 
-## Implementation in Codebase
+## Implementation Status (Updated March 2026)
+
+### Implemented
+
+- **TDS calculation + auto-deduction**: `lib/payments/tax/tds-service.ts` — calculates TDS at payout time, deducts before sending to gateway
+- **ConsultantTaxInfo model**: PAN, GSTIN, country tracking in `prisma/schema.prisma`
+- **TDSRecord model**: Per-deduction audit trail for Form 26Q filing
+- **Admin TDS API**: `GET/POST /api/admin/tds` — FY summary, per-consultant breakdown, filing status
+- **Consultant Tax Info API**: `GET/PUT /api/consultant/tax-info` — PAN/GSTIN collection
+- **Export zero-rating**: `lib/payments/tax/tax-engine.ts` — 0% for international buyers (buyer country detection)
+- **Gateway auto-routing**: `lib/payments/gateway-router.ts` — Razorpay for all (domestic + IBT)
+- **Invoice zero-rating**: Fixed bug where `currency !== "INR"` check never triggered
+- **Currency guards**: Discount + referral credit currency validation
+
+### Pending
+
+- [ ] CA opinion on e-commerce operator classification
+- [ ] LUT filing with GST authorities
+- [ ] Form 16A auto-generation for consultants
+- [ ] EU VAT OSS registration (when thresholds approached)
+- [ ] Razorpay IBT activation on dashboard (KYC process)
+
+See `docs/payments/multi-currency/` for detailed architecture docs.
+
+---
+
+## Original Implementation Notes (Reference)
 
 ### Track TDS-Applicable Payments
 

--- a/docs/finances/08-tax-compliance-marketplace-obligations.md
+++ b/docs/finances/08-tax-compliance-marketplace-obligations.md
@@ -1,0 +1,300 @@
+# Tax Compliance — Marketplace Obligations (March 2026)
+
+> Comprehensive tax, compliance, and financial infrastructure requirements for Familiarise as an Indian services marketplace. Supplements [07-tax-compliance-india.md](./07-tax-compliance-india.md).
+
+**Last Updated**: 2026-03-19
+
+---
+
+## The 3 Money Flows
+
+### Flow 1: Consultee → Platform (Checkout)
+
+| Question | Indian Buyer | International Buyer |
+|----------|-------------|-------------------|
+| What do we charge? | Plan price + 18% GST | Plan price only (0% tax) |
+| Which gateway? | Razorpay (domestic) | Razorpay IBT |
+| What currency? | INR | INR (Razorpay converts for us) |
+
+**Code's job**: Detect buyer country → apply correct tax → route to gateway. ✅ Built.
+
+### Flow 2: Platform → Consultant (Payout)
+
+| Question | Answer |
+|----------|--------|
+| How much do they get? | 80% of original price (before tax) |
+| Do we deduct anything? | Only if we've paid them > ₹50K total this financial year (Apr–Mar) |
+| How much to deduct? | 10% if they gave us their PAN, 20% if they didn't |
+| Where does the deducted money go? | We deposit it to the government (not our money, not theirs — it's prepaid tax) |
+
+**Code's job**: Track cumulative FY payments → deduct TDS if over ₹50K → send net amount to Razorpay. ✅ Built.
+
+### Flow 3: Platform → Government (Filing)
+
+This is NOT code — it's CA/accountant work. Our code provides the data.
+
+---
+
+## GST for E-Commerce Operators
+
+### Is GST Registration Mandatory?
+
+**YES.** Under **Section 24(ix) of the CGST Act**, every e-commerce operator (ECO) must register under GST irrespective of turnover. The normal Rs 20 lakh threshold does NOT apply.
+
+The definition in **Section 2(45)** is broad: "any person who owns, operates or manages digital or electronic facility or platform for electronic commerce." Familiarise qualifies.
+
+### Consultants on the Platform
+
+Under **Notification 65/2017-C.T.**, service providers (consultants) with turnover below Rs 20 lakh are exempt from mandatory GST registration, **unless** their services fall under **Section 9(5)**.
+
+Consulting/professional services are **NOT** in the Section 9(5) notified list (which covers only: passenger transport, accommodation, restaurant services, housekeeping). So consultants with turnover under Rs 20L don't need GST registration.
+
+### TCS (Tax Collected at Source) — GST
+
+| Parameter | Value |
+|-----------|-------|
+| TCS Rate | **0.5%** (reduced from 1% effective July 10, 2024) |
+| Intra-state split | 0.25% CGST + 0.25% SGST |
+| Inter-state | 0.5% IGST |
+| Calculated on | Net value of taxable supplies (minus returns/cancellations) |
+| Filing | **GSTR-8** by 10th of following month |
+| Annual statement | By December 31 following the FY |
+| Legal basis | **Section 52 of CGST Act** |
+
+The consultant gets credit in their electronic cash ledger.
+
+### GST on Platform Commission
+
+| Item | Rate | SAC Code |
+|------|------|----------|
+| Platform commission/fees | **18%** | 9962 (retail trade services) |
+| Educational services | **18%** | 999293 |
+
+Commission invoices to consultants should use SAC 9962 for marketplace commission.
+
+---
+
+## TDS Obligations
+
+### Section 194-O (TDS by E-Commerce Operator)
+
+| Parameter | Value |
+|-----------|-------|
+| TDS Rate (from Oct 1, 2024) | **0.1%** (reduced from 1%) |
+| Threshold (Individual/HUF) | Rs 5 lakh gross sales/year (if PAN/Aadhaar furnished) |
+| Threshold (Companies/Firms/LLP) | **No threshold** — TDS from first rupee |
+| No PAN/Aadhaar rate | **5%** (per Section 206AA) |
+| Calculated on | Gross amount (including GST, shipping charges) |
+| Filing | Quarterly in **Form 26Q** (residents) or **27Q** (non-residents) |
+
+### Section 194J (Professional Services TDS)
+
+| Parameter | FY 2025-26 |
+|-----------|-----------|
+| Threshold | Rs 50,000/year per consultant |
+| Rate (Professional services) | **10%** |
+| Rate (Technical services) | **2%** |
+| No PAN rate | **20%** |
+
+### TDS Filing Calendar
+
+| Due Date | Action | Form |
+|----------|--------|------|
+| 7th of each month | TDS deposit | Challan 281 |
+| July 31 | Q1 return (Apr–Jun) | 26Q |
+| October 31 | Q2 return (Jul–Sep) | 26Q |
+| January 31 | Q3 return (Oct–Dec) | 26Q |
+| May 31 | Q4 return (Jan–Mar) | 26Q |
+| Within 15 days of quarterly filing due date | Issue TDS certificate | Form 16A |
+
+Late filing penalty: Rs 200/day (capped at total TDS amount).
+
+### Critical CA Question
+
+**Do both 194-O (0.1% on gross e-commerce sales) AND 194J (10% on professional services above Rs 50K) apply simultaneously?** They are separate tax provisions (income tax vs e-commerce). Whether one supersedes the other for our specific marketplace model needs professional opinion.
+
+---
+
+## Section 44AD Risk
+
+> **WARNING**: Commission/brokerage income may be excluded from Section 44AD presumptive taxation. Persons earning commission or brokerage income, or carrying on agency businesses, are specifically excluded from 44AD in some interpretations.
+
+| Parameter | Detail |
+|-----------|--------|
+| Turnover limit | Rs 3 crore (if 95%+ digital receipts) or Rs 2 crore |
+| Deemed profit | 6% (digital) or 8% (cash) of turnover |
+| Lock-in | 5 consecutive years once opted |
+| NOT available for | Companies, LLPs, persons earning commission/brokerage (debated) |
+
+**Impact**: If a CA rules that marketplace commission income disqualifies us from 44AD, the "0% tax up to Rs 50L" advantage of Sole Proprietorship in the CFO Master Plan shrinks significantly. **This needs urgent CA verification before finalizing entity structure.**
+
+---
+
+## Cross-Border Payment Compliance
+
+### FEMA Regulations
+
+- All cross-border transactions must comply with **FEMA (Foreign Exchange Management Act), 1999**
+- Must use RBI-authorized banks or payment aggregators (Razorpay qualifies)
+- Export proceeds must be realized and repatriated within **9 months** from date of invoice
+- Records must be kept for **5 years** (invoices, FIRA, contracts, bank advices)
+
+### Export of Services — GST
+
+- Export of services is **zero-rated** under IGST Act **Section 16**
+- Conditions: supplier in India, recipient outside India, payment in convertible foreign exchange
+- No GST charged on export value
+- Exporter eligible to claim ITC refunds on inputs
+- Current implementation (`currency !== "INR"` = zero-rated) is directionally correct but should add buyer location verification via billing address
+
+### LRS (Liberalised Remittance Scheme) — For International Consultant Payouts
+
+- Annual limit: **USD 250,000** per resident individual
+- TCS threshold (from Budget 2025): **Rs 10 lakh** per FY (increased from Rs 7 lakh)
+- LRS is for resident individuals, NOT for companies/partnerships/HUFs
+- For a marketplace paying international consultants, use **business outward remittance through an AD bank** under normal FEMA guidelines, not LRS
+
+### International Consultant Payouts
+
+| Method | Speed | Cost | Notes |
+|--------|-------|------|-------|
+| Xflow | 1–2 days | ~1% flat, 0% FX markup | RBI PA-CB licensed, JP Morgan rails, auto eFIRA |
+| Wise | 1–3 days | ~1.6–1.7% + $2 | Good UI, mid-market FX rate |
+| PayPal | 1–3 days | Up to 4.4% + FX markup | Widest reach, highest cost |
+| Payoneer | 2–5 days | 2% FX markup | Popular for freelancer payouts |
+| SWIFT/Wire | 3–7 days | Rs 1,000+ per transfer | Costliest, most traditional |
+
+For Section 195 TDS on payments to non-resident consultants, rates vary by DTAA (Double Taxation Avoidance Agreement). Requires 15CA/15CB certificates for outward remittances.
+
+---
+
+## Payment Aggregator License
+
+### Does Familiarise Need One?
+
+**Almost certainly NO**, as long as we use a licensed PA (Razorpay) rather than directly handling payment flows.
+
+| Scenario | PA License Needed? |
+|----------|-------------------|
+| Use Razorpay to collect payments, they settle to our account | **No** — we are a merchant |
+| Use Razorpay Route to split payments to sellers | **No** — Razorpay is the PA |
+| Collect payments into our own pool/escrow and distribute | **Possibly YES** |
+| Directly handle card data or bank details | **YES** |
+
+PA license requirements (for reference): Rs 15 crore net worth at application, Rs 25 crore within 3 years, escrow account with Scheduled Commercial Bank.
+
+---
+
+## Mandatory Compliance Summary
+
+### From Day 1
+
+| Obligation | Rate | Filing |
+|------------|------|--------|
+| GST Registration (as ECO, no turnover threshold) | N/A | Must register before launch |
+| TCS collection on net taxable supplies | 0.5% | GSTR-8 by 10th monthly |
+| TDS u/s 194-O on gross e-commerce payments | 0.1% | Form 26Q quarterly |
+| TDS u/s 194J on consultant payouts > Rs 50K/yr | 10% | Form 26Q quarterly |
+| GST on platform commission | 18% | GSTR-1/GSTR-3B monthly |
+| Export zero-rating (international buyers) | 0% | Verify buyer location |
+
+### For International Transactions
+
+- FEMA compliance for all cross-border payments
+- Export of services = zero-rated GST (with billing address verification)
+- Section 195 TDS on payments to non-resident consultants (rate per DTAA)
+- 15CA/15CB certificates for outward remittances
+
+### Annual
+
+- GSTR-9 annual return
+- Income tax return (ITR-4 if 44AD, ITR-3 otherwise)
+- TDS annual statement by December 31
+
+---
+
+## The Jargon Decoder
+
+| Scary Term | What It Actually Means |
+|------------|----------------------|
+| GST (18%) | Sales tax. We add it on top of the price for Indian buyers. |
+| Zero-rated export | Fancy way of saying "no tax for international buyers" |
+| TDS (Section 194J) | When we pay consultants, we hold back 10% as their prepaid income tax and send it to the government. Only kicks in after ₹50K/year. |
+| PAN | Like a tax SSN. If consultant doesn't give us one, we deduct 20% instead of 10% (penalty rate). |
+| eFIRC | A receipt proving we received foreign money legally. Razorpay generates this automatically. We don't write code for it. |
+| LUT (Letter of Undertaking) | A form filed with GST authorities saying "we export services, don't charge us GST on those." One-time filing, not code. |
+| SAC Code (999293) | Category code for "consulting services" — goes on invoices. Already hardcoded. |
+| Form 26Q | Quarterly report to government: "here's all the TDS we deducted." Our admin API provides the data, CA files the form. |
+| FEMA | Foreign exchange law. As long as we use Razorpay (RBI-licensed), we're compliant. Not our problem in code. |
+| TCS | Tax Collected at Source — 0.5% the platform collects from supplier on behalf of government. Different from TDS. |
+| Section 194-O | E-commerce specific TDS — 0.1% on gross sales. Separate from 194J. |
+| PA-CB | Payment Aggregator — Cross Border license from RBI. Needed to process international payments. Razorpay has one. |
+
+---
+
+## Recommended Financial SaaS Stack
+
+| Need | Recommendation | Cost | Why |
+|------|---------------|------|-----|
+| Accounting | Zoho Books | Rs 1,249/mo | GST-compliant, auto-reconciliation with Razorpay, TDS management, multi-currency |
+| GST Filing | ClearTax or Zoho Books built-in | Varies | Auto GSTR-1/3B/8 filing, e-invoicing |
+| TDS Filing | RazorpayX (auto-TDS) + ClearTax | Included/varies | RazorpayX auto-deducts/deposits TDS, generates Form 16A |
+| Invoicing | Zoho Invoice (free up to 1,000/yr) or built-in | Free–low | GST-compliant invoices with SAC codes |
+| Reconciliation | Razorpay Dashboard + Zoho Books sync | Included | Auto-match payments to invoices |
+| International payouts | Wise Business (later) | ~1.6% per transfer | Best FX rates, API available, for paying international consultants |
+
+### Phased Approach
+
+1. **Pre-launch to Rs 50L revenue**: Zoho Books + RazorpayX auto-TDS + hire CA for quarterly returns
+2. **Growing**: Add ClearTax for GST/TDS filing automation
+3. **50+ consultants**: Consider Firmway for 26AS reconciliation
+
+---
+
+## Before-Launch Checklist
+
+### ✅ Already Done
+
+- Detect buyer country at checkout
+- Charge 18% GST for India, 0% for international
+- Auto-route to Razorpay for all payments
+- Track buyerCountry and isInternational on Payment record
+- TDS calculation (₹50K threshold, 10%/20% rates)
+- TDS auto-deduction at payout time
+- Consultant PAN/GSTIN collection API
+- Admin TDS dashboard API
+- Currency validation on discounts and referral credits
+- Invoice zero-rating for international
+
+### ⬜ Before Launch (Non-Code — You + CA)
+
+- [ ] Get CA opinion: are we an "e-commerce operator"? (affects GST registration)
+- [ ] Get CA opinion: does 44AD apply to marketplace commission income?
+- [ ] Get CA opinion: do 194-O and 194J both apply simultaneously?
+- [ ] File LUT with GST authorities (one-time, enables zero-rating legally)
+- [ ] Activate Razorpay IBT on dashboard (KYC process with Razorpay)
+- [ ] Register for GST (likely mandatory from day 1)
+
+### ⬜ After Launch (When Volume Grows)
+
+- [ ] EU VAT registration (only if EU sales exceed thresholds)
+- [ ] Australian GST (only if AU sales > AUD 75K/year)
+- [ ] International consultant payouts via Wise/Xflow
+- [ ] Form 16A auto-generation for consultants (annual TDS certificate)
+
+### 🚫 NOT Our Problem
+
+- 1099-NEC for US consultants — we're not a US company, doesn't apply
+- Withholding tax on international consultants — not required from India
+- Currency conversion — Razorpay handles forex, we always deal in INR
+- FEMA compliance — handled by using an RBI-licensed gateway (Razorpay)
+- PA license — not needed since we use Razorpay as PA
+
+---
+
+## Related Documentation
+
+- [07-tax-compliance-india.md](./07-tax-compliance-india.md) — Original tax compliance doc
+- [Gateway Evaluation](../payments/gateways/gateway-evaluation-mar-2026.md) — Full gateway comparison
+- [Multi-Currency Architecture](../payments/multi-currency/) — IBT, gateway auto-routing
+- [11-cfo-master-plan.md](./11-cfo-master-plan.md) — Financial strategy and entity structure

--- a/docs/payments/gateways/README.md
+++ b/docs/payments/gateways/README.md
@@ -2,41 +2,51 @@
 
 > Overview of Familiarise's payment gateway integrations, selection logic, and configuration.
 
-**Last Updated**: 2026-02-14
+**Last Updated**: 2026-03-19
 
 ---
 
 ## Overview
 
-Familiarise uses two payment gateways to serve customers globally:
+Familiarise uses **Razorpay as the sole payment gateway** for both domestic and international payments:
 
-| Gateway      | Region        | Currency | Payouts Product          |
-| ------------ | ------------- | -------- | ------------------------ |
-| **Razorpay** | India         | INR      | RazorpayX Payouts        |
-| **Stripe**   | International | USD      | Stripe Connect (Express) |
+| Gateway      | Region                    | Currency | Payouts Product   |
+| ------------ | ------------------------- | -------- | ----------------- |
+| **Razorpay** | India + International     | INR      | RazorpayX Payouts |
 
-Two additional gateways are registered in the codebase but **not yet production-ready**:
+### Previously Evaluated & Removed
 
-- **Lemon Squeezy** — awaiting KYC completion
-- **XFlow** — awaiting production readiness
+| Gateway | Status | Reason |
+|---------|--------|--------|
+| Stripe | **Removed** | Invite-only in India since May 2024, no UPI, 5–6% international fees |
+| Lemon Squeezy | **Removed** | Services explicitly prohibited in ToS, no UPI, 6.5%+ fees |
+| Xflow | **Removed (for now)** | Not a gateway — cross-border B2B settlement. Revisit when international > Rs 5L/month |
+
+### Future Consideration
+
+| Gateway | When | Why |
+|---------|------|-----|
+| Cashfree | Month 3-6 | Cheaper fees (1.6–1.95% vs 2%), better split fees (0.1% vs 0.25%) |
+| Xflow | International > Rs 5L/mo | 0% FX markup, auto eFIRA, JP Morgan rails |
+| Wise Business | International payouts | Best FX rates for paying international consultants |
+
+> See [gateway-evaluation-mar-2026.md](./gateway-evaluation-mar-2026.md) for the full analysis.
 
 ---
 
 ## Gateway Selection
 
-Gateway selection is **user-driven** via the checkout UI. The customer explicitly picks which gateway to use during checkout.
-
-**Currency is forced by gateway**:
-
-- Razorpay selected → currency locked to **INR**
-- Stripe selected → currency locked to **USD**
+All payments route through **Razorpay**. Currency is always **INR** — Razorpay handles FX conversion for international payments via IBT (International Bank Transfer at 1% + GST).
 
 **Gateway detection from payment IDs**:
 
 | ID Prefix          | Gateway  |
 | ------------------ | -------- |
-| `cs_` or `pi_`     | Stripe   |
 | `order_` or `pay_` | Razorpay |
+
+**Buyer location detection** determines tax treatment:
+- Indian buyer → Plan price + 18% GST
+- International buyer → Plan price only (zero-rated export)
 
 **Source files**:
 
@@ -46,18 +56,22 @@ Gateway selection is **user-driven** via the checkout UI. The customer explicitl
 
 ---
 
-## Feature Comparison
+## Razorpay Features
 
-| Feature             | Razorpay                                          | Stripe                                          |
-| ------------------- | ------------------------------------------------- | ----------------------------------------------- |
-| **Checkout**        | Order → Modal (client-side SDK)                   | Checkout Session → Redirect (hosted page)       |
-| **Refunds**         | Full API (create, get, list)                      | Full API (create, get, list)                    |
-| **Disputes**        | Webhook-only (no API management)                  | Full API (get, submit evidence, list)           |
-| **Payouts**         | RazorpayX: Contacts + Fund Accounts + Payouts API | Stripe Connect: Express accounts + Transfers    |
-| **KYC**             | Platform collects data, creates accounts via API  | Stripe handles everything via hosted onboarding |
-| **Payment methods** | Cards, UPI, Net Banking, Wallets, EMI             | Cards, Apple Pay, Google Pay, ACH, SEPA         |
-| **Gateway fee**     | ~2% + 18% GST (~2.36%)                            | 2.9% + $0.30 (US), varies by region             |
-| **Settlement**      | T+2 business days                                 | 2-7 business days (varies by country)           |
+| Feature | Details |
+| ------- | ------- |
+| **Checkout** | Order → Modal (client-side SDK) |
+| **Refunds** | Full API (create, get, list). Original PG fee NOT reversed. |
+| **Disputes** | Webhook-only (no API management). ~Rs 500/chargeback. |
+| **Payouts** | RazorpayX: Contacts + Fund Accounts + Payouts API, auto-TDS |
+| **KYC** | Platform collects data, creates accounts via API |
+| **Payment methods** | Cards, UPI (0%), Net Banking, Wallets, EMI, BNPL, RuPay |
+| **Domestic fee** | UPI: 0% / Cards: 2% + 18% GST (~2.36%) |
+| **International fee** | Cards: 3% + GST / IBT: 1% + GST |
+| **Settlement** | T+2 business days (instant available for ~1% extra) |
+| **Marketplace** | Route: linked accounts, auto-splits, escrow-like hold/release |
+| **Subscriptions** | UPI Autopay, e-Mandate, card recurring (RBI-compliant) |
+| **RBI Licenses** | PA-O + PA-P + PA-CB (full house) |
 
 ---
 
@@ -69,14 +83,14 @@ A **flat 20% platform fee** applies to all consultants regardless of appointment
 Customer pays amount
     |
     v
-Gateway deducts fee (Razorpay ~2.36% / Stripe ~3.2%)
+Razorpay deducts PG fee (~2.36% domestic / ~3.54% intl cards / ~1.18% IBT)
     |
     v
 Net amount to platform
     |
     +---> Platform keeps 20% of net
     |
-    +---> Consultant receives 80% of net
+    +---> Consultant receives 80% of net (minus TDS if over ₹50K/yr)
 ```
 
 **Source**: `lib/payments/payouts/constants.ts` (`PLATFORM_FEE_PERCENTAGE: 20`)
@@ -102,21 +116,6 @@ Net amount to platform
 | `RAZORPAYX_ACCOUNT_NUMBER` | RazorpayX account number for payouts                   |
 | `RAZORPAYX_WEBHOOK_SECRET` | RazorpayX webhook signature verification               |
 
-### Stripe (Payments)
-
-| Variable                 | Purpose                        |
-| ------------------------ | ------------------------------ |
-| `STRIPE_SECRET_KEY`      | Server-side secret key         |
-| `STRIPE_WEBHOOK_SECRET`  | Webhook signature verification |
-| `NEXT_PUBLIC_STRIPE_KEY` | Client-side publishable key    |
-
-### Stripe Connect (Payouts)
-
-| Variable                        | Purpose                                |
-| ------------------------------- | -------------------------------------- |
-| `STRIPE_CONNECT_CLIENT_ID`      | OAuth client ID for Connect            |
-| `STRIPE_CONNECT_WEBHOOK_SECRET` | Connect webhook signature verification |
-
 ---
 
 ## Shared Infrastructure
@@ -135,6 +134,10 @@ Both gateways share a common abstraction layer:
 
 ## Documentation
 
+### Gateway Evaluation
+
+- [gateway-evaluation-mar-2026.md](./gateway-evaluation-mar-2026.md) — Full gateway comparison: Razorpay, Cashfree, Stripe, Lemon Squeezy, Xflow, Dodo, Polar
+
 ### Razorpay
 
 - [01-setup.md](./razorpay/01-setup.md) — Account setup, env vars, dashboard config, testing
@@ -142,7 +145,7 @@ Both gateways share a common abstraction layer:
 - [03-payout-flow.md](./razorpay/03-payout-flow.md) — RazorpayX Payouts: Contacts, Fund Accounts, payout lifecycle
 - [04-kyc-and-onboarding.md](./razorpay/04-kyc-and-onboarding.md) — KYC requirements and onboarding checklist
 
-### Stripe
+### Stripe (Historical — Removed)
 
 - [01-setup.md](./stripe/01-setup.md) — Account setup, env vars, dashboard config, testing
 - [02-architecture-and-flow.md](./stripe/02-architecture-and-flow.md) — Checkout Sessions flow, revenue split, webhook events
@@ -156,3 +159,4 @@ Both gateways share a common abstraction layer:
 - [Status Enums Reference](../03-status-enums-reference.md) — PaymentStatus, RefundStatus, DisputeStatus
 - [Payouts](../payouts/README.md) — Payout algorithm, earnings lifecycle, batch processing
 - [Webhooks](../webhooks/README.md) — Webhook monitoring and schemas
+- [Tax Compliance — Marketplace Obligations](../../finances/08-tax-compliance-marketplace-obligations.md) — GST, TCS, TDS, Section 44AD, cross-border compliance

--- a/docs/payments/gateways/gateway-evaluation-mar-2026.md
+++ b/docs/payments/gateways/gateway-evaluation-mar-2026.md
@@ -1,0 +1,317 @@
+# Payment Gateway Evaluation — March 2026
+
+> Comprehensive analysis of payment gateways for Familiarise's services marketplace. 90% Indian users, 10% international.
+
+**Last Updated**: 2026-03-19
+
+---
+
+## The Verdict
+
+| Gateway | Decision | Reason |
+|---------|----------|--------|
+| **Razorpay** | **KEEP (Primary)** | Best Indian marketplace infra — Route, RazorpayX payouts, subscriptions, UPI, all methods |
+| **Cashfree** | **ADD (Consider at Month 3-6)** | Cheaper than Razorpay (1.6–1.95% vs 2%), better split fees (0.1% vs 0.25%), PA-CB licensed |
+| **Stripe** | **REMOVE** | Invite-only in India since May 2024, no UPI, no Connect for Indian marketplaces, 5–6% effective on international |
+| **Lemon Squeezy** | **REMOVE** | Services explicitly prohibited in ToS. No UPI. Being absorbed into Stripe. 6.5%+ fees |
+| **Xflow** | **REMOVE (for now)** | Not a payment gateway — cross-border B2B settlement. Useful later at scale, not at launch |
+| **Dodo Payments** | **DO NOT ADD** | Pre-seed startup ($1.1M funding), fund-hold reports, services may not be supported, no marketplace splits |
+| **Polar** | **DO NOT ADD** | Explicitly prohibits marketplaces AND human services in ToS |
+
+---
+
+## 1. Razorpay — KEEP (Primary)
+
+### Why It Wins for 90% Indian Market
+
+- **UPI at 0% MDR** — RBI mandate, zero charges on UPI P2M. Huge for Indian consultees
+- **Route** for marketplace splits — linked accounts per consultant, settlement hold/release (escrow-like), automatic commission deduction
+- **RazorpayX Payouts** — IMPS/NEFT/RTGS/UPI 24x7, bulk payouts (30K/day), auto-TDS calculation & filing
+- **Subscriptions** with UPI Autopay + card mandates (RBI-compliant)
+- **International Bank Transfer** at 1% + GST (cheapest cross-border option)
+- **All Indian payment methods**: cards, net banking, wallets, EMI, BNPL
+- **PA + PA-CB licensed** by RBI
+- **55% market share** in India's online payment gateway market
+- Preparing for **late 2026 IPO** — strong signal of stability
+
+### Fees
+
+| Method | Fee |
+|--------|-----|
+| UPI | 0% (RBI mandate) |
+| RuPay Debit | 0% (RBI mandate) |
+| Domestic cards (Visa/MC) | 2% + 18% GST |
+| Net Banking | 2% + 18% GST |
+| Wallets | ~2% + 18% GST |
+| EMI (Credit Card) | 3% + 18% GST |
+| International Cards | 3% + 18% GST |
+| International Bank Transfer (IBT) | 1% + 18% GST |
+| Route transfer fee | ~0.25% per linked account transfer |
+
+### Settlement
+
+- **Domestic**: T+2 business days
+- **International**: T+7 business days
+- **On-demand settlement**: ~1% extra fee, settles in 10 seconds
+- At **50L+ monthly volume**, Razorpay negotiates custom rates (typically 1.5–1.75%)
+
+### Refunds
+
+- **Normal refund fee**: Zero (but original PG fee is NOT reversed — you eat the 2% + GST)
+- **Normal refund timeline**: 5–7 working days
+- **Instant refund**: Small per-transaction fee, within 2 minutes
+- If instant refund fails, falls back to normal and fee is credited back
+
+### Disputes/Chargebacks
+
+- **Chargeback handling fee**: ~Rs 500 per chargeback
+- Disputed amount debited from settlement balance during dispute period
+- **Razorpay Shield** (fraud protection): extra ~1% fee, covers international chargebacks only
+- Domestic chargebacks are unprotected by Shield
+
+### Route (Marketplace Splits)
+
+How it works for Familiarise's 80/20 model:
+
+1. Customer pays Rs 1,000 to platform via Razorpay
+2. Razorpay deducts PG fee (2% = Rs 20 + GST)
+3. Split configured: 80% to consultant's Linked Account, 20% to platform
+4. Razorpay deducts transfer fee (~0.25%) on amount transferred to linked account
+5. Platform commission = Payment − PG Fee − Transfer Fees − Linked Account amount
+
+**Linked Account features**:
+- Each consultant gets a Linked Account under the main Razorpay account
+- Sub-merchant onboarding API — consultants KYC on your platform, no Razorpay login needed
+- Settlement can be deferred indefinitely (escrow-like) and released on-demand
+- Per-linked-account settlement schedules (must be ≥ T+2)
+
+### RazorpayX (Payouts & TDS)
+
+- Auto-calculates TDS based on vendor category and invoice
+- Auto-deducts and deposits TDS with government by 4th of every month
+- Auto-generates challans, files returns, provides Form 16A on dashboard
+- Configurable TDS categories at vendor level or invoice level
+- Bulk payouts: up to 30,000/day via CSV or API
+- Payout modes: IMPS, NEFT, RTGS, UPI (24x7 for IMPS/UPI)
+
+### Subscriptions
+
+- Plans, trials, add-ons, proration, smart retry (recovers up to 30% of failed payments)
+- UPI Autopay: 60+ UPI apps
+- e-Mandate: via Netbanking or Debit Card
+- Card recurring: credit/debit including international
+- RBI-compliant: AFA for mandates, pre-debit notifications, Rs 15K limit handling
+
+### KYC for Sole Proprietorship
+
+- PAN Card (personal), Aadhaar, bank account proof
+- Business existence proof: Shop & Establishment certificate, GST certificate, or professional body registration
+- Timeline: 1–3 business days, 100% online
+- Known issue: new accounts may face 7–14 day fund holds during initial risk assessment
+
+### RBI Compliance
+
+- Holds all three RBI payment licenses: PA-O (online), PA-P (physical), PA-CB (cross-border)
+- Compliant with 2025 Master Directions on Payment Aggregators
+- Supreme Court dismissed ED appeal — no regulatory overhang
+
+---
+
+## 2. Cashfree — Consider Adding (Month 3-6)
+
+### Why It Deserves Consideration
+
+- **Cheaper gateway fee**: 1.6% promo (until Mar 2026 signup, 12-month validity, capped at 1Cr/month GTV) / 1.95% standard vs Razorpay's 2%
+- **Cheaper splits**: Easy Split at 0.1% on order value vs Route at 0.25% on transfer amount
+- **First non-bank PA-CB license** (July 2024) — strongest cross-border credentials
+- **140+ currencies from 240 countries** — better international than Razorpay
+- **Global Collection Accounts** — virtual USD/EUR/GBP/CAD/AUD accounts for international clients
+- Same Indian methods: UPI (0%), cards, net banking, wallets, EMI
+
+### Cost Comparison (Rs 1,000 domestic card, 80/20 split)
+
+| | Razorpay | Cashfree |
+|---|---|---|
+| PG Fee | Rs 20 (2%) | Rs 16 (1.6%) |
+| Split Fee | Rs 2 (0.25% of Rs 800) | Rs 1 (0.1% of Rs 1,000) |
+| GST on fees | Rs 3.96 | Rs 3.06 |
+| **Total cost** | **Rs 25.96** | **Rs 20.06** |
+| **Your effective commission (20%)** | **Rs 174.04** | **Rs 179.94** |
+
+**At Rs 10L monthly GMV**: ~Rs 5,900/month savings with Cashfree.
+
+### Easy Split (Marketplace)
+
+- Accept payments, deduct commission, auto-settle to vendors
+- Unlimited vendor onboarding with integrated KYC
+- Custom settlement cycles per vendor (including instant)
+- Automated refund management with vendor settlement adjustments
+- Vendor ledger via API or dashboard
+
+### International
+
+- 140+ currencies from 240 countries
+- PayPal integration + international cards
+- Global Collection Accounts: virtual accounts in USD/EUR/GBP/CAD/AUD
+- Local methods: ACH (US), SEPA (EU), Faster Payments (UK)
+- Pay Native (DCC): customer pays in their currency, merchant receives INR
+
+### When to Add
+
+Add Cashfree when:
+- Volume exceeds Rs 10L/month (cost savings justify complexity)
+- OR Razorpay uptime/support becomes an issue
+- Consider Juspay/Hyperswitch for smart routing between both gateways
+
+---
+
+## 3. Stripe — REMOVE
+
+### Why Remove
+
+- **Invite-only in India since May 2024** — can't reliably sign up. Promised "second half of 2025" broader availability — has NOT materialized
+- **No UPI** (beta only, must contact Stripe) — kills 90% of user base
+- **No RuPay, no wallets, no net banking** — cards only (Visa, MC, Amex)
+- **Stripe Connect severely limited in India** — custom accounts can't be self-served, must go through sales team case-by-case
+- **5–6% effective cost on international** (3% base + 1.5% cross-border + 2% FX markup + GST)
+- **No FIRA/eFIRC generation** — must coordinate with bank separately for export compliance
+- **Razorpay IBT at 1% + GST** is far cheaper for international
+- **No PA-CB license** — operates cross-border through AD bank partnerships
+- **Sole proprietorship may face onboarding issues**
+- Settlement: 2–5 business days (7–10 for first payment), no instant option
+- Refund: processing fee NOT returned + additional ~$0.30 per refund
+- Chargeback: $15 per dispute
+
+### The Only Counter-Argument
+
+Brand recognition with international consultees. But Razorpay/Cashfree accept international Visa/MC/Amex too, at lower fees.
+
+### Stripe Atlas Note
+
+If Familiarise ever incorporates a US entity (via Atlas at $500), full Stripe access becomes available. But this adds significant compliance overhead (US tax filing, India-US dual compliance, FEMA/RBI reporting) and is not justified for the current 10% international mix.
+
+---
+
+## 4. Lemon Squeezy — REMOVE
+
+### Hard Blockers
+
+1. **Services explicitly prohibited** in acceptable use policy — "Services of any kind including marketing, design, web development, consulting or other related services" are not allowed. Consultations, webinars, and classes would violate ToS and risk account termination.
+2. **No UPI** — cards and PayPal only
+3. **6.5% + $0.50 per transaction** for non-US (all Familiarise transactions are "international" from Lemon Squeezy's US perspective). On a Rs 500 (~$5.50) consultation, effective take rate is ~15.5%.
+4. **Being absorbed into Stripe Managed Payments** — acquired by Stripe July 2024, uncertain future
+5. **Sole proprietorship may not be accepted** — prefers Pvt Ltd
+6. **Twice-monthly payouts with 13-day hold** — cash flow drag
+7. **Stripe invite-only in India affects payouts** — may require PayPal as fallback
+
+---
+
+## 5. Xflow — REMOVE (for now)
+
+### Critical Correction
+
+**Xflow (xflowpay.com) is NOT a Razorpay product.** It is an independent company founded 2021 in Bengaluru. Investors include General Catalyst, Square Peg, Stripe, Lightspeed, PayPal Ventures — but NOT Razorpay.
+
+### What It Actually Is
+
+Xflow is **cross-border B2B payment infrastructure** — not a payment gateway. It helps Indian businesses receive international payments via:
+- Virtual Receiving Accounts (clients abroad pay to local-looking accounts)
+- Currency conversion at live mid-market FX rates with 0% markup
+- Settlement to Indian bank accounts in 1 business day
+- Automatic eFIRA within 24 hours
+- RBI PA-CB licensed, transactions via JP Morgan Chase rails
+
+### Pricing
+
+| Plan | Fee |
+|------|-----|
+| Starter (invoices < $3,500) | $12 flat for invoices ≤ $2,000; 0.6% for > $2,000 |
+| Standard | ~1% flat per transaction |
+| Minimum fee | $8 per transaction |
+| FX markup | 0% (mid-market rate) |
+
+### When It Becomes Relevant
+
+When international volume exceeds Rs 5L+/month and Xflow's 0% FX markup + 24hr eFIRA generation saves money vs Razorpay's FX spread. Not at launch with 10% international.
+
+---
+
+## 6. Dodo Payments — DO NOT ADD
+
+- **Only $1.1M pre-seed funding** (Feb 2025, Antler + 9Unicorns) — extreme counterparty risk as MoR (they hold your money)
+- **Multiple reports of accounts frozen** and funds held at payout thresholds (~$1,000)
+- **Service-based businesses may not be supported** — users discovered this after signing up
+- **Not built for 2-sided marketplace splits** — no Razorpay Route equivalent
+- **4% + Rs 4** is more expensive than Razorpay's 2% for domestic
+- **Fake review allegations** on Trustpilot/AppSumo
+- The MoR model is fundamentally designed for single-seller digital products/SaaS, not for two-sided service marketplaces
+
+---
+
+## 7. Polar — DO NOT ADD
+
+- **Explicitly prohibits marketplaces** in acceptable use policy: "Marketplaces — selling others' products or services using Polar against an upfront payment or with an agreed upon revenue share — are explicitly not allowed."
+- **Explicitly prohibits human services** — consultations would not be allowed
+- **No UPI/INR payment collection** — card-only via Stripe
+- Non-starter for Familiarise in any form
+
+---
+
+## Architecture Roadmap
+
+### LAUNCH (Day 1)
+
+```
+Primary Gateway: Razorpay
+├── Domestic: UPI (0%), Cards (2%), Net Banking, Wallets
+├── International: Razorpay IBT (1%) + International Cards (3%)
+├── Marketplace: Route (linked accounts, auto-splits)
+├── Payouts: RazorpayX (auto-TDS, bulk payouts)
+└── Subscriptions: Razorpay Subscriptions (UPI Autopay)
+```
+
+### MONTH 3-6 (Evaluate)
+
+```
+Add Cashfree as second gateway IF:
+├── Volume exceeds Rs 10L/month (cost savings justify complexity)
+├── OR Razorpay uptime/support becomes an issue
+└── Consider Juspay/Hyperswitch for smart routing between the two
+```
+
+### LATER (International > Rs 5L/month)
+
+```
+├── Add Xflow for cross-border settlement optimization
+└── Add Wise Business API for international consultant payouts
+```
+
+---
+
+## Other Gateways Evaluated But Not Recommended
+
+### PayU India
+
+- 2% domestic, 3% international, has split settlements
+- Prosus (Naspers) subsidiary, 500K+ businesses
+- Has PA + PA-P + PA-CB licenses (Nov 2025)
+- **Not recommended because**: No clear advantage over Razorpay/Cashfree for marketplace model, less developer-friendly
+
+### PhonePe Payment Gateway
+
+- 1.95% standard (currently FREE promo)
+- Has UPI, cards, net banking
+- **Not recommended because**: Marketplace/split infrastructure is immature, thin documentation, dropped third-party partnerships (Juspay)
+
+### Juspay/Hyperswitch
+
+- Payment orchestration layer (not a gateway itself)
+- Routes between multiple gateways based on success rates, cost, latency
+- Open-source (Apache 2.0, Rust, 14K+ GitHub stars)
+- **Not needed now**: Premature optimization at pre-launch scale. Revisit when running multiple gateways
+
+---
+
+## Bottom Line
+
+**Go Razorpay-only at launch. Remove Stripe, Lemon Squeezy, and Xflow from the codebase. Don't add Dodo or Polar. Evaluate Cashfree at Month 3. Get GST registered and set up TCS/TDS before going live.**

--- a/docs/payments/multi-currency/01-architecture.md
+++ b/docs/payments/multi-currency/01-architecture.md
@@ -1,0 +1,76 @@
+# Multi-Currency Architecture
+
+## Strategy: India-First + Accept International
+
+All prices are stored in **INR paise**. International buyers see approximate prices in their local currency (client-side conversion), but all charges are processed in INR via Razorpay.
+
+### Gateway Selection
+
+| Buyer Country | Gateway | Method | Fee | Settlement |
+|--------------|---------|--------|-----|-----------|
+| India | Razorpay | Domestic (UPI, cards, netbanking) | 2% + GST (~2.36%) | INR, T+2 |
+| International | Razorpay | IBT (International Bank Transfer) | 1% + GST, zero forex | INR, T+1 |
+| Fallback | Stripe | Checkout Sessions | ~6.3% (4.3% + 2% forex) | INR, T+5-7 |
+
+### Why Razorpay for Everything
+
+1. **Cost**: Razorpay IBT is 1% vs Stripe's 6.3% for international — **5x cheaper**
+2. **eFIRC**: Razorpay auto-generates eFIRC (Foreign Inward Remittance Certificate) monthly — Stripe requires manual coordination with bank
+3. **PA-CB License**: Razorpay received RBI PA-CB license (Dec 2025) — authorized for cross-border
+4. **UPI**: Zero-fee domestic payments (unique advantage over TopMate which uses Stripe)
+
+### Competitive Advantage vs TopMate
+
+TopMate's effective international cost: **15-18%** (10% commission + 3% Stripe + 2-3% forex)
+Familiarise's effective international cost: **~11%** (10% commission + 1% Razorpay IBT)
+
+**Structural moat**: 4-7% cost advantage per international transaction.
+
+## Currency Flow
+
+```
+[Consultant sets price in INR paise]
+    ↓
+[Consultee sees price in local currency (client-side conversion)]
+    ↓
+[Checkout: buyer country detected → tax determined → gateway auto-routed]
+    ↓
+[Razorpay charges in INR (or auto-converts for IBT)]
+    ↓
+[Payment recorded with buyerCountry + isInternational flags]
+    ↓
+[Earnings created in INR → hold period → TDS calculated → payout in INR]
+```
+
+## Buyer Country Detection
+
+Server-side cascade at checkout:
+1. `User.country` (profile field — highest confidence)
+2. `cf-ipcountry` header (Cloudflare geo-IP)
+3. `Accept-Language` → country mapping
+4. Fallback: `"IN"` (conservative — charges GST rather than missing it)
+
+## Exchange Rate Handling
+
+- Rates from `open.er-api.com` (free, daily updates, INR base)
+- Cached for 24 hours server-side
+- Client-side: React Query with 1-hour stale time
+- Disclaimer shown: "Final amount may vary based on current exchange rate"
+- `exchangeRateAtCheckout` stored on Payment record for audit
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/payments/tax/buyer-country.ts` | Buyer country detection cascade |
+| `lib/payments/tax/tax-engine.ts` | Tax determination (GST vs zero-rated) |
+| `lib/payments/gateway-router.ts` | Auto-routing to Razorpay/Stripe |
+| `lib/payments/validation/currency-guards.ts` | Currency consistency validation |
+| `lib/currency.ts` | Exchange rates + locale→currency mapping |
+| `hooks/useCurrency.ts` | Client-side currency display hook |
+
+## Future Phases
+
+- **Phase 2**: Multi-currency pricing (consultants set prices in their currency)
+- **Phase 3**: International consultant payouts via Wise
+- **Phase 4**: EU VAT OSS + AU GST collection

--- a/docs/payments/multi-currency/01-architecture.md
+++ b/docs/payments/multi-currency/01-architecture.md
@@ -6,11 +6,11 @@ All prices are stored in **INR paise**. International buyers see approximate pri
 
 ### Gateway Selection
 
-| Buyer Country | Gateway | Method | Fee | Settlement |
-|--------------|---------|--------|-----|-----------|
-| India | Razorpay | Domestic (UPI, cards, netbanking) | 2% + GST (~2.36%) | INR, T+2 |
-| International | Razorpay | IBT (International Bank Transfer) | 1% + GST, zero forex | INR, T+1 |
-| Fallback | Stripe | Checkout Sessions | ~6.3% (4.3% + 2% forex) | INR, T+5-7 |
+| Buyer Country | Gateway  | Method                            | Fee                     | Settlement |
+| ------------- | -------- | --------------------------------- | ----------------------- | ---------- |
+| India         | Razorpay | Domestic (UPI, cards, netbanking) | 2% + GST (~2.36%)       | INR, T+2   |
+| International | Razorpay | IBT (International Bank Transfer) | 1% + GST, zero forex    | INR, T+1   |
+| Fallback      | Stripe   | Checkout Sessions                 | ~6.3% (4.3% + 2% forex) | INR, T+5-7 |
 
 ### Why Razorpay for Everything
 
@@ -45,6 +45,7 @@ Familiarise's effective international cost: **~11%** (10% commission + 1% Razorp
 ## Buyer Country Detection
 
 Server-side cascade at checkout:
+
 1. `User.country` (profile field — highest confidence)
 2. `cf-ipcountry` header (Cloudflare geo-IP)
 3. `Accept-Language` → country mapping
@@ -60,14 +61,14 @@ Server-side cascade at checkout:
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `lib/payments/tax/buyer-country.ts` | Buyer country detection cascade |
-| `lib/payments/tax/tax-engine.ts` | Tax determination (GST vs zero-rated) |
-| `lib/payments/gateway-router.ts` | Auto-routing to Razorpay/Stripe |
-| `lib/payments/validation/currency-guards.ts` | Currency consistency validation |
-| `lib/currency.ts` | Exchange rates + locale→currency mapping |
-| `hooks/useCurrency.ts` | Client-side currency display hook |
+| File                                         | Purpose                                  |
+| -------------------------------------------- | ---------------------------------------- |
+| `lib/payments/tax/buyer-country.ts`          | Buyer country detection cascade          |
+| `lib/payments/tax/tax-engine.ts`             | Tax determination (GST vs zero-rated)    |
+| `lib/payments/gateway-router.ts`             | Auto-routing to Razorpay/Stripe          |
+| `lib/payments/validation/currency-guards.ts` | Currency consistency validation          |
+| `lib/currency.ts`                            | Exchange rates + locale→currency mapping |
+| `hooks/useCurrency.ts`                       | Client-side currency display hook        |
 
 ## Future Phases
 

--- a/docs/payments/multi-currency/01-architecture.md
+++ b/docs/payments/multi-currency/01-architecture.md
@@ -57,7 +57,8 @@ Server-side cascade at checkout:
 - Cached for 24 hours server-side
 - Client-side: React Query with 1-hour stale time
 - Disclaimer shown: "Final amount may vary based on current exchange rate"
-- `exchangeRateAtCheckout` stored on Payment record for audit
+- `displayCurrencyAtCheckout` stored on Payment record (currency code shown to buyer, e.g., "USD")
+- `exchangeRateAtCheckout` stored on Payment record (INR→display rate snapshot for audit)
 
 ## Key Files
 

--- a/docs/payments/multi-currency/02-tax-engine.md
+++ b/docs/payments/multi-currency/02-tax-engine.md
@@ -1,0 +1,71 @@
+# Tax Engine
+
+## Overview
+
+Centralized tax determination for all checkout transactions. Handles domestic GST and zero-rating for export of services.
+
+## Rules
+
+### Domestic (India)
+
+- **Rate**: 18% GST
+- **SAC Codes**: 999293 (consulting), 999294 (education/webinars/classes), 999295 (training)
+- **Calculation**: Tax-exclusive (plan price + 18% GST)
+- **Invoice**: Standard GST invoice with tax breakdown
+
+### International (Export of Services)
+
+- **Rate**: 0% (zero-rated)
+- **Legal basis**: IGST Act Section 2(6) — Export of services
+- **Conditions** (all must be met):
+  1. Supplier is in India
+  2. Recipient is outside India
+  3. Payment received in convertible foreign exchange
+  4. Place of supply is outside India
+  5. Supplier and recipient are not establishments of the same person
+- **Invoice note**: "Export of services — Zero-rated under IGST Act Section 2(6)"
+- **LUT requirement**: Letter of Undertaking must be filed to supply without charging IGST
+
+### Key Change (Finance Bill 2026)
+
+The intermediary rule (Section 13(8)(b)) that could classify marketplace services as domestic is being **deleted**. This confirms marketplace/intermediary services to foreign clients qualify as exports.
+
+## Detection Logic
+
+Tax jurisdiction is determined by **buyer country**, not currency:
+
+```typescript
+determineTax({
+  baseAmountPaise: 50000,
+  buyerCountry: "US",        // → 0% (export)
+  serviceType: "CONSULTING",
+})
+
+determineTax({
+  baseAmountPaise: 50000,
+  buyerCountry: "IN",        // → 18% GST
+  serviceType: "CONSULTING",
+})
+```
+
+### Previous Bug (Fixed)
+
+The old code used `currency !== "INR"` to detect international transactions. Since ALL plans default to `priceCurrency: "INR"`, this condition **never triggered**, meaning every transaction was charged 18% GST — including exports. Now uses `buyerCountry !== "IN"`.
+
+## E-Commerce Operator Classification
+
+**Status**: UNRESOLVED — needs CA opinion before launch.
+
+If Familiarise is classified as an "e-commerce operator" under Section 24 CGST Act:
+- GST registration is **mandatory from Day 1** (no ₹20L threshold)
+- Must collect TCS (Tax Collected at Source) of 0.5% on supplies
+- Monthly GSTR-8 filing required
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/payments/tax/tax-engine.ts` | `determineTax()` — core tax logic |
+| `lib/payments/tax/buyer-country.ts` | `detectBuyerCountry()` — buyer location |
+| `lib/payments/payouts/constants.ts` | `TAX_CONSTANTS` — rates and SAC codes |
+| `lib/payments/payouts/invoice-service.ts` | Invoice generation with zero-rating |

--- a/docs/payments/multi-currency/02-tax-engine.md
+++ b/docs/payments/multi-currency/02-tax-engine.md
@@ -37,15 +37,15 @@ Tax jurisdiction is determined by **buyer country**, not currency:
 ```typescript
 determineTax({
   baseAmountPaise: 50000,
-  buyerCountry: "US",        // → 0% (export)
+  buyerCountry: "US", // → 0% (export)
   serviceType: "CONSULTING",
-})
+});
 
 determineTax({
   baseAmountPaise: 50000,
-  buyerCountry: "IN",        // → 18% GST
+  buyerCountry: "IN", // → 18% GST
   serviceType: "CONSULTING",
-})
+});
 ```
 
 ### Previous Bug (Fixed)
@@ -57,15 +57,16 @@ The old code used `currency !== "INR"` to detect international transactions. Sin
 **Status**: UNRESOLVED — needs CA opinion before launch.
 
 If Familiarise is classified as an "e-commerce operator" under Section 24 CGST Act:
+
 - GST registration is **mandatory from Day 1** (no ₹20L threshold)
 - Must collect TCS (Tax Collected at Source) of 0.5% on supplies
 - Monthly GSTR-8 filing required
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `lib/payments/tax/tax-engine.ts` | `determineTax()` — core tax logic |
-| `lib/payments/tax/buyer-country.ts` | `detectBuyerCountry()` — buyer location |
-| `lib/payments/payouts/constants.ts` | `TAX_CONSTANTS` — rates and SAC codes |
-| `lib/payments/payouts/invoice-service.ts` | Invoice generation with zero-rating |
+| File                                      | Purpose                                 |
+| ----------------------------------------- | --------------------------------------- |
+| `lib/payments/tax/tax-engine.ts`          | `determineTax()` — core tax logic       |
+| `lib/payments/tax/buyer-country.ts`       | `detectBuyerCountry()` — buyer location |
+| `lib/payments/payouts/constants.ts`       | `TAX_CONSTANTS` — rates and SAC codes   |
+| `lib/payments/payouts/invoice-service.ts` | Invoice generation with zero-rating     |

--- a/docs/payments/multi-currency/03-tds-compliance.md
+++ b/docs/payments/multi-currency/03-tds-compliance.md
@@ -1,0 +1,92 @@
+# TDS Compliance — Section 194J
+
+## Overview
+
+Tax Deducted at Source (TDS) under Section 194J applies to payments for professional/technical services to consultants. Familiarise must deduct TDS when cumulative payments to a consultant exceed ₹50,000 in a financial year.
+
+## Rules
+
+| Parameter | Value |
+|-----------|-------|
+| **Section** | 194J (Fees for professional/technical services) |
+| **Threshold** | ₹50,000 per financial year |
+| **Rate (with PAN)** | 10% |
+| **Rate (without PAN)** | 20% (Section 206AA) |
+| **Financial Year** | April 1 – March 31 |
+| **Deposit deadline** | 7th of the month following deduction |
+| **Filing** | Quarterly Form 26Q |
+| **Due dates** | Q1: Jul 31, Q2: Oct 31, Q3: Jan 31, Q4: May 31 |
+
+## How It Works
+
+### Threshold Tracking
+
+The system tracks cumulative `grossAmount` from `ConsultantEarnings` for each financial year. When cumulative payments cross ₹50,000:
+
+1. **First time crossing**: TDS calculated only on the excess amount
+2. **Already above threshold**: TDS on full payout amount
+
+### Deduction Flow
+
+```
+[Payout batch created]
+    ↓
+[For each payout: calculateTDS()]
+    ↓
+[If above threshold:]
+    ↓
+[netAmount = amount - tdsAmount]
+    ↓
+[Send netAmount to Razorpay/Stripe (not gross)]
+    ↓
+[Record TDSRecord for Form 26Q filing]
+```
+
+### PAN Verification
+
+- **10% rate**: Applied when `ConsultantTaxInfo.panVerified === true`
+- **20% rate**: Applied when PAN is not provided or not verified
+- PAN should be collected during consultant onboarding (not blocking, but encouraged)
+- PAN verification resets if PAN number is changed
+
+## Database Models
+
+### ConsultantTaxInfo
+Stores PAN, GSTIN, country, and LUT info per consultant.
+
+### TDSRecord
+One record per deduction event, linked to payout. Tracks:
+- Financial year + quarter
+- Cumulative gross payments at time of deduction
+- TDS amount and rate
+- Form 26Q filing status
+
+## Admin Dashboard
+
+### Endpoints
+
+- `GET /api/admin/tds?fy=2026-27` — FY summary (quarterly breakdown)
+- `GET /api/admin/tds?fy=2026-27&view=consultants` — Per-consultant breakdown
+- `POST /api/admin/tds` — Mark records as filed in Form 26Q
+
+### Filing Workflow
+
+1. At quarter end, admin views TDS summary
+2. Downloads per-consultant breakdown for CA
+3. CA files Form 26Q with IT department
+4. Admin marks records as filed via POST endpoint
+
+## Consultant API
+
+- `GET /api/consultant/tax-info` — View masked PAN, GSTIN, verification status
+- `PUT /api/consultant/tax-info` — Update PAN, GSTIN, country
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/payments/tax/tds-service.ts` | Core TDS calculation + record-keeping |
+| `lib/payments/payouts/payout-service.ts` | TDS integration in payout processing |
+| `app/api/admin/tds/route.ts` | Admin TDS dashboard API |
+| `app/api/consultant/tax-info/route.ts` | Consultant tax info CRUD |
+| `prisma/schema.prisma` | `ConsultantTaxInfo` + `TDSRecord` models |

--- a/docs/payments/multi-currency/03-tds-compliance.md
+++ b/docs/payments/multi-currency/03-tds-compliance.md
@@ -6,16 +6,16 @@ Tax Deducted at Source (TDS) under Section 194J applies to payments for professi
 
 ## Rules
 
-| Parameter | Value |
-|-----------|-------|
-| **Section** | 194J (Fees for professional/technical services) |
-| **Threshold** | ₹50,000 per financial year |
-| **Rate (with PAN)** | 10% |
-| **Rate (without PAN)** | 20% (Section 206AA) |
-| **Financial Year** | April 1 – March 31 |
-| **Deposit deadline** | 7th of the month following deduction |
-| **Filing** | Quarterly Form 26Q |
-| **Due dates** | Q1: Jul 31, Q2: Oct 31, Q3: Jan 31, Q4: May 31 |
+| Parameter              | Value                                           |
+| ---------------------- | ----------------------------------------------- |
+| **Section**            | 194J (Fees for professional/technical services) |
+| **Threshold**          | ₹50,000 per financial year                      |
+| **Rate (with PAN)**    | 10%                                             |
+| **Rate (without PAN)** | 20% (Section 206AA)                             |
+| **Financial Year**     | April 1 – March 31                              |
+| **Deposit deadline**   | 7th of the month following deduction            |
+| **Filing**             | Quarterly Form 26Q                              |
+| **Due dates**          | Q1: Jul 31, Q2: Oct 31, Q3: Jan 31, Q4: May 31  |
 
 ## How It Works
 
@@ -52,10 +52,13 @@ The system tracks cumulative `grossAmount` from `ConsultantEarnings` for each fi
 ## Database Models
 
 ### ConsultantTaxInfo
+
 Stores PAN, GSTIN, country, and LUT info per consultant.
 
 ### TDSRecord
+
 One record per deduction event, linked to payout. Tracks:
+
 - Financial year + quarter
 - Cumulative gross payments at time of deduction
 - TDS amount and rate
@@ -83,10 +86,10 @@ One record per deduction event, linked to payout. Tracks:
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `lib/payments/tax/tds-service.ts` | Core TDS calculation + record-keeping |
-| `lib/payments/payouts/payout-service.ts` | TDS integration in payout processing |
-| `app/api/admin/tds/route.ts` | Admin TDS dashboard API |
-| `app/api/consultant/tax-info/route.ts` | Consultant tax info CRUD |
-| `prisma/schema.prisma` | `ConsultantTaxInfo` + `TDSRecord` models |
+| File                                     | Purpose                                  |
+| ---------------------------------------- | ---------------------------------------- |
+| `lib/payments/tax/tds-service.ts`        | Core TDS calculation + record-keeping    |
+| `lib/payments/payouts/payout-service.ts` | TDS integration in payout processing     |
+| `app/api/admin/tds/route.ts`             | Admin TDS dashboard API                  |
+| `app/api/consultant/tax-info/route.ts`   | Consultant tax info CRUD                 |
+| `prisma/schema.prisma`                   | `ConsultantTaxInfo` + `TDSRecord` models |

--- a/docs/payments/multi-currency/03-tds-compliance.md
+++ b/docs/payments/multi-currency/03-tds-compliance.md
@@ -21,7 +21,7 @@ Tax Deducted at Source (TDS) under Section 194J applies to payments for professi
 
 ### Threshold Tracking
 
-The system tracks cumulative `consultantShare` from `ConsultantEarnings` for each financial year (per Section 194J — TDS applies to the amount credited/paid to the consultant, not the full sale amount). When cumulative payments cross ₹50,000:
+The system tracks cumulative completed payout amounts for each financial year (per Section 194J — TDS applies to the amount credited/paid to the consultant). When cumulative payments cross ₹50,000:
 
 1. **First time crossing**: TDS calculated only on the excess amount
 2. **Already above threshold**: TDS on full payout amount
@@ -31,16 +31,20 @@ The system tracks cumulative `consultantShare` from `ConsultantEarnings` for eac
 ```
 [Payout batch created]
     ↓
-[For each payout: calculateTDS()]
+[For each payout: calculateTDS() using completed payout history]
     ↓
-[If above threshold:]
+[If above threshold: compute tdsAmount, store tdsRateApplied on Payout]
     ↓
 [netAmount = amount - tdsAmount]
     ↓
 [Send netAmount to Razorpay/Stripe (not gross)]
     ↓
-[Record TDSRecord for Form 26Q filing]
+[Gateway webhook fires COMPLETED]
+    ↓
+[Create TDSRecord atomically inside the same transaction]
 ```
+
+> **Note:** TDS records are only created when the payout is confirmed by the gateway webhook (COMPLETED status). If the payout fails or is cancelled, all TDS data is cleaned up. The `tdsRateApplied` field on the Payout record bridges the gap between calculation and confirmation.
 
 ### PAN Verification
 
@@ -60,7 +64,7 @@ Stores PAN, GSTIN, country, and LUT info per consultant.
 One record per deduction event, linked to payout. Tracks:
 
 - Financial year + quarter
-- Cumulative gross payments at time of deduction
+- Cumulative amount credited to consultant at time of deduction (`cumulativeAmountCredited`)
 - TDS amount and rate
 - Form 26Q filing status
 

--- a/docs/payments/multi-currency/03-tds-compliance.md
+++ b/docs/payments/multi-currency/03-tds-compliance.md
@@ -21,7 +21,7 @@ Tax Deducted at Source (TDS) under Section 194J applies to payments for professi
 
 ### Threshold Tracking
 
-The system tracks cumulative `grossAmount` from `ConsultantEarnings` for each financial year. When cumulative payments cross ₹50,000:
+The system tracks cumulative `consultantShare` from `ConsultantEarnings` for each financial year (per Section 194J — TDS applies to the amount credited/paid to the consultant, not the full sale amount). When cumulative payments cross ₹50,000:
 
 1. **First time crossing**: TDS calculated only on the excess amount
 2. **Already above threshold**: TDS on full payout amount
@@ -83,6 +83,39 @@ One record per deduction event, linked to payout. Tracks:
 
 - `GET /api/consultant/tax-info` — View masked PAN, GSTIN, verification status
 - `PUT /api/consultant/tax-info` — Update PAN, GSTIN, country
+
+## LAUNCH BLOCKERS — Requires CA Confirmation
+
+> **These items MUST be resolved with a written CA memo before accepting real payments.**
+
+### 1. Section 194-O vs 194J Applicability
+
+The current implementation auto-deducts only under **Section 194J**. However, if Familiarise is classified as an **e-commerce operator (ECO)**, Section **194-O** may apply instead (or in addition), with different thresholds/rates. A CA memo must confirm which section applies for:
+
+- Resident individual/HUF consultant
+- Resident firm/company consultant
+- Non-resident consultant (Section 195 may apply instead)
+- Whether 194-O overrides or co-exists with 194J
+
+**Do not hard-code one withholding section for all consultant payouts until this is confirmed.**
+
+### 2. PAN Storage Security
+
+PAN is currently stored in **plaintext** in the database. This is a compliance risk. Before production:
+
+- Encrypt PAN at rest via KMS (AWS KMS, HashiCorp Vault, or similar)
+- Store only masked last-4 in cleartext for display/lookup
+- Keep verification state separate from the raw identifier
+
+### 3. Export Zero-Rating Evidence
+
+The current `buyerCountry !== "IN"` check is sufficient for MVP product logic but **not sufficient for tax-defense records**. Before claiming zero-rated export status, each international payment should capture:
+
+- Billing country / billing address from the gateway
+- Gateway-confirmed payment instrument or remittance country
+- Remittance / FIRC / eFIRC reference
+- LUT / export-supporting record state at time of invoice
+- Stored reason code for why zero-rating was applied
 
 ## Key Files
 

--- a/lib/payments/gateway-router.ts
+++ b/lib/payments/gateway-router.ts
@@ -1,0 +1,70 @@
+/**
+ * Gateway Auto-Router
+ *
+ * Automatically selects the optimal payment gateway based on buyer country.
+ * Strategy: Razorpay for everything (domestic + IBT for international).
+ * Stripe as fallback only when explicitly requested.
+ *
+ * Cost comparison:
+ * - Razorpay domestic: 2% + GST (~2.36%)
+ * - Razorpay IBT (international): 1% + GST, zero forex markup
+ * - Stripe international: ~6.3% (4.3% processing + 2% currency conversion)
+ */
+
+import { PaymentGateway } from "@prisma/client";
+
+export interface GatewayRoutingResult {
+  /** Selected payment gateway */
+  gateway: PaymentGateway;
+  /** Human-readable reason for the selection (for audit logs) */
+  reason: string;
+  /** Whether this is a Razorpay International Bank Transfer */
+  isIBT: boolean;
+  /** Currency to charge in (always INR for Razorpay) */
+  currency: string;
+}
+
+/**
+ * Route to the optimal payment gateway based on buyer country and preferences.
+ *
+ * Rules:
+ * 1. India buyers → Razorpay domestic (cheapest, UPI support)
+ * 2. International buyers → Razorpay IBT (1% + GST, zero forex, auto eFIRC)
+ * 3. Client explicitly requests STRIPE → honor it (for testing/edge cases)
+ * 4. Fallback: Razorpay
+ */
+export function routeGateway(params: {
+  buyerCountry: string;
+  requestedGateway?: PaymentGateway;
+  amount: number;
+}): GatewayRoutingResult {
+  const { buyerCountry, requestedGateway } = params;
+
+  // Honor explicit STRIPE request (for testing or when Razorpay is unavailable)
+  if (requestedGateway === "STRIPE") {
+    return {
+      gateway: "STRIPE",
+      reason: `Client explicitly requested Stripe (buyer: ${buyerCountry})`,
+      isIBT: false,
+      currency: "INR",
+    };
+  }
+
+  // India — Razorpay domestic
+  if (buyerCountry === "IN") {
+    return {
+      gateway: "RAZORPAY",
+      reason: "Domestic India buyer — Razorpay (UPI + cards, 2% + GST)",
+      isIBT: false,
+      currency: "INR",
+    };
+  }
+
+  // International — Razorpay IBT (much cheaper than Stripe)
+  return {
+    gateway: "RAZORPAY",
+    reason: `International buyer (${buyerCountry}) — Razorpay IBT (1% + GST, zero forex, auto eFIRC)`,
+    isIBT: true,
+    currency: "INR", // Razorpay always settles in INR
+  };
+}

--- a/lib/payments/gateway-router.ts
+++ b/lib/payments/gateway-router.ts
@@ -36,7 +36,6 @@ export interface GatewayRoutingResult {
 export function routeGateway(params: {
   buyerCountry: string;
   requestedGateway?: PaymentGateway;
-  amount: number;
 }): GatewayRoutingResult {
   const { buyerCountry, requestedGateway } = params;
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -30,6 +30,7 @@ import {
   countWebinarParticipants,
 } from "@/lib/payments/utils/participants";
 import { markWaitlistAsBooked } from "@/lib/waitlist/slot-handler";
+import { getExchangeRates } from "@/lib/currency";
 import {
   applyCreditsToPayment,
   getUserCredits,
@@ -48,7 +49,6 @@ import {
   validatePlanCurrency,
   validateDiscountCurrency,
 } from "@/lib/payments/validation/currency-guards";
-import { getExchangeRates } from "@/lib/currency";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -1504,13 +1504,15 @@ export async function handleCheckout(
       isInternational,
     } = await calculateAmountAndValidate(validatedData, userId, buyerCountry);
 
-    // Snapshot exchange rate for international payments (audit trail)
+    const displayCurrencyAtCheckout =
+      validatedData.displayCurrency?.toUpperCase() || currency;
+
+    // Snapshot the displayed exchange rate for auditability.
     let exchangeRateAtCheckout: number | null = null;
-    if (isInternational) {
+    if (displayCurrencyAtCheckout !== "INR") {
       try {
         const rates = await getExchangeRates();
-        // Use USD as the reference rate for international audit trail
-        exchangeRateAtCheckout = rates["USD"] ?? null;
+        exchangeRateAtCheckout = rates[displayCurrencyAtCheckout] ?? null;
       } catch {
         // Non-critical — don't block checkout if rate fetch fails
       }
@@ -1642,6 +1644,7 @@ export async function handleCheckout(
               expiresAt: new Date(Date.now() + 30 * 60 * 1000), // 30 minutes
               buyerCountry: detectedBuyerCountry,
               isInternational,
+              displayCurrencyAtCheckout,
               exchangeRateAtCheckout,
             },
           });

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -40,6 +40,14 @@ import {
   createEarningsFromPayment,
   type AppointmentType,
 } from "@/lib/payments/payouts";
+import {
+  determineTax,
+  appointmentTypeToServiceType,
+} from "@/lib/payments/tax/tax-engine";
+import {
+  validatePlanCurrency,
+  validateDiscountCurrency,
+} from "@/lib/payments/validation/currency-guards";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -178,10 +186,12 @@ export class PaymentIntentManager {
 export async function calculateAmountAndValidate(
   validatedData: CheckoutInput,
   userId: string,
+  buyerCountry: string = "IN",
 ) {
   return await prisma.$transaction(async (tx) => {
     let amount = 0;
     let plan;
+    let priceCurrency = "INR";
 
     // Get user profile
     const user = await tx.user.findUnique({
@@ -218,6 +228,7 @@ export async function calculateAmountAndValidate(
           plan.consultantProfile.user.id, // FIX: Pass consultant user ID to filter by consultant
         );
         amount = plan.price;
+        priceCurrency = plan.priceCurrency;
         break;
 
       case "SUBSCRIPTION":
@@ -241,6 +252,7 @@ export async function calculateAmountAndValidate(
           plan.consultantProfile.user.id, // FIX: Pass consultant user ID to filter by consultant
         );
         amount = plan.price;
+        priceCurrency = plan.priceCurrency;
         break;
 
       case "WEBINAR": {
@@ -283,6 +295,7 @@ export async function calculateAmountAndValidate(
         }
 
         amount = plan.price;
+        priceCurrency = plan.priceCurrency;
         break;
       }
 
@@ -326,6 +339,7 @@ export async function calculateAmountAndValidate(
         }
 
         amount = plan.price;
+        priceCurrency = plan.priceCurrency;
         break;
       }
 
@@ -363,6 +377,18 @@ export async function calculateAmountAndValidate(
 
         discountCodeId = discount.id;
 
+        // Validate FIXED_AMOUNT discount currency matches plan currency (INR for MVP)
+        if (
+          !validateDiscountCurrency(
+            { discountType: discount.discountType, currency: discount.currency },
+            priceCurrency,
+          )
+        ) {
+          throw new Error(
+            "Discount code currency does not match plan currency",
+          );
+        }
+
         // Calculate discounted amount with maxDiscount cap
         if (discount.discountType === "PERCENTAGE") {
           let discountAmount = amount * (discount.discountValue / 100);
@@ -383,25 +409,23 @@ export async function calculateAmountAndValidate(
       }
     }
 
-    // Extract currency from plan based on appointment type
-    let currency = "INR"; // Default fallback
+    // Use priceCurrency extracted from plan (set in the switch above)
+    const currency = priceCurrency;
 
-    switch (validatedData.appointmentType) {
-      case "CONSULTATION":
-      case "SUBSCRIPTION":
-      case "WEBINAR":
-      case "CLASS":
-        currency = (plan as { priceCurrency?: string })?.priceCurrency || "INR";
-        break;
-      default:
-        currency = validatedData.paymentGateway === "RAZORPAY" ? "INR" : "USD";
-    }
+    // Validate plan currency (MVP: all plans must be INR)
+    validatePlanCurrency(currency);
 
     // Calculate GST on the discounted price (tax-exclusive: plan.price + 18% GST)
-    // Zero-rate GST for international buyers (export of services is zero-rated under IGST Act §16)
-    const isInternational = currency !== "INR";
-    const applicableTaxRate = isInternational ? 0 : TAX_CONSTANTS.GST_RATE;
-    const taxAmount = Math.round((amount * applicableTaxRate) / 100);
+    // Zero-rate GST for international buyers (export of services is zero-rated under IGST Act §2(6))
+    // BUG FIX: Previously used `currency !== "INR"` which never triggered since all plans default to INR.
+    // Now uses buyer country detection for correct tax jurisdiction determination.
+    const isInternational = buyerCountry !== "IN";
+    const taxDetermination = determineTax({
+      baseAmountPaise: amount,
+      buyerCountry,
+      serviceType: appointmentTypeToServiceType(validatedData.appointmentType),
+    });
+    const taxAmount = taxDetermination.taxAmount;
     amount = amount + taxAmount;
 
     // Apply referral credits AFTER tax (credits act as a payment method, not a trade discount)
@@ -423,6 +447,8 @@ export async function calculateAmountAndValidate(
       discountCodeId,
       consulteeProfileId: user.consulteeProfile.id,
       creditsApplied,
+      buyerCountry,
+      isInternational,
     };
   });
 }
@@ -1452,6 +1478,7 @@ export async function handleCheckout(
   validatedData: CheckoutInput,
   userId: string,
   isMockPayment: boolean = false,
+  buyerCountry: string = "IN",
 ) {
   let lock: ApprovalLock | null = null;
   let lockType = "";
@@ -1469,7 +1496,9 @@ export async function handleCheckout(
       discountCodeId,
       consulteeProfileId,
       creditsApplied,
-    } = await calculateAmountAndValidate(validatedData, userId);
+      buyerCountry: detectedBuyerCountry,
+      isInternational,
+    } = await calculateAmountAndValidate(validatedData, userId, buyerCountry);
 
     // Get plan data for consultant ID (needed for lock acquisition)
     const planData = await getPlanDataForLock(validatedData);
@@ -1595,6 +1624,8 @@ export async function handleCheckout(
               appointmentId: createdAppointment?.id || null,
               discountCodeId,
               expiresAt: new Date(Date.now() + 30 * 60 * 1000), // 30 minutes
+              buyerCountry: detectedBuyerCountry,
+              isInternational,
             },
           });
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -48,6 +48,7 @@ import {
   validatePlanCurrency,
   validateDiscountCurrency,
 } from "@/lib/payments/validation/currency-guards";
+import { getExchangeRates } from "@/lib/currency";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -1503,6 +1504,18 @@ export async function handleCheckout(
       isInternational,
     } = await calculateAmountAndValidate(validatedData, userId, buyerCountry);
 
+    // Snapshot exchange rate for international payments (audit trail)
+    let exchangeRateAtCheckout: number | null = null;
+    if (isInternational) {
+      try {
+        const rates = await getExchangeRates();
+        // Use USD as the reference rate for international audit trail
+        exchangeRateAtCheckout = rates["USD"] ?? null;
+      } catch {
+        // Non-critical — don't block checkout if rate fetch fails
+      }
+    }
+
     // Get plan data for consultant ID (needed for lock acquisition)
     const planData = await getPlanDataForLock(validatedData);
 
@@ -1629,6 +1642,7 @@ export async function handleCheckout(
               expiresAt: new Date(Date.now() + 30 * 60 * 1000), // 30 minutes
               buyerCountry: detectedBuyerCountry,
               isInternational,
+              exchangeRateAtCheckout,
             },
           });
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -380,7 +380,10 @@ export async function calculateAmountAndValidate(
         // Validate FIXED_AMOUNT discount currency matches plan currency (INR for MVP)
         if (
           !validateDiscountCurrency(
-            { discountType: discount.discountType, currency: discount.currency },
+            {
+              discountType: discount.discountType,
+              currency: discount.currency,
+            },
             priceCurrency,
           )
         ) {

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -7,6 +7,7 @@ import prisma from "@/lib/prisma";
 import { EarningRole, EarningStatus, Payment, Prisma } from "@prisma/client";
 import { PAYOUT_CONSTANTS, AppointmentType } from "./constants";
 import { calculateRevenueSplit } from "@/lib/collaborators/service";
+import { getIndianFYQuarter } from "@/lib/payments/tax/tds-service";
 
 // ============================================
 // Types
@@ -334,7 +335,10 @@ export async function getConsultantEarnings(
 /**
  * Refund earnings (called when a payment is refunded)
  */
-export async function refundEarnings(paymentId: string): Promise<boolean> {
+export async function refundEarnings(
+  paymentId: string,
+  options?: { forceRefund?: boolean },
+): Promise<boolean> {
   const allEarnings = await prisma.consultantEarnings.findMany({
     where: { paymentId },
   });
@@ -354,15 +358,62 @@ export async function refundEarnings(paymentId: string): Promise<boolean> {
       continue;
     }
 
-    // Can only refund if not yet paid out
+    // Handle already-paid earnings (payout completed)
     if (earnings.status === EarningStatus.PAID) {
-      console.error(
-        `Cannot refund earnings ${earnings.id} - already paid out. Manual intervention required.`,
-      );
+      if (!options?.forceRefund) {
+        console.error(
+          `Cannot refund earnings ${earnings.id} - already paid out. Use forceRefund: true to proceed with TDS reversal.`,
+        );
+        continue;
+      }
+
+      // Force refund of PAID earnings: create TDS reversal record
+      if (earnings.payoutId) {
+        const tdsRecord = await prisma.tDSRecord.findFirst({
+          where: {
+            payoutId: earnings.payoutId,
+            consultantProfileId: earnings.consultantProfileId,
+            isReversal: false,
+          },
+        });
+
+        if (tdsRecord && tdsRecord.tdsDeducted > 0) {
+          await prisma.tDSRecord.create({
+            data: {
+              consultantProfileId: earnings.consultantProfileId,
+              financialYear: tdsRecord.financialYear,
+              quarter: getIndianFYQuarter(),
+              cumulativeAmountCredited: tdsRecord.cumulativeAmountCredited,
+              tdsDeducted: -tdsRecord.tdsDeducted,
+              tdsRate: tdsRecord.tdsRate,
+              payoutId: earnings.payoutId,
+              earningsId: earnings.id,
+              isReversal: true,
+            },
+          });
+
+          console.log(
+            `TDS reversal created for earnings ${earnings.id}: -${tdsRecord.tdsDeducted} paise`,
+          );
+        }
+      }
+
+      // Mark as refunded
+      await prisma.consultantEarnings.update({
+        where: { id: earnings.id },
+        data: { status: EarningStatus.REFUNDED },
+      });
+
+      // For PAID earnings, decrement totalRevenue (not pendingRevenue — already paid)
+      await prisma.consultantProfile.update({
+        where: { id: earnings.consultantProfileId },
+        data: { totalRevenue: { decrement: earnings.consultantShare } },
+      });
+
       continue;
     }
 
-    // Update earnings status to refunded
+    // Update earnings status to refunded (PENDING/HELD/READY)
     await prisma.consultantEarnings.update({
       where: { id: earnings.id },
       data: {

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -127,6 +127,7 @@ export async function createEarningsFromPayment({
               sharePercentage: Math.round(sharePercentage * 100) / 100,
               status: EarningStatus.PENDING,
               holdUntil,
+              currency: "INR", // Explicit — all earnings in INR for MVP
             },
           });
 
@@ -173,6 +174,7 @@ export async function createEarningsFromPayment({
             consultantShare: totalConsultantPool,
             status: EarningStatus.PENDING,
             holdUntil,
+            currency: "INR", // Explicit — all earnings in INR for MVP
           },
         });
 

--- a/lib/payments/payouts/invoice-service.ts
+++ b/lib/payments/payouts/invoice-service.ts
@@ -161,9 +161,11 @@ export async function createInvoice(
     throw new Error(`Invoice already exists for payment: ${paymentId}`);
   }
 
-  // Calculate amounts — zero-rate GST for international (non-INR) transactions
+  // Calculate amounts — zero-rate GST for international buyers
+  // BUG FIX: Previously used `currency !== "INR"` which never triggered since all plans default to INR.
+  // Now uses payment.isInternational (set from buyer country detection at checkout).
   const subtotal = items.reduce((sum, item) => sum + item.amount, 0);
-  const isInternational = payment.currency !== "INR";
+  const isInternational = payment.isInternational ?? payment.currency !== "INR";
   const taxRate = isInternational ? 0 : TAX_CONSTANTS.GST_RATE;
   const taxAmount = Math.round((subtotal * taxRate) / 100);
   const total = subtotal + taxAmount;
@@ -209,7 +211,10 @@ export async function createInvoice(
     dueDate: invoice.dueDate || undefined,
     paidAt: invoice.paidAt || undefined,
     hsnCode,
-    notes,
+    notes: isInternational
+      ? (notes ? `${notes}\n` : "") +
+        "Export of services — Zero-rated under IGST Act Section 2(6)"
+      : notes,
   };
 }
 
@@ -269,7 +274,7 @@ export async function createInvoiceFromPayment(
 
     // Tax breakdown from stored payment data (tax-exclusive: plan.price + GST)
     const totalAmount = payment.amount;
-    const isInternational = payment.currency !== "INR";
+    const isInternational = payment.isInternational ?? payment.currency !== "INR";
     const taxRate = isInternational ? 0 : TAX_CONSTANTS.GST_RATE;
     const taxAmount = payment.taxAmount;
     const baseAmount = totalAmount - taxAmount;

--- a/lib/payments/payouts/invoice-service.ts
+++ b/lib/payments/payouts/invoice-service.ts
@@ -274,7 +274,8 @@ export async function createInvoiceFromPayment(
 
     // Tax breakdown from stored payment data (tax-exclusive: plan.price + GST)
     const totalAmount = payment.amount;
-    const isInternational = payment.isInternational ?? payment.currency !== "INR";
+    const isInternational =
+      payment.isInternational ?? payment.currency !== "INR";
     const taxRate = isInternational ? 0 : TAX_CONSTANTS.GST_RATE;
     const taxAmount = payment.taxAmount;
     const baseAmount = totalAmount - taxAmount;

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -459,6 +459,17 @@ async function processSinglePayout(payout: {
       throw new Error("No payout account found");
     }
 
+    // Non-resident payout guard — Razorpay only pays to Indian bank accounts
+    const consultantTaxInfo = await prisma.consultantTaxInfo.findUnique({
+      where: { consultantProfileId: payout.consultantProfileId },
+    });
+    if (consultantTaxInfo && !consultantTaxInfo.isIndianResident) {
+      throw new Error(
+        "Payouts to non-resident consultants are not supported yet (Section 195 TDS not implemented). " +
+          `Consultant: ${payout.consultantProfileId}. Please process this payout manually.`,
+      );
+    }
+
     // Calculate TDS (Section 194J) — deduct before sending to gateway
     const tdsResult = await calculateTDS({
       consultantProfileId: payout.consultantProfileId,
@@ -505,6 +516,7 @@ async function processSinglePayout(payout: {
         tdsDeducted: tdsResult.tdsAmount,
         netAmount: payoutAmountAfterTDS,
         tdsRateApplied: tdsResult.tdsRate || null,
+        tdsFinancialYear: tdsResult.financialYear,
         status: PayoutStatus.PROCESSING, // Will be updated via webhook
       },
     });
@@ -528,6 +540,7 @@ async function processSinglePayout(payout: {
         tdsDeducted: 0,
         netAmount: null,
         tdsRateApplied: null,
+        tdsFinancialYear: null,
       },
     });
 
@@ -701,7 +714,7 @@ export async function handlePayoutWebhook(
 
     // If completed, update earnings and consultant stats
     if (payoutStatus === PayoutStatus.COMPLETED) {
-      const financialYear = getIndianFinancialYear();
+      const financialYear = payout.tdsFinancialYear || getIndianFinancialYear();
       const { start, end } = getFYDateRange(financialYear);
       const previousCompletedPayouts = await tx.payout.aggregate({
         where: {
@@ -774,6 +787,7 @@ export async function handlePayoutWebhook(
           tdsDeducted: 0,
           netAmount: null,
           tdsRateApplied: null,
+          tdsFinancialYear: null,
         },
       });
     }

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -21,6 +21,10 @@ import {
 } from "./stripe-connect";
 import { randomUUID } from "crypto";
 import { acquireLock, releaseLock } from "@/lib/redis";
+import {
+  calculateTDS,
+  recordTDSDeduction,
+} from "@/lib/payments/tax/tds-service";
 
 // ============================================
 // Types
@@ -453,24 +457,66 @@ async function processSinglePayout(payout: {
       throw new Error("No payout account found");
     }
 
+    // Calculate TDS (Section 194J) — deduct before sending to gateway
+    const tdsResult = await calculateTDS({
+      consultantProfileId: payout.consultantProfileId,
+      payoutAmountPaise: payout.amount,
+    });
+
+    const payoutAmountAfterTDS = payout.amount - tdsResult.tdsAmount;
+
+    if (tdsResult.tdsAmount > 0) {
+      console.log(
+        JSON.stringify({
+          event: "tds_deduction",
+          payoutId: payout.id,
+          consultantProfileId: payout.consultantProfileId,
+          grossAmount: payout.amount,
+          tdsAmount: tdsResult.tdsAmount,
+          tdsRate: tdsResult.tdsRate,
+          netAmount: payoutAmountAfterTDS,
+          financialYear: tdsResult.financialYear,
+          cumulativeBeforePayout: tdsResult.cumulativeBeforePayout,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    }
+
+    // Use the payout object but with reduced amount for gateway call
+    const payoutForGateway = { ...payout, amount: payoutAmountAfterTDS };
+
     let providerPayoutId: string | undefined;
 
     if (payout.provider === PaymentGateway.RAZORPAY) {
-      providerPayoutId = await processRazorpayPayout(payout, account);
+      providerPayoutId = await processRazorpayPayout(payoutForGateway, account);
     } else if (payout.provider === PaymentGateway.STRIPE) {
-      providerPayoutId = await processStripePayout(payout, account);
+      providerPayoutId = await processStripePayout(payoutForGateway, account);
     } else {
       throw new Error(`Unsupported provider: ${payout.provider}`);
     }
 
-    // Update payout with provider ID
+    // Update payout with provider ID and TDS info
     await prisma.payout.update({
       where: { id: payout.id },
       data: {
         providerPayoutId,
+        tdsDeducted: tdsResult.tdsAmount,
+        netAmount: payoutAmountAfterTDS,
         status: PayoutStatus.PROCESSING, // Will be updated via webhook
       },
     });
+
+    // Record TDS deduction for Form 26Q filing
+    if (tdsResult.tdsAmount > 0) {
+      await recordTDSDeduction({
+        consultantProfileId: payout.consultantProfileId,
+        financialYear: tdsResult.financialYear,
+        tdsDeducted: tdsResult.tdsAmount,
+        tdsRate: tdsResult.tdsRate,
+        cumulativeGrossPayments: tdsResult.cumulativeAfterPayout,
+        payoutId: payout.id,
+      });
+    }
 
     return {
       payoutId: payout.id,
@@ -526,6 +572,14 @@ async function processRazorpayPayout(
 ): Promise<string> {
   if (!isRazorpayPayoutsConfigured()) {
     throw new Error("RazorpayX Payouts not configured");
+  }
+
+  // Guard: Razorpay only processes INR payouts
+  if (payout.currency !== "INR") {
+    throw new Error(
+      `Razorpay payouts only support INR. Got: ${payout.currency}. ` +
+        `International payouts require manual processing for MVP.`,
+    );
   }
 
   if (!account.razorpayFundAccId) {

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -23,6 +23,8 @@ import { randomUUID } from "crypto";
 import { acquireLock, releaseLock } from "@/lib/redis";
 import {
   calculateTDS,
+  getFYDateRange,
+  getIndianFinancialYear,
   recordTDSDeduction,
 } from "@/lib/payments/tax/tds-service";
 
@@ -502,21 +504,10 @@ async function processSinglePayout(payout: {
         providerPayoutId,
         tdsDeducted: tdsResult.tdsAmount,
         netAmount: payoutAmountAfterTDS,
+        tdsRateApplied: tdsResult.tdsRate || null,
         status: PayoutStatus.PROCESSING, // Will be updated via webhook
       },
     });
-
-    // Record TDS deduction for Form 26Q filing
-    if (tdsResult.tdsAmount > 0) {
-      await recordTDSDeduction({
-        consultantProfileId: payout.consultantProfileId,
-        financialYear: tdsResult.financialYear,
-        tdsDeducted: tdsResult.tdsAmount,
-        tdsRate: tdsResult.tdsRate,
-        cumulativeGrossPayments: tdsResult.cumulativeAfterPayout,
-        payoutId: payout.id,
-      });
-    }
 
     return {
       payoutId: payout.id,
@@ -534,6 +525,9 @@ async function processSinglePayout(payout: {
         status: PayoutStatus.FAILED,
         failureReason: errorMessage,
         retryCount: { increment: 1 },
+        tdsDeducted: 0,
+        netAmount: null,
+        tdsRateApplied: null,
       },
     });
 
@@ -707,6 +701,20 @@ export async function handlePayoutWebhook(
 
     // If completed, update earnings and consultant stats
     if (payoutStatus === PayoutStatus.COMPLETED) {
+      const financialYear = getIndianFinancialYear();
+      const { start, end } = getFYDateRange(financialYear);
+      const previousCompletedPayouts = await tx.payout.aggregate({
+        where: {
+          consultantProfileId: payout.consultantProfileId,
+          status: PayoutStatus.COMPLETED,
+          processedAt: { gte: start, lte: end },
+          id: { not: payout.id },
+        },
+        _sum: { amount: true },
+      });
+      const cumulativeCreditedPayments =
+        (previousCompletedPayouts._sum.amount || 0) + payout.amount;
+
       // Update earnings to PAID
       await tx.consultantEarnings.updateMany({
         where: { payoutId: payout.id },
@@ -724,6 +732,22 @@ export async function handlePayoutWebhook(
           pendingRevenue: { decrement: payout.amount },
         },
       });
+
+      if (payout.tdsDeducted > 0 && payout.tdsRateApplied) {
+        await tx.tDSRecord.deleteMany({
+          where: { payoutId: payout.id },
+        });
+
+        await recordTDSDeduction({
+          consultantProfileId: payout.consultantProfileId,
+          financialYear,
+          tdsDeducted: payout.tdsDeducted,
+          tdsRate: payout.tdsRateApplied,
+          cumulativeAmountCredited: cumulativeCreditedPayments,
+          payoutId: payout.id,
+          db: tx,
+        });
+      }
     }
 
     // If failed or cancelled, unlink earnings and reverse TDS records
@@ -749,6 +773,7 @@ export async function handlePayoutWebhook(
         data: {
           tdsDeducted: 0,
           netAmount: null,
+          tdsRateApplied: null,
         },
       });
     }

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -726,7 +726,7 @@ export async function handlePayoutWebhook(
       });
     }
 
-    // If failed or cancelled, unlink earnings so they can be included in next batch
+    // If failed or cancelled, unlink earnings and reverse TDS records
     if (
       payoutStatus === PayoutStatus.FAILED ||
       payoutStatus === PayoutStatus.CANCELLED
@@ -735,6 +735,20 @@ export async function handlePayoutWebhook(
         where: { payoutId: payout.id },
         data: {
           payoutId: null,
+        },
+      });
+
+      // Delete TDS records — payout never completed, so TDS was never actually withheld
+      await tx.tDSRecord.deleteMany({
+        where: { payoutId: payout.id },
+      });
+
+      // Reset TDS fields on the payout record
+      await tx.payout.update({
+        where: { id: payout.id },
+        data: {
+          tdsDeducted: 0,
+          netAmount: null,
         },
       });
     }

--- a/lib/payments/tax/buyer-country.ts
+++ b/lib/payments/tax/buyer-country.ts
@@ -1,0 +1,131 @@
+/**
+ * Buyer Country Detection
+ *
+ * Server-side detection cascade for determining buyer's country at checkout.
+ * Used for tax jurisdiction determination (GST vs zero-rated export).
+ */
+
+// Maps locale strings to ISO 3166-1 alpha-2 country codes
+const LOCALE_COUNTRY_MAP: Record<string, string> = {
+  "en-US": "US",
+  "en-GB": "GB",
+  "en-AU": "AU",
+  "en-CA": "CA",
+  "en-IN": "IN",
+  "hi-IN": "IN",
+  hi: "IN",
+  "de-DE": "DE",
+  de: "DE",
+  "fr-FR": "FR",
+  fr: "FR",
+  "es-ES": "ES",
+  es: "ES",
+  "it-IT": "IT",
+  it: "IT",
+  "pt-BR": "BR",
+  pt: "PT",
+  "ja-JP": "JP",
+  ja: "JP",
+  "zh-CN": "CN",
+  zh: "CN",
+  "ko-KR": "KR",
+  ko: "KR",
+  "ar-AE": "AE",
+  "ar-SA": "SA",
+  "ru-RU": "RU",
+  ru: "RU",
+  "nl-NL": "NL",
+  nl: "NL",
+  "sv-SE": "SE",
+  sv: "SE",
+  "pl-PL": "PL",
+  pl: "PL",
+  "tr-TR": "TR",
+  tr: "TR",
+  "th-TH": "TH",
+  th: "TH",
+  "id-ID": "ID",
+  "ms-MY": "MY",
+  "en-SG": "SG",
+  "en-NZ": "NZ",
+  "da-DK": "DK",
+  da: "DK",
+  "nb-NO": "NO",
+  nb: "NO",
+  "fi-FI": "FI",
+  fi: "FI",
+  "en-ZA": "ZA",
+  "en-NG": "NG",
+  "en-KE": "KE",
+  "en-GH": "GH",
+};
+
+/**
+ * Detect country from Accept-Language header
+ */
+function detectCountryFromLocale(acceptLanguage: string): string | null {
+  // Parse Accept-Language: "en-US,en;q=0.9,hi-IN;q=0.8"
+  const locales = acceptLanguage
+    .split(",")
+    .map((part) => part.split(";")[0].trim());
+
+  for (const locale of locales) {
+    if (LOCALE_COUNTRY_MAP[locale]) return LOCALE_COUNTRY_MAP[locale];
+    const base = locale.split("-")[0];
+    if (LOCALE_COUNTRY_MAP[base]) return LOCALE_COUNTRY_MAP[base];
+  }
+
+  return null;
+}
+
+/**
+ * Detect buyer country using a cascading strategy.
+ *
+ * Priority:
+ * 1. User's profile country (highest confidence — explicitly set)
+ * 2. Cloudflare cf-ipcountry header (geo-IP, available on Netlify with CF DNS)
+ * 3. Accept-Language header mapping
+ * 4. Fallback: "IN" (conservative — charges GST rather than missing it)
+ */
+export function detectBuyerCountry(params: {
+  userCountry?: string | null;
+  cfIpCountry?: string | null;
+  acceptLanguage?: string | null;
+}): string {
+  // 1. User profile country (most reliable)
+  if (params.userCountry && params.userCountry.length === 2) {
+    return params.userCountry.toUpperCase();
+  }
+
+  // 2. Cloudflare geo-IP header
+  if (
+    params.cfIpCountry &&
+    params.cfIpCountry !== "XX" &&
+    params.cfIpCountry !== "T1"
+  ) {
+    return params.cfIpCountry.toUpperCase();
+  }
+
+  // 3. Accept-Language header
+  if (params.acceptLanguage) {
+    const detected = detectCountryFromLocale(params.acceptLanguage);
+    if (detected) return detected;
+  }
+
+  // 4. Conservative fallback — assume India (charge GST rather than miss it)
+  return "IN";
+}
+
+/**
+ * Extract buyer country detection params from a Request/Headers object.
+ * Use this in API routes to get the params for detectBuyerCountry.
+ */
+export function extractBuyerCountryParams(headers: Headers): {
+  cfIpCountry: string | null;
+  acceptLanguage: string | null;
+} {
+  return {
+    cfIpCountry: headers.get("cf-ipcountry"),
+    acceptLanguage: headers.get("accept-language"),
+  };
+}

--- a/lib/payments/tax/checkout-context.ts
+++ b/lib/payments/tax/checkout-context.ts
@@ -1,0 +1,28 @@
+import prisma from "@/lib/prisma";
+import { detectBuyerCountry, extractBuyerCountryParams } from "./buyer-country";
+
+export interface CheckoutTaxContext {
+  buyerCountry: string;
+  isInternational: boolean;
+}
+
+export async function resolveCheckoutTaxContext(params: {
+  userId: string;
+  headers: Headers;
+}): Promise<CheckoutTaxContext> {
+  const userRecord = await prisma.user.findUnique({
+    where: { id: params.userId },
+    select: { country: true },
+  });
+
+  const headerParams = extractBuyerCountryParams(params.headers);
+  const buyerCountry = detectBuyerCountry({
+    userCountry: userRecord?.country,
+    ...headerParams,
+  });
+
+  return {
+    buyerCountry,
+    isInternational: buyerCountry !== "IN",
+  };
+}

--- a/lib/payments/tax/pan-crypto.ts
+++ b/lib/payments/tax/pan-crypto.ts
@@ -28,16 +28,22 @@ function getKey(): Buffer {
  * Encrypt a PAN string.
  * Returns { encrypted: Buffer (IV + ciphertext + auth tag), last4: string }
  */
-export function encryptPAN(pan: string): { encrypted: Buffer; last4: string } {
+export function encryptPAN(pan: string): {
+  encrypted: Uint8Array<ArrayBuffer>;
+  last4: string;
+} {
   const key = getKey();
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
 
   const encrypted = Buffer.concat([cipher.update(pan, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
+  const combined = Buffer.concat([iv, encrypted, authTag]);
+  const result = new Uint8Array(combined.length);
+  result.set(combined);
 
   return {
-    encrypted: Buffer.concat([iv, encrypted, authTag]),
+    encrypted: result,
     last4: pan.slice(-4),
   };
 }

--- a/lib/payments/tax/pan-crypto.ts
+++ b/lib/payments/tax/pan-crypto.ts
@@ -1,0 +1,66 @@
+/**
+ * PAN Encryption Utility — AES-256-GCM
+ *
+ * Format: [12 bytes IV][ciphertext][16 bytes auth tag]
+ * Key: PAN_ENCRYPTION_KEY env var (64 hex chars = 32 bytes)
+ *
+ * Generate key: openssl rand -hex 32
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+function getKey(): Buffer {
+  const hex = process.env.PAN_ENCRYPTION_KEY;
+  if (!hex || hex.length !== 64) {
+    throw new Error(
+      "PAN_ENCRYPTION_KEY must be set to a 64-character hex string (32 bytes). " +
+        "Generate with: openssl rand -hex 32",
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/**
+ * Encrypt a PAN string.
+ * Returns { encrypted: Buffer (IV + ciphertext + auth tag), last4: string }
+ */
+export function encryptPAN(pan: string): { encrypted: Buffer; last4: string } {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([cipher.update(pan, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    encrypted: Buffer.concat([iv, encrypted, authTag]),
+    last4: pan.slice(-4),
+  };
+}
+
+/**
+ * Decrypt a PAN buffer back to plaintext string.
+ * Only needed for Form 26Q admin filing.
+ */
+export function decryptPAN(combined: Buffer): string {
+  const key = getKey();
+
+  const iv = combined.subarray(0, IV_LENGTH);
+  const authTag = combined.subarray(combined.length - AUTH_TAG_LENGTH);
+  const ciphertext = combined.subarray(
+    IV_LENGTH,
+    combined.length - AUTH_TAG_LENGTH,
+  );
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}

--- a/lib/payments/tax/tax-engine.ts
+++ b/lib/payments/tax/tax-engine.ts
@@ -1,0 +1,115 @@
+/**
+ * Tax Engine
+ *
+ * Centralized tax determination for checkout.
+ * Handles GST for domestic (India) and zero-rating for export of services.
+ *
+ * Legal basis:
+ * - Domestic: 18% GST on consulting/education services
+ * - Export: Zero-rated under IGST Act Section 2(6) when:
+ *   1. Supplier is in India
+ *   2. Recipient is outside India
+ *   3. Payment is received in convertible foreign exchange
+ *   4. Place of supply is outside India
+ *   5. Supplier and recipient are not establishments of the same person
+ */
+
+import { TAX_CONSTANTS } from "@/lib/payments/payouts/constants";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface TaxDetermination {
+  /** Tax rate as percentage (18 for GST, 0 for export) */
+  taxRate: number;
+  /** Tax amount in paise */
+  taxAmount: number;
+  /** Whether this is a zero-rated export */
+  isZeroRated: boolean;
+  /** Tax jurisdiction identifier */
+  jurisdiction: "IN-GST" | "EXPORT-ZERO" | "DEFERRED";
+  /** SAC (Service Accounting Code) */
+  sacCode: string;
+  /** Human-readable note for invoices */
+  notes?: string;
+}
+
+export type ServiceType = "CONSULTING" | "EDUCATION" | "TRAINING";
+
+// ============================================================================
+// Core Tax Logic
+// ============================================================================
+
+/**
+ * Determine applicable tax based on buyer country and service type.
+ *
+ * For MVP: India = 18% GST, everywhere else = 0% (export zero-rated).
+ * Extensible for EU VAT, AU GST, etc. in future phases.
+ */
+export function determineTax(params: {
+  baseAmountPaise: number;
+  buyerCountry: string;
+  serviceType?: ServiceType;
+}): TaxDetermination {
+  const { baseAmountPaise, buyerCountry, serviceType = "CONSULTING" } = params;
+
+  // Domestic India — charge GST
+  if (buyerCountry === "IN") {
+    const taxRate = TAX_CONSTANTS.GST_RATE;
+    const sacCode = getSacCode(serviceType);
+    const taxAmount = Math.round((baseAmountPaise * taxRate) / 100);
+
+    return {
+      taxRate,
+      taxAmount,
+      isZeroRated: false,
+      jurisdiction: "IN-GST",
+      sacCode,
+    };
+  }
+
+  // International — zero-rated export of services
+  return {
+    taxRate: 0,
+    taxAmount: 0,
+    isZeroRated: true,
+    jurisdiction: "EXPORT-ZERO",
+    sacCode: getSacCode(serviceType),
+    notes: "Export of services — Zero-rated under IGST Act Section 2(6)",
+  };
+}
+
+/**
+ * Get the SAC (Service Accounting Code) for a service type.
+ */
+function getSacCode(serviceType: ServiceType): string {
+  switch (serviceType) {
+    case "CONSULTING":
+      return TAX_CONSTANTS.HSN_CODES.CONSULTING;
+    case "EDUCATION":
+      return TAX_CONSTANTS.HSN_CODES.EDUCATION;
+    case "TRAINING":
+      return TAX_CONSTANTS.HSN_CODES.TRAINING;
+    default:
+      return TAX_CONSTANTS.SAC_CODE;
+  }
+}
+
+/**
+ * Map appointment type to service type for tax purposes.
+ */
+export function appointmentTypeToServiceType(
+  appointmentType: string,
+): ServiceType {
+  switch (appointmentType) {
+    case "CONSULTATION":
+    case "SUBSCRIPTION":
+      return "CONSULTING";
+    case "WEBINAR":
+    case "CLASS":
+      return "EDUCATION";
+    default:
+      return "CONSULTING";
+  }
+}

--- a/lib/payments/tax/tax-engine.ts
+++ b/lib/payments/tax/tax-engine.ts
@@ -70,6 +70,9 @@ export function determineTax(params: {
   }
 
   // International — zero-rated export of services
+  // TODO: For production tax-defense, capture additional evidence per payment:
+  // billing address, gateway-confirmed remittance country, FIRC/eFIRC reference,
+  // LUT state at invoice time, and stored reason code for zero-rating.
   return {
     taxRate: 0,
     taxAmount: 0,

--- a/lib/payments/tax/tds-service.ts
+++ b/lib/payments/tax/tds-service.ts
@@ -12,6 +12,7 @@
  */
 
 import prisma from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 
 // ============================================================================
 // Constants
@@ -74,9 +75,8 @@ export function getFYDateRange(fy: string): { start: Date; end: Date } {
 // ============================================================================
 
 /**
- * Get cumulative consultant share payments for the current FY.
- * Uses consultantShare (amount credited/paid to consultant) as the basis,
- * per Section 194J — TDS applies to the amount credited, not the full sale.
+ * Get cumulative payout amounts actually credited/paid for the current FY.
+ * Uses completed payouts as the basis instead of raw earnings creation time.
  */
 export async function getCurrentFYCumulativePayments(
   consultantProfileId: string,
@@ -85,16 +85,16 @@ export async function getCurrentFYCumulativePayments(
   const fy = financialYear || getIndianFinancialYear();
   const { start, end } = getFYDateRange(fy);
 
-  const result = await prisma.consultantEarnings.aggregate({
+  const result = await prisma.payout.aggregate({
     where: {
       consultantProfileId,
-      createdAt: { gte: start, lte: end },
-      status: { not: "REFUNDED" },
+      status: "COMPLETED",
+      processedAt: { gte: start, lte: end },
     },
-    _sum: { consultantShare: true },
+    _sum: { amount: true },
   });
 
-  return result._sum.consultantShare || 0;
+  return result._sum.amount || 0;
 }
 
 /**
@@ -124,9 +124,9 @@ export interface TDSCalculationResult {
   tdsRate: number;
   /** Whether cumulative payments crossed the threshold */
   isAboveThreshold: boolean;
-  /** Cumulative gross payments for FY (BEFORE this payout), in paise */
+  /** Cumulative credited/payout amounts for FY (BEFORE this payout), in paise */
   cumulativeBeforePayout: number;
-  /** Cumulative gross payments for FY (AFTER this payout), in paise */
+  /** Cumulative credited/payout amounts for FY (AFTER this payout), in paise */
   cumulativeAfterPayout: number;
   /** Current financial year */
   financialYear: string;
@@ -205,18 +205,21 @@ export async function recordTDSDeduction(params: {
   financialYear: string;
   tdsDeducted: number;
   tdsRate: number;
-  cumulativeGrossPayments: number;
+  cumulativeAmountCredited: number;
   payoutId?: string;
   earningsId?: string;
+  db?: Prisma.TransactionClient | typeof prisma;
 }) {
   const quarter = getIndianFYQuarter();
 
-  return prisma.tDSRecord.create({
+  const db = params.db || prisma;
+
+  return db.tDSRecord.create({
     data: {
       consultantProfileId: params.consultantProfileId,
       financialYear: params.financialYear,
       quarter,
-      cumulativeGrossPayments: params.cumulativeGrossPayments,
+      cumulativeAmountCredited: params.cumulativeAmountCredited,
       tdsDeducted: params.tdsDeducted,
       tdsRate: params.tdsRate,
       payoutId: params.payoutId,
@@ -270,7 +273,7 @@ export async function getConsultantTDSBreakdown(financialYear: string) {
   return prisma.tDSRecord.groupBy({
     by: ["consultantProfileId", "tdsRate"],
     where: { financialYear },
-    _sum: { tdsDeducted: true, cumulativeGrossPayments: true },
+    _sum: { tdsDeducted: true, cumulativeAmountCredited: true },
     _count: true,
     orderBy: { _sum: { tdsDeducted: "desc" } },
   });

--- a/lib/payments/tax/tds-service.ts
+++ b/lib/payments/tax/tds-service.ts
@@ -74,8 +74,9 @@ export function getFYDateRange(fy: string): { start: Date; end: Date } {
 // ============================================================================
 
 /**
- * Get cumulative gross payments to a consultant for the current FY.
- * This is the sum of all consultant earnings (grossAmount) for the FY.
+ * Get cumulative consultant share payments for the current FY.
+ * Uses consultantShare (amount credited/paid to consultant) as the basis,
+ * per Section 194J — TDS applies to the amount credited, not the full sale.
  */
 export async function getCurrentFYCumulativePayments(
   consultantProfileId: string,
@@ -90,10 +91,10 @@ export async function getCurrentFYCumulativePayments(
       createdAt: { gte: start, lte: end },
       status: { not: "REFUNDED" },
     },
-    _sum: { grossAmount: true },
+    _sum: { consultantShare: true },
   });
 
-  return result._sum.grossAmount || 0;
+  return result._sum.consultantShare || 0;
 }
 
 /**

--- a/lib/payments/tax/tds-service.ts
+++ b/lib/payments/tax/tds-service.ts
@@ -168,8 +168,9 @@ export async function calculateTDS(params: {
     where: { consultantProfileId },
   });
 
-  const tdsRate =
-    taxInfo?.panVerified ? TDS_RATE_WITH_PAN : TDS_RATE_WITHOUT_PAN;
+  const tdsRate = taxInfo?.panVerified
+    ? TDS_RATE_WITH_PAN
+    : TDS_RATE_WITHOUT_PAN;
 
   // Calculate taxable amount
   let taxableAmount: number;

--- a/lib/payments/tax/tds-service.ts
+++ b/lib/payments/tax/tds-service.ts
@@ -147,6 +147,26 @@ export async function calculateTDS(params: {
   const { consultantProfileId, payoutAmountPaise } = params;
   const financialYear = getIndianFinancialYear();
 
+  // Fetch tax info early for residency check + PAN verification
+  const taxInfo = await prisma.consultantTaxInfo.findUnique({
+    where: { consultantProfileId },
+  });
+
+  // Non-resident guard: Section 194J does not apply to non-residents.
+  // Non-residents would need Section 195 (international withholding) which is not yet supported.
+  if (taxInfo && !taxInfo.isIndianResident) {
+    const cumulativeBeforePayout =
+      await getCurrentFYCumulativePayments(consultantProfileId);
+    return {
+      tdsAmount: 0,
+      tdsRate: 0,
+      isAboveThreshold: false,
+      cumulativeBeforePayout,
+      cumulativeAfterPayout: cumulativeBeforePayout + payoutAmountPaise,
+      financialYear,
+    };
+  }
+
   // Get cumulative payments for this FY
   const cumulativeBeforePayout =
     await getCurrentFYCumulativePayments(consultantProfileId);
@@ -163,11 +183,6 @@ export async function calculateTDS(params: {
       financialYear,
     };
   }
-
-  // Determine TDS rate based on PAN verification
-  const taxInfo = await prisma.consultantTaxInfo.findUnique({
-    where: { consultantProfileId },
-  });
 
   const tdsRate = taxInfo?.panVerified
     ? TDS_RATE_WITH_PAN

--- a/lib/payments/tax/tds-service.ts
+++ b/lib/payments/tax/tds-service.ts
@@ -1,0 +1,296 @@
+/**
+ * TDS (Tax Deducted at Source) Service — Section 194J
+ *
+ * Handles TDS calculation, deduction, and record-keeping for consultant payouts.
+ *
+ * Rules:
+ * - Threshold: ₹50,000/financial year (April–March)
+ * - Rate: 10% with verified PAN, 20% without PAN
+ * - Applies to professional/technical services (Section 194J)
+ * - Must be deposited by 7th of next month
+ * - Quarterly filing: Form 26Q
+ */
+
+import prisma from "@/lib/prisma";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** TDS threshold per financial year in paise (₹50,000 = 5,000,000 paise) */
+export const TDS_THRESHOLD_PAISE = 5_000_000;
+
+/** TDS rate with verified PAN (10%) */
+export const TDS_RATE_WITH_PAN = 10;
+
+/** TDS rate without PAN (20%) — Section 206AA */
+export const TDS_RATE_WITHOUT_PAN = 20;
+
+// ============================================================================
+// Financial Year Utilities
+// ============================================================================
+
+/**
+ * Get Indian financial year string for a date.
+ * FY runs April 1 to March 31.
+ * e.g., March 2027 → "2026-27", April 2027 → "2027-28"
+ */
+export function getIndianFinancialYear(date: Date = new Date()): string {
+  const month = date.getMonth(); // 0-indexed (0=Jan, 3=Apr)
+  const year = date.getFullYear();
+
+  // If Jan-Mar, FY started previous year
+  const fyStartYear = month < 3 ? year - 1 : year;
+  const fyEndYear = fyStartYear + 1;
+
+  return `${fyStartYear}-${String(fyEndYear).slice(2)}`;
+}
+
+/**
+ * Get the quarter number (1-4) for a date within the Indian FY.
+ * Q1: Apr-Jun, Q2: Jul-Sep, Q3: Oct-Dec, Q4: Jan-Mar
+ */
+export function getIndianFYQuarter(date: Date = new Date()): number {
+  const month = date.getMonth(); // 0-indexed
+  if (month >= 3 && month <= 5) return 1; // Apr-Jun
+  if (month >= 6 && month <= 8) return 2; // Jul-Sep
+  if (month >= 9 && month <= 11) return 3; // Oct-Dec
+  return 4; // Jan-Mar
+}
+
+/**
+ * Get FY start and end dates for a financial year string.
+ */
+export function getFYDateRange(fy: string): { start: Date; end: Date } {
+  const startYear = parseInt(fy.split("-")[0]);
+  return {
+    start: new Date(startYear, 3, 1), // April 1
+    end: new Date(startYear + 1, 2, 31, 23, 59, 59), // March 31
+  };
+}
+
+// ============================================================================
+// TDS Calculation
+// ============================================================================
+
+/**
+ * Get cumulative gross payments to a consultant for the current FY.
+ * This is the sum of all consultant earnings (grossAmount) for the FY.
+ */
+export async function getCurrentFYCumulativePayments(
+  consultantProfileId: string,
+  financialYear?: string,
+): Promise<number> {
+  const fy = financialYear || getIndianFinancialYear();
+  const { start, end } = getFYDateRange(fy);
+
+  const result = await prisma.consultantEarnings.aggregate({
+    where: {
+      consultantProfileId,
+      createdAt: { gte: start, lte: end },
+      status: { not: "REFUNDED" },
+    },
+    _sum: { grossAmount: true },
+  });
+
+  return result._sum.grossAmount || 0;
+}
+
+/**
+ * Get cumulative TDS already deducted for a consultant in a FY.
+ */
+export async function getCumulativeTDSDeducted(
+  consultantProfileId: string,
+  financialYear?: string,
+): Promise<number> {
+  const fy = financialYear || getIndianFinancialYear();
+
+  const result = await prisma.tDSRecord.aggregate({
+    where: {
+      consultantProfileId,
+      financialYear: fy,
+    },
+    _sum: { tdsDeducted: true },
+  });
+
+  return result._sum.tdsDeducted || 0;
+}
+
+export interface TDSCalculationResult {
+  /** TDS amount to deduct, in paise */
+  tdsAmount: number;
+  /** TDS rate applied (10 or 20) */
+  tdsRate: number;
+  /** Whether cumulative payments crossed the threshold */
+  isAboveThreshold: boolean;
+  /** Cumulative gross payments for FY (BEFORE this payout), in paise */
+  cumulativeBeforePayout: number;
+  /** Cumulative gross payments for FY (AFTER this payout), in paise */
+  cumulativeAfterPayout: number;
+  /** Current financial year */
+  financialYear: string;
+}
+
+/**
+ * Calculate TDS for a payout.
+ *
+ * TDS applies when cumulative FY payments exceed ₹50,000.
+ * If the threshold is crossed mid-payout, TDS is calculated on:
+ * - The excess amount if this payout crosses the threshold
+ * - The full payout amount if already above threshold
+ */
+export async function calculateTDS(params: {
+  consultantProfileId: string;
+  payoutAmountPaise: number;
+}): Promise<TDSCalculationResult> {
+  const { consultantProfileId, payoutAmountPaise } = params;
+  const financialYear = getIndianFinancialYear();
+
+  // Get cumulative payments for this FY
+  const cumulativeBeforePayout =
+    await getCurrentFYCumulativePayments(consultantProfileId);
+  const cumulativeAfterPayout = cumulativeBeforePayout + payoutAmountPaise;
+
+  // Below threshold — no TDS
+  if (cumulativeAfterPayout <= TDS_THRESHOLD_PAISE) {
+    return {
+      tdsAmount: 0,
+      tdsRate: 0,
+      isAboveThreshold: false,
+      cumulativeBeforePayout,
+      cumulativeAfterPayout,
+      financialYear,
+    };
+  }
+
+  // Determine TDS rate based on PAN verification
+  const taxInfo = await prisma.consultantTaxInfo.findUnique({
+    where: { consultantProfileId },
+  });
+
+  const tdsRate =
+    taxInfo?.panVerified ? TDS_RATE_WITH_PAN : TDS_RATE_WITHOUT_PAN;
+
+  // Calculate taxable amount
+  let taxableAmount: number;
+
+  if (cumulativeBeforePayout >= TDS_THRESHOLD_PAISE) {
+    // Already above threshold — TDS on full payout
+    taxableAmount = payoutAmountPaise;
+  } else {
+    // Crossing threshold this payout — TDS only on excess
+    taxableAmount = cumulativeAfterPayout - TDS_THRESHOLD_PAISE;
+  }
+
+  const tdsAmount = Math.round((taxableAmount * tdsRate) / 100);
+
+  return {
+    tdsAmount,
+    tdsRate,
+    isAboveThreshold: true,
+    cumulativeBeforePayout,
+    cumulativeAfterPayout,
+    financialYear,
+  };
+}
+
+/**
+ * Record a TDS deduction.
+ * Called after payout is processed to create an audit trail.
+ */
+export async function recordTDSDeduction(params: {
+  consultantProfileId: string;
+  financialYear: string;
+  tdsDeducted: number;
+  tdsRate: number;
+  cumulativeGrossPayments: number;
+  payoutId?: string;
+  earningsId?: string;
+}) {
+  const quarter = getIndianFYQuarter();
+
+  return prisma.tDSRecord.create({
+    data: {
+      consultantProfileId: params.consultantProfileId,
+      financialYear: params.financialYear,
+      quarter,
+      cumulativeGrossPayments: params.cumulativeGrossPayments,
+      tdsDeducted: params.tdsDeducted,
+      tdsRate: params.tdsRate,
+      payoutId: params.payoutId,
+      earningsId: params.earningsId,
+    },
+  });
+}
+
+// ============================================================================
+// Admin Queries
+// ============================================================================
+
+/**
+ * Get TDS summary for a financial year.
+ */
+export async function getTDSSummary(financialYear: string) {
+  const records = await prisma.tDSRecord.groupBy({
+    by: ["quarter"],
+    where: { financialYear },
+    _sum: { tdsDeducted: true },
+    _count: true,
+  });
+
+  const totalDeducted = await prisma.tDSRecord.aggregate({
+    where: { financialYear },
+    _sum: { tdsDeducted: true },
+    _count: true,
+  });
+
+  const unfiled = await prisma.tDSRecord.count({
+    where: { financialYear, reportedInForm26Q: false },
+  });
+
+  return {
+    financialYear,
+    quarterWise: records.map((r) => ({
+      quarter: r.quarter,
+      totalDeducted: r._sum.tdsDeducted || 0,
+      count: r._count,
+    })),
+    totalDeducted: totalDeducted._sum.tdsDeducted || 0,
+    totalRecords: totalDeducted._count,
+    unfiledRecords: unfiled,
+  };
+}
+
+/**
+ * Get per-consultant TDS breakdown for a financial year.
+ */
+export async function getConsultantTDSBreakdown(financialYear: string) {
+  return prisma.tDSRecord.groupBy({
+    by: ["consultantProfileId", "tdsRate"],
+    where: { financialYear },
+    _sum: { tdsDeducted: true, cumulativeGrossPayments: true },
+    _count: true,
+    orderBy: { _sum: { tdsDeducted: "desc" } },
+  });
+}
+
+/**
+ * Mark TDS records as filed in Form 26Q.
+ */
+export async function markTDSAsFiled(params: {
+  financialYear: string;
+  quarter: number;
+  filingDate: Date;
+}) {
+  return prisma.tDSRecord.updateMany({
+    where: {
+      financialYear: params.financialYear,
+      quarter: params.quarter,
+      reportedInForm26Q: false,
+    },
+    data: {
+      reportedInForm26Q: true,
+      form26QFilingDate: params.filingDate,
+    },
+  });
+}

--- a/lib/payments/validation/currency-guards.ts
+++ b/lib/payments/validation/currency-guards.ts
@@ -1,0 +1,57 @@
+/**
+ * Currency Validation Guards
+ *
+ * Ensures currency consistency across plans, discounts, credits, and payments.
+ * All prices are stored in INR paise for MVP. These guards prevent
+ * cross-currency mismatches that could cause incorrect charges.
+ */
+
+/**
+ * Validate that a plan's price currency matches the expected charge currency.
+ * For MVP: all plans must be INR.
+ *
+ * @throws Error if currency doesn't match
+ */
+export function validatePlanCurrency(
+  priceCurrency: string,
+  expected: string = "INR",
+): void {
+  if (priceCurrency !== expected) {
+    throw new Error(
+      `Plan currency mismatch: expected ${expected}, got ${priceCurrency}. ` +
+        `Multi-currency pricing is not yet supported.`,
+    );
+  }
+}
+
+/**
+ * Validate that a FIXED_AMOUNT discount is in the correct currency.
+ * Percentage discounts are currency-agnostic and always pass.
+ *
+ * @returns true if valid, false if mismatch
+ */
+export function validateDiscountCurrency(
+  discount: {
+    discountType: string;
+    currency?: string;
+  },
+  planCurrency: string,
+): boolean {
+  // Percentage discounts are currency-agnostic
+  if (discount.discountType === "PERCENTAGE") return true;
+
+  // FIXED_AMOUNT must match plan currency
+  const discountCurrency = discount.currency || "INR";
+  return discountCurrency === planCurrency;
+}
+
+/**
+ * Validate that referral credits can be applied to a payment.
+ * Credits must be in the same currency as the payment.
+ */
+export function validateCreditCurrency(
+  creditCurrency: string,
+  paymentCurrency: string,
+): boolean {
+  return creditCurrency === paymentCurrency;
+}

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -299,6 +299,7 @@ export async function getUserCredits(
   const credits = await db.referralCredit.findMany({
     where: {
       userId,
+      currency: "INR", // Only INR credits for MVP — prevents cross-currency application
       remainingAmount: { gt: 0 },
       OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
     },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -482,6 +482,10 @@ model ConsultantProfile {
   payouts        Payout[]
   payoutAccounts PayoutAccount[]
 
+  // Tax & compliance
+  taxInfo    ConsultantTaxInfo?
+  tdsRecords TDSRecord[]
+
   // Profile verification
   verificationRequests ConsultantProfileVerification[]
 
@@ -1498,6 +1502,11 @@ model Payment {
   expiresAt      DateTime? // For tracking payment intent expiration
   isMockPayment  Boolean        @default(false) // For development: mock payments skip gateway calls
 
+  // International payment tracking
+  buyerCountry           String?  // ISO 3166-1 alpha-2 code detected at checkout
+  isInternational        Boolean  @default(false) // Denormalized for query efficiency
+  exchangeRateAtCheckout Float?   // Snapshot of INR→display-currency rate for audit
+
   user           User          @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId         String
   appointment    Appointment?  @relation(fields: [appointmentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
@@ -1657,6 +1666,9 @@ model ConsultantEarnings {
   holdUntil DateTime // Release after hold period
   paidAt    DateTime?
 
+  // Currency (always INR for MVP, extensible for multi-currency)
+  currency String @default("INR")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -1682,6 +1694,10 @@ model Payout {
   method              PayoutMethod
   batchId             String?
 
+  // TDS (Tax Deducted at Source) — Section 194J
+  tdsDeducted Int @default(0) // TDS amount deducted from this payout, in paise
+  netAmount   Int? // Amount after TDS deduction (amount - tdsDeducted), sent to gateway
+
   // Processing
   failureReason String?
   retryCount    Int       @default(0)
@@ -1697,6 +1713,7 @@ model Payout {
 
   consultantProfile ConsultantProfile    @relation(fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   earnings          ConsultantEarnings[]
+  tdsRecords        TDSRecord[]
 
   @@index([consultantProfileId, status])
   @@index([batchId])
@@ -1736,6 +1753,58 @@ model PayoutAccount {
 
   @@index([consultantProfileId])
   @@index([isDefault])
+}
+
+////////////////////////////////////////// TAX & COMPLIANCE //////////////////////////////////////////
+
+model ConsultantTaxInfo {
+  id                  String  @id @default(cuid())
+  consultantProfileId String  @unique
+  panNumber           String? // PAN for TDS rate determination (store encrypted)
+  panVerified         Boolean @default(false)
+  gstin               String? // GSTIN for registered consultants
+  gstinVerified       Boolean @default(false)
+  country             String  @default("IN") // ISO 3166-1 alpha-2
+  isIndianResident    Boolean @default(true)
+  lutNumber           String? // Letter of Undertaking for export zero-rating
+  lutValidUntil       DateTime?
+
+  consultantProfile ConsultantProfile @relation(fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([consultantProfileId])
+}
+
+model TDSRecord {
+  id                      String  @id @default(cuid())
+  consultantProfileId     String
+  financialYear           String  // "2026-27" format (Apr-Mar)
+  quarter                 Int     // 1=Apr-Jun, 2=Jul-Sep, 3=Oct-Dec, 4=Jan-Mar
+
+  // Amounts in paise
+  cumulativeGrossPayments Int     // Sum of all grossAmount for this FY up to this record
+  tdsDeducted             Int     // TDS amount deducted this record
+  tdsRate                 Float   // Rate at time of deduction (10 or 20)
+
+  // Link to the payout that triggered this deduction
+  payoutId   String?
+  earningsId String?
+
+  // Filing status
+  reportedInForm26Q Boolean   @default(false)
+  form26QFilingDate DateTime?
+
+  consultantProfile ConsultantProfile @relation(fields: [consultantProfileId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  payout            Payout?           @relation(fields: [payoutId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([consultantProfileId, financialYear])
+  @@index([financialYear, quarter])
+  @@index([reportedInForm26Q])
 }
 
 model Invoice {
@@ -1788,7 +1857,8 @@ model DiscountCode {
   code          String       @unique
   description   String
   discountType  DiscountType
-  discountValue Int // For PERCENTAGE: whole number (10 = 10%). For FIXED_AMOUNT: in paise
+  discountValue Int    // For PERCENTAGE: whole number (10 = 10%). For FIXED_AMOUNT: in paise
+  currency      String @default("INR") // Currency for FIXED_AMOUNT discounts
   isActive      Boolean      @default(true)
   expiresAt     DateTime?
   maxUses       Int?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1559,7 +1559,9 @@ model Refund {
   status         RefundStatus
   refundId       String         @unique // Gateway-specific refund ID (Stripe/Razorpay)
   paymentGateway PaymentGateway
-  metadata       Json? // Additional gateway-specific metadata
+  metadata             Json? // Additional gateway-specific metadata
+  exchangeRateAtRefund Float? // INR→displayCurrency rate snapshot at refund time
+  displayCurrency      String? @db.VarChar(3) // Currency the buyer originally saw
 
   payment   Payment @relation(fields: [paymentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   paymentId String
@@ -1698,7 +1700,8 @@ model Payout {
   // TDS (Tax Deducted at Source) — Section 194J
   tdsDeducted Int @default(0) // TDS amount deducted from this payout, in paise
   netAmount   Int? // Amount after TDS deduction (amount - tdsDeducted), sent to gateway
-  tdsRateApplied Float? // TDS rate reserved for this payout, used when creating the final audit record
+  tdsRateApplied   Float?  // TDS rate reserved for this payout, used when creating the final audit record
+  tdsFinancialYear String? // FY when TDS was calculated (e.g. "2026-27"). Persisted to avoid FY-boundary drift.
 
   // Processing
   failureReason String?
@@ -1762,7 +1765,8 @@ model PayoutAccount {
 model ConsultantTaxInfo {
   id                  String  @id @default(cuid())
   consultantProfileId String  @unique
-  panNumber           String? // TODO: Encrypt at rest via KMS — currently plaintext. PAN is high-sensitivity PII.
+  panEncrypted        Bytes?           // AES-256-GCM encrypted PAN. Format: [12B IV][ciphertext][16B auth tag]
+  panLast4            String?  @db.VarChar(4) // Cleartext last 4 chars for masked display
   panVerified         Boolean @default(false)
   gstin               String? // GSTIN for registered consultants
   gstinVerified       Boolean @default(false)
@@ -1793,6 +1797,9 @@ model TDSRecord {
   // Link to the payout that triggered this deduction
   payoutId   String?
   earningsId String?
+
+  // Reversal flag (for refund-triggered TDS reversals — negative tdsDeducted)
+  isReversal        Boolean   @default(false)
 
   // Filing status
   reportedInForm26Q Boolean   @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1505,7 +1505,8 @@ model Payment {
   // International payment tracking
   buyerCountry           String?  // ISO 3166-1 alpha-2 code detected at checkout
   isInternational        Boolean  @default(false) // Denormalized for query efficiency
-  exchangeRateAtCheckout Float?   // Snapshot of INR→display-currency rate for audit
+  displayCurrencyAtCheckout String? @db.VarChar(3) // Currency code shown to the buyer at checkout
+  exchangeRateAtCheckout Float?   // Snapshot of INR→displayCurrencyAtCheckout for audit
 
   user           User          @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId         String
@@ -1697,6 +1698,7 @@ model Payout {
   // TDS (Tax Deducted at Source) — Section 194J
   tdsDeducted Int @default(0) // TDS amount deducted from this payout, in paise
   netAmount   Int? // Amount after TDS deduction (amount - tdsDeducted), sent to gateway
+  tdsRateApplied Float? // TDS rate reserved for this payout, used when creating the final audit record
 
   // Processing
   failureReason String?
@@ -1784,7 +1786,7 @@ model TDSRecord {
   quarter                 Int     // 1=Apr-Jun, 2=Jul-Sep, 3=Oct-Dec, 4=Jan-Mar
 
   // Amounts in paise
-  cumulativeGrossPayments Int     // Sum of all grossAmount for this FY up to this record
+  cumulativeAmountCredited Int    // FY cumulative of amounts credited/paid to consultant (sum of completed payouts)
   tdsDeducted             Int     // TDS amount deducted this record
   tdsRate                 Float   // Rate at time of deduction (10 or 20)
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1760,7 +1760,7 @@ model PayoutAccount {
 model ConsultantTaxInfo {
   id                  String  @id @default(cuid())
   consultantProfileId String  @unique
-  panNumber           String? // PAN for TDS rate determination (store encrypted)
+  panNumber           String? // TODO: Encrypt at rest via KMS — currently plaintext. PAN is high-sensitivity PII.
   panVerified         Boolean @default(false)
   gstin               String? // GSTIN for registered consultants
   gstinVerified       Boolean @default(false)

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -84,7 +84,7 @@ export const checkoutSchema = z
     schedulingPeriodStartsAt: z.string().datetime().optional(),
     schedulingPeriodEndsAt: z.string().datetime().optional(),
     discountCode: z.string().optional(),
-    paymentGateway: paymentGatewaySchema,
+    paymentGateway: paymentGatewaySchema.default("RAZORPAY"), // Server auto-routes; client hint only
     notes: z.string().optional(),
     fromWaitlist: z.string().optional(), // Waitlist ID if coming from waitlist flow
     useReferralCredits: z.boolean().optional(), // Apply available referral credits

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -85,6 +85,7 @@ export const checkoutSchema = z
     schedulingPeriodEndsAt: z.string().datetime().optional(),
     discountCode: z.string().optional(),
     paymentGateway: paymentGatewaySchema.default("RAZORPAY"), // Server auto-routes; client hint only
+    displayCurrency: z.string().length(3).optional(), // Currency shown in the checkout UI
     notes: z.string().optional(),
     fromWaitlist: z.string().optional(), // Waitlist ID if coming from waitlist flow
     useReferralCredits: z.boolean().optional(), // Apply available referral credits
@@ -300,6 +301,7 @@ export const createCheckoutData = (params: {
   schedulingPeriodStartsAt?: string;
   schedulingPeriodEndsAt?: string;
   discountCode?: string;
+  displayCurrency?: string;
   notes?: string;
   fromWaitlist?: string;
   useReferralCredits?: boolean;
@@ -316,6 +318,7 @@ export const createCheckoutData = (params: {
     schedulingPeriodStartsAt: params.schedulingPeriodStartsAt,
     schedulingPeriodEndsAt: params.schedulingPeriodEndsAt,
     discountCode: params.discountCode,
+    displayCurrency: params.displayCurrency?.toUpperCase(),
     notes: params.notes,
     fromWaitlist: params.fromWaitlist,
     useReferralCredits: params.useReferralCredits,


### PR DESCRIPTION
## What is this PR?

Familiarise is an Indian marketplace where consultants sell services (consultations, subscriptions, webinars, classes) to buyers worldwide. This PR adds the financial plumbing needed to handle **international buyers correctly** — tax compliance, smart payment routing, and audit trails. It also fixes a critical bug where every international buyer was being overcharged.

---

## The Problem (Why This PR Exists)

### 1. Every international buyer was charged 18% GST incorrectly

The checkout code checked `currency !== "INR"` to decide if a transaction was international. But **all plans store prices in INR** (that's our base currency). So the condition was always `false`, and every international buyer got hit with 18% Indian GST — even though exports of services are legally **tax-free** under Indian law (IGST Act Section 2(6)).

### 2. No tax withholding system (TDS)

Indian law (Section 194J) requires platforms to withhold 10-20% tax from consultant payouts once cumulative payments exceed ₹50,000/year. We had nothing for this — no tracking, no deduction, no records for quarterly filings (Form 26Q).

### 3. Payment gateway costs were unoptimized

Stripe charges ~6.3% for international transactions. Razorpay's International Bank Transfer (IBT) charges ~1% + GST with zero forex markup. We had no smart routing — the user just picked a gateway from the UI.

### 4. No audit trail for international payments

No record of buyer country, whether a transaction was international, or what exchange rate was displayed at checkout.

### 5. PAN stored in plaintext

Consultant PAN numbers (Indian tax ID — equivalent to SSN) were stored as plain `String` in the database. No encryption at rest.

### 6. No failure path handling

Refunds on already-paid-out earnings had no mechanism to reverse TDS deductions. Non-resident consultants could silently trigger incorrect Section 194J withholding. Payouts crossing the March 31/April 1 financial year boundary could record TDS against the wrong year.

---

## What We Built (The Solution)

### Buyer Country Detection

**New file:** `lib/payments/tax/buyer-country.ts`

The system now figures out where the buyer is, using a cascading approach:
1. Check the user's `country` field in the database (most reliable)
2. Check Cloudflare's `cf-ipcountry` header (IP geolocation)
3. Parse the browser's `Accept-Language` header
4. Default to India (`"IN"`) if nothing else works

This detection runs server-side for the actual charge, and also via a new API endpoint (`/api/checkout/context`) so the checkout page can show the correct tax preview.

### Tax Engine

**New file:** `lib/payments/tax/tax-engine.ts`

Simple rules:
- **Indian buyer** → 18% GST (standard rate for consulting/education services)
- **International buyer** → 0% (zero-rated export of services)

The checkout page now shows the correct tax to the buyer BEFORE they pay, using a new React hook (`useCheckoutTaxContext`) that fetches the server-detected country.

### TDS (Tax Deducted at Source) System

**New file:** `lib/payments/tax/tds-service.ts`

When we pay a consultant, the system:
1. Checks their cumulative payouts for the current financial year (April–March)
2. If it exceeds ₹50,000: deducts 10% (with PAN) or 20% (without PAN)
3. Sends the **net amount** (after TDS) to the payment gateway
4. Creates a `TDSRecord` for Form 26Q quarterly filing — but **only after the payout is confirmed** by the gateway webhook

The TDS lifecycle went through 3 iterations during review:
- **v1:** Created TDS records at payout initiation → Problem: failed payouts left phantom records
- **v2:** Added deletion on failure → Problem: records existed in a limbo state between initiation and webhook
- **v3 (current):** TDS records are ONLY created when the COMPLETED webhook fires, inside the same database transaction that marks earnings as paid. Failed/cancelled payouts clean up all TDS data. The rate and financial year are persisted on the Payout record (`tdsRateApplied`, `tdsFinancialYear`) to bridge the gap between calculation and confirmation.

### Smart Gateway Routing

**New file:** `lib/payments/gateway-router.ts`

All payments auto-route through Razorpay:
- **Indian buyers** → Razorpay domestic (2% + GST, supports UPI)
- **International buyers** → Razorpay IBT (1% + GST, zero forex markup)
- **Explicit Stripe request** → Honored (for testing/edge cases)

This gives us a structural cost advantage: ~11% effective international cost vs TopMate's ~15-18%.

### PAN Encryption (AES-256-GCM)

**New file:** `lib/payments/tax/pan-crypto.ts`

PAN numbers are now encrypted at rest using AES-256-GCM with a 32-byte key from the `PAN_ENCRYPTION_KEY` environment variable. The old plaintext `panNumber` field is **removed entirely** from the schema and replaced with:
- `panEncrypted` (Bytes) — ciphertext in format `[12B IV][ciphertext][16B auth tag]`
- `panLast4` (VarChar(4)) — cleartext last 4 digits for masked display (`XXXXXX1234`)

The admin Form 26Q view (`GET /api/admin/tds?view=form26q`) is the only path that decrypts PAN — restricted to ADMIN role only (not STAFF).

### Non-Resident Payout Guard

Two-layer protection:
1. **`calculateTDS`**: Returns zero TDS immediately if `isIndianResident === false` (Section 194J doesn't apply to non-residents)
2. **`processSinglePayout`**: Blocks payout entirely with clear error message — Razorpay can only pay to Indian bank accounts anyway

When Section 195 (international withholding) support is added in the future, the guard is the single place to modify.

### Refund → TDS Reversal

When a refund happens **after a payout has already completed** (consultant already paid):
- A reversal `TDSRecord` with negative `tdsDeducted` is created, preserving the full audit trail
- The `forceRefund` flag from the admin refund API flows through to the webhook handler via refund metadata
- Consultant's `totalRevenue` is decremented (not `pendingRevenue`, since the payout was already completed)

### Refund Exchange Rate Audit

For international payment refunds:
- `exchangeRateAtRefund` — INR→display currency rate at refund time
- `displayCurrency` — the currency code from the original payment

Since Razorpay settles in INR, the FX delta is absorbed by the buyer's card network. These fields are for audit purposes only.

### Exchange Rate Audit Trail (Checkout)

When an international buyer checks out, we now save:
- `displayCurrencyAtCheckout` — what currency they were viewing prices in (e.g., "USD")
- `exchangeRateAtCheckout` — the INR→display rate at that moment

### Currency Guards

**New file:** `lib/payments/validation/currency-guards.ts`

Prevents currency mismatches:
- Plans must be in INR (MVP constraint)
- Fixed-amount discount codes can't be applied to a plan in a different currency
- Referral credits are filtered by currency

---

## Schema Changes

### New Models

| Model | Purpose |
|-------|---------|
| `ConsultantTaxInfo` | Encrypted PAN, GSTIN, country, LUT info, verification status |
| `TDSRecord` | Per-deduction audit trail for Form 26Q filing (supports reversals) |

### Modified Models

| Model | New Fields | Purpose |
|-------|-----------|---------|
| `Payment` | `buyerCountry`, `isInternational`, `displayCurrencyAtCheckout`, `exchangeRateAtCheckout` | International payment tracking + audit |
| `Payout` | `tdsDeducted`, `netAmount`, `tdsRateApplied`, `tdsFinancialYear` | TDS withholding data + FY-boundary protection |
| `ConsultantEarnings` | `currency` | Explicit currency (was implicit) |
| `DiscountCode` | `currency` | Currency-aware discount validation |
| `Refund` | `exchangeRateAtRefund`, `displayCurrency` | International refund audit trail |

### Field Naming

- `TDSRecord.cumulativeAmountCredited` — aligns with Section 194J language ("amount credited or paid to the payee"). Tracks the running total of all completed payouts to a consultant for the financial year.
- `ConsultantTaxInfo.panEncrypted` + `panLast4` — replaced plaintext `panNumber`. Encrypted at rest, masked for display.
- `TDSRecord.isReversal` — `true` for refund-triggered reversal records (negative `tdsDeducted`).
- `Payout.tdsFinancialYear` — persisted FY snapshot to prevent drift when payouts cross April 1.

---

## New API Endpoints

| Endpoint | Method | Purpose | Auth |
|----------|--------|---------|------|
| `/api/admin/tds` | GET | FY TDS summary, per-consultant breakdown, or Form 26Q data (decrypts PAN) | Admin/Staff (Form 26Q: Admin only) |
| `/api/admin/tds` | POST | Mark records as filed in Form 26Q | Admin only |
| `/api/consultant/tax-info` | GET | View masked PAN (`XXXXXX1234`), GSTIN, verification status | Consultant |
| `/api/consultant/tax-info` | PUT | Update PAN (encrypted), GSTIN, country | Consultant |
| `/api/checkout/context` | GET | Server-detected buyer country for checkout UI tax preview | Authenticated |

---

## Bug Fixes

| Bug | Where | Impact | Fix |
|-----|-------|--------|-----|
| Export zero-rating never triggered | `checkout.ts:402` | Every international buyer overcharged 18% | Check `buyerCountry !== "IN"` instead of `currency !== "INR"` |
| Same bug in invoice service | `invoice-service.ts:166` | International invoices showed wrong tax | Use `payment.isInternational` field |
| Checkout UI showed 18% for international | All 4 checkout pages | Buyer sees wrong price before paying | New `useCheckoutTaxContext` hook with server detection |
| TDS mixed gross and net bases | `tds-service.ts` | Threshold crossing calculated incorrectly | Standardized on completed payout amounts |
| Failed payouts left TDS records | `payout-service.ts` | Form 26Q inflated with phantom deductions | Records only created on COMPLETED webhook |
| PAN stored in plaintext | `schema.prisma`, `tax-info/route.ts` | Identity document exposed in DB | AES-256-GCM encryption, plaintext field removed |
| FY-boundary TDS drift | `payout-service.ts` | TDS recorded in wrong financial year | FY persisted on Payout at calculation time |
| Non-resident gets Section 194J | `tds-service.ts` | Incorrect withholding for international consultants | Guard in calculateTDS + payout blocked |
| Refund doesn't reverse TDS | `earnings-service.ts` | Over-reported TDS after refund | Reversal TDSRecord with negative amount |
| Refund has no FX audit trail | `refunds/route.ts` | No record of refund exchange rate | `exchangeRateAtRefund` + `displayCurrency` on Refund |
| Razorpay component hardcoded | `RazorpayCheckout.tsx` | "Your App Name", "Test Transaction" in production | Fixed to "Familiarise", dynamic descriptions |
| Gateway labels misleading | `utils.ts` | "Stripe = International USD" contradicted auto-routing | Updated to reflect actual behavior |
| `exchangeRateAtCheckout` never written | `checkout.ts` | Schema field existed but was always null | Populated from exchange rate API for international payments |

---

## Review History

This PR went through **5 rounds of review** by 3 different AI reviewers (Gemini, ChatGPT 5.4 Codex, Claude), with fixes applied after each round.

### Round 1 — Gemini Code Assist
- Found unused `amount` parameter in gateway router → **Fixed**
- Noted client-side `isInternational` flag → **Non-actionable** (display-only, server is authoritative)

### Round 2 — ChatGPT 5.4 Codex (3-part review)

**Part 1 — Code bugs (3 findings):**
- C1: TDS basis mismatch → **Fixed** (standardized on payout amounts)
- C2: TDS records not reversed on failure → **Fixed** (complete lifecycle redesign)
- C3: PAN plaintext → ~~Deferred~~ **Now fixed** (AES-256-GCM encryption)

**Part 2 — Tax/legal (4 findings):**
- C4: 194-O vs 194J needs CA memo → **Documented as launch blocker**
- C5: Zero-rating needs more evidence → **Deferred** with TODO
- C6: Non-resident payouts → ~~Out of scope~~ **Now guarded** (payout blocked + TDS skipped)
- C7: GST TCS / GSTR-8 → **Out of scope** (post-launch)

**Part 3 — UX (4 findings):**
- C8: Tax preview wrong for international → **Fixed** (server-side detection hook)
- C9: Gateway labels wrong → **Fixed**
- C10: Exchange rate never saved → **Fixed** (with display currency tracking)
- C11: Financial planning notes → **Acknowledged** (not code)

### Round 3 — Claude (independent re-review of accumulated changes)
- F1: TDS record timing (medium) → **Acceptable** by design (payout record bridges gap)
- F2: `cumulativeGrossPayments` name misleading → **Fixed** (renamed to `cumulativeAmountCredited`)
- F3: Dead Stripe code → **Resolved** (Stripe intentionally restored — cleanup is separate PR)
- F4: `displayCurrency` validation loose → **Acceptable** (worst case: null exchange rate)
- F5: First-render flash for international users → **Known, cosmetic** (server charges correctly)

### Round 4 — ChatGPT 5.4 Codex (re-review)
- P1: FY-boundary edge case in TDS → ~~Known~~ **Now fixed** (FY persisted on Payout)
- P2: First-render tax flash → **Known, cosmetic**
- P3: PAN plaintext → ~~Deferred~~ **Now fixed** (AES-256-GCM)
- Confirmed C1, C9, C10 as resolved

### Round 5 — Engineering hardening (self-review)

All remaining engineering gaps from ChatGPT 5.4's final assessment closed:
- PAN encryption → **Fixed** (AES-256-GCM, plaintext field removed)
- FY-boundary → **Fixed** (`tdsFinancialYear` persisted on Payout)
- Non-resident guard → **Fixed** (two-layer: calculateTDS + processSinglePayout)
- Refund → TDS reversal → **Fixed** (reversal TDSRecord with negative amount)
- Refund exchange rate → **Fixed** (`exchangeRateAtRefund` + `displayCurrency` on Refund)
- Prisma schema validated → **Passed** (migration pending explicit run)

---

## Known Limitations & Remaining Items

| Item | Status | Notes |
|------|--------|-------|
| 194-O vs 194J CA memo | Launch blocker | Legal question — requires chartered accountant opinion before accepting real payments |
| Export zero-rating evidence (FIRC, LUT, billing address) | TODO in code | Current `buyerCountry` heuristic is sufficient for MVP; full evidence needed for audit defense |
| Non-resident consultant Section 195 | Guarded | Payouts blocked with clear error. Section 195 withholding logic is future work (needs per-country DTAA analysis) |
| GST TCS / GSTR-8 reporting | Out of scope | Post-launch operational work |
| PAN key rotation | Not yet needed | Current key is static. Key rotation would require re-encrypting all stored PANs |
| International tax preview flash | Known, cosmetic | Shows 18% for ~200ms until `/api/checkout/context` returns. Server charges correctly regardless |
| Prisma migration | Pending | Schema validated. Run `npx prisma migrate dev --name tds-pan-encryption-and-guardrails` to apply |

---

## Documentation Added/Updated

| File | Content |
|------|---------|
| `docs/payments/multi-currency/01-architecture.md` | Gateway selection, cost comparison, currency flow, buyer country detection, exchange rate audit fields |
| `docs/payments/multi-currency/02-tax-engine.md` | GST rules, zero-rating conditions, e-commerce operator classification |
| `docs/payments/multi-currency/03-tds-compliance.md` | TDS 194J rules, threshold tracking (completed payouts basis), deduction flow (COMPLETED webhook), **launch blockers** |
| `docs/payments/gateways/gateway-evaluation-mar-2026.md` | 7-gateway comparison (Razorpay, Cashfree, Stripe, Lemon Squeezy, Xflow, Dodo, Polar) |
| `docs/finances/07-tax-compliance-india.md` | Updated zero-rating description + implementation status |
| `docs/finances/08-tax-compliance-marketplace-obligations.md` | GST/TCS/TDS obligations, Section 44AD risk, cross-border compliance |

---

## Commit History

| Commit | Description |
|--------|-------------|
| `5c2f2323` | Initial implementation: tax engine, TDS, gateway auto-routing, buyer country detection |
| `c003d4c7` | Prettier + remove unused `amount` param (Gemini feedback) |
| `8a116277` | Merge dev (soft-cancel test fix) |
| `46fba89e` | Gateway evaluation + marketplace tax compliance docs |
| `699e2e86` | Round 2 fixes: TDS basis, failed payout reversal, checkout UX, gateway labels |
| `7784dcd6` | Round 3 fixes: TDS lifecycle redesign, field rename, Stripe restore, checkout tax context |
| `e004b2f3` | Fix stale doc references |
| `9d002c1a` | Round 5: PAN encryption, FY-boundary fix, non-resident guard, refund TDS reversal, refund FX audit |

---

## Stats

- **36 files changed**, 2,723 insertions, 244 deletions
- **10 commits** across 5 review rounds
- **4 new services** (tax engine, TDS service, gateway router, PAN crypto)
- **5 new API endpoints** (+ 1 new view on existing endpoint)
- **2 new Prisma models**, 5 modified models
- **676/676 tests passing**
- **Reviewed by 3 AI reviewers** across 5 rounds — all engineering findings resolved

---

## Test Plan

- [ ] Set `PAN_ENCRYPTION_KEY` env var (`openssl rand -hex 32`)
- [ ] Run `npx prisma migrate dev --name tds-pan-encryption-and-guardrails`
- [ ] Domestic checkout (India): should see 18% GST, route to Razorpay
- [ ] International checkout (set `cf-ipcountry: US`): should see 0% tax, route to Razorpay IBT
- [ ] Verify `displayCurrencyAtCheckout` + `exchangeRateAtCheckout` saved on Payment for international checkout
- [ ] Verify TDS: consultant below ₹50K/FY = no deduction; above = 10% with PAN, 20% without
- [ ] Verify failed payout webhook cleans up TDS records and resets `tdsFinancialYear`
- [ ] Verify non-resident consultant payout → FAILED with "not supported" message
- [ ] Verify `PUT /api/consultant/tax-info` encrypts PAN (check DB: `panEncrypted` is bytes, `panNumber` column gone)
- [ ] Verify `GET /api/consultant/tax-info` returns `panMasked: "XXXXXX1234"`
- [ ] Verify `GET /api/admin/tds?view=form26q` decrypts PAN (ADMIN only, not STAFF)
- [ ] Verify refund with `forceRefund: true` on PAID earnings → creates reversal TDSRecord with negative amount
- [ ] Verify international refund → `exchangeRateAtRefund` populated on Refund record
- [ ] Verify FIXED_AMOUNT discount with wrong currency is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)