### PR TITLE
fix: profile grid timezone + explore experts company multi-select & debounce

### DIFF
--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -22,13 +22,12 @@ export async function GET(request: NextRequest) {
     const rawMinPrice = searchParams.get("minPrice");
     const rawMaxPrice = searchParams.get("maxPrice");
     const language = searchParams.get("language");
-    const availability = searchParams.get("availability") as
-      | "has_slots"
-      | "this_week"
-      | null;
+    const rawMinRating = searchParams.get("minRating");
+    const companies = searchParams.get("companies")?.split(",").filter(Boolean);
 
     const minPrice = rawMinPrice ? parseFloat(rawMinPrice) : undefined;
     const maxPrice = rawMaxPrice ? parseFloat(rawMaxPrice) : undefined;
+    const minRating = rawMinRating ? parseFloat(rawMinRating) : undefined;
 
     // Calculate offset
     const skip = (page - 1) * limit;
@@ -96,34 +95,19 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Availability filter
-    if (availability === "has_slots") {
+    // Rating filter
+    if (minRating !== undefined && !isNaN(minRating)) {
+      where.AND.push({ rating: { gte: minRating } });
+    }
+
+    // Company filter (multi-select — values come from pre-fetched list, exact match)
+    if (companies && companies.length > 0) {
       where.AND.push({
-        OR: [
-          { slotsOfAvailabilityWeekly: { some: {} } },
-          { slotsOfAvailabilityCustom: { some: {} } },
-        ],
-      });
-    } else if (availability === "this_week") {
-      const now = new Date();
-      const oneWeekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-      where.AND.push({
-        OR: [
-          // Weekly slots are recurring — if they exist, the consultant
-          // has availability every week
-          { slotsOfAvailabilityWeekly: { some: {} } },
-          // Custom slots within the next 7 days
-          {
-            slotsOfAvailabilityCustom: {
-              some: {
-                startsAt: {
-                  gte: now,
-                  lte: oneWeekFromNow,
-                },
-              },
-            },
+        user: {
+          workExperiences: {
+            some: { company: { in: companies } },
           },
-        ],
+        },
       });
     }
 

--- a/app/explore/experts/ExpertsInteractiveContent.tsx
+++ b/app/explore/experts/ExpertsInteractiveContent.tsx
@@ -352,6 +352,20 @@ export default function ExpertsInteractiveContent({
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.2 }}
           >
+            <div className="relative mb-6 py-10 px-6 rounded-2xl bg-gradient-to-br from-zinc-900 via-zinc-800 to-zinc-700 overflow-hidden">
+              <div className="absolute inset-0 opacity-10">
+                <div className="absolute top-0 right-0 w-72 h-72 bg-white rounded-full blur-3xl -translate-y-1/2 translate-x-1/4" />
+                <div className="absolute bottom-0 left-0 w-56 h-56 bg-white rounded-full blur-3xl translate-y-1/2 -translate-x-1/4" />
+              </div>
+              <div className="relative text-center">
+                <h2 className="text-2xl md:text-3xl font-bold text-white mb-2">
+                  Find Your Perfect Expert
+                </h2>
+                <p className="text-zinc-400 text-sm md:text-base max-w-lg mx-auto">
+                  Search by name, skill, or specialty to connect with top consultants
+                </p>
+              </div>
+            </div>
             <SearchBar
               onSearch={(term) => updateFilters({ search: term })}
               onSort={(option) => updateFilters({ sort: option })}

--- a/app/explore/experts/ExpertsInteractiveContent.tsx
+++ b/app/explore/experts/ExpertsInteractiveContent.tsx
@@ -79,14 +79,21 @@ export default function ExpertsInteractiveContent({
     loadMore,
   } = useConsultants(filters);
 
-  // Sync filters to URL
+  // Sync filters to URL (debounced to avoid excessive history entries during rapid changes)
+  const urlSyncRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    const qs = filtersToSearchParams(filters);
-    const target = `/explore/experts${qs ? `?${qs}` : ""}`;
-    const current = window.location.pathname + window.location.search;
-    if (target !== current) {
-      router.replace(target, { scroll: false });
-    }
+    if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
+    urlSyncRef.current = setTimeout(() => {
+      const qs = filtersToSearchParams(filters);
+      const target = `/explore/experts${qs ? `?${qs}` : ""}`;
+      const current = window.location.pathname + window.location.search;
+      if (target !== current) {
+        router.replace(target, { scroll: false });
+      }
+    }, 300);
+    return () => {
+      if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
+    };
   }, [filters, router]);
 
   const updateFilters = useCallback((partial: Partial<IExpertFilters>) => {
@@ -175,15 +182,16 @@ export default function ExpertsInteractiveContent({
             : `${formatCurrencyPrice(min)} - ${formatCurrencyPrice(max)}`;
       chips.push({ key: "price", label: "Price", value: label });
     }
-    if (filters.availability) {
-      const availLabel =
-        filters.availability === "has_slots"
-          ? "Has Open Slots"
-          : "Available This Week";
+    if (filters.minRating !== undefined) {
       chips.push({
-        key: "availability",
-        label: "Availability",
-        value: availLabel,
+        key: "minRating",
+        label: "Rating",
+        value: `${filters.minRating}+ stars`,
+      });
+    }
+    if (filters.companies.length > 0) {
+      filters.companies.forEach((company) => {
+        chips.push({ key: `company-${company}`, label: "Company", value: company });
       });
     }
     if (filters.language) {
@@ -226,8 +234,11 @@ export default function ExpertsInteractiveContent({
         updateFilters({ experience: 0 });
       } else if (key === "price") {
         updateFilters({ minPrice: undefined, maxPrice: undefined });
-      } else if (key === "availability") {
-        updateFilters({ availability: undefined });
+      } else if (key === "minRating") {
+        updateFilters({ minRating: undefined });
+      } else if (key.startsWith("company-")) {
+        const companyName = key.replace("company-", "");
+        updateFilters({ companies: filters.companies.filter((c) => c !== companyName) });
       } else if (key === "language") {
         updateFilters({ language: undefined });
       } else if (key === "search") {
@@ -236,7 +247,7 @@ export default function ExpertsInteractiveContent({
         updateFilters({ sort: "nameAsc" });
       }
     },
-    [updateFilters, filters.tags],
+    [updateFilters, filters.tags, filters.companies],
   );
 
   const handleClearAll = useCallback(() => {
@@ -322,10 +333,12 @@ export default function ExpertsInteractiveContent({
               onMinPriceChange={(val) => updateFilters({ minPrice: val })}
               maxPrice={filters.maxPrice}
               onMaxPriceChange={(val) => updateFilters({ maxPrice: val })}
-              availability={filters.availability}
-              onAvailabilityChange={(val) =>
-                updateFilters({ availability: val })
+              minRating={filters.minRating}
+              onMinRatingChange={(val) =>
+                updateFilters({ minRating: val })
               }
+              selectedCompanies={filters.companies}
+              setSelectedCompanies={(val) => updateFilters({ companies: val })}
               language={filters.language}
               onLanguageChange={(val) => updateFilters({ language: val })}
             />

--- a/app/explore/experts/ExpertsInteractiveContent.tsx
+++ b/app/explore/experts/ExpertsInteractiveContent.tsx
@@ -74,6 +74,7 @@ export default function ExpertsInteractiveContent({
     consultants,
     isLoading: isLoadingConsultants,
     isLoadingMore,
+    isRefetching,
     hasMore,
     loadMore,
   } = useConsultants(filters);
@@ -359,14 +360,18 @@ export default function ExpertsInteractiveContent({
 
           {/* Results */}
           <div className="mt-8 min-h-[400px] relative">
-            {isLoadingConsultants ? (
-              <div className="absolute inset-0 flex items-center justify-center bg-white/80 backdrop-blur-sm rounded-2xl">
+            {/* Loading overlay — on top of stale results to preserve scroll position */}
+            {(isLoadingConsultants || isRefetching) && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 backdrop-blur-sm rounded-2xl">
                 <div className="flex flex-col items-center gap-4">
                   <div className="w-12 h-12 border-4 border-zinc-200 border-t-zinc-900 rounded-full animate-spin" />
                   <p className="text-zinc-500 text-sm">Finding experts...</p>
                 </div>
               </div>
-            ) : filters.domain ? (
+            )}
+
+            {/* Consultant cards — always rendered (stale placeholder data stays visible during refetch) */}
+            {filters.domain ? (
               <>
                 {metadata?.domains.map((domain) => {
                   const domainConsultants =
@@ -414,40 +419,38 @@ export default function ExpertsInteractiveContent({
                     </motion.div>
                   );
                 })}
-
-                {consultants.length === 0 && <EmptyState />}
               </>
             ) : (
-              <>
-                <div className="space-y-6">
-                  {consultants.map(
-                    (consultant: IConsultantCardData, index: number) => (
-                      <motion.div
-                        key={consultant.id}
-                        ref={
-                          index === consultants.length - 1
-                            ? lastConsultantRef
-                            : undefined
-                        }
-                        initial={{ opacity: 0, y: 20 }}
-                        whileInView={{ opacity: 1, y: 0 }}
-                        viewport={{ once: true }}
-                        transition={{
-                          duration: 0.4,
-                          delay: Math.min(index * 0.05, 0.6),
-                        }}
-                      >
-                        <ConsultantCard
-                          consultant={consultant}
-                          metadata={metadata}
-                        />
-                      </motion.div>
-                    ),
-                  )}
-                </div>
+              <div className="space-y-6">
+                {consultants.map(
+                  (consultant: IConsultantCardData, index: number) => (
+                    <motion.div
+                      key={consultant.id}
+                      ref={
+                        index === consultants.length - 1
+                          ? lastConsultantRef
+                          : undefined
+                      }
+                      initial={{ opacity: 0, y: 20 }}
+                      whileInView={{ opacity: 1, y: 0 }}
+                      viewport={{ once: true }}
+                      transition={{
+                        duration: 0.4,
+                        delay: Math.min(index * 0.05, 0.6),
+                      }}
+                    >
+                      <ConsultantCard
+                        consultant={consultant}
+                        metadata={metadata}
+                      />
+                    </motion.div>
+                  ),
+                )}
+              </div>
+            )}
 
-                {consultants.length === 0 && <EmptyState />}
-              </>
+            {consultants.length === 0 && !isLoadingConsultants && !isRefetching && (
+              <EmptyState />
             )}
 
             {isLoadingMore && (

--- a/app/explore/experts/[consultantId]/ExpertProfileClient.tsx
+++ b/app/explore/experts/[consultantId]/ExpertProfileClient.tsx
@@ -19,7 +19,7 @@ import { ExpertPricing } from "./components/ExpertPricing";
 import { ProfileHeader } from "./components/ProfileHeader";
 import { ReviewsSection } from "./components/ReviewsSection";
 import { useTimezone } from "./hooks/useTimezone";
-import { format as formatTz } from "date-fns-tz";
+import { formatInTimeZone } from "date-fns-tz";
 
 interface ExpertProfileClientProps {
   consultantDetails: TConsultantDetailData;
@@ -84,9 +84,7 @@ export function ExpertProfileClient({
           }
 
           const { data } = await response.json();
-          const selectedDateKey = formatTz(selectedDate, "yyyy-MM-dd", {
-            timeZone: timezone,
-          });
+          const selectedDateKey = formatInTimeZone(selectedDate, timezone, "yyyy-MM-dd");
           const slotsForSelectedDate = data[selectedDateKey] || [];
           setSlotTimings(slotsForSelectedDate);
         } catch (error) {

--- a/app/explore/experts/[consultantId]/components/ConsultantAvailability.tsx
+++ b/app/explore/experts/[consultantId]/components/ConsultantAvailability.tsx
@@ -5,7 +5,7 @@ import { TSlotTiming } from "@/types/slots";
 import { WeeklyAvailability } from "./WeeklyAvailability";
 import { CustomAvailability } from "./CustomAvailability";
 import { addDays, startOfDay, endOfDay } from "date-fns";
-import { toZonedTime, format as formatTz } from "date-fns-tz";
+import { toZonedTime, formatInTimeZone } from "date-fns-tz";
 import type { ProcessedSlot } from "../types";
 
 interface ConsultantAvailabilityProps {
@@ -124,7 +124,7 @@ export function ConsultantAvailability({
     const windowStart = addDays(today, weekOffset * 7);
     const days: DayWithSlots[] = Array.from({ length: 7 }, (_, i) => {
       const date = addDays(startOfDay(toZonedTime(windowStart, timezone)), i);
-      const dateKey = formatTz(date, "yyyy-MM-dd", { timeZone: timezone });
+      const dateKey = formatInTimeZone(date, timezone, "yyyy-MM-dd");
 
       const slots: ProcessedSlot[] = (availabilityData[dateKey] || [])
         .filter((slot) => slot.type === "CUSTOM")

--- a/app/explore/experts/components/ConsultantCard.tsx
+++ b/app/explore/experts/components/ConsultantCard.tsx
@@ -14,6 +14,7 @@ import {
   MapPin,
   Clock,
   Briefcase,
+  Globe,
   ArrowRight,
   CheckCircle2,
   BadgeCheck,
@@ -188,6 +189,14 @@ export const ConsultantCard = memo(function ConsultantCard({
                 value={consultant.domain?.name}
               />
             </div>
+            {/* Languages */}
+            {consultant.languages && consultant.languages.length > 0 && (
+              <ConsultantInfo
+                icon={Globe}
+                label="Languages"
+                value={consultant.languages.join(", ")}
+              />
+            )}
           </div>
 
           {/* Company Logos */}

--- a/app/explore/experts/components/ExpertMiniCard.tsx
+++ b/app/explore/experts/components/ExpertMiniCard.tsx
@@ -3,7 +3,7 @@
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { User, Star, ArrowRight, Flame, Clock, BadgeCheck } from "lucide-react";
+import { User, Star, ArrowRight, Flame, Clock, BadgeCheck, Globe } from "lucide-react";
 import { CompanyLogo } from "@/components/ui/company-logo";
 import type { IConsultantCardData } from "@/types/consultant";
 
@@ -71,43 +71,58 @@ export default function ExpertMiniCard({ expert, badge }: ExpertMiniCardProps) {
           </div>
         </div>
 
-        {/* Company Logos */}
-        {expert.user.workExperiences &&
-          expert.user.workExperiences.length > 0 && (
-            <div className="flex items-center gap-1.5 mb-2">
-              {expert.user.workExperiences.slice(0, 2).map((exp, i) => (
-                <CompanyLogo
-                  key={`${expert.id}-company-${i}`}
-                  companyName={exp.company}
-                  companyDomain={exp.companyDomain ?? undefined}
-                  size={24}
-                  className="border-zinc-200"
-                />
+        {/* Bottom section — pinned to bottom for consistent card height */}
+        <div className="mt-auto">
+          {/* Company Logos */}
+          {expert.user.workExperiences &&
+            expert.user.workExperiences.length > 0 && (
+              <div className="flex items-center gap-1.5 mb-2">
+                {expert.user.workExperiences.slice(0, 2).map((exp, i) => (
+                  <CompanyLogo
+                    key={`${expert.id}-company-${i}`}
+                    companyName={exp.company}
+                    companyDomain={exp.companyDomain ?? undefined}
+                    size={24}
+                    className="border-zinc-200"
+                  />
+                ))}
+              </div>
+            )}
+
+          {/* Languages */}
+          {expert.languages && expert.languages.length > 0 && (
+            <div className="flex items-center gap-1 mb-2">
+              <Globe className="w-3 h-3 text-zinc-400 flex-shrink-0" />
+              <p className="text-[10px] text-zinc-500 line-clamp-1">
+                {expert.languages.slice(0, 2).join(", ")}
+              </p>
+            </div>
+          )}
+
+          {/* Domain badge */}
+          <Badge className="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 hover:bg-zinc-100 border-0 w-fit mb-2">
+            {expert.domain?.name || "General"}
+          </Badge>
+
+          {/* Tags */}
+          {expert.tags && expert.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-3">
+              {expert.tags.slice(0, 2).map((tag) => (
+                <span
+                  key={tag.id}
+                  className="text-[10px] px-2 py-0.5 bg-zinc-50 text-zinc-500 rounded-full"
+                >
+                  {tag.name}
+                </span>
               ))}
             </div>
           )}
 
-        {/* Domain badge */}
-        <Badge className="text-[10px] px-2 py-0.5 bg-zinc-100 text-zinc-600 hover:bg-zinc-100 border-0 w-fit mb-2">
-          {expert.domain?.name || "General"}
-        </Badge>
-
-        {/* Tags */}
-        <div className="flex flex-wrap gap-1 mb-3 flex-1">
-          {expert.tags?.slice(0, 2).map((tag) => (
-            <span
-              key={tag.id}
-              className="text-[10px] px-2 py-0.5 bg-zinc-50 text-zinc-500 rounded-full"
-            >
-              {tag.name}
-            </span>
-          ))}
-        </div>
-
-        {/* View Profile */}
-        <div className="flex items-center gap-1 text-xs font-medium text-zinc-500 group-hover:text-zinc-900 transition-colors">
-          <span>View Profile</span>
-          <ArrowRight className="w-3 h-3 group-hover:translate-x-1 transition-transform" />
+          {/* View Profile */}
+          <div className="flex items-center gap-1 text-xs font-medium text-zinc-500 group-hover:text-zinc-900 transition-colors">
+            <span>View Profile</span>
+            <ArrowRight className="w-3 h-3 group-hover:translate-x-1 transition-transform" />
+          </div>
         </div>
       </div>
     </Link>

--- a/app/explore/experts/components/FeaturedExperts.tsx
+++ b/app/explore/experts/components/FeaturedExperts.tsx
@@ -4,7 +4,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { User, Star, StarHalf, ArrowRight, Award, BadgeCheck } from "lucide-react";
+import { User, Star, StarHalf, ArrowRight, Award, BadgeCheck, Globe } from "lucide-react";
 import { CompanyLogo } from "@/components/ui/company-logo";
 import type { IConsultantCardData } from "@/types/consultant";
 
@@ -84,6 +84,7 @@ export function FeaturedExperts({ experts, isLoading }: FeaturedExpertsProps) {
             : experts.map((expert, index) => (
                 <motion.div
                   key={expert.id}
+                  className="h-full"
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
@@ -94,7 +95,7 @@ export function FeaturedExperts({ experts, isLoading }: FeaturedExpertsProps) {
                 >
                   <Link
                     href={`/explore/experts/${expert.id}`}
-                    className="group block"
+                    className="group block h-full"
                   >
                     <div className="bg-white rounded-2xl p-6 shadow-sm border border-zinc-200 hover:border-zinc-300 hover:shadow-lg transition-all duration-300 h-full flex flex-col">
                       {/* Avatar */}
@@ -135,7 +136,7 @@ export function FeaturedExperts({ experts, isLoading }: FeaturedExpertsProps) {
                       </div>
 
                       {/* Headline */}
-                      <div className="text-center flex-1">
+                      <div className="text-center">
                         <p className="text-sm text-zinc-600 font-medium line-clamp-1 mb-1">
                           {expert.headline || expert.domain?.name}
                         </p>
@@ -144,40 +145,55 @@ export function FeaturedExperts({ experts, isLoading }: FeaturedExpertsProps) {
                         </p>
                       </div>
 
-                      {/* Company Logos */}
-                      {expert.user.workExperiences &&
-                        expert.user.workExperiences.length > 0 && (
-                          <div className="flex items-center justify-center gap-1.5 mt-3">
-                            {expert.user.workExperiences
-                              .slice(0, 2)
-                              .map((exp, i) => (
-                                <CompanyLogo
-                                  key={`${expert.id}-company-${i}`}
-                                  companyName={exp.company}
-                                  companyDomain={exp.companyDomain ?? undefined}
-                                  size={22}
-                                  className="border-zinc-200"
-                                />
-                              ))}
+                      {/* Bottom section — pinned to bottom for consistent card height */}
+                      <div className="mt-auto pt-3">
+                        {/* Company Logos */}
+                        {expert.user.workExperiences &&
+                          expert.user.workExperiences.length > 0 && (
+                            <div className="flex items-center justify-center gap-1.5 mb-3">
+                              {expert.user.workExperiences
+                                .slice(0, 2)
+                                .map((exp, i) => (
+                                  <CompanyLogo
+                                    key={`${expert.id}-company-${i}`}
+                                    companyName={exp.company}
+                                    companyDomain={exp.companyDomain ?? undefined}
+                                    size={22}
+                                    className="border-zinc-200"
+                                  />
+                                ))}
+                            </div>
+                          )}
+
+                        {/* Languages */}
+                        {expert.languages && expert.languages.length > 0 && (
+                          <div className="flex items-center justify-center gap-1 mb-3">
+                            <Globe className="w-3 h-3 text-zinc-400 flex-shrink-0" />
+                            <p className="text-xs text-zinc-500 line-clamp-1">
+                              {expert.languages.slice(0, 3).join(", ")}
+                            </p>
                           </div>
                         )}
 
-                      {/* Tags */}
-                      <div className="flex flex-wrap gap-1.5 justify-center mt-4">
-                        {expert.tags?.slice(0, 2).map((tag) => (
-                          <Badge
-                            key={tag.id}
-                            className="text-xs px-2 py-0.5 bg-zinc-100 text-zinc-700 hover:bg-zinc-200 border-0"
-                          >
-                            {tag.name}
-                          </Badge>
-                        ))}
-                      </div>
+                        {/* Tags */}
+                        {expert.tags && expert.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5 justify-center mb-3">
+                            {expert.tags.slice(0, 2).map((tag) => (
+                              <Badge
+                                key={tag.id}
+                                className="text-xs px-2 py-0.5 bg-zinc-100 text-zinc-700 hover:bg-zinc-200 border-0"
+                              >
+                                {tag.name}
+                              </Badge>
+                            ))}
+                          </div>
+                        )}
 
-                      {/* View Profile */}
-                      <div className="mt-4 flex items-center justify-center gap-1 text-sm font-medium text-zinc-500 group-hover:text-zinc-900 transition-colors">
-                        <span>View Profile</span>
-                        <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                        {/* View Profile */}
+                        <div className="flex items-center justify-center gap-1 text-sm font-medium text-zinc-500 group-hover:text-zinc-900 transition-colors">
+                          <span>View Profile</span>
+                          <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                        </div>
                       </div>
                     </div>
                   </Link>

--- a/app/explore/experts/components/FiltersSection.tsx
+++ b/app/explore/experts/components/FiltersSection.tsx
@@ -228,7 +228,7 @@ export function FiltersSection({
                 value={selectedDomain || "all"}
                 onValueChange={handleDomainChange}
               >
-                <SelectTrigger className="w-full h-11 bg-zinc-50 border-zinc-200 rounded-lg focus:ring-zinc-900">
+                <SelectTrigger className="w-full h-11 bg-zinc-100 border-zinc-300 rounded-lg focus:ring-zinc-900">
                   <SelectValue placeholder="All Domains" />
                 </SelectTrigger>
                 <SelectContent>
@@ -250,7 +250,7 @@ export function FiltersSection({
                 value={selectedSubdomain || "all"}
                 onValueChange={handleSubdomainChange}
               >
-                <SelectTrigger className="w-full h-11 bg-zinc-50 border-zinc-200 rounded-lg focus:ring-zinc-900 disabled:opacity-50">
+                <SelectTrigger className="w-full h-11 bg-zinc-100 border-zinc-300 rounded-lg focus:ring-zinc-900 disabled:opacity-50">
                   <SelectValue
                     placeholder={
                       selectedDomain ? "All Subdomains" : "Select domain first"
@@ -288,7 +288,7 @@ export function FiltersSection({
             </label>
             <div className="relative" ref={tagDropdownRef}>
               <input
-                className="w-full h-11 px-4 bg-zinc-50 border border-zinc-200 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all disabled:opacity-50"
+                className="w-full h-11 px-4 bg-zinc-100 border border-zinc-300 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all disabled:opacity-50"
                 placeholder={
                   selectedDomain ? "Search skills..." : "Select domain first"
                 }
@@ -456,7 +456,7 @@ export function FiltersSection({
             </label>
             <div className="relative" ref={companyDropdownRef}>
               <input
-                className="w-full h-11 px-4 bg-zinc-50 border border-zinc-200 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all"
+                className="w-full h-11 px-4 bg-zinc-100 border border-zinc-300 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all"
                 placeholder="e.g. Google, Deloitte..."
                 type="text"
                 value={companySearchTerm}
@@ -512,7 +512,7 @@ export function FiltersSection({
               value={language || "all"}
               onValueChange={handleLanguageChange}
             >
-              <SelectTrigger className="w-full h-11 bg-zinc-50 border-zinc-200 rounded-lg focus:ring-zinc-900">
+              <SelectTrigger className="w-full h-11 bg-zinc-100 border-zinc-300 rounded-lg focus:ring-zinc-900">
                 <SelectValue placeholder="Any Language" />
               </SelectTrigger>
               <SelectContent>

--- a/app/explore/experts/components/FiltersSection.tsx
+++ b/app/explore/experts/components/FiltersSection.tsx
@@ -76,10 +76,26 @@ export function FiltersSection({
   // Tag autocomplete state
   const [searchTerm, setSearchTerm] = useState("");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const tagDropdownRef = useRef<HTMLDivElement>(null);
 
   // Company autocomplete state
   const [companySearchTerm, setCompanySearchTerm] = useState("");
   const [isCompanyDropdownOpen, setIsCompanyDropdownOpen] = useState(false);
+  const companyDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdowns on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (tagDropdownRef.current && !tagDropdownRef.current.contains(e.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+      if (companyDropdownRef.current && !companyDropdownRef.current.contains(e.target as Node)) {
+        setIsCompanyDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   const { formatPrice, currency } = useCurrency();
 
@@ -270,7 +286,7 @@ export function FiltersSection({
             <label className="block mb-1.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">
               Search Tags
             </label>
-            <div className="relative">
+            <div className="relative" ref={tagDropdownRef}>
               <input
                 className="w-full h-11 px-4 bg-zinc-50 border border-zinc-200 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all disabled:opacity-50"
                 placeholder={
@@ -438,7 +454,7 @@ export function FiltersSection({
             <label className="block mb-1.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">
               Search Companies
             </label>
-            <div className="relative">
+            <div className="relative" ref={companyDropdownRef}>
               <input
                 className="w-full h-11 px-4 bg-zinc-50 border border-zinc-200 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all"
                 placeholder="e.g. Google, Deloitte..."

--- a/app/explore/experts/components/FiltersSection.tsx
+++ b/app/explore/experts/components/FiltersSection.tsx
@@ -16,7 +16,8 @@ import {
   Tag as TagIcon,
   Clock,
   DollarSign,
-  CalendarCheck,
+  Star,
+  Building2,
   Globe,
 } from "lucide-react";
 import { useCurrency } from "@/hooks/useCurrency";
@@ -29,7 +30,7 @@ interface FiltersSectionProps {
     subdomains: { id: string; name: string; domainId: string | null }[];
     tags: { id: string; name: string; domainId: string | null }[];
     availableLanguages?: string[];
-    availabilityStats?: { hasSlots: number };
+    availableCompanies?: string[];
   } | null;
   selectedDomain: string | null;
   setSelectedDomain: (value: string | null) => void;
@@ -43,8 +44,10 @@ interface FiltersSectionProps {
   onMinPriceChange?: (value: number | undefined) => void;
   maxPrice?: number;
   onMaxPriceChange?: (value: number | undefined) => void;
-  availability?: "has_slots" | "this_week";
-  onAvailabilityChange?: (value: "has_slots" | "this_week" | undefined) => void;
+  minRating?: number;
+  onMinRatingChange?: (value: number | undefined) => void;
+  selectedCompanies: string[];
+  setSelectedCompanies: (companies: string[]) => void;
   language?: string;
   onLanguageChange?: (value: string | undefined) => void;
 }
@@ -63,13 +66,20 @@ export function FiltersSection({
   onMinPriceChange,
   maxPrice,
   onMaxPriceChange,
-  availability,
-  onAvailabilityChange,
+  minRating,
+  onMinRatingChange,
+  selectedCompanies,
+  setSelectedCompanies,
   language,
   onLanguageChange,
 }: FiltersSectionProps) {
+  // Tag autocomplete state
   const [searchTerm, setSearchTerm] = useState("");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  // Company autocomplete state
+  const [companySearchTerm, setCompanySearchTerm] = useState("");
+  const [isCompanyDropdownOpen, setIsCompanyDropdownOpen] = useState(false);
 
   const { formatPrice, currency } = useCurrency();
 
@@ -80,10 +90,18 @@ export function FiltersSection({
   ]);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Local experience state with debounce
+  const [localExperience, setLocalExperience] = useState(experienceYears);
+  const expDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Sync local state when external props change (e.g. filter chip removal)
   useEffect(() => {
     setLocalRange([minPrice ?? 0, maxPrice ?? MAX_PRICE_INR]);
   }, [minPrice, maxPrice]);
+
+  useEffect(() => {
+    setLocalExperience(experienceYears);
+  }, [experienceYears]);
 
   const handleSliderChange = useCallback(
     (value: number[]) => {
@@ -128,11 +146,24 @@ export function FiltersSection({
     setIsDropdownOpen(true);
   };
 
-  const handleAvailabilityChange = (value: string) => {
-    onAvailabilityChange?.(
-      value === "all" ? undefined : (value as "has_slots" | "this_week"),
-    );
+  const handleCompanySelect = (company: string) => {
+    if (!selectedCompanies.includes(company)) {
+      setSelectedCompanies([...selectedCompanies, company]);
+    }
+    setIsCompanyDropdownOpen(false);
+    setCompanySearchTerm("");
   };
+
+  const handleCompanyRemove = (company: string) => {
+    setSelectedCompanies(selectedCompanies.filter((c) => c !== company));
+  };
+
+  const handleCompanyInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCompanySearchTerm(e.target.value);
+    setIsCompanyDropdownOpen(true);
+  };
+
+  const RATING_OPTIONS = [4.5, 4.0, 3.5, 3.0] as const;
 
   const handleLanguageChange = (value: string) => {
     onLanguageChange?.(value === "all" ? undefined : value);
@@ -144,6 +175,13 @@ export function FiltersSection({
       if (!searchTerm) return true;
       if (selectedTags.includes(tag.name)) return false;
       return tag.name.toLowerCase().includes(searchTerm.toLowerCase());
+    }) || [];
+
+  const filteredCompanies =
+    metadata?.availableCompanies?.filter((company) => {
+      if (selectedCompanies.includes(company)) return false;
+      if (!companySearchTerm) return true;
+      return company.toLowerCase().includes(companySearchTerm.toLowerCase());
     }) || [];
 
   return (
@@ -279,37 +317,75 @@ export function FiltersSection({
           </div>
         </div>
 
-        {/* Experience */}
+        {/* Experience & Rating (combined) */}
         <div className="bg-white rounded-xl p-4 border border-zinc-200">
           <div className="flex items-center gap-2 mb-4">
             <Clock className="w-4 h-4 text-zinc-500" />
             <span className="text-sm font-medium text-zinc-700">
-              Experience
+              Experience & Rating
             </span>
           </div>
-          <div>
-            <label className="block mb-1.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">
-              Minimum Years
-            </label>
-            <div className="mt-2">
+          <div className="space-y-4">
+            {/* Experience slider */}
+            <div>
+              <label className="block mb-1.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                Minimum Years
+              </label>
               <input
                 type="range"
                 min="0"
                 max="30"
-                value={experienceYears}
-                onChange={(e) => setExperienceYears(Number(e.target.value))}
+                value={localExperience}
+                onChange={(e) => {
+                  const val = Number(e.target.value);
+                  setLocalExperience(val);
+                  if (expDebounceRef.current) clearTimeout(expDebounceRef.current);
+                  expDebounceRef.current = setTimeout(() => {
+                    setExperienceYears(val);
+                  }, 300);
+                }}
                 className="w-full h-2 bg-zinc-200 rounded-full appearance-none cursor-pointer accent-zinc-900"
               />
-              <div className="flex justify-between mt-2 text-xs text-zinc-500">
+              <div className="flex justify-between mt-1 text-xs text-zinc-500">
                 <span>0 yrs</span>
-                <span>15 yrs</span>
-                <span>30+ yrs</span>
-              </div>
-              <div className="text-center mt-4">
-                <span className="inline-flex items-center px-4 py-2 bg-zinc-900 text-white rounded-full text-sm font-semibold">
-                  {experienceYears === 30 ? "30+" : experienceYears} years
-                  minimum
+                <span className="font-semibold text-zinc-900">
+                  {localExperience === 30 ? "30+" : localExperience} yrs
                 </span>
+                <span>30+</span>
+              </div>
+            </div>
+            {/* Rating buttons */}
+            <div>
+              <label className="block mb-1.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                Minimum Rating
+              </label>
+              <div className="flex flex-wrap gap-1.5">
+                {RATING_OPTIONS.map((rating) => (
+                  <button
+                    key={rating}
+                    onClick={() =>
+                      onMinRatingChange?.(minRating === rating ? undefined : rating)
+                    }
+                    className={`inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                      minRating === rating
+                        ? "bg-zinc-900 text-white"
+                        : "bg-zinc-50 border border-zinc-200 text-zinc-700 hover:bg-zinc-100"
+                    }`}
+                  >
+                    <Star className="w-3 h-3 fill-current" />
+                    {rating}+
+                  </button>
+                ))}
+                <button
+                  onClick={() => onMinRatingChange?.(undefined)}
+                  className={`inline-flex items-center px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                    minRating === undefined
+                      ? "bg-zinc-900 text-white"
+                      : "bg-zinc-50 border border-zinc-200 text-zinc-700 hover:bg-zinc-100"
+                  }`}
+                >
+                  Any
+                </button>
               </div>
             </div>
           </div>
@@ -352,36 +428,57 @@ export function FiltersSection({
           </div>
         </div>
 
-        {/* Availability */}
+        {/* Companies */}
         <div className="bg-white rounded-xl p-4 border border-zinc-200">
           <div className="flex items-center gap-2 mb-4">
-            <CalendarCheck className="w-4 h-4 text-zinc-500" />
-            <span className="text-sm font-medium text-zinc-700">
-              Availability
-            </span>
+            <Building2 className="w-4 h-4 text-zinc-500" />
+            <span className="text-sm font-medium text-zinc-700">Company</span>
           </div>
           <div>
             <label className="block mb-1.5 text-xs font-medium text-zinc-500 uppercase tracking-wide">
-              Schedule Status
+              Search Companies
             </label>
-            <Select
-              value={availability || "all"}
-              onValueChange={handleAvailabilityChange}
-            >
-              <SelectTrigger className="w-full h-11 bg-zinc-50 border-zinc-200 rounded-lg focus:ring-zinc-900">
-                <SelectValue placeholder="Any Availability" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Any Availability</SelectItem>
-                <SelectItem value="has_slots">
-                  Has Open Slots
-                  {metadata?.availabilityStats
-                    ? ` (${metadata.availabilityStats.hasSlots})`
-                    : ""}
-                </SelectItem>
-                <SelectItem value="this_week">Available This Week</SelectItem>
-              </SelectContent>
-            </Select>
+            <div className="relative">
+              <input
+                className="w-full h-11 px-4 bg-zinc-50 border border-zinc-200 text-zinc-900 text-sm rounded-lg focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-all"
+                placeholder="e.g. Google, Deloitte..."
+                type="text"
+                value={companySearchTerm}
+                onChange={handleCompanyInputChange}
+                onFocus={() => setIsCompanyDropdownOpen(true)}
+              />
+              {isCompanyDropdownOpen && filteredCompanies.length > 0 && (
+                <div className="absolute z-20 w-full mt-2 bg-white border border-zinc-200 rounded-xl shadow-xl max-h-48 overflow-auto">
+                  {filteredCompanies.map((company) => (
+                    <button
+                      key={company}
+                      className="w-full px-4 py-2.5 text-left text-sm text-zinc-700 hover:bg-zinc-50 first:rounded-t-xl last:rounded-b-xl transition-colors"
+                      onClick={() => handleCompanySelect(company)}
+                    >
+                      {company}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {selectedCompanies.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-3">
+                {selectedCompanies.map((company) => (
+                  <span
+                    key={company}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-900 text-white text-xs font-medium rounded-full"
+                  >
+                    {company}
+                    <button
+                      className="hover:bg-white/20 rounded-full p-0.5 transition-colors"
+                      onClick={() => handleCompanyRemove(company)}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 

--- a/app/explore/experts/components/SearchBar.tsx
+++ b/app/explore/experts/components/SearchBar.tsx
@@ -41,12 +41,12 @@ export function SearchBar({
   return (
     <div className="flex flex-col sm:flex-row gap-4">
       {/* Search Input */}
-      <div className="flex-1 relative">
+      <div className="flex-1 relative shadow-lg rounded-xl focus-within:shadow-xl focus-within:ring-2 focus-within:ring-zinc-900 transition-shadow">
         <div className="absolute left-4 top-1/2 -translate-y-1/2">
-          <Search className="w-5 h-5 text-zinc-400" />
+          <Search className="w-6 h-6 text-zinc-400" />
         </div>
         <Input
-          className="w-full h-12 pl-12 pr-4 bg-white border-zinc-200 rounded-xl focus:border-zinc-400 focus:ring-zinc-400 placeholder:text-zinc-400"
+          className="w-full h-14 pl-14 pr-4 bg-white border-0 rounded-xl focus:ring-0 focus-visible:ring-0 placeholder:text-zinc-400 text-base"
           placeholder="Search experts by name, skill, or specialty..."
           type="search"
           value={localValue}
@@ -59,7 +59,7 @@ export function SearchBar({
 
       {/* Sort Dropdown */}
       <div className="flex items-center gap-2">
-        <div className="flex items-center gap-2 px-4 h-12 bg-zinc-100 rounded-xl">
+        <div className="flex items-center gap-2 px-4 h-14 bg-zinc-100 rounded-xl shadow-md">
           <SlidersHorizontal className="w-4 h-4 text-zinc-500" />
           <span className="text-sm font-medium text-zinc-600 hidden sm:inline">
             Sort by
@@ -69,7 +69,7 @@ export function SearchBar({
           value={sortBy}
           onValueChange={(value) => onSort(value as SortOption)}
         >
-          <SelectTrigger className="w-[180px] h-12 bg-white border-zinc-200 rounded-xl focus:ring-zinc-400">
+          <SelectTrigger className="w-[180px] h-14 bg-white border-0 rounded-xl shadow-md focus:ring-zinc-400">
             <SelectValue placeholder="Sort by" />
           </SelectTrigger>
           <SelectContent>

--- a/app/explore/experts/components/SearchBar.tsx
+++ b/app/explore/experts/components/SearchBar.tsx
@@ -41,12 +41,12 @@ export function SearchBar({
   return (
     <div className="flex flex-col sm:flex-row gap-4">
       {/* Search Input */}
-      <div className="flex-1 relative shadow-lg rounded-xl focus-within:shadow-xl focus-within:ring-2 focus-within:ring-zinc-900 transition-shadow">
+      <div className="flex-1 relative rounded-xl focus-within:ring-2 focus-within:ring-zinc-900 transition-shadow">
         <div className="absolute left-4 top-1/2 -translate-y-1/2">
           <Search className="w-6 h-6 text-zinc-400" />
         </div>
         <Input
-          className="w-full h-14 pl-14 pr-4 bg-white border-0 rounded-xl focus:ring-0 focus-visible:ring-0 placeholder:text-zinc-400 text-base"
+          className="w-full h-14 pl-14 pr-4 bg-zinc-100 border border-zinc-300 rounded-xl focus:ring-0 focus-visible:ring-0 placeholder:text-zinc-400 text-base"
           placeholder="Search experts by name, skill, or specialty..."
           type="search"
           value={localValue}
@@ -59,7 +59,7 @@ export function SearchBar({
 
       {/* Sort Dropdown */}
       <div className="flex items-center gap-2">
-        <div className="flex items-center gap-2 px-4 h-14 bg-zinc-100 rounded-xl shadow-md">
+        <div className="flex items-center gap-2 px-4 h-14 bg-zinc-100 border border-zinc-300 rounded-xl">
           <SlidersHorizontal className="w-4 h-4 text-zinc-500" />
           <span className="text-sm font-medium text-zinc-600 hidden sm:inline">
             Sort by
@@ -69,7 +69,7 @@ export function SearchBar({
           value={sortBy}
           onValueChange={(value) => onSort(value as SortOption)}
         >
-          <SelectTrigger className="w-[180px] h-14 bg-white border-0 rounded-xl shadow-md focus:ring-zinc-400">
+          <SelectTrigger className="w-[180px] h-14 bg-zinc-100 border border-zinc-300 rounded-xl focus:ring-zinc-400">
             <SelectValue placeholder="Sort by" />
           </SelectTrigger>
           <SelectContent>

--- a/app/explore/experts/hooks.ts
+++ b/app/explore/experts/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
 import type { IConsultantCardData } from "@/types/consultant";
 import { SortOption } from "./components/SearchBar";
 import { useCallback, useMemo } from "react";
@@ -114,6 +114,7 @@ export function useConsultants(filters: IExpertFilters) {
     fetchNextPage,
     hasNextPage,
     isLoading,
+    isFetching,
     isFetchingNextPage,
     refetch,
   } = useInfiniteQuery({
@@ -138,6 +139,7 @@ export function useConsultants(filters: IExpertFilters) {
       return undefined;
     },
     initialPageParam: 0,
+    placeholderData: keepPreviousData,
     staleTime: 2 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     retry: 3,
@@ -157,6 +159,7 @@ export function useConsultants(filters: IExpertFilters) {
     error,
     isLoading,
     isLoadingMore,
+    isRefetching: isFetching && !isLoading && !isFetchingNextPage,
     hasMore,
     loadMore: () => fetchNextPage(),
     refresh: refetch,

--- a/app/explore/experts/hooks.ts
+++ b/app/explore/experts/hooks.ts
@@ -71,7 +71,8 @@ export function useConsultants(filters: IExpertFilters) {
     sort: sortBy,
     minPrice,
     maxPrice,
-    availability,
+    minRating,
+    companies,
     language,
   } = filters;
 
@@ -88,7 +89,8 @@ export function useConsultants(filters: IExpertFilters) {
         sort: sortBy,
         ...(minPrice !== undefined && { minPrice: String(minPrice) }),
         ...(maxPrice !== undefined && { maxPrice: String(maxPrice) }),
-        ...(availability && { availability }),
+        ...(minRating !== undefined && { minRating: String(minRating) }),
+        ...(companies.length > 0 && { companies: companies.join(",") }),
         ...(language && { language }),
       });
 
@@ -103,7 +105,8 @@ export function useConsultants(filters: IExpertFilters) {
       sortBy,
       minPrice,
       maxPrice,
-      availability,
+      minRating,
+      companies,
       language,
     ],
   );
@@ -128,7 +131,8 @@ export function useConsultants(filters: IExpertFilters) {
       sortBy,
       minPrice,
       maxPrice,
-      availability,
+      minRating,
+      companies,
       language,
     ],
     queryFn: ({ pageParam = 0 }) => fetchConsultantsData(getKey(pageParam)),

--- a/app/explore/experts/utils.ts
+++ b/app/explore/experts/utils.ts
@@ -13,7 +13,8 @@ export interface IExpertFilters {
   sort: SortOption;
   minPrice?: number;
   maxPrice?: number;
-  availability?: "has_slots" | "this_week";
+  minRating?: number;
+  companies: string[];
   language?: string;
 }
 
@@ -26,7 +27,8 @@ export const DEFAULT_EXPERT_FILTERS: IExpertFilters = {
   sort: "nameAsc",
   minPrice: undefined,
   maxPrice: undefined,
-  availability: undefined,
+  minRating: undefined,
+  companies: [],
   language: undefined,
 };
 
@@ -44,9 +46,7 @@ export interface IExpertsMetaData {
     averageRating: number;
   };
   availableLanguages: string[];
-  availabilityStats: {
-    hasSlots: number;
-  };
+  availableCompanies: string[];
 }
 
 export interface IConsultantsByDomain {
@@ -73,7 +73,7 @@ export function filtersFromSearchParams(
   const rawMinPrice = params.get("minPrice");
   const rawMaxPrice = params.get("maxPrice");
   const rawExperience = params.get("experience");
-  const rawAvailability = params.get("availability");
+  const rawMinRating = params.get("minRating");
 
   return {
     domain: params.get("domain"),
@@ -84,10 +84,8 @@ export function filtersFromSearchParams(
     sort: (params.get("sort") as SortOption) || "nameAsc",
     minPrice: rawMinPrice ? parseFloat(rawMinPrice) || undefined : undefined,
     maxPrice: rawMaxPrice ? parseFloat(rawMaxPrice) || undefined : undefined,
-    availability:
-      rawAvailability === "has_slots" || rawAvailability === "this_week"
-        ? rawAvailability
-        : undefined,
+    minRating: rawMinRating ? parseFloat(rawMinRating) || undefined : undefined,
+    companies: params.get("companies")?.split(",").filter(Boolean) || [],
     language: params.get("language") || undefined,
   };
 }
@@ -106,7 +104,9 @@ export function filtersToSearchParams(filters: IExpertFilters): string {
     params.set("minPrice", String(filters.minPrice));
   if (filters.maxPrice !== undefined)
     params.set("maxPrice", String(filters.maxPrice));
-  if (filters.availability) params.set("availability", filters.availability);
+  if (filters.minRating !== undefined)
+    params.set("minRating", String(filters.minRating));
+  if (filters.companies.length > 0) params.set("companies", filters.companies.join(","));
   if (filters.language) params.set("language", filters.language);
   return params.toString();
 }

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -53,7 +53,7 @@ export async function fetchExpertsMetadata() {
     tags,
     consultantMetadata,
     availableLanguages,
-    availabilityStats,
+    availableCompanies,
   ] = await Promise.all([
     // Domains + subdomains
     prisma.domain.findMany({
@@ -110,16 +110,18 @@ export async function fetchExpertsMetadata() {
         WHERE "verificationStatus" = 'VERIFIED'
         ORDER BY lang
       `.then((result) => result.map((r) => r.lang)),
-    // Availability stats
-    prisma.consultantProfile.count({
+    // Available companies (from verified consultants' work experiences)
+    prisma.workExperience.findMany({
       where: {
-        verificationStatus: "VERIFIED",
-        OR: [
-          { slotsOfAvailabilityWeekly: { some: {} } },
-          { slotsOfAvailabilityCustom: { some: {} } },
-        ],
+        company: { not: "" },
+        user: {
+          consultantProfile: { verificationStatus: "VERIFIED" },
+        },
       },
-    }),
+      select: { company: true },
+      distinct: ["company"],
+      orderBy: { company: "asc" },
+    }).then((result) => result.map((r) => r.company)),
   ]);
 
   return {
@@ -134,7 +136,7 @@ export async function fetchExpertsMetadata() {
     tags,
     consultantMetadata,
     availableLanguages,
-    availabilityStats: { hasSlots: availabilityStats },
+    availableCompanies,
   };
 }
 

--- a/types/consultant.ts
+++ b/types/consultant.ts
@@ -60,6 +60,7 @@ export interface IConsultantCardData {
       isCurrent: boolean;
     }>;
   };
+  languages?: string[];
   domain: { id: string; name: string } | null;
   subDomains: { id: string; name: string }[];
   tags: { id: string; name: string }[];

--- a/utils/timeSlotsProcessing.ts
+++ b/utils/timeSlotsProcessing.ts
@@ -1,6 +1,6 @@
 import { DayOfWeek } from "@prisma/client";
 import { addDays, endOfDay, isBefore, startOfDay } from "date-fns";
-import { format, toZonedTime, fromZonedTime } from "date-fns-tz";
+import { format, formatInTimeZone, toZonedTime, fromZonedTime } from "date-fns-tz";
 import { TSlotTiming } from "@/types/slots";
 
 // Booking status constants and types
@@ -453,8 +453,8 @@ export function convertToSlotTimings(
       slotEndTimeInUTC: slot.end.toISOString(),
       slotOfAvailabilityId: slot.availabilityId,
       slotOfAppointmentId: "",
-      localStartTime: format(slot.start, "p", { timeZone: timezone }),
-      localEndTime: format(slot.end, "p", { timeZone: timezone }),
+      localStartTime: formatInTimeZone(slot.start, timezone, "p"),
+      localEndTime: formatInTimeZone(slot.end, timezone, "p"),
       type: slot.type, // Explicitly set the type field
       isAllocated,
       bookingStatus,
@@ -595,8 +595,8 @@ export function breakDownSlotsByDuration(
         slotId: `${slot.slotOfAvailabilityId}-${currentStart.getTime()}`,
         slotStartTimeInUTC: currentStart.toISOString(),
         slotEndTimeInUTC: currentEnd.toISOString(),
-        localStartTime: format(currentStart, "p", { timeZone: timezone }),
-        localEndTime: format(currentEnd, "p", { timeZone: timezone }),
+        localStartTime: formatInTimeZone(currentStart, timezone, "p"),
+        localEndTime: formatInTimeZone(currentEnd, timezone, "p"),
         isAllocated: isSegmentAllocated,
         bookingStatus: segmentBookingStatus,
       });


### PR DESCRIPTION
## Summary

### Fix 1: Profile grid UTC timezone bug
- **Bug:** Profile grid displayed raw UTC times instead of consultant's local times on Netlify (UTC environment)
- **Root cause:** `date-fns-tz` v3's `format(date, pattern, { timeZone })` silently ignores the `timeZone` option when `process.env.TZ` is UTC
- **Fix:** Replace all 6 affected `format()` calls with `formatInTimeZone()` across 3 files

### Fix 2: Explore experts — scroll-to-top on filter change
- Prevented unwanted scroll-to-top when changing filters on the explore experts page

### Feat: Company multi-select autocomplete
- Replaced plain text company input with multi-select autocomplete dropdown (same UX pattern as tags filter)
- Fetches distinct company names from WorkExperience table via Prisma ORM (verified consultants only)
- Selected companies shown as removable chips; API uses exact `in` match

### Feat: Global debounce for performance
- **Experience slider:** Added 300ms debounce (was firing API calls on every drag tick)
- **URL sync:** Added 300ms debounce on `router.replace` (was firing on every state change)
- Price slider already had debounce; discrete click filters (domain, tags, rating) don't need it

## Files changed

| File | Changes |
|------|---------|
| `lib/data/explore-experts.ts` | Add distinct companies query to metadata |
| `app/explore/experts/utils.ts` | `company?: string` → `companies: string[]`, update serialization |
| `app/api/user/consultants/route.ts` | `company` → `companies` (comma-split, `in` filter) |
| `app/explore/experts/hooks.ts` | `company` → `companies` in queryKey + URL params |
| `app/explore/experts/components/FiltersSection.tsx` | Company autocomplete multi-select + debounce experience slider |
| `app/explore/experts/ExpertsInteractiveContent.tsx` | `companies` props + chips + debounce URL sync |
| `utils/timeSlotsProcessing.ts` | 4x `format()` → `formatInTimeZone()` |
| `ExpertProfileClient.tsx` | 1x `formatTz()` → `formatInTimeZone()` |
| `ConsultantAvailability.tsx` | 1x `formatTz()` → `formatInTimeZone()` |

## Test plan

- [ ] Type "Goo" in company filter → dropdown shows matching companies
- [ ] Select multiple companies → chips appear, results filter correctly
- [ ] Drag experience slider rapidly → only 1 API call fires (after 300ms pause)
- [ ] Change multiple filters quickly → URL updates once (debounced)
- [ ] Profile grid on Netlify shows local times, not UTC
- [ ] No page crashes on rapid filter interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)