### PR TITLE
fix: resolve booking modal wrong times — local minutes stored as UTC

### DIFF
--- a/app/form/onboarding/components/ConsultantPreferredScheduleForm.tsx
+++ b/app/form/onboarding/components/ConsultantPreferredScheduleForm.tsx
@@ -134,17 +134,10 @@ const ConsultantPreferredScheduleForm: React.FC<Props> = ({
     }
   }, [initialData, timezone, timezoneLoading]);
 
-  // Format weekly slots for API
-  useEffect(() => {
-    if (!timezone) return;
-    setValue("weeklySlots", buildWeeklySlotsForSave(weeklySlots, timezone));
-  }, [weeklySlots, setValue, timezone]);
-
-  // Format custom slots for API
-  useEffect(() => {
-    if (!timezone) return;
-    setValue("customSlots", buildCustomSlotsForSave(customSlots, timezone));
-  }, [customSlots, setValue, timezone]);
+  // NOTE: Conversion from local HH:MM → UTC minutes is done synchronously
+  // in onSubmitForm (not in a useEffect) to avoid a race condition where
+  // the form could submit stale/unconverted values if the user clicks "Next"
+  // before the useEffect fires. This mirrors the working pattern in SettingsTab.
 
   const handleAddSlot = useCallback(
     (
@@ -334,9 +327,22 @@ const ConsultantPreferredScheduleForm: React.FC<Props> = ({
         return;
       }
 
-      onNext(data);
+      // Convert local HH:MM → UTC minutes synchronously at submit time
+      // (not in a useEffect) to prevent race condition
+      const tz = timezone || "UTC";
+      onNext({
+        ...data,
+        weeklySlots:
+          data.scheduleType === "WEEKLY"
+            ? buildWeeklySlotsForSave(weeklySlots, tz)
+            : undefined,
+        customSlots:
+          data.scheduleType === "CUSTOM"
+            ? buildCustomSlotsForSave(customSlots, tz)
+            : undefined,
+      });
     },
-    [validationFeedback, onNext, toast],
+    [validationFeedback, onNext, toast, timezone, weeklySlots, customSlots],
   );
 
   const [currentDate, setCurrentDate] = useState(new Date());

--- a/utils/dateTimeUtils.ts
+++ b/utils/dateTimeUtils.ts
@@ -195,9 +195,12 @@ export const convertTimezoneToUtc = (
       return isNaN(date.getTime()) ? "" : date.toISOString();
     }
 
-    // Create a date in the specified timezone using date-fns-tz
-    const localDateTime = `${dateStr}T${timeStr}:00`;
-    const zonedDate = new Date(localDateTime);
+    // Construct the Date explicitly to avoid browser date-string parsing
+    // ambiguity (strings without a TZ designator may be parsed as UTC in
+    // some engines, making fromZonedTime a no-op).
+    const [hours, minutes] = timeStr.split(":").map(Number);
+    const [year, month, day] = dateStr.split("-").map(Number);
+    const zonedDate = new Date(year, month - 1, day, hours, minutes, 0, 0);
 
     if (isNaN(zonedDate.getTime())) return "";
 

--- a/utils/onboarding-server.ts
+++ b/utils/onboarding-server.ts
@@ -185,6 +185,17 @@ async function syncAvailabilitySlots(
         }
       }
 
