### PR TITLE
fix: class/webinar detail pages — schedule, timezone, hydration

### DIFF
--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
@@ -16,8 +16,12 @@ import {
   Award,
   CheckCircle2,
   ArrowLeft,
-  Play,
 } from "lucide-react";
+import { formatInTimeZone } from "date-fns-tz";
+import {
+  buildSessionsFromAppointments,
+  groupSessionsByWeek,
+} from "@/app/explore/programs/plans/schedule-utils";
 import { ClientClassRegistration } from "./ClientClassRegistration";
 import { useCurrency } from "@/hooks/useCurrency";
 import type { Topic } from "@prisma/client";
@@ -238,86 +242,92 @@ export function ClassDetails({ plan }: ClassDetailsProps) {
                   Class Schedule
                 </h2>
                 {plan.classes && plan.classes.length > 0 ? (
-                  <div className="space-y-4">
-                    {plan.classes.map((classInstance, classIndex) => (
-                      <div
-                        key={classInstance.id}
-                        className="p-4 border border-zinc-200 rounded-xl"
-                      >
-                        {plan.classes.length > 1 && (
-                          <h3 className="font-medium text-zinc-900 mb-3">
-                            Batch {classIndex + 1}
-                          </h3>
-                        )}
-                        {classInstance.appointments?.length > 0 ? (
-                          classInstance.appointments.map((appointment) => (
-                            <div key={appointment.id} className="space-y-2">
-                              {appointment.slotsOfAppointment?.length > 0 ? (
-                                appointment.slotsOfAppointment.map(
-                                  (slot, slotIndex) => {
-                                    const startTime = new Date(slot.startsAt);
-                                    const userTimeZone =
-                                      Intl.DateTimeFormat().resolvedOptions()
-                                        .timeZone;
-                                    const formattedStartTime =
-                                      new Intl.DateTimeFormat(
-                                        navigator.language,
-                                        {
-                                          dateStyle: "full",
-                                          timeStyle: "long",
-                                          timeZone: userTimeZone,
-                                        },
-                                      ).format(startTime);
+                  <div className="space-y-6">
+                    {plan.classes.map((classInstance, classIndex) => {
+                      const userTimeZone =
+                        Intl.DateTimeFormat().resolvedOptions().timeZone;
+                      const sessions = buildSessionsFromAppointments(
+                        classInstance.appointments ?? [],
+                      );
+                      const weeks = groupSessionsByWeek(sessions);
 
-                                    const now = new Date();
-                                    const endTime = slot.endsAt
-                                      ? new Date(slot.endsAt)
-                                      : null;
-                                    let status = "Upcoming";
-                                    if (endTime && now > endTime) {
-                                      status = "Completed";
-                                    } else if (
-                                      now >= startTime &&
-                                      (!endTime || now < endTime)
-                                    ) {
-                                      status = "Happening Now";
-                                    }
-
-                                    return (
-                                      <div
-                                        key={slot.id}
-                                        className="flex items-center justify-between p-3 bg-zinc-50 rounded-lg"
-                                      >
-                                        <div className="flex items-center gap-3">
-                                          <Play className="w-4 h-4 text-zinc-400" />
-                                          <span className="text-sm text-zinc-700">
-                                            Session {slotIndex + 1}:{" "}
-                                            {formattedStartTime}
-                                          </span>
-                                        </div>
-                                        <Badge
-                                          variant={getBadgeVariant(status)}
+                      return (
+                        <div
+                          key={classInstance.id}
+                          className="p-4 border border-zinc-200 rounded-xl"
+                        >
+                          {plan.classes.length > 1 && (
+                            <h3 className="font-medium text-zinc-900 mb-4">
+                              Batch {classIndex + 1}
+                            </h3>
+                          )}
+                          {sessions.length > 0 ? (
+                            <div className="space-y-4">
+                              {Array.from(weeks.entries()).map(
+                                ([weekNum, weekSessions]) => (
+                                  <div key={weekNum}>
+                                    <h4 className="text-xs font-medium text-zinc-400 uppercase tracking-wider mb-2 px-1">
+                                      Week {weekNum}
+                                    </h4>
+                                    <div className="space-y-2">
+                                      {weekSessions.map((session) => (
+                                        <div
+                                          key={session.appointmentId}
+                                          className={`flex items-center justify-between p-3 rounded-lg ${
+                                            session.status === "Completed"
+                                              ? "bg-zinc-50 opacity-60"
+                                              : "bg-zinc-50"
+                                          }`}
                                         >
-                                          {status}
-                                        </Badge>
-                                      </div>
-                                    );
-                                  },
-                                )
-                              ) : (
-                                <p className="text-sm text-zinc-500">
-                                  Schedule to be announced
-                                </p>
+                                          <div className="flex items-center gap-3">
+                                            <div className="w-7 h-7 rounded-full bg-zinc-200 text-zinc-700 flex items-center justify-center text-xs font-semibold flex-shrink-0">
+                                              {session.sessionNumber}
+                                            </div>
+                                            <div className="text-sm">
+                                              <span className="font-medium text-zinc-800">
+                                                {formatInTimeZone(
+                                                  session.sessionStart,
+                                                  userTimeZone,
+                                                  "EEEE, MMMM d",
+                                                )}
+                                              </span>
+                                              <span className="text-zinc-500 ml-2">
+                                                {formatInTimeZone(
+                                                  session.sessionStart,
+                                                  userTimeZone,
+                                                  "h:mm a",
+                                                )}
+                                                {" – "}
+                                                {formatInTimeZone(
+                                                  session.sessionEnd,
+                                                  userTimeZone,
+                                                  "h:mm a zzz",
+                                                )}
+                                              </span>
+                                            </div>
+                                          </div>
+                                          <Badge
+                                            variant={getBadgeVariant(
+                                              session.status,
+                                            )}
+                                          >
+                                            {session.status}
+                                          </Badge>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  </div>
+                                ),
                               )}
                             </div>
-                          ))
-                        ) : (
-                          <p className="text-sm text-zinc-500">
-                            Schedule to be announced
-                          </p>
-                        )}
-                      </div>
-                    ))}
+                          ) : (
+                            <p className="text-sm text-zinc-500">
+                              Schedule to be announced
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
                 ) : (
                   <p className="text-zinc-500">

--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
@@ -43,6 +44,10 @@ interface ClassDetailsProps {
 
 export function ClassDetails({ plan }: ClassDetailsProps) {
   const { formatPrice } = useCurrency();
+  const [userTimeZone, setUserTimeZone] = useState("UTC");
+  useEffect(() => {
+    setUserTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
 
   return (
     <main className="min-h-screen bg-zinc-50">
@@ -244,8 +249,6 @@ export function ClassDetails({ plan }: ClassDetailsProps) {
                 {plan.classes && plan.classes.length > 0 ? (
                   <div className="space-y-6">
                     {plan.classes.map((classInstance, classIndex) => {
-                      const userTimeZone =
-                        Intl.DateTimeFormat().resolvedOptions().timeZone;
                       const sessions = buildSessionsFromAppointments(
                         classInstance.appointments ?? [],
                       );

--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClientClassRegistration.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClientClassRegistration.tsx
@@ -37,13 +37,16 @@ export function ClientClassRegistration({
 }: ClientClassRegistrationProps) {
   const { id: classId, price, classes } = plan;
   const startDate = classes?.[0]?.schedulingPeriodStartsAt;
-  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const { data: session } = useSession();
   const { formatPrice } = useCurrency();
 
-  // Defer auth-dependent rendering until after hydration to avoid mismatch
+  // Defer auth + timezone until after hydration to avoid mismatch
   const [hasMounted, setHasMounted] = useState(false);
-  useEffect(() => setHasMounted(true), []);
+  const [userTimeZone, setUserTimeZone] = useState("UTC");
+  useEffect(() => {
+    setHasMounted(true);
+    setUserTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
 
   const isLoggedIn = hasMounted && !!session?.user;
   const userId = session?.user?.id;

--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClientClassRegistration.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClientClassRegistration.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useSession } from "@/lib/auth-client";
 import {
   Card,
@@ -17,6 +18,7 @@ import {
   countUniqueParticipants,
 } from "@/lib/payments/utils/participants";
 import { useCurrency } from "@/hooks/useCurrency";
+import { formatInTimeZone } from "date-fns-tz";
 import { JoinWaitlistButton } from "@/components/waitlist/JoinWaitlistButton";
 import { WaitlistBadge } from "@/components/waitlist/WaitlistBadge";
 
@@ -34,10 +36,16 @@ export function ClientClassRegistration({
   consultantUserId,
 }: ClientClassRegistrationProps) {
   const { id: classId, price, classes } = plan;
-  const startDate = classes?.[0]?.startDate; // Corrected to startDate
+  const startDate = classes?.[0]?.schedulingPeriodStartsAt;
+  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const { data: session } = useSession();
   const { formatPrice } = useCurrency();
-  const isLoggedIn = !!session?.user;
+
+  // Defer auth-dependent rendering until after hydration to avoid mismatch
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => setHasMounted(true), []);
+
+  const isLoggedIn = hasMounted && !!session?.user;
   const userId = session?.user?.id;
 
   // Check if user is already enrolled in this class
@@ -77,19 +85,12 @@ export function ClientClassRegistration({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Register for Class</CardTitle>
+          <CardTitle>Class Registration</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-gray-600 mb-4">
             {startDate
-              ? `Class starts on ${new Date(startDate).toLocaleString(
-                  undefined,
-                  {
-                    dateStyle: "long",
-                    timeStyle: "short",
-                    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                  },
-                )}`
+              ? `Class starts on ${formatInTimeZone(new Date(startDate), userTimeZone, "MMMM d, yyyy 'at' h:mm a zzz")}`
               : "Start date to be announced"}
           </p>
           {isFull && (
@@ -134,14 +135,7 @@ export function ClientClassRegistration({
           </div>
           <p className="text-sm text-gray-600 mb-4">
             {startDate
-              ? `Class starts on ${new Date(startDate).toLocaleString(
-                  undefined,
-                  {
-                    dateStyle: "long",
-                    timeStyle: "short",
-                    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                  },
-                )}`
+              ? `Class starts on ${formatInTimeZone(new Date(startDate), userTimeZone, "MMMM d, yyyy 'at' h:mm a zzz")}`
               : "Start date to be announced"}
           </p>
           <p className="text-sm text-gray-600">
@@ -161,19 +155,12 @@ export function ClientClassRegistration({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Join Class</CardTitle>
+          <CardTitle>Class Registration</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-gray-600 mb-4">
             {startDate
-              ? `Class starts on ${new Date(startDate).toLocaleString(
-                  undefined,
-                  {
-                    dateStyle: "long",
-                    timeStyle: "short",
-                    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                  },
-                )}`
+              ? `Class starts on ${formatInTimeZone(new Date(startDate), userTimeZone, "MMMM d, yyyy 'at' h:mm a zzz")}`
               : "Start date to be announced"}
           </p>
           <Badge
@@ -214,16 +201,12 @@ export function ClientClassRegistration({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Join Class</CardTitle>
+        <CardTitle>Class Registration</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="text-sm text-gray-600 mb-4">
           {startDate
-            ? `Class starts on ${new Date(startDate).toLocaleString(undefined, {
-                dateStyle: "long",
-                timeStyle: "short",
-                timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-              })}`
+            ? `Class starts on ${formatInTimeZone(new Date(startDate), userTimeZone, "MMMM d, yyyy 'at' h:mm a zzz")}`
             : "Start date to be announced"}
         </p>
       </CardContent>

--- a/app/explore/programs/plans/schedule-utils.ts
+++ b/app/explore/programs/plans/schedule-utils.ts
@@ -1,0 +1,78 @@
+import { differenceInDays, startOfDay } from "date-fns";
+
+export type SessionStatus = "Upcoming" | "Completed" | "Happening Now";
+
+export interface SessionInfo {
+  sessionNumber: number;
+  appointmentId: string;
+  sessionStart: Date;
+  sessionEnd: Date;
+  status: SessionStatus;
+}
+
+/**
+ * Consolidate appointment slots into session rows.
+ *
+ * Each appointment represents one class session — its slots are consecutive
+ * time blocks (e.g. 3×30 min = 1.5 hr). This function merges them into a
+ * single start→end range per appointment and assigns a global session number.
+ */
+export function buildSessionsFromAppointments(
+  appointments: any[],
+): SessionInfo[] {
+  const now = new Date();
+
+  const sorted = [...appointments]
+    .filter((a) => a.slotsOfAppointment?.length > 0)
+    .sort((a, b) => {
+      const aStart = new Date(a.slotsOfAppointment[0].startsAt).getTime();
+      const bStart = new Date(b.slotsOfAppointment[0].startsAt).getTime();
+      return aStart - bStart;
+    });
+
+  return sorted.map((appointment, idx) => {
+    const slots = [...appointment.slotsOfAppointment].sort(
+      (a: any, b: any) =>
+        new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
+    );
+    const sessionStart = new Date(slots[0].startsAt);
+    const sessionEnd = new Date(slots[slots.length - 1].endsAt);
+
+    let status: SessionStatus = "Upcoming";
+    if (now > sessionEnd) status = "Completed";
+    else if (now >= sessionStart && now < sessionEnd) status = "Happening Now";
+
+    return {
+      sessionNumber: idx + 1,
+      appointmentId: appointment.id,
+      sessionStart,
+      sessionEnd,
+      status,
+    };
+  });
+}
+
+/**
+ * Group sessions by week number relative to the first session's date.
+ * Returns a Map of weekNumber → sessions in that week.
+ */
+export function groupSessionsByWeek(
+  sessions: SessionInfo[],
+): Map<number, SessionInfo[]> {
+  const weeks = new Map<number, SessionInfo[]>();
+  if (sessions.length === 0) return weeks;
+
+  const firstDate = sessions[0].sessionStart;
+
+  for (const session of sessions) {
+    const daysDiff = differenceInDays(
+      startOfDay(session.sessionStart),
+      startOfDay(firstDate),
+    );
+    const weekNum = Math.floor(daysDiff / 7) + 1;
+    if (!weeks.has(weekNum)) weeks.set(weekNum, []);
+    weeks.get(weekNum)!.push(session);
+  }
+
+  return weeks;
+}

--- a/app/explore/programs/plans/schedule-utils.ts
+++ b/app/explore/programs/plans/schedule-utils.ts
@@ -17,8 +17,18 @@ export interface SessionInfo {
  * time blocks (e.g. 3×30 min = 1.5 hr). This function merges them into a
  * single start→end range per appointment and assigns a global session number.
  */
+interface AppointmentSlot {
+  startsAt: string | Date;
+  endsAt: string | Date;
+}
+
+interface AppointmentWithSlots {
+  id: string;
+  slotsOfAppointment: AppointmentSlot[];
+}
+
 export function buildSessionsFromAppointments(
-  appointments: any[],
+  appointments: AppointmentWithSlots[],
 ): SessionInfo[] {
   const now = new Date();
 
@@ -32,7 +42,7 @@ export function buildSessionsFromAppointments(
 
   return sorted.map((appointment, idx) => {
     const slots = [...appointment.slotsOfAppointment].sort(
-      (a: any, b: any) =>
+      (a, b) =>
         new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
     );
     const sessionStart = new Date(slots[0].startsAt);

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useSession } from "@/lib/auth-client";
 import {
   Card,
@@ -12,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { CheckCircle } from "lucide-react";
 import { useCurrency } from "@/hooks/useCurrency";
+import { formatInTimeZone } from "date-fns-tz";
 import { JoinWaitlistButton } from "@/components/waitlist/JoinWaitlistButton";
 import { WaitlistBadge } from "@/components/waitlist/WaitlistBadge";
 import { countWebinarParticipants } from "@/lib/payments/utils/participants";
@@ -46,7 +48,12 @@ export function ClientWebinarRegistration({
 }: ClientWebinarRegistrationProps) {
   const { data: session } = useSession();
   const { formatPrice } = useCurrency();
-  const isLoggedIn = !!session?.user;
+
+  // Defer auth-dependent rendering until after hydration to avoid mismatch
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => setHasMounted(true), []);
+
+  const isLoggedIn = hasMounted && !!session?.user;
   const userId = session?.user?.id;
 
   // Check if user is already registered for this webinar
@@ -82,11 +89,11 @@ export function ClientWebinarRegistration({
 
   let sessionInfoText: string;
   if (nextSessionDate) {
-    const formattedDate = new Date(nextSessionDate).toLocaleString(undefined, {
-      dateStyle: "long",
-      timeStyle: "short",
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    });
+    const formattedDate = formatInTimeZone(
+      new Date(nextSessionDate),
+      Intl.DateTimeFormat().resolvedOptions().timeZone,
+      "MMMM d, yyyy 'at' h:mm a zzz",
+    );
     if (sessionStatus === "Completed") {
       sessionInfoText = `Session ended: ${formattedDate}`;
     } else if (sessionStatus === "Happening Now") {
@@ -142,7 +149,7 @@ export function ClientWebinarRegistration({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Register for Webinar</CardTitle>
+          <CardTitle>Webinar Registration</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-gray-600 mb-4">
@@ -193,7 +200,7 @@ export function ClientWebinarRegistration({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Join Webinar</CardTitle>
+          <CardTitle>Webinar Registration</CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-gray-600 mb-4">{sessionInfoText}</p>
@@ -234,7 +241,7 @@ export function ClientWebinarRegistration({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Join Webinar</CardTitle>
+        <CardTitle>Webinar Registration</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="text-sm text-gray-600 mb-4">{sessionInfoText}</p>

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
@@ -49,9 +49,13 @@ export function ClientWebinarRegistration({
   const { data: session } = useSession();
   const { formatPrice } = useCurrency();
 
-  // Defer auth-dependent rendering until after hydration to avoid mismatch
+  // Defer auth + timezone until after hydration to avoid mismatch
   const [hasMounted, setHasMounted] = useState(false);
-  useEffect(() => setHasMounted(true), []);
+  const [userTimeZone, setUserTimeZone] = useState("UTC");
+  useEffect(() => {
+    setHasMounted(true);
+    setUserTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
 
   const isLoggedIn = hasMounted && !!session?.user;
   const userId = session?.user?.id;
@@ -91,7 +95,7 @@ export function ClientWebinarRegistration({
   if (nextSessionDate) {
     const formattedDate = formatInTimeZone(
       new Date(nextSessionDate),
-      Intl.DateTimeFormat().resolvedOptions().timeZone,
+      userTimeZone,
       "MMMM d, yyyy 'at' h:mm a zzz",
     );
     if (sessionStatus === "Completed") {

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
@@ -15,6 +15,7 @@ import {
   Globe,
   GraduationCap,
 } from "lucide-react";
+import { formatInTimeZone } from "date-fns-tz";
 import { ClientWebinarRegistration } from "./ClientWebinarRegistration";
 import { generateProgramImageUrl } from "../../../../utils";
 import { useCurrency } from "@/hooks/useCurrency";
@@ -36,6 +37,7 @@ export function WebinarDetails({
   const { formatPrice } = useCurrency();
   let sessionStatus: TSessionStatus = "To be announced";
   let formattedNextSessionDisplay = "To be announced";
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   if (
     nextSession &&
@@ -48,45 +50,20 @@ export function WebinarDetails({
       sessionStart.getTime() + durationInMilliseconds,
     );
     const now = new Date();
-    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     if (now > sessionEnd) {
       sessionStatus = "Completed";
-      formattedNextSessionDisplay = `Ended on ${sessionEnd.toLocaleString(
-        undefined,
-        {
-          dateStyle: "long",
-          timeStyle: "short",
-          timeZone,
-        },
-      )}`;
+      formattedNextSessionDisplay = `Ended on ${formatInTimeZone(sessionEnd, timeZone, "MMMM d, yyyy 'at' h:mm a zzz")}`;
     } else if (now >= sessionStart && now <= sessionEnd) {
       sessionStatus = "Happening Now";
-      formattedNextSessionDisplay = `Ends at ${sessionEnd.toLocaleTimeString(
-        undefined,
-        {
-          timeStyle: "short",
-          timeZone,
-        },
-      )}`;
+      formattedNextSessionDisplay = `Ends at ${formatInTimeZone(sessionEnd, timeZone, "h:mm a zzz")}`;
     } else if (now < sessionStart) {
       sessionStatus = "Upcoming";
-      formattedNextSessionDisplay = sessionStart.toLocaleString(undefined, {
-        dateStyle: "long",
-        timeStyle: "short",
-        timeZone,
-      });
+      formattedNextSessionDisplay = formatInTimeZone(sessionStart, timeZone, "MMMM d, yyyy 'at' h:mm a zzz");
     }
   } else if (nextSession) {
     sessionStatus = "Upcoming";
-    formattedNextSessionDisplay = new Date(nextSession).toLocaleString(
-      undefined,
-      {
-        dateStyle: "long",
-        timeStyle: "short",
-        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      },
-    );
+    formattedNextSessionDisplay = formatInTimeZone(new Date(nextSession), timeZone, "MMMM d, yyyy 'at' h:mm a zzz");
   }
 
   const getStatusBadgeClass = (status: TSessionStatus) => {

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
@@ -35,9 +36,12 @@ export function WebinarDetails({
   webinarId,
 }: WebinarDetailsProps) {
   const { formatPrice } = useCurrency();
+  const [timeZone, setTimeZone] = useState("UTC");
+  useEffect(() => {
+    setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
   let sessionStatus: TSessionStatus = "To be announced";
   let formattedNextSessionDisplay = "To be announced";
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
   if (
     nextSession &&

--- a/lib/data/plan-details.ts
+++ b/lib/data/plan-details.ts
@@ -49,7 +49,6 @@ export async function fetchWebinarPlanDetail(webinarPlanId: string) {
                   },
                 },
               },
-              payment: true,
             },
           },
           waitlist: {


### PR DESCRIPTION
## Summary

- **Class schedule display was broken**: each 30-min slot rendered as a separate "Session" (24 rows), numbering reset per appointment. Seed data is correct — 8 appointments × 3 slots = 8 sessions of 1.5hrs. Fixed to consolidate slots per appointment into single session rows with time ranges, global numbering (1–8), and week grouping.
- **Timezone formatting broken across all 4 detail components**: `toLocaleString()` / `Intl.DateTimeFormat` showed seconds ("2:00:00 PM"), "GMT+5:30" instead of "IST", and hit the Netlify UTC bug. Replaced with `formatInTimeZone` from `date-fns-tz`.
- **`startDate` bug**: `ClientClassRegistration` referenced `.startDate` which doesn't exist on the `Class` model — always showed "Start date to be announced". Fixed to `.schedulingPeriodStartsAt`.
- **Webinar page crash**: unused `payment: true` include in webinar query caused "column does not exist" error.
- **Hydration mismatches**: registration card titles and auth-dependent rendering differed between server (no session) and client (active session). Fixed with `hasMounted` guard and consistent titles.

## Files changed

| File | Changes |
|------|---------|
| `app/explore/programs/plans/schedule-utils.ts` | **New** — shared `buildSessionsFromAppointments` + `groupSessionsByWeek` utilities |
| `.../classes/[classPlanId]/components/ClassDetails.tsx` | Rewrite schedule section: consolidated sessions, week grouping, `formatInTimeZone` |
| `.../classes/[classPlanId]/components/ClientClassRegistration.tsx` | Fix `startDate` bug, timezone (4x), hydration mismatch |
| `.../webinars/[webinarPlanId]/components/WebinarDetails.tsx` | Timezone fix (4x `toLocaleString` → `formatInTimeZone`) |
| `.../webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx` | Timezone fix (1x), hydration mismatch |
| `lib/data/plan-details.ts` | Remove unused `payment: true` include from webinar query |

## Test plan

- [ ] Visit class detail page — should show 8 sessions (not 24), grouped by week, with time ranges like "2:00 PM – 3:30 PM IST"
- [ ] No seconds in time display ("2:00 PM" not "2:00:00 PM")
- [ ] Timezone abbreviation shown (e.g., "IST" not "GMT+5:30")
- [ ] Past sessions show "Completed" badge with muted styling
- [ ] Class registration card shows actual start date
- [ ] Webinar detail page loads without crash
- [ ] No hydration errors in console
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)