+      console.info("[syncAvailabilitySlots] Saving weekly slots:", {
+        consultantProfileId,
+        utcOffsetMinutes,
+        slotCount: weeklySlotsToCreate.length,
+        slots: weeklySlotsToCreate.map((s) => ({
+          day: s.startDay,
+          start: s.startTimeUtc,
+          end: s.endTimeUtc,
+        })),
+      });
+
       await tx.slotOfAvailabilityWeekly.createMany({
         data: weeklySlotsToCreate.map((slot) => ({
           startDay: slot.startDay,

--- a/utils/schedule/formatting.ts
+++ b/utils/schedule/formatting.ts
@@ -53,7 +53,7 @@ const getNextDayOfWeek = (dayOfWeek: string): string => {
 /**
  * Shift a day of the week by an offset (positive or negative).
  */
-const shiftDayOfWeek = (dayOfWeek: string, offset: number): string => {
+export const shiftDayOfWeek = (dayOfWeek: string, offset: number): string => {
   const days = [
     "MONDAY",
     "TUESDAY",
@@ -300,7 +300,17 @@ export function buildWeeklySlotsForSave(
 
         const startMinutes = dateToMinuteUtc(new Date(startUTC));
         const endMinutes = dateToMinuteUtc(new Date(endUTC));
-        const startDay = day.toUpperCase() as DayOfWeek;
+
+        // Compute actual UTC start day — timezone conversion may shift the day
+        // (e.g., IST Monday 1:00 AM → UTC Sunday 7:30 PM)
+        const baseDateMs = new Date(baseDate + "T00:00:00Z").getTime();
+        const startDayOffset = Math.floor(
+          (new Date(startUTC).getTime() - baseDateMs) / 86400000,
+        );
+        const startDay = shiftDayOfWeek(
+          day.toUpperCase(),
+          startDayOffset,
+        ) as DayOfWeek;
 
         if (overnight) {
           const endDay = getNextDayOfWeek(startDay) as DayOfWeek;
@@ -315,10 +325,15 @@ export function buildWeeklySlotsForSave(
           ];
         }
 
+        // Check if the slot becomes overnight in UTC (startMin >= endMin)
+        const isOvernightInUtc = startMinutes >= endMinutes;
+
         return [
           {
             startDay,
-            endDay: startDay,
+            endDay: isOvernightInUtc
+              ? (getNextDayOfWeek(startDay) as DayOfWeek)
+              : startDay,
             startTimeUtc: startMinutes,
             endTimeUtc: endMinutes,
           },


### PR DESCRIPTION
## Summary

Shubham set a **Monday 1:00 PM – 3:00 PM IST** weekly slot during onboarding. The booking modal displayed **6:30 PM – 8:30 PM** — shifted by exactly +5h30m (the IST offset). The profile grid appeared correct only by coincidence (it was reading the raw local minutes as-if they were UTC).

### Root cause

The onboarding form converted local HH:MM → UTC minutes inside a **`useEffect`**, but form submission ran **synchronously** via `handleSubmit(onSubmitForm)`. If the user clicked "Next" before the async effect fired, stale/unconverted local values were submitted as UTC. The settings path (`SettingsTab.tsx`) didn't have this bug because it calls `formatSlotsForApi()` synchronously inside the submit handler.

### What changed

| File | Change |
|------|--------|
| `ConsultantPreferredScheduleForm.tsx` | Removed the two `useEffect`s that called `buildWeeklySlotsForSave`/`buildCustomSlotsForSave`. Conversion now happens synchronously in `onSubmitForm`, matching the working SettingsTab pattern. |
| `utils/dateTimeUtils.ts` | `convertTimezoneToUtc` now uses explicit `new Date(year, month-1, day, hours, minutes)` constructor instead of parsing `"1970-01-01T13:00:00"` strings — avoids browser ambiguity where TZ-less ISO strings may be parsed as UTC, making `fromZonedTime` a no-op. |
| `utils/schedule/formatting.ts` | `buildWeeklySlotsForSave` now computes the actual UTC day-of-week after timezone conversion (e.g., IST Monday 1:00 AM → UTC Sunday 7:30 PM shifts the day back). Also detects when a same-day local slot becomes overnight in UTC. Exported `shiftDayOfWeek` for reuse. |
| `utils/onboarding-server.ts` | Added `console.info` logging before `createMany` to aid future debugging of slot values hitting the DB. |

### DB fix (already applied)

Shubham's existing slot was corrected via Supabase SQL:
```
startTimeUtc: 780 → 450  (7:30 AM UTC = 1:00 PM IST)
endTimeUtc:   900 → 570  (9:30 AM UTC = 3:00 PM IST)
```

Audit of all consultants with `utcOffsetMinutes != 0` confirmed only Shubham's production data was affected — all other rows are E2E test seed data with intentionally set values.

## Test plan

- [ ] Verify Shubham's profile: booking modal should show 1:00–2:00 / 1:30–2:30 / 2:00–3:00 PM IST slots (not 6:30 PM+)
- [ ] Create a new test consultant via onboarding with an IST weekly slot → check DB `startTimeUtc`/`endTimeUtc` are actual UTC values (local minus 330)
- [ ] Modify a weekly slot via Settings → verify DB values remain correct (regression check — settings path was already working)
- [ ] View a consultant profile from a UTC browser → verify displayed times convert correctly
- [ ] Test overnight slot edge case: set a slot crossing midnight (e.g., 11 PM – 1 AM IST) → verify `startDay` and `endDay` are correct in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)