### PR TITLE
fix: Stream SDK production hardening — security, bugs, features

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -42,6 +42,14 @@
         "DIRECTUS_URL": "https://your-project.directus.app",
         "DIRECTUS_TOKEN": "your-directus-admin-token"
       }
+    },
+    "streamio": {
+      "command": "npx",
+      "args": ["-y", "unofficial-streamio-mcp-server@latest"],
+      "env": {
+        "STREAM_API_KEY": "${STREAM_API_KEY}",
+        "STREAM_API_SECRET": "${STREAM_API_SECRET}"
+      }
     }
   }
 }

--- a/__tests__/stream/channel-actions.test.ts
+++ b/__tests__/stream/channel-actions.test.ts
@@ -176,10 +176,10 @@ describe("Channel Actions", () => {
 
       const result = await createDirectMessageChannel("bob", "alice");
 
-      expect(result.channelId).toBe("alice-bob");
+      expect(result.channelId).toBe("dm-alice-bob");
       expect(mockStreamClient.channel).toHaveBeenCalledWith(
         "messaging",
-        "alice-bob",
+        "dm-alice-bob",
         expect.anything(),
       );
     });

--- a/actions/stream/chat/channel.action.ts
+++ b/actions/stream/chat/channel.action.ts
@@ -7,6 +7,7 @@ import { streamLogger } from "@/lib/stream-logger";
 import { markChannelExists } from "@/lib/stream-cache";
 import { upsertUsersToStream } from "./user.action";
 import { getDmChannelId } from "@/lib/stream-utils";
+import { getChannelTypeFromId } from "@/lib/stream-channel-ids";
 
 // Input validation schemas
 const channelTypeSchema = z.enum(["messaging", "team"]);
@@ -99,10 +100,7 @@ export async function createDirectMessageChannel(
   memberIdSchema.parse(currentUserId);
   memberIdSchema.parse(targetUserId);
 
-  // Create a unique channel ID for the DM using localeCompare for reliable sorting
-  const channelId = [currentUserId, targetUserId]
-    .sort((a, b) => a.localeCompare(b))
-    .join("-");
+  const channelId = getDmChannelId(currentUserId, targetUserId);
 
   return createChannel({
     channelType: "messaging",
@@ -281,6 +279,7 @@ export async function createConsultationChannel(consultationId: string) {
     members: [consultantId, consulteeId],
     createdById: consultantId,
     additionalData: {
+      consultation_id: consultationId,
       dm_consultant_user_id: consultantId,
       dm_consultee_user_id: consulteeId,
     },
@@ -328,6 +327,7 @@ export async function createSubscriptionChannel(subscriptionId: string) {
     members: [consultantId, consulteeId],
     createdById: consultantId,
     additionalData: {
+      subscription_id: subscriptionId,
       dm_consultant_user_id: consultantId,
       dm_consultee_user_id: consulteeId,
     },
@@ -655,14 +655,7 @@ export async function addMemberToChannel(channelId: string, userId: string) {
 
   const client = getStreamChatClient();
 
-  // Infer channel type from ID pattern
-  const channelType =
-    channelId.startsWith("consultation-") ||
-    channelId.startsWith("subscription-") ||
-    channelId.startsWith("collab-") ||
-    channelId.startsWith("dm-")
-      ? "messaging"
-      : "team";
+  const channelType = getChannelTypeFromId(channelId);
 
   streamLogger.debug("Adding member to channel", {
     channelId,

--- a/actions/stream/chat/event-channel.action.ts
+++ b/actions/stream/chat/event-channel.action.ts
@@ -13,6 +13,7 @@ import {
   clearSyncCacheForUser,
 } from "@/lib/stream-cache";
 import { upsertUserToStream, upsertUsersToStream } from "./user.action";
+import { MANAGED_CHANNEL_PREFIXES } from "@/lib/stream-channel-ids";
 import { getDmChannelId } from "@/lib/stream-utils";
 
 // Validation schemas
@@ -501,19 +502,11 @@ export async function syncUserEventChannels(
 
     // Only clean up channels with managed prefixes — preserve collab, support,
     // and manually-created channels that aren't part of the event/dm lifecycle.
-    const MANAGED_PREFIXES = [
-      "consultation-",
-      "subscription-",
-      "webinar-",
-      "class-",
-      "trial-",
-      "dm-",
-    ];
     const staleChannels = streamChannels.filter(
       (ch) =>
         ch.id &&
         !expectedChannelIds.has(ch.id) &&
-        MANAGED_PREFIXES.some((prefix) => ch.id!.startsWith(prefix)),
+        MANAGED_CHANNEL_PREFIXES.some((prefix) => ch.id!.startsWith(prefix)),
     );
 
     let staleRemovedCount = 0;

--- a/actions/stream/chat/stream.action.ts
+++ b/actions/stream/chat/stream.action.ts
@@ -8,6 +8,9 @@ import {
 } from "@/lib/stream-client";
 import { streamLogger } from "@/lib/stream-logger";
 
+// Token expiry for both chat and video (1 hour)
+const TOKEN_EXPIRATION_SECONDS = 3600;
+
 // Input validation
 const userIdSchema = z.string().min(1, "User ID is required");
 
@@ -27,7 +30,7 @@ export async function tokenProvider(userId: string): Promise<string> {
   }
 
   try {
-    const token = generateVideoToken(validatedUserId, 3600); // 1 hour
+    const token = generateVideoToken(validatedUserId, TOKEN_EXPIRATION_SECONDS);
 
     streamLogger.debug("Generated video token", { userId: validatedUserId });
 
@@ -56,7 +59,7 @@ export async function chatTokenProvider(userId: string): Promise<string> {
   }
 
   try {
-    const token = generateChatToken(validatedUserId, 3600); // 1 hour, matching video token
+    const token = generateChatToken(validatedUserId, TOKEN_EXPIRATION_SECONDS);
 
     streamLogger.debug("Generated chat token", { userId: validatedUserId });
 

--- a/actions/stream/chat/stream.action.ts
+++ b/actions/stream/chat/stream.action.ts
@@ -42,6 +42,7 @@ export async function tokenProvider(userId: string): Promise<string> {
 
 /**
  * Generate a chat token for a user
+ * Token is valid for 1 hour by default
  * @param userId The user ID to generate token for
  * @returns The chat token string
  */
@@ -55,7 +56,7 @@ export async function chatTokenProvider(userId: string): Promise<string> {
   }
 
   try {
-    const token = generateChatToken(validatedUserId);
+    const token = generateChatToken(validatedUserId, 3600); // 1 hour, matching video token
 
     streamLogger.debug("Generated chat token", { userId: validatedUserId });
 

--- a/app/api/consultants/[consultantId]/recordings/route.ts
+++ b/app/api/consultants/[consultantId]/recordings/route.ts
@@ -50,8 +50,8 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       },
     );
 
-    // Map recordings to response format with best URLs
-    const formattedRecordings = recordings.map((recording) => {
+    // Map recordings to response format with best URLs (async — presigned URLs)
+    const formattedRecordings = await Promise.all(recordings.map(async (recording) => {
       const appointment =
         recording.meetingSession.slotOfAppointment.appointment;
 
@@ -76,7 +76,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         recordedAt: recording.recordedAt,
         status: recording.status,
         storageType: recording.storageType,
-        playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+        playbackUrl: await RecordingTransferService.getBestRecordingUrl(recording),
         thumbnailUrl: recording.thumbnailUrl,
         resolution: recording.resolution,
         streamUrlExpiresAt: recording.streamUrlExpiresAt,
@@ -86,7 +86,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         planTitle,
         createdAt: recording.createdAt,
       };
-    });
+    }));
 
     return NextResponse.json({
       recordings: formattedRecordings,

--- a/app/api/consultees/[consulteeId]/recordings/route.ts
+++ b/app/api/consultees/[consulteeId]/recordings/route.ts
@@ -45,8 +45,8 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       { type: type || undefined },
     );
 
-    // Format recordings for response
-    const formattedRecordings = recordings.map((recording) => {
+    // Format recordings for response (async — generates presigned URLs)
+    const formattedRecordings = await Promise.all(recordings.map(async (recording) => {
       const appointment =
         recording.meetingSession?.slotOfAppointment?.appointment;
 
@@ -71,7 +71,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         recordedAt: recording.recordedAt,
         status: recording.status,
         storageType: recording.storageType,
-        playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+        playbackUrl: await RecordingTransferService.getBestRecordingUrl(recording),
         thumbnailUrl: recording.thumbnailUrl,
         resolution: recording.resolution,
         planType,
@@ -79,7 +79,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         planTitle,
         createdAt: recording.createdAt,
       };
-    });
+    }));
 
     return NextResponse.json({
       recordings: formattedRecordings,

--- a/app/api/dashboard/consultee/[consulteeId]/resources/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/resources/route.ts
@@ -282,7 +282,7 @@ export async function GET(
     );
 
     const transform = {
-      consultations: consultations.map((c: ConsultationWithResources) => ({
+      consultations: await Promise.all(consultations.map(async (c: ConsultationWithResources) => ({
         id: c.id,
         planTitle: c.consultationPlan.title,
         consultantName: c.consultationPlan.consultantProfile.user.name,
@@ -290,9 +290,9 @@ export async function GET(
         status: c.requestStatus,
         date: c.appointment?.slotsOfAppointment?.[0]?.startsAt || c.requestedAt,
         materials: c.consultationPlan.materials,
-        recordings: extractRecordings(c.appointment ? [c.appointment] : []),
-      })),
-      subscriptions: subscriptions.map((s: SubscriptionWithResources) => ({
+        recordings: await extractRecordings(c.appointment ? [c.appointment] : []),
+      }))),
+      subscriptions: await Promise.all(subscriptions.map(async (s: SubscriptionWithResources) => ({
         id: s.id,
         planTitle: s.subscriptionPlan.title,
         consultantName: s.subscriptionPlan.consultantProfile.user.name,
@@ -300,9 +300,9 @@ export async function GET(
         status: s.requestStatus,
         date: s.schedulingPeriodStartsAt || s.requestedAt,
         materials: s.subscriptionPlan.materials,
-        recordings: extractRecordings(s.appointments),
-      })),
-      webinars: webinars.map((w: WebinarWithResources) => ({
+        recordings: await extractRecordings(s.appointments),
+      }))),
+      webinars: await Promise.all(webinars.map(async (w: WebinarWithResources) => ({
         id: w.id,
         planTitle: w.webinarPlan.title,
         consultantName: w.webinarPlan.consultantProfile?.user.name ?? null,
@@ -310,9 +310,9 @@ export async function GET(
         status: w.status,
         date: w.appointment?.slotsOfAppointment?.[0]?.startsAt || w.createdAt,
         materials: w.webinarPlan.materials,
-        recordings: extractRecordings(w.appointment ? [w.appointment] : []),
-      })),
-      classes: classes.map((cl: ClassWithResources) => ({
+        recordings: await extractRecordings(w.appointment ? [w.appointment] : []),
+      }))),
+      classes: await Promise.all(classes.map(async (cl: ClassWithResources) => ({
         id: cl.id,
         planTitle: cl.classPlan.title,
         consultantName: cl.classPlan.consultantProfile?.user.name ?? null,
@@ -323,8 +323,8 @@ export async function GET(
           cl.appointments?.[0]?.slotsOfAppointment?.[0]?.startsAt ||
           cl.createdAt,
         materials: cl.classPlan.materials,
-        recordings: extractRecordings(cl.appointments),
-      })),
+        recordings: await extractRecordings(cl.appointments),
+      }))),
     };
 
     return NextResponse.json({ data: transform, success: true });
@@ -337,19 +337,23 @@ export async function GET(
   }
 }
 
-function extractRecordings(appointments: AppointmentWithSlots[]) {
-  return appointments.flatMap((apt) =>
+async function extractRecordings(appointments: AppointmentWithSlots[]) {
+  const recordings = appointments.flatMap((apt) =>
     apt.slotsOfAppointment.flatMap(
       (slot) =>
-        slot.meetingSession?.recordings?.map((rec) => ({
-          id: rec.id,
-          title: rec.title,
-          durationInMinutes: rec.durationInMinutes,
-          recordedAt: rec.recordedAt,
-          playbackUrl: RecordingTransferService.getBestRecordingUrl(rec),
-          thumbnailUrl: rec.thumbnailUrl,
-          status: rec.status,
-        })) ?? [],
+        slot.meetingSession?.recordings?.map((rec) => rec) ?? [],
     ),
+  );
+
+  return Promise.all(
+    recordings.map(async (rec) => ({
+      id: rec.id,
+      title: rec.title,
+      durationInMinutes: rec.durationInMinutes,
+      recordedAt: rec.recordedAt,
+      playbackUrl: await RecordingTransferService.getBestRecordingUrl(rec),
+      thumbnailUrl: rec.thumbnailUrl,
+      status: rec.status,
+    })),
   );
 }

--- a/app/api/events/consultations/[consultationId]/route.ts
+++ b/app/api/events/consultations/[consultationId]/route.ts
@@ -21,6 +21,9 @@ import {
   isPrivileged,
   forbiddenResponse,
 } from "@/lib/auth-helpers";
+import { addUserToEventChannel } from "@/actions/stream/chat/event-channel.action";
+import { createDirectMessageChannel } from "@/actions/stream/chat/channel.action";
+import { streamLogger } from "@/lib/stream-logger";
 
 /**
  * Type for consultation with all related details needed for payment processing
@@ -722,6 +725,32 @@ export async function PATCH(
             emailError instanceof Error ? emailError.message : "Unknown error",
           );
         }
+      }
+
+      // --- Stream channel creation (fire-and-forget, after transaction) ---
+      try {
+        const consultationData = result.data;
+        const consultantUserId =
+          consultationData.consultationPlan?.consultantProfile?.userId;
+        const consulteeUserId = consultationData.requestedBy?.userId;
+
+        if (consultantUserId && consulteeUserId) {
+          await addUserToEventChannel(
+            "consultation",
+            consultationId,
+            consulteeUserId,
+          );
+          await createDirectMessageChannel(consultantUserId, consulteeUserId);
+          streamLogger.info("Stream channel created on consultation approval", {
+            consultationId,
+          });
+        }
+      } catch (channelError) {
+        streamLogger.error(
+          "Auto-channel creation failed on consultation approval",
+          channelError,
+          { consultationId },
+        );
       }
 
       // Return success response (exclude emailData from response)

--- a/app/api/events/consultations/[consultationId]/route.ts
+++ b/app/api/events/consultations/[consultationId]/route.ts
@@ -727,8 +727,8 @@ export async function PATCH(
         }
       }
 
-      // --- Stream channel creation (fire-and-forget, after transaction) ---
-      try {
+      // --- Stream channel creation (fire-and-forget, only on approval) ---
+      if (!result.duplicate && status === RequestStatus.APPROVED) try {
         const consultationData = result.data;
         const consultantUserId =
           consultationData.consultationPlan?.consultantProfile?.userId;

--- a/app/api/events/subscriptions/[subscriptionId]/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/route.ts
@@ -27,6 +27,9 @@ import {
   isPrivileged,
   forbiddenResponse,
 } from "@/lib/auth-helpers";
+import { addUserToEventChannel } from "@/actions/stream/chat/event-channel.action";
+import { createDirectMessageChannel } from "@/actions/stream/chat/channel.action";
+import { streamLogger } from "@/lib/stream-logger";
 
 /**
  * Type for subscription with all related details needed for payment processing
@@ -726,6 +729,40 @@ export async function PATCH(
               dashboardUrl: "/dashboard",
             });
           }
+        }
+      }
+
+      // --- Stream channel creation (fire-and-forget, after transaction) ---
+      if (
+        !result.duplicate &&
+        status === RequestStatus.APPROVED &&
+        "data" in result &&
+        result.data
+      ) {
+        try {
+          const subData = result.data;
+          const consultantUid =
+            subData.subscriptionPlan?.consultantProfile?.user?.id;
+          const consulteeUid = subData.requestedBy?.user?.id;
+
+          if (consultantUid && consulteeUid) {
+            await addUserToEventChannel(
+              "subscription",
+              subData.id,
+              consulteeUid,
+            );
+            await createDirectMessageChannel(consultantUid, consulteeUid);
+            streamLogger.info(
+              "Stream channel created on subscription approval",
+              { subscriptionId: subData.id },
+            );
+          }
+        } catch (channelError) {
+          streamLogger.error(
+            "Auto-channel creation failed on subscription approval",
+            channelError,
+            { subscriptionId },
+          );
         }
       }
 

--- a/app/api/plans/classes/[classPlanId]/recordings/route.ts
+++ b/app/api/plans/classes/[classPlanId]/recordings/route.ts
@@ -92,22 +92,22 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     const recordings =
       await RecordingService.getClassPlanRecordings(classPlanId);
 
-    // Map recordings to response format
-    const formattedRecordings = recordings.map((recording) => ({
+    // Map recordings to response format (async — presigned URLs)
+    const formattedRecordings = await Promise.all(recordings.map(async (recording) => ({
       id: recording.id,
       title: recording.title,
       durationInMinutes: recording.durationInMinutes,
       recordedAt: recording.recordedAt,
       status: recording.status,
       storageType: recording.storageType,
-      playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+      playbackUrl: await RecordingTransferService.getBestRecordingUrl(recording),
       thumbnailUrl: recording.thumbnailUrl,
       resolution: recording.resolution,
       previewClipUrl: recording.previewClipUrl,
       previewClipDuration: recording.previewClipDuration,
       streamUrlExpiresAt: recording.streamUrlExpiresAt,
       createdAt: recording.createdAt,
-    }));
+    })));
 
     return NextResponse.json({
       planId: classPlanId,

--- a/app/api/plans/webinars/[webinarPlanId]/recordings/route.ts
+++ b/app/api/plans/webinars/[webinarPlanId]/recordings/route.ts
@@ -92,22 +92,22 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     const recordings =
       await RecordingService.getWebinarPlanRecordings(webinarPlanId);
 
-    // Map recordings to response format
-    const formattedRecordings = recordings.map((recording) => ({
+    // Map recordings to response format (async — presigned URLs)
+    const formattedRecordings = await Promise.all(recordings.map(async (recording) => ({
       id: recording.id,
       title: recording.title,
       durationInMinutes: recording.durationInMinutes,
       recordedAt: recording.recordedAt,
       status: recording.status,
       storageType: recording.storageType,
-      playbackUrl: RecordingTransferService.getBestRecordingUrl(recording),
+      playbackUrl: await RecordingTransferService.getBestRecordingUrl(recording),
       thumbnailUrl: recording.thumbnailUrl,
       resolution: recording.resolution,
       previewClipUrl: recording.previewClipUrl,
       previewClipDuration: recording.previewClipDuration,
       streamUrlExpiresAt: recording.streamUrlExpiresAt,
       createdAt: recording.createdAt,
-    }));
+    })));
 
     return NextResponse.json({
       planId: webinarPlanId,

--- a/app/api/stream/channels/create/route.ts
+++ b/app/api/stream/channels/create/route.ts
@@ -7,6 +7,7 @@ import {
   createChannel,
 } from "@/actions/stream/chat/channel.action";
 import { getSession } from "@/lib/auth-server";
+import { streamLogger } from "@/lib/stream-logger";
 
 export async function POST(req: NextRequest) {
   try {
@@ -49,9 +50,11 @@ export async function POST(req: NextRequest) {
 
     if (eventType && eventId) {
       // Event-linked channel creation - use our improved functions with full participant lists
-      console.log(
-        `Creating ${eventType} channel for event ${eventId} by user ${createdById}`,
-      );
+      streamLogger.info("Creating event channel", {
+        eventType,
+        eventId,
+        createdById,
+      });
 
       try {
         switch (eventType) {
@@ -74,15 +77,12 @@ export async function POST(req: NextRequest) {
             );
         }
 
-        console.log(
-          `Successfully created ${eventType} channel for event ${eventId}:`,
-          result,
-        );
+        streamLogger.info("Event channel created", { eventType, eventId });
       } catch (eventError) {
-        console.error(
-          `Error creating ${eventType} channel for event ${eventId}:`,
-          eventError,
-        );
+        streamLogger.error("Event channel creation failed", eventError, {
+          eventType,
+          eventId,
+        });
         throw eventError; // Re-throw to be caught by outer catch block
       }
     } else {
@@ -98,9 +98,11 @@ export async function POST(req: NextRequest) {
       }
 
       const channelId = crypto.randomUUID();
-      console.log(
-        `Creating custom ${channelType} channel: ${channelId} with name: ${channelName}`,
-      );
+      streamLogger.info("Creating custom channel", {
+        channelId,
+        channelType,
+        channelName,
+      });
 
       result = await createChannel({
         channelType: channelType as "messaging" | "team",
@@ -120,7 +122,7 @@ export async function POST(req: NextRequest) {
         : "Custom channel created successfully",
     });
   } catch (error) {
-    console.error("Error creating channel via API:", error);
+    streamLogger.error("Channel creation API error", error);
     return NextResponse.json(
       {
         success: false,

--- a/app/api/stream/recordings/[recordingId]/route.ts
+++ b/app/api/stream/recordings/[recordingId]/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { RecordingService } from "@/lib/stream/recording-service";
 import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 import prisma from "@/lib/prisma";
+import { streamLogger } from "@/lib/stream-logger";
 
 import { getSession } from "@/lib/auth-server";
 type RouteParams = {
@@ -105,8 +106,25 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Get the best available URL
-    const playbackUrl = RecordingTransferService.getBestRecordingUrl(recording);
+    // Check if Stream URL has expired
+    if (
+      recording.storageType === "STREAM_S3" &&
+      recording.streamUrlExpiresAt &&
+      new Date(recording.streamUrlExpiresAt) < new Date()
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Recording has expired on Stream storage. Transfer to permanent storage or sync recordings.",
+          expired: true,
+        },
+        { status: 410 },
+      );
+    }
+
+    // Get the best available URL (async — generates presigned URL for Supabase)
+    const playbackUrl =
+      await RecordingTransferService.getBestRecordingUrl(recording);
 
     return NextResponse.json({
       recording: {
@@ -126,7 +144,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       },
     });
   } catch (error) {
-    console.error("Error getting recording:", error);
+    streamLogger.error("Error getting recording", error);
     return NextResponse.json(
       { error: "Failed to get recording" },
       { status: 500 },

--- a/app/api/stream/recordings/start/route.ts
+++ b/app/api/stream/recordings/start/route.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { RecordingService } from "@/lib/stream/recording-service";
 import { getMeetingSessionOwnershipInfo } from "@/lib/stream/recording-utils";
 import prisma from "@/lib/prisma";
+import { streamLogger } from "@/lib/stream-logger";
 
 import { getSession } from "@/lib/auth-server";
 const startRecordingSchema = z.object({
@@ -100,11 +101,20 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Check if already recording
-    if (meetingSession.isRecording) {
+    // Atomically set isRecording=true (prevents race condition with concurrent requests)
+    const updated = await prisma.meetingSession.updateMany({
+      where: { id: meetingSessionId, isRecording: false },
+      data: {
+        isRecording: true,
+        recordingStartedAt: new Date(),
+        recordingStartedBy: session.user.id,
+      },
+    });
+
+    if (updated.count === 0) {
       return NextResponse.json(
         { error: "Recording is already in progress" },
-        { status: 400 },
+        { status: 409 },
       );
     }
 
@@ -115,28 +125,23 @@ export async function POST(req: NextRequest) {
     );
 
     if (!result.success) {
+      // Revert the DB state since Stream API failed
+      await prisma.meetingSession.update({
+        where: { id: meetingSessionId },
+        data: { isRecording: false, recordingStartedAt: null, recordingStartedBy: null },
+      });
       return NextResponse.json(
         { error: result.error || "Failed to start recording" },
         { status: 500 },
       );
     }
 
-    // Update meeting session (webhook will also update, but we update immediately for UI)
-    await prisma.meetingSession.update({
-      where: { id: meetingSessionId },
-      data: {
-        isRecording: true,
-        recordingStartedAt: new Date(),
-        recordingStartedBy: session.user.id,
-      },
-    });
-
     return NextResponse.json({
       success: true,
       message: "Recording started",
     });
   } catch (error) {
-    console.error("Error starting recording:", error);
+    streamLogger.error("Error starting recording", error);
 
     if (error instanceof z.ZodError) {
       return NextResponse.json(

--- a/app/api/stream/recordings/stop/route.ts
+++ b/app/api/stream/recordings/stop/route.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { RecordingService } from "@/lib/stream/recording-service";
 import { getMeetingSessionOwnershipInfo } from "@/lib/stream/recording-utils";
 import prisma from "@/lib/prisma";
+import { streamLogger } from "@/lib/stream-logger";
 
 import { getSession } from "@/lib/auth-server";
 const stopRecordingSchema = z.object({
@@ -90,11 +91,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Check if recording is active
-    if (!meetingSession.isRecording) {
+    // Atomically set isRecording=false (prevents race condition with concurrent requests)
+    const updated = await prisma.meetingSession.updateMany({
+      where: { id: meetingSessionId, isRecording: true },
+      data: { isRecording: false },
+    });
+
+    if (updated.count === 0) {
       return NextResponse.json(
         { error: "No recording in progress" },
-        { status: 400 },
+        { status: 409 },
       );
     }
 
@@ -108,20 +114,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Update meeting session (webhook will also update, but we update immediately for UI)
-    await prisma.meetingSession.update({
-      where: { id: meetingSessionId },
-      data: {
-        isRecording: false,
-      },
-    });
-
     return NextResponse.json({
       success: true,
       message: "Recording stopped",
     });
   } catch (error) {
-    console.error("Error stopping recording:", error);
+    streamLogger.error("Error stopping recording", error);
 
     if (error instanceof z.ZodError) {
       return NextResponse.json(

--- a/app/api/stream/search/route.ts
+++ b/app/api/stream/search/route.ts
@@ -6,8 +6,18 @@ import {
 import { NextRequest, NextResponse } from "next/server";
 
 import { getSession } from "@/lib/auth-server";
+import { streamLogger } from "@/lib/stream-logger";
+
 export async function GET(req: NextRequest) {
   try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
     const url = new URL(req.url);
     const searchTerm = url.searchParams.get("term");
     const withRelationships = url.searchParams.get("relationships") === "true";
@@ -19,26 +29,11 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    console.log(
-      `Searching for users with term: ${searchTerm}, with relationships: ${withRelationships}`,
-    );
+    streamLogger.debug("Searching users", { searchTerm, withRelationships });
 
     let users;
 
     if (withRelationships) {
-      // Get current user session for relationship checking
-      const session = await getSession();
-
-      if (!session?.user?.id) {
-        return NextResponse.json(
-          {
-            success: false,
-            error: "Authentication required for relationship search",
-          },
-          { status: 401 },
-        );
-      }
-
       // Use enhanced search with relationship checking
       users = await searchUsersWithRelationships(searchTerm, session.user.id);
     } else {
@@ -46,20 +41,18 @@ export async function GET(req: NextRequest) {
       users = await searchUsers(searchTerm);
     }
 
-    console.log(`Found ${users.length} users`);
+    streamLogger.debug("Search results", { count: users.length });
 
     // If users are found, upsert them to Stream Chat
     if (users.length > 0) {
       try {
-        // Get user IDs
         const userIds = users.map((user) => user.id);
-
-        // Upsert users to Stream Chat
         await upsertUsersToStream(userIds);
-
-        console.log(`Upserted ${users.length} users to Stream Chat`);
+        streamLogger.debug("Users upserted to Stream", {
+          count: users.length,
+        });
       } catch (upsertError) {
-        console.error("Error upserting users to Stream Chat:", upsertError);
+        streamLogger.warn("User upsert to Stream failed", upsertError);
         // Continue even if upserting fails
       }
     }
@@ -69,7 +62,7 @@ export async function GET(req: NextRequest) {
       users,
     });
   } catch (error) {
-    console.error("Error searching users:", error);
+    streamLogger.error("User search failed", error);
     return NextResponse.json(
       { success: false, error: (error as Error).message },
       { status: 500 },

--- a/app/api/stream/search/route.ts
+++ b/app/api/stream/search/route.ts
@@ -52,7 +52,7 @@ export async function GET(req: NextRequest) {
           count: users.length,
         });
       } catch (upsertError) {
-        streamLogger.warn("User upsert to Stream failed", upsertError);
+        streamLogger.error("User upsert to Stream failed", upsertError);
         // Continue even if upserting fails
       }
     }

--- a/app/api/stream/users/block/route.ts
+++ b/app/api/stream/users/block/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth-server";
+import { getStreamChatClient } from "@/lib/stream-client";
+import { streamLogger } from "@/lib/stream-logger";
+import prisma from "@/lib/prisma";
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { targetUserId } = body;
+
+    if (!targetUserId || typeof targetUserId !== "string") {
+      return NextResponse.json(
+        { error: "targetUserId is required" },
+        { status: 400 },
+      );
+    }
+
+    if (targetUserId === session.user.id) {
+      return NextResponse.json(
+        { error: "You cannot block yourself" },
+        { status: 400 },
+      );
+    }
+
+    // Verify target user exists
+    const targetUser = await prisma.user.findUnique({
+      where: { id: targetUserId },
+    });
+    if (!targetUser) {
+      return NextResponse.json(
+        { error: "Target user not found" },
+        { status: 404 },
+      );
+    }
+
+    // Ban the user in Stream Chat (server-side only)
+    const chatClient = getStreamChatClient();
+    await chatClient.banUser(targetUserId, {
+      banned_by_id: session.user.id,
+      reason: "user_block",
+    });
+
+    // Create a moderation report in our DB
+    await prisma.moderationReport.create({
+      data: {
+        type: "OTHER",
+        reason: "User blocked via chat",
+        description: `User ${session.user.id} blocked user ${targetUserId} from chat`,
+        reportedById: session.user.id,
+        targetUserId,
+      },
+    });
+
+    streamLogger.info("User blocked", {
+      blockedBy: session.user.id,
+      targetUserId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "User blocked successfully",
+    });
+  } catch (error) {
+    streamLogger.error("Failed to block user", error);
+    return NextResponse.json(
+      { error: "Failed to block user" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/stream/users/block/route.ts
+++ b/app/api/stream/users/block/route.ts
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth-server";
 import { getStreamChatClient } from "@/lib/stream-client";
 import { streamLogger } from "@/lib/stream-logger";
 import prisma from "@/lib/prisma";
+import { getDmChannelId } from "@/lib/stream-utils";
 
 export async function POST(req: NextRequest) {
   try {
@@ -39,9 +40,28 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Ban the user in Stream Chat (server-side only)
+    // Verify the blocker has an existing DM channel with the target
+    // (prevents arbitrary users from banning others they've never interacted with)
     const chatClient = getStreamChatClient();
-    await chatClient.banUser(targetUserId, {
+    const dmChannelId = getDmChannelId(session.user.id, targetUserId);
+    const dmChannel = chatClient.channel("messaging", dmChannelId);
+    try {
+      const state = await dmChannel.query({ members: { limit: 0 } });
+      if (!state.channel) {
+        return NextResponse.json(
+          { error: "You can only block users you have a conversation with" },
+          { status: 403 },
+        );
+      }
+    } catch {
+      return NextResponse.json(
+        { error: "You can only block users you have a conversation with" },
+        { status: 403 },
+      );
+    }
+
+    // Ban the user in this specific channel (scoped, not global)
+    await dmChannel.banUser(targetUserId, {
       banned_by_id: session.user.id,
       reason: "user_block",
     });

--- a/app/api/stream/webhooks/route.ts
+++ b/app/api/stream/webhooks/route.ts
@@ -1,6 +1,6 @@
 /**
- * Stream Video Webhook Handler
- * Handles recording lifecycle and call session events from Stream
+ * Stream Webhook Handler
+ * Handles recording lifecycle, call session, and chat moderation events
  *
  * Recording Events:
  * - call.recording_started
@@ -11,6 +11,10 @@
  * Session Events:
  * - call.session_ended
  * - call.ended
+ *
+ * Chat Moderation Events:
+ * - user.flagged
+ * - message.flagged
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -33,6 +37,12 @@ import {
   StreamCallEndedEvent,
 } from "@/lib/stream/session-handlers";
 import {
+  handleUserFlagged,
+  handleMessageFlagged,
+  StreamUserFlaggedEvent,
+  StreamMessageFlaggedEvent,
+} from "@/lib/stream/chat-moderation-handlers";
+import {
   logWebhookEvent,
   markWebhookEventProcessed,
   isDbHealthy,
@@ -48,19 +58,30 @@ const HANDLED_EVENT_TYPES = [
   // Session events
   "call.session_ended",
   "call.ended",
+  // Chat moderation events
+  "user.flagged",
+  "message.flagged",
 ] as const;
 
 type HandledEventType = (typeof HANDLED_EVENT_TYPES)[number];
 
-// Base event schema
+// Base event schema for all Stream webhook events
+// call_cid is optional because chat moderation events don't include it
 const streamBaseEventSchema = z.object({
+  type: z.string(),
+  call_cid: z.string().optional(),
+  created_at: z.string(),
+});
+
+// Base schema for call/video events (call_cid required)
+const streamCallBaseEventSchema = z.object({
   type: z.string(),
   call_cid: z.string(),
   created_at: z.string(),
 });
 
 // Recording ready event schema
-const streamRecordingReadySchema = streamBaseEventSchema.extend({
+const streamRecordingReadySchema = streamCallBaseEventSchema.extend({
   type: z.literal("call.recording_ready"),
   call_recording: z.object({
     filename: z.string(),
@@ -71,7 +92,7 @@ const streamRecordingReadySchema = streamBaseEventSchema.extend({
 });
 
 // Recording failed event schema
-const streamRecordingFailedSchema = streamBaseEventSchema.extend({
+const streamRecordingFailedSchema = streamCallBaseEventSchema.extend({
   type: z.literal("call.recording_failed"),
   error: z
     .object({
@@ -82,7 +103,7 @@ const streamRecordingFailedSchema = streamBaseEventSchema.extend({
 });
 
 // Recording started schema
-const streamRecordingStartedSchema = streamBaseEventSchema.extend({
+const streamRecordingStartedSchema = streamCallBaseEventSchema.extend({
   type: z.literal("call.recording_started"),
   user: z
     .object({
@@ -93,12 +114,12 @@ const streamRecordingStartedSchema = streamBaseEventSchema.extend({
 });
 
 // Recording stopped schema
-const streamRecordingStoppedSchema = streamBaseEventSchema.extend({
+const streamRecordingStoppedSchema = streamCallBaseEventSchema.extend({
   type: z.literal("call.recording_stopped"),
 });
 
 // Session ended schema
-const streamSessionEndedSchema = streamBaseEventSchema.extend({
+const streamSessionEndedSchema = streamCallBaseEventSchema.extend({
   type: z.literal("call.session_ended"),
   call: z
     .object({
@@ -110,7 +131,7 @@ const streamSessionEndedSchema = streamBaseEventSchema.extend({
 });
 
 // Call ended schema
-const streamCallEndedSchema = streamBaseEventSchema.extend({
+const streamCallEndedSchema = streamCallBaseEventSchema.extend({
   type: z.literal("call.ended"),
   call: z
     .object({
@@ -120,6 +141,26 @@ const streamCallEndedSchema = streamBaseEventSchema.extend({
     })
     .optional(),
   ended_by_user_id: z.string().optional(),
+});
+
+// Chat moderation: user flagged schema
+const streamUserFlaggedSchema = streamBaseEventSchema.extend({
+  type: z.literal("user.flagged"),
+  user: z.object({ id: z.string() }).optional(),
+  target_user: z.object({ id: z.string() }).optional(),
+});
+
+// Chat moderation: message flagged schema
+const streamMessageFlaggedSchema = streamBaseEventSchema.extend({
+  type: z.literal("message.flagged"),
+  user: z.object({ id: z.string() }).optional(),
+  message: z
+    .object({
+      id: z.string(),
+      text: z.string().optional(),
+      user: z.object({ id: z.string() }).optional(),
+    })
+    .optional(),
 });
 
 /**
@@ -203,7 +244,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Generate unique event ID for idempotency
-    const eventId = `stream_${eventType}_${baseEvent.call_cid}_${baseEvent.created_at}`;
+    const eventId = `stream_${eventType}_${baseEvent.call_cid || "chat"}_${baseEvent.created_at}`;
 
     // Log webhook event (idempotency check)
     const { isNew } = await logWebhookEvent(
@@ -267,6 +308,24 @@ export async function POST(req: NextRequest) {
         case "call.ended": {
           const callEndedEvent = streamCallEndedSchema.parse(event);
           await handleCallEnded(callEndedEvent as StreamCallEndedEvent);
+          break;
+        }
+
+        // Chat moderation events
+        case "user.flagged": {
+          const userFlaggedEvent = streamUserFlaggedSchema.parse(event);
+          await handleUserFlagged(
+            userFlaggedEvent as StreamUserFlaggedEvent,
+          );
+          break;
+        }
+
+        case "message.flagged": {
+          const messageFlaggedEvent =
+            streamMessageFlaggedSchema.parse(event);
+          await handleMessageFlagged(
+            messageFlaggedEvent as StreamMessageFlaggedEvent,
+          );
           break;
         }
 

--- a/app/api/stream/webhooks/route.ts
+++ b/app/api/stream/webhooks/route.ts
@@ -20,6 +20,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { z } from "zod";
+import { streamLogger } from "@/lib/stream-logger";
 import {
   handleRecordingStarted,
   handleRecordingStopped,
@@ -174,7 +175,7 @@ async function verifyStreamSignature(
   const signature = req.headers.get("x-signature");
 
   if (!signature) {
-    console.warn("No x-signature header found in Stream webhook request");
+    streamLogger.warn("No x-signature header found in Stream webhook request");
     return false;
   }
 
@@ -191,7 +192,7 @@ async function verifyStreamSignature(
       Buffer.from(expectedSignature),
     );
   } catch (error) {
-    console.error("Error verifying Stream webhook signature:", error);
+    streamLogger.error("Error verifying Stream webhook signature", error);
     return false;
   }
 }
@@ -201,7 +202,7 @@ export async function POST(req: NextRequest) {
 
   // Validate webhook secret is configured
   if (!secret) {
-    console.error("STREAM_WEBHOOK_SECRET not configured");
+    streamLogger.error("STREAM_WEBHOOK_SECRET not configured");
     return NextResponse.json(
       { error: "Webhook secret not configured" },
       { status: 500 },
@@ -215,15 +216,13 @@ export async function POST(req: NextRequest) {
   const isValid = await verifyStreamSignature(req, body, secret);
 
   if (!isValid) {
-    console.warn("Invalid Stream webhook signature");
+    streamLogger.warn("Invalid Stream webhook signature");
     return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
   }
 
   // DB health check — return 503 if DB is unreachable so Stream retries
   if (!(await isDbHealthy())) {
-    console.warn(
-      "[stream webhook] DB unhealthy — returning 503 for Stream retry",
-    );
+    streamLogger.warn("DB unhealthy — returning 503 for Stream retry");
     return NextResponse.json(
       { error: "Service temporarily unavailable" },
       { status: 503 },
@@ -239,7 +238,7 @@ export async function POST(req: NextRequest) {
 
     // Check if this is an event type we handle
     if (!HANDLED_EVENT_TYPES.includes(eventType as HandledEventType)) {
-      console.log(`Unhandled Stream event type: ${eventType}`);
+      streamLogger.debug(`Unhandled Stream event type: ${eventType}`);
       return NextResponse.json({ status: "ok", handled: false });
     }
 
@@ -256,13 +255,12 @@ export async function POST(req: NextRequest) {
     );
 
     if (!isNew) {
-      console.log(`Duplicate Stream webhook event ${eventId}, returning OK`);
+      streamLogger.debug(`Duplicate Stream webhook event: ${eventId}`);
       return NextResponse.json({ status: "ok", duplicate: true });
     }
 
-    console.log(`Processing Stream webhook: ${eventType}`, {
-      call_cid: baseEvent.call_cid,
-      created_at: baseEvent.created_at,
+    streamLogger.info(`Processing Stream webhook: ${eventType}`, {
+      call_cid: baseEvent.call_cid || "chat",
     });
 
     let processingError: string | undefined;
@@ -330,14 +328,14 @@ export async function POST(req: NextRequest) {
         }
 
         default:
-          console.log(`Unhandled Stream event type: ${eventType}`);
+          streamLogger.debug(`Unhandled Stream event type: ${eventType}`);
       }
     } catch (handlerError) {
       processingError =
         handlerError instanceof Error
           ? handlerError.message
           : String(handlerError);
-      console.error(`Error processing ${eventType}:`, handlerError);
+      streamLogger.error(`Error processing ${eventType}`, handlerError);
       throw handlerError;
     } finally {
       // Mark event as processed
@@ -346,12 +344,12 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ status: "ok" });
   } catch (error) {
-    console.error("Stream webhook error:", error);
+    streamLogger.error("Stream webhook error", error);
 
     // Return 200 to prevent retries for parsing errors
     // Stream will retry on 5xx errors
     if (error instanceof z.ZodError) {
-      console.error("Stream webhook validation error:", error.errors);
+      streamLogger.error("Stream webhook validation error", error);
       return NextResponse.json(
         { error: "Invalid event format", details: error.errors },
         { status: 400 },

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
@@ -293,6 +293,7 @@ export function EventPlannerForClass({
           consultantProfile: null,
           certificateProvided: formData.certificateProvided ?? false,
           recordingEnabled: formData.recordingEnabled ?? false,
+          recordingStoragePolicy: initialData?.classPlan?.recordingStoragePolicy ?? "STREAM_ONLY",
           sessionDurationInHours:
             initialData?.classPlan?.sessionDurationInHours ?? 1,
           meetingsPerWeek: formData.meetingsPerWeek,

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
@@ -275,6 +275,7 @@ export function EventPlannerForWebinar({
           priceCurrency: formData.priceCurrency ?? "INR",
           certificateProvided: formData.certificateProvided ?? false,
           recordingEnabled: formData.recordingEnabled ?? false,
+          recordingStoragePolicy: initialData?.webinarPlan?.recordingStoragePolicy ?? "STREAM_ONLY",
           durationInHours: formData.durationInHours,
           maxParticipants: formData.maxParticipants,
           language: formData.language ?? "English",

--- a/app/dashboard/staff/[staffId]/layout.tsx
+++ b/app/dashboard/staff/[staffId]/layout.tsx
@@ -28,6 +28,7 @@ import Link from "next/link";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { signOut, useSession } from "@/lib/auth-client";
+import { disconnectStreamClients } from "@/providers/StreamProvider";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -96,7 +97,12 @@ export default function StaffDashboardLayout({
   // Sync user as Novu subscriber (once per session)
   useNovuSubscriberSync();
 
-  const handleSignOut = () => {
+  const handleSignOut = async () => {
+    try {
+      await disconnectStreamClients();
+    } catch {
+      // Don't block sign-out if disconnect fails
+    }
     signOut({
       fetchOptions: {
         onSuccess: () => {

--- a/app/meetings/[id]/components/RecordingControls.tsx
+++ b/app/meetings/[id]/components/RecordingControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useCall } from "@stream-io/video-react-sdk";
 import { useSession } from "@/lib/auth-client";
 import { Circle, Square, Loader2 } from "lucide-react";
@@ -30,6 +30,12 @@ const RecordingControls = ({
   // Only consultants (hosts) should be able to control recordings
   // Use session role instead of Stream's createdBy, as consultee might join first
   const isConsultant = session?.user?.role === "CONSULTANT";
+
+  // Ref to avoid stale closure in call event handlers
+  const isRecordingRef = useRef(isRecording);
+  useEffect(() => {
+    isRecordingRef.current = isRecording;
+  }, [isRecording]);
 
   // Subscribe to call recording state changes
   useEffect(() => {
@@ -77,10 +83,10 @@ const RecordingControls = ({
     // Also subscribe to general call state updates to catch recording changes
     const unsubscribeUpdated = call.on("call.updated", () => {
       const recording = call.state.recording;
-      if (recording && !isRecording) {
+      if (recording && !isRecordingRef.current) {
         setIsRecording(true);
         setIsLoading(false);
-      } else if (!recording && isRecording) {
+      } else if (!recording && isRecordingRef.current) {
         setIsRecording(false);
         setIsLoading(false);
         setRecordingDuration(0);
@@ -93,7 +99,7 @@ const RecordingControls = ({
       unsubscribeFailed();
       unsubscribeUpdated();
     };
-  }, [call, toast, isRecording]);
+  }, [call, toast]);
 
   // Recording duration timer
   useEffect(() => {

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -19,6 +19,7 @@ import {
   Presentation,
 } from "lucide-react";
 import { signOut, useSession } from "@/lib/auth-client";
+import { disconnectStreamClients } from "@/providers/StreamProvider";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -349,7 +350,12 @@ const Navbar = () => {
 
   if (excludeNavbar) return null;
 
-  const handleSignOut = () => {
+  const handleSignOut = async () => {
+    try {
+      await disconnectStreamClients();
+    } catch {
+      // Don't block sign-out if disconnect fails
+    }
     signOut({
       fetchOptions: {
         onSuccess: () => {

--- a/components/chat/ChannelInfoAndManageDialog.tsx
+++ b/components/chat/ChannelInfoAndManageDialog.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/use-toast";
 import {
   AlertTriangleIcon,
+  BanIcon,
   BellIcon,
   BellOffIcon,
   InfoIcon,
@@ -210,13 +211,42 @@ export const ChannelInfoAndManageDialog = ({
     }
   };
 
-  // Report the other user in a 1-on-1 DM
+  // Permission check for clear chat (truncate)
+  const canTruncateChannel = (() => {
+    // In 1-on-1 DMs, both users can clear their view
+    if (isDirectMessage && !displayInfo.isGroupDM) return true;
+    // In group DMs and channels, only creator or privileged roles
+    const isCreator = channel.data?.created_by_id === client?.userID;
+    const userRole = client?.user?.role;
+    const isPrivileged =
+      userRole === "CONSULTANT" ||
+      userRole === "ADMIN" ||
+      userRole === "STAFF";
+    return isCreator || isPrivileged;
+  })();
+
+  // Report the other user in a 1-on-1 DM (flags in Stream + persists to DB)
   const handleReportUser = async () => {
     if (!client || !otherUserId) return;
 
     setIsLoading(true);
     try {
+      // Flag in Stream
       await client.flagUser(otherUserId, { reason: "user_report" });
+
+      // Also persist to our DB so staff can see it
+      await fetch("/api/report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "PROFILE",
+          reason: "User reported via chat",
+          description:
+            "User was reported from a direct message conversation",
+          targetUserId: otherUserId,
+        }),
+      });
+
       toast({
         title: "User reported",
         description: "Our team will review this report",
@@ -233,7 +263,41 @@ export const ChannelInfoAndManageDialog = ({
     }
   };
 
-  // Toggle mute/unmute for event channels
+  // Block the other user in a 1-on-1 DM
+  const handleBlockUser = async () => {
+    if (!otherUserId) return;
+
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/stream/users/block", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetUserId: otherUserId }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Block failed");
+      }
+
+      toast({
+        title: "User blocked",
+        description: "This user can no longer message you",
+      });
+    } catch (error) {
+      console.error("Error blocking user:", error);
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error ? error.message : "Failed to block user",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Toggle mute/unmute for channels and DMs
   const handleMuteChannel = async () => {
     setIsLoading(true);
     try {
@@ -333,6 +397,26 @@ export const ChannelInfoAndManageDialog = ({
                           variant="outline"
                           size="sm"
                           className="w-full flex items-center justify-center gap-2"
+                          onClick={handleMuteChannel}
+                          disabled={isLoading}
+                        >
+                          {isMuted ? (
+                            <>
+                              <BellIcon className="h-4 w-4" />
+                              Unmute Notifications
+                            </>
+                          ) : (
+                            <>
+                              <BellOffIcon className="h-4 w-4" />
+                              Mute Notifications
+                            </>
+                          )}
+                        </Button>
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full flex items-center justify-center gap-2"
                           onClick={handleAddMember}
                           disabled={isLoading}
                         >
@@ -340,16 +424,18 @@ export const ChannelInfoAndManageDialog = ({
                           Add Members
                         </Button>
 
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="w-full flex items-center justify-center gap-2"
-                          onClick={() => setShowClearConfirm(true)}
-                          disabled={isLoading}
-                        >
-                          <Trash2Icon className="h-4 w-4" />
-                          Clear Chat
-                        </Button>
+                        {canTruncateChannel && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full flex items-center justify-center gap-2"
+                            onClick={() => setShowClearConfirm(true)}
+                            disabled={isLoading}
+                          >
+                            <Trash2Icon className="h-4 w-4" />
+                            Clear Chat
+                          </Button>
+                        )}
 
                         <Button
                           variant="destructive"
@@ -365,6 +451,26 @@ export const ChannelInfoAndManageDialog = ({
                     ) : (
                       // Individual DM Actions
                       <>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full flex items-center justify-center gap-2"
+                          onClick={handleMuteChannel}
+                          disabled={isLoading}
+                        >
+                          {isMuted ? (
+                            <>
+                              <BellIcon className="h-4 w-4" />
+                              Unmute Notifications
+                            </>
+                          ) : (
+                            <>
+                              <BellOffIcon className="h-4 w-4" />
+                              Mute Notifications
+                            </>
+                          )}
+                        </Button>
+
                         <Button
                           variant="outline"
                           size="sm"
@@ -385,6 +491,17 @@ export const ChannelInfoAndManageDialog = ({
                         >
                           <AlertTriangleIcon className="h-4 w-4" />
                           Report User
+                        </Button>
+
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-full flex items-center justify-center gap-2 text-red-600 hover:text-red-700"
+                          onClick={handleBlockUser}
+                          disabled={isLoading || !otherUserId}
+                        >
+                          <BanIcon className="h-4 w-4" />
+                          Block User
                         </Button>
                       </>
                     )

--- a/components/chat/ChannelInfoAndManageDialog.tsx
+++ b/components/chat/ChannelInfoAndManageDialog.tsx
@@ -235,7 +235,7 @@ export const ChannelInfoAndManageDialog = ({
       await client.flagUser(otherUserId, { reason: "user_report" });
 
       // Also persist to our DB so staff can see it
-      await fetch("/api/report", {
+      const reportResponse = await fetch("/api/report", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -246,6 +246,11 @@ export const ChannelInfoAndManageDialog = ({
           targetUserId: otherUserId,
         }),
       });
+
+      if (!reportResponse.ok) {
+        const data = await reportResponse.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to submit report");
+      }
 
       toast({
         title: "User reported",

--- a/components/chat/ChannelInfoAndManageDialog.tsx
+++ b/components/chat/ChannelInfoAndManageDialog.tsx
@@ -284,12 +284,10 @@ export const ChannelInfoAndManageDialog = ({
         title: "User blocked",
         description: "This user can no longer message you",
       });
-    } catch (error) {
-      console.error("Error blocking user:", error);
+    } catch {
       toast({
         title: "Error",
-        description:
-          error instanceof Error ? error.message : "Failed to block user",
+        description: "Failed to block user",
         variant: "destructive",
       });
     } finally {

--- a/components/chat/ChannelInfoAndManageDialog.tsx
+++ b/components/chat/ChannelInfoAndManageDialog.tsx
@@ -30,6 +30,7 @@ import { Channel } from "stream-chat";
 import { useChatContext } from "stream-chat-react";
 import { getChannelDisplayInfo } from "./utils/channelUtils";
 import { AddMembersDialog } from "./AddMembersDialog";
+import { isEventChannel } from "@/lib/stream-channel-ids";
 
 interface ChannelInfoAndManageDialogProps {
   channel: Channel;
@@ -49,8 +50,7 @@ export const ChannelInfoAndManageDialog = ({
 
   const isTeamChannel = channel.type === "team";
   const isDirectMessage = channel.type === "messaging";
-  const isEventChannel =
-    channel.id?.startsWith("webinar-") || channel.id?.startsWith("class-");
+  const isEvent = isEventChannel(channel.id);
   const memberCount = Object.keys(channel.state.members || {}).length;
 
   // Get display info using shared utility
@@ -68,7 +68,7 @@ export const ChannelInfoAndManageDialog = ({
 
   // Check if current user is the event owner consultant
   const isEventOwner =
-    isEventChannel &&
+    isEvent &&
     channel.data?.created_by_id === client?.userID &&
     client?.user?.role === "CONSULTANT";
 
@@ -366,7 +366,7 @@ export const ChannelInfoAndManageDialog = ({
                     : displayInfo.isGroupDM
                       ? "Group Direct Message"
                       : "Direct Message"}
-                  {isEventChannel && " (Event Channel)"}
+                  {isEvent && " (Event Channel)"}
                 </p>
               </div>
 

--- a/components/chat/ChatContainer.tsx
+++ b/components/chat/ChatContainer.tsx
@@ -64,10 +64,6 @@ export const ChatContainer = () => {
         channel.id?.includes("class-");
 
       setShouldUseVirtualized(isHighTrafficChannel || false);
-
-      console.log(
-        `Channel ${channel.id}: members=${memberCount}, messages=${messageCount}, type=${channel.type}, useVirtualized=${isHighTrafficChannel}`,
-      );
     }
   }, [channel]);
 

--- a/components/chat/ChatContainer.tsx
+++ b/components/chat/ChatContainer.tsx
@@ -15,6 +15,7 @@ import { CustomChannelHeader } from "./CustomChannelHeader";
 import { CustomMessage } from "./CustomMessage";
 import { StreamChatErrorBoundary } from "@/components/stream/StreamErrorBoundary";
 import { useMaintenanceState } from "@/providers/MaintenanceProvider";
+import { isEventChannel } from "@/lib/stream-channel-ids";
 
 // Empty state component for when no channel is selected
 const EmptyChannelState = () => (
@@ -60,8 +61,7 @@ export const ChatContainer = () => {
       const isHighTrafficChannel =
         (isTeamChannel && memberCount > 5) ||
         messageCount > 100 ||
-        channel.id?.includes("webinar-") ||
-        channel.id?.includes("class-");
+        isEventChannel(channel.id);
 
       setShouldUseVirtualized(isHighTrafficChannel || false);
     }

--- a/components/chat/CustomMessage.tsx
+++ b/components/chat/CustomMessage.tsx
@@ -211,7 +211,7 @@ export const CustomMessage = () => {
       await client.flagMessage(message.id);
 
       // Persist to our DB
-      await fetch("/api/report", {
+      const reportResponse = await fetch("/api/report", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -221,6 +221,11 @@ export const CustomMessage = () => {
           contentText: message.text?.substring(0, 500),
         }),
       });
+
+      if (!reportResponse.ok) {
+        const data = await reportResponse.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to submit report");
+      }
 
       toast({
         title: "Message reported",

--- a/components/chat/CustomMessage.tsx
+++ b/components/chat/CustomMessage.tsx
@@ -151,8 +151,7 @@ export const CustomMessage = () => {
         text: editText,
       });
       setIsEditing(false);
-    } catch (error) {
-      console.error("Error editing message:", error);
+    } catch {
       toast({
         title: "Edit failed",
         description: "Could not edit the message. Please try again.",
@@ -175,8 +174,7 @@ export const CustomMessage = () => {
     if (!client) return;
     try {
       await client.deleteMessage(message.id);
-    } catch (error) {
-      console.error("Error deleting message:", error);
+    } catch {
       toast({
         title: "Delete failed",
         description: "Could not delete the message. Please try again.",
@@ -190,8 +188,7 @@ export const CustomMessage = () => {
     if (!channel) return;
     try {
       await channel.sendReaction(message.id, { type: reactionType });
-    } catch (error) {
-      console.error("Error sending reaction:", error);
+    } catch {
       toast({
         title: "Reaction failed",
         description: "Could not add reaction. Please try again.",
@@ -229,8 +226,7 @@ export const CustomMessage = () => {
         title: "Message reported",
         description: "Our team will review this message",
       });
-    } catch (error) {
-      console.error("Error reporting message:", error);
+    } catch {
       toast({
         title: "Report failed",
         description: "Could not report message. Please try again.",

--- a/components/chat/CustomMessage.tsx
+++ b/components/chat/CustomMessage.tsx
@@ -17,6 +17,7 @@ import {
   Trash2Icon,
   CheckIcon,
   XIcon,
+  FlagIcon,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -205,6 +206,40 @@ export const CustomMessage = () => {
     messageComposer.setQuotedMessage(message);
   };
 
+  // Report a message (flags in Stream + persists to DB)
+  const handleReportMessage = async () => {
+    if (!channel || !message.user?.id) return;
+    try {
+      // Flag in Stream
+      await channel.flagMessage(message.id);
+
+      // Persist to our DB
+      await fetch("/api/report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "MESSAGE",
+          reason: "Reported message",
+          targetUserId: message.user.id,
+          contentText: message.text?.substring(0, 500),
+        }),
+      });
+
+      toast({
+        title: "Message reported",
+        description: "Our team will review this message",
+      });
+    } catch (error) {
+      console.error("Error reporting message:", error);
+      toast({
+        title: "Report failed",
+        description: "Could not report message. Please try again.",
+        variant: "destructive",
+      });
+    }
+    setShowMoreOptions(false);
+  };
+
   return (
     <div
       className={`flex items-end ${isMyMessage ? "justify-end" : "justify-start"} mb-4 group relative`}
@@ -270,37 +305,47 @@ export const CustomMessage = () => {
               <ReplyIcon className="w-4 h-4 text-gray-600" />
             </button>
 
-            {/* More Options (Edit, Delete) - Only for own messages */}
-            {isMyMessage && (
-              <div className="relative" ref={moreOptionsRef}>
-                <button
-                  onClick={() => setShowMoreOptions(!showMoreOptions)}
-                  className="p-1.5 hover:bg-gray-100 rounded-r-lg transition-colors"
-                  title="More options"
-                >
-                  <MoreHorizontalIcon className="w-4 h-4 text-gray-600" />
-                </button>
-                {/* More Options Dropdown */}
-                {showMoreOptions && (
-                  <div className="absolute top-full right-0 mt-1 bg-white rounded-lg shadow-lg border py-1 min-w-[120px] z-30">
+            {/* More Options (Edit, Delete for own; Report for others) */}
+            <div className="relative" ref={moreOptionsRef}>
+              <button
+                onClick={() => setShowMoreOptions(!showMoreOptions)}
+                className="p-1.5 hover:bg-gray-100 rounded-r-lg transition-colors"
+                title="More options"
+              >
+                <MoreHorizontalIcon className="w-4 h-4 text-gray-600" />
+              </button>
+              {/* More Options Dropdown */}
+              {showMoreOptions && (
+                <div className="absolute top-full right-0 mt-1 bg-white rounded-lg shadow-lg border py-1 min-w-[120px] z-30">
+                  {isMyMessage ? (
+                    <>
+                      <button
+                        onClick={handleEditClick}
+                        className="w-full px-3 py-1.5 text-left text-sm hover:bg-gray-100 flex items-center gap-2"
+                      >
+                        <EditIcon className="w-4 h-4" />
+                        Edit
+                      </button>
+                      <button
+                        onClick={handleDeleteClick}
+                        className="w-full px-3 py-1.5 text-left text-sm hover:bg-gray-100 text-red-600 flex items-center gap-2"
+                      >
+                        <Trash2Icon className="w-4 h-4" />
+                        Delete
+                      </button>
+                    </>
+                  ) : (
                     <button
-                      onClick={handleEditClick}
-                      className="w-full px-3 py-1.5 text-left text-sm hover:bg-gray-100 flex items-center gap-2"
-                    >
-                      <EditIcon className="w-4 h-4" />
-                      Edit
-                    </button>
-                    <button
-                      onClick={handleDeleteClick}
+                      onClick={handleReportMessage}
                       className="w-full px-3 py-1.5 text-left text-sm hover:bg-gray-100 text-red-600 flex items-center gap-2"
                     >
-                      <Trash2Icon className="w-4 h-4" />
-                      Delete
+                      <FlagIcon className="w-4 h-4" />
+                      Report Message
                     </button>
-                  </div>
-                )}
-              </div>
-            )}
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/components/chat/CustomMessage.tsx
+++ b/components/chat/CustomMessage.tsx
@@ -208,10 +208,10 @@ export const CustomMessage = () => {
 
   // Report a message (flags in Stream + persists to DB)
   const handleReportMessage = async () => {
-    if (!channel || !message.user?.id) return;
+    if (!client || !message.user?.id) return;
     try {
-      // Flag in Stream
-      await channel.flagMessage(message.id);
+      // Flag in Stream (flagMessage is on the client, not the channel)
+      await client.flagMessage(message.id);
 
       // Persist to our DB
       await fetch("/api/report", {

--- a/components/chat/CustomMessage.tsx
+++ b/components/chat/CustomMessage.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -35,6 +36,7 @@ export const CustomMessage = () => {
   const { message } = useMessageContext();
   const { client, channel } = useChatContext();
   const messageComposer = useMessageComposer();
+  const { toast } = useToast();
   const isMyMessage = message.user?.id === client.userID;
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [showMoreOptions, setShowMoreOptions] = useState(false);
@@ -150,6 +152,11 @@ export const CustomMessage = () => {
       setIsEditing(false);
     } catch (error) {
       console.error("Error editing message:", error);
+      toast({
+        title: "Edit failed",
+        description: "Could not edit the message. Please try again.",
+        variant: "destructive",
+      });
     }
   };
 
@@ -169,6 +176,11 @@ export const CustomMessage = () => {
       await client.deleteMessage(message.id);
     } catch (error) {
       console.error("Error deleting message:", error);
+      toast({
+        title: "Delete failed",
+        description: "Could not delete the message. Please try again.",
+        variant: "destructive",
+      });
     }
     setShowDeleteDialog(false);
   };
@@ -179,6 +191,11 @@ export const CustomMessage = () => {
       await channel.sendReaction(message.id, { type: reactionType });
     } catch (error) {
       console.error("Error sending reaction:", error);
+      toast({
+        title: "Reaction failed",
+        description: "Could not add reaction. Please try again.",
+        variant: "destructive",
+      });
     }
   };
 

--- a/components/dashboard/DashboardSidebar.tsx
+++ b/components/dashboard/DashboardSidebar.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { signOut } from "@/lib/auth-client";
+import { disconnectStreamClients } from "@/providers/StreamProvider";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { motion } from "framer-motion";
@@ -124,6 +125,15 @@ export function DashboardSidebar({
 
   // Get current path relative to basePath for matching
   const relativePath = pathname.replace(basePath + "/", "");
+
+  const handleSignOut = async () => {
+    try {
+      await disconnectStreamClients();
+    } catch {
+      // Don't block sign-out if disconnect fails
+    }
+    signOut();
+  };
 
   const getRoleColor = () => {
     switch (userRole) {
@@ -366,7 +376,7 @@ export function DashboardSidebar({
           })}
 
           <button
-            onClick={() => signOut()}
+            onClick={handleSignOut}
             className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-red-400 hover:bg-red-500/10 hover:text-red-300 transition-all"
           >
             <span className="flex h-8 w-8 items-center justify-center rounded-md bg-red-500/10 text-red-500">

--- a/components/dashboard/UserDropdown.tsx
+++ b/components/dashboard/UserDropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signOut } from "@/lib/auth-client";
+import { disconnectStreamClients } from "@/providers/StreamProvider";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -28,6 +29,21 @@ export function UserDropdown({
   settingsPath,
   profilePath,
 }: UserDropdownProps) {
+  const handleSignOut = async () => {
+    try {
+      await disconnectStreamClients();
+    } catch {
+      // Don't block sign-out if disconnect fails
+    }
+    signOut({
+      fetchOptions: {
+        onSuccess: () => {
+          window.location.href = "/auth/signin";
+        },
+      },
+    });
+  };
+
   const getRoleBadgeColor = () => {
     switch (userRole) {
       case "ADMIN":
@@ -97,15 +113,7 @@ export function UserDropdown({
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onClick={() =>
-            signOut({
-              fetchOptions: {
-                onSuccess: () => {
-                  window.location.href = "/auth/signin";
-                },
-              },
-            })
-          }
+          onClick={handleSignOut}
           className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50"
         >
           <LogOut className="mr-2 h-4 w-4" />

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -27,6 +27,9 @@ import {
   notifyAppointmentBooked,
 } from "@/lib/novu";
 import { processQualifyingAction } from "@/lib/referrals/service";
+import { addUserToEventChannel } from "@/actions/stream/chat/event-channel.action";
+import { createDirectMessageChannel } from "@/actions/stream/chat/channel.action";
+import { streamLogger } from "@/lib/stream-logger";
 
 // ============================================================================
 // Type Definitions
@@ -502,6 +505,90 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
     console.error(
       `⚠️ Failed to send Novu notifications for payment ${paymentId}:`,
       novuError,
+    );
+  }
+
+  // --- Stream channel creation (fire-and-forget) ---
+  try {
+    const eventType = metadata.appointmentType?.toUpperCase();
+    const appointmentForChannel = await prisma.appointment.findUnique({
+      where: { id: appointmentId },
+      include: {
+        consultation: {
+          include: {
+            consultationPlan: {
+              include: { consultantProfile: true },
+            },
+          },
+        },
+        subscription: {
+          include: {
+            subscriptionPlan: {
+              include: { consultantProfile: true },
+            },
+          },
+        },
+        webinar: {
+          include: {
+            webinarPlan: {
+              include: { consultantProfile: true },
+            },
+          },
+        },
+        class: {
+          include: {
+            classPlan: {
+              include: { consultantProfile: true },
+            },
+          },
+        },
+      },
+    });
+
+    const consultantProfile =
+      appointmentForChannel?.consultation?.consultationPlan
+        ?.consultantProfile ||
+      appointmentForChannel?.subscription?.subscriptionPlan
+        ?.consultantProfile ||
+      appointmentForChannel?.webinar?.webinarPlan?.consultantProfile ||
+      appointmentForChannel?.class?.classPlan?.consultantProfile;
+
+    const consultantUserId = consultantProfile?.userId;
+
+    if (appointmentForChannel && consultantUserId) {
+      const consultation = appointmentForChannel.consultation;
+      const subscription = appointmentForChannel.subscription;
+      const webinar = appointmentForChannel.webinar;
+      const classEvent = appointmentForChannel.class;
+
+      if (eventType === "CONSULTATION" && consultation) {
+        await addUserToEventChannel("consultation", consultation.id, userId);
+        await createDirectMessageChannel(consultantUserId, userId);
+      } else if (eventType === "SUBSCRIPTION" && subscription) {
+        await addUserToEventChannel(
+          "subscription",
+          subscription.id,
+          userId,
+        );
+        await createDirectMessageChannel(consultantUserId, userId);
+      } else if (eventType === "WEBINAR" && webinar) {
+        await addUserToEventChannel("webinar", webinar.id, userId);
+      } else if (eventType === "CLASS" && classEvent) {
+        await addUserToEventChannel("class", classEvent.id, userId);
+      }
+
+      streamLogger.info("Stream channel created on payment success", {
+        appointmentType: eventType,
+        appointmentId,
+        userId,
+      });
+    }
+  } catch (channelError) {
+    // Log but never fail the payment — sync job will catch up
+    streamLogger.error(
+      "Auto-channel creation failed on payment success",
+      channelError,
+      { appointmentId, userId },
     );
   }
 }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -508,89 +508,95 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
     );
   }
 
-  // --- Stream channel creation (fire-and-forget) ---
-  try {
-    const eventType = metadata.appointmentType?.toUpperCase();
-    const appointmentForChannel = await prisma.appointment.findUnique({
-      where: { id: appointmentId },
-      include: {
-        consultation: {
-          include: {
-            consultationPlan: {
-              include: { consultantProfile: true },
+  // --- Stream channel creation (truly fire-and-forget — does not block webhook response) ---
+  void (async () => {
+    try {
+      const eventType = metadata.appointmentType?.toUpperCase();
+      const appointmentForChannel = await prisma.appointment.findUnique({
+        where: { id: appointmentId },
+        include: {
+          consultation: {
+            include: {
+              consultationPlan: {
+                include: { consultantProfile: true },
+              },
+            },
+          },
+          subscription: {
+            include: {
+              subscriptionPlan: {
+                include: { consultantProfile: true },
+              },
+            },
+          },
+          webinar: {
+            include: {
+              webinarPlan: {
+                include: { consultantProfile: true },
+              },
+            },
+          },
+          class: {
+            include: {
+              classPlan: {
+                include: { consultantProfile: true },
+              },
             },
           },
         },
-        subscription: {
-          include: {
-            subscriptionPlan: {
-              include: { consultantProfile: true },
-            },
-          },
-        },
-        webinar: {
-          include: {
-            webinarPlan: {
-              include: { consultantProfile: true },
-            },
-          },
-        },
-        class: {
-          include: {
-            classPlan: {
-              include: { consultantProfile: true },
-            },
-          },
-        },
-      },
-    });
-
-    const consultantProfile =
-      appointmentForChannel?.consultation?.consultationPlan
-        ?.consultantProfile ||
-      appointmentForChannel?.subscription?.subscriptionPlan
-        ?.consultantProfile ||
-      appointmentForChannel?.webinar?.webinarPlan?.consultantProfile ||
-      appointmentForChannel?.class?.classPlan?.consultantProfile;
-
-    const consultantUserId = consultantProfile?.userId;
-
-    if (appointmentForChannel && consultantUserId) {
-      const consultation = appointmentForChannel.consultation;
-      const subscription = appointmentForChannel.subscription;
-      const webinar = appointmentForChannel.webinar;
-      const classEvent = appointmentForChannel.class;
-
-      if (eventType === "CONSULTATION" && consultation) {
-        await addUserToEventChannel("consultation", consultation.id, userId);
-        await createDirectMessageChannel(consultantUserId, userId);
-      } else if (eventType === "SUBSCRIPTION" && subscription) {
-        await addUserToEventChannel(
-          "subscription",
-          subscription.id,
-          userId,
-        );
-        await createDirectMessageChannel(consultantUserId, userId);
-      } else if (eventType === "WEBINAR" && webinar) {
-        await addUserToEventChannel("webinar", webinar.id, userId);
-      } else if (eventType === "CLASS" && classEvent) {
-        await addUserToEventChannel("class", classEvent.id, userId);
-      }
-
-      streamLogger.info("Stream channel created on payment success", {
-        appointmentType: eventType,
-        appointmentId,
-        userId,
       });
+
+      const consultantProfile =
+        appointmentForChannel?.consultation?.consultationPlan
+          ?.consultantProfile ||
+        appointmentForChannel?.subscription?.subscriptionPlan
+          ?.consultantProfile ||
+        appointmentForChannel?.webinar?.webinarPlan?.consultantProfile ||
+        appointmentForChannel?.class?.classPlan?.consultantProfile;
+
+      const consultantUserId = consultantProfile?.userId;
+
+      if (appointmentForChannel && consultantUserId) {
+        const consultation = appointmentForChannel.consultation;
+        const subscription = appointmentForChannel.subscription;
+        const webinar = appointmentForChannel.webinar;
+        const classEvent = appointmentForChannel.class;
+
+        if (eventType === "CONSULTATION" && consultation) {
+          await addUserToEventChannel(
+            "consultation",
+            consultation.id,
+            userId,
+          );
+          await createDirectMessageChannel(consultantUserId, userId);
+        } else if (eventType === "SUBSCRIPTION" && subscription) {
+          await addUserToEventChannel(
+            "subscription",
+            subscription.id,
+            userId,
+          );
+          await createDirectMessageChannel(consultantUserId, userId);
+        } else if (eventType === "WEBINAR" && webinar) {
+          await addUserToEventChannel("webinar", webinar.id, userId);
+        } else if (eventType === "CLASS" && classEvent) {
+          await addUserToEventChannel("class", classEvent.id, userId);
+        }
+
+        streamLogger.info("Stream channel created on payment success", {
+          appointmentType: eventType,
+          appointmentId,
+          userId,
+        });
+      }
+    } catch (channelError) {
+      // Log but never fail the payment — sync job will catch up
+      streamLogger.error(
+        "Auto-channel creation failed on payment success",
+        channelError,
+        { appointmentId, userId },
+      );
     }
-  } catch (channelError) {
-    // Log but never fail the payment — sync job will catch up
-    streamLogger.error(
-      "Auto-channel creation failed on payment success",
-      channelError,
-      { appointmentId, userId },
-    );
-  }
+  })();
 }
 
 /**

--- a/lib/stream-channel-ids.ts
+++ b/lib/stream-channel-ids.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared Stream channel ID conventions and utilities.
+ * All channel ID pattern detection should go through these helpers
+ * to avoid scattered .startsWith()/.includes() checks.
+ */
+
+// Channel ID prefixes
+export const DM_PREFIX = "dm-";
+export const WEBINAR_PREFIX = "webinar-";
+export const CLASS_PREFIX = "class-";
+export const COLLAB_PREFIX = "collab-";
+export const CONSULTATION_PREFIX = "consultation-";
+export const SUBSCRIPTION_PREFIX = "subscription-";
+
+/** Prefixes managed by syncUserEventChannels for reconciliation */
+export const MANAGED_CHANNEL_PREFIXES = [
+  WEBINAR_PREFIX,
+  CLASS_PREFIX,
+  DM_PREFIX,
+  CONSULTATION_PREFIX,
+  SUBSCRIPTION_PREFIX,
+] as const;
+
+/** Check if channel is a webinar or class event channel (group/team) */
+export function isEventChannel(channelId: string | undefined): boolean {
+  if (!channelId) return false;
+  return (
+    channelId.startsWith(WEBINAR_PREFIX) ||
+    channelId.startsWith(CLASS_PREFIX)
+  );
+}
+
+/** Check if channel is a direct message */
+export function isDMChannel(channelId: string | undefined): boolean {
+  if (!channelId) return false;
+  return channelId.startsWith(DM_PREFIX);
+}
+
+/** Check if channel is a collaborator channel */
+export function isCollaboratorChannel(
+  channelId: string | undefined,
+): boolean {
+  if (!channelId) return false;
+  return channelId.startsWith(COLLAB_PREFIX);
+}
+
+/**
+ * Infer Stream channel type from channel ID prefix.
+ * DM, collaborator, consultation, and subscription channels use "messaging".
+ * Event channels (webinar, class) use "team".
+ */
+export function getChannelTypeFromId(
+  channelId: string,
+): "messaging" | "team" {
+  if (
+    channelId.startsWith(DM_PREFIX) ||
+    channelId.startsWith(COLLAB_PREFIX) ||
+    channelId.startsWith(CONSULTATION_PREFIX) ||
+    channelId.startsWith(SUBSCRIPTION_PREFIX)
+  ) {
+    return "messaging";
+  }
+  return "team";
+}

--- a/lib/stream-utils.ts
+++ b/lib/stream-utils.ts
@@ -3,6 +3,6 @@
  * IDs are sorted so the same value is produced regardless of call order.
  */
 export function getDmChannelId(userId1: string, userId2: string): string {
-  const [a, b] = [userId1, userId2].sort();
+  const [a, b] = [userId1, userId2].sort((x, y) => x.localeCompare(y));
   return `dm-${a}-${b}`;
 }

--- a/lib/stream/chat-moderation-handlers.ts
+++ b/lib/stream/chat-moderation-handlers.ts
@@ -1,0 +1,158 @@
+/**
+ * Chat Moderation Webhook Handlers
+ * Handles user.flagged and message.flagged events from Stream Chat
+ * Creates ModerationReport records in our DB for staff review
+ */
+
+import prisma from "@/lib/prisma";
+import { streamLogger } from "@/lib/stream-logger";
+
+export interface StreamUserFlaggedEvent {
+  type: "user.flagged";
+  created_at: string;
+  user?: { id: string };
+  target_user?: { id: string };
+}
+
+export interface StreamMessageFlaggedEvent {
+  type: "message.flagged";
+  created_at: string;
+  user?: { id: string };
+  message?: {
+    id: string;
+    text?: string;
+    user?: { id: string };
+  };
+}
+
+/**
+ * Handle user.flagged webhook event
+ * Creates or increments a ModerationReport with type PROFILE
+ */
+export async function handleUserFlagged(
+  event: StreamUserFlaggedEvent,
+): Promise<void> {
+  const flaggerId = event.user?.id;
+  const targetUserId = event.target_user?.id;
+
+  if (!targetUserId) {
+    streamLogger.warn("user.flagged event missing target_user", {
+      eventType: event.type,
+    });
+    return;
+  }
+
+  try {
+    // Check for existing pending report from same flagger
+    const existing = flaggerId
+      ? await prisma.moderationReport.findFirst({
+          where: {
+            reportedById: flaggerId,
+            targetUserId,
+            type: "PROFILE",
+            status: { in: ["PENDING", "UNDER_REVIEW"] },
+          },
+        })
+      : null;
+
+    if (existing) {
+      // Increment report count
+      await prisma.moderationReport.update({
+        where: { id: existing.id },
+        data: { reportCount: { increment: 1 } },
+      });
+      streamLogger.info("User flag report incremented", {
+        reportId: existing.id,
+        targetUserId,
+      });
+    } else if (flaggerId) {
+      // Create new report (requires a reporter)
+      await prisma.moderationReport.create({
+        data: {
+          type: "PROFILE",
+          reason: "User flagged via Stream webhook",
+          description: `User flagged at ${event.created_at}`,
+          reportedById: flaggerId,
+          targetUserId,
+        },
+      });
+      streamLogger.info("User flag report created", { targetUserId });
+    } else {
+      streamLogger.warn("user.flagged event missing flagger, skipping DB report", {
+        targetUserId,
+      });
+    }
+  } catch (error) {
+    streamLogger.error("Failed to process user.flagged event", error, {
+      targetUserId,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Handle message.flagged webhook event
+ * Creates or increments a ModerationReport with type MESSAGE
+ */
+export async function handleMessageFlagged(
+  event: StreamMessageFlaggedEvent,
+): Promise<void> {
+  const flaggerId = event.user?.id;
+  const messageAuthorId = event.message?.user?.id;
+  const messageText = event.message?.text?.substring(0, 500);
+
+  if (!messageAuthorId) {
+    streamLogger.warn("message.flagged event missing message author", {
+      eventType: event.type,
+    });
+    return;
+  }
+
+  try {
+    // Check for existing pending report for same message author
+    const existing = flaggerId
+      ? await prisma.moderationReport.findFirst({
+          where: {
+            reportedById: flaggerId,
+            targetUserId: messageAuthorId,
+            type: "MESSAGE",
+            status: { in: ["PENDING", "UNDER_REVIEW"] },
+          },
+        })
+      : null;
+
+    if (existing) {
+      await prisma.moderationReport.update({
+        where: { id: existing.id },
+        data: { reportCount: { increment: 1 } },
+      });
+      streamLogger.info("Message flag report incremented", {
+        reportId: existing.id,
+        targetUserId: messageAuthorId,
+      });
+    } else if (flaggerId) {
+      await prisma.moderationReport.create({
+        data: {
+          type: "MESSAGE",
+          reason: "Message flagged via Stream webhook",
+          description: `Message flagged at ${event.created_at}`,
+          contentText: messageText,
+          reportedById: flaggerId,
+          targetUserId: messageAuthorId,
+        },
+      });
+      streamLogger.info("Message flag report created", {
+        targetUserId: messageAuthorId,
+      });
+    } else {
+      streamLogger.warn("message.flagged event missing flagger, skipping DB report", {
+        messageAuthorId,
+      });
+    }
+  } catch (error) {
+    streamLogger.error("Failed to process message.flagged event", error, {
+      messageAuthorId,
+    });
+    throw error;
+  }
+}

--- a/lib/stream/recording-transfer-service.ts
+++ b/lib/stream/recording-transfer-service.ts
@@ -181,16 +181,10 @@ export class RecordingTransferService {
         return { success: false, error: uploadError.message };
       }
 
-      // Get public URL
-      const { data: urlData } = supabase.storage
-        .from(RECORDINGS_BUCKET)
-        .getPublicUrl(storagePath);
-
-      // Update recording with Supabase details
+      // Store the path (NOT a public URL) — presigned URLs are generated on access
       await prisma.recording.update({
         where: { id: recordingId },
         data: {
-          supabaseUrl: urlData.publicUrl,
           supabasePath: storagePath,
           storageType: "SUPABASE",
           status: "AVAILABLE" as RecordingStatus,
@@ -202,7 +196,6 @@ export class RecordingTransferService {
       streamLogger.info("Recording transferred successfully", {
         recordingId,
         storagePath,
-        supabaseUrl: urlData.publicUrl,
       });
 
       return { success: true };
@@ -401,9 +394,42 @@ export class RecordingTransferService {
    * Returns Supabase URL if available, otherwise Stream URL
    * @param recording The recording object
    */
-  static getBestRecordingUrl(recording: Recording): string | null {
-    if (recording.status === "AVAILABLE" && recording.supabaseUrl) {
-      return recording.supabaseUrl;
+  /**
+   * Generate a presigned URL for a Supabase-stored recording.
+   * URLs expire after the specified duration (default: 1 hour).
+   * Requires the recordings bucket to be private (not public).
+   */
+  static async generateSignedUrl(
+    storagePath: string,
+    expiresIn: number = 3600,
+  ): Promise<string | null> {
+    const { data, error } = await supabase.storage
+      .from(RECORDINGS_BUCKET)
+      .createSignedUrl(storagePath, expiresIn);
+
+    if (error || !data?.signedUrl) {
+      streamLogger.error("Failed to generate signed URL", error, {
+        storagePath,
+      });
+      return null;
+    }
+
+    return data.signedUrl;
+  }
+
+  /**
+   * Get the best available playback URL for a recording.
+   * For Supabase storage: generates a 1-hour presigned URL.
+   * For Stream S3: returns the temporary URL directly.
+   */
+  static async getBestRecordingUrl(
+    recording: Recording,
+  ): Promise<string | null> {
+    if (
+      recording.status === "AVAILABLE" &&
+      recording.supabasePath
+    ) {
+      return this.generateSignedUrl(recording.supabasePath);
     }
 
     if (recording.status === "READY" && recording.recordingUrl) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -988,9 +988,10 @@ model WebinarPlan {
   price               Int // in paise (smallest currency unit, e.g. 50000 = ₹500)
   priceCurrency       String   @default("INR")
   certificateProvided Boolean  @default(false)
-  recordingEnabled    Boolean  @default(false) // Allow consultant to record sessions
-  durationInHours     Float    @default(1) // Duration in hours
-  maxParticipants     Int      @default(100)
+  recordingEnabled       Boolean                @default(false) // Allow consultant to record sessions
+  recordingStoragePolicy RecordingStoragePolicy @default(STREAM_ONLY)
+  durationInHours        Float                  @default(1) // Duration in hours
+  maxParticipants        Int                    @default(100)
   language            String?  @default("English")
   level               String?  @default("Beginner")
   prerequisites       String?  @default("None")
@@ -1044,9 +1045,10 @@ model ClassPlan {
   classContents          ClassContent[]
   price                  Int // in paise (smallest currency unit, e.g. 50000 = ₹500)
   priceCurrency          String           @default("INR")
-  certificateProvided    Boolean          @default(false)
-  recordingEnabled       Boolean          @default(false) // Allow consultant to record sessions
-  durationInMonths       Int              @default(1) // Duration in months
+  certificateProvided    Boolean                @default(false)
+  recordingEnabled       Boolean                @default(false) // Allow consultant to record sessions
+  recordingStoragePolicy RecordingStoragePolicy @default(STREAM_ONLY)
+  durationInMonths       Int                    @default(1) // Duration in months
   meetingsPerWeek        Int              @default(1)
   sessionDurationInHours Float            @default(1.0) // Duration of each session in hours
   totalSessions          Int              @default(4) // meetingsPerWeek × durationInMonths × 4
@@ -1413,6 +1415,12 @@ model MeetingSession {
 enum RecordingStorageType {
   STREAM_S3 // Default: expires in 2 weeks
   SUPABASE // Permanent storage
+}
+
+// Recording storage policy for plans (determines where recordings are stored)
+enum RecordingStoragePolicy {
+  STREAM_ONLY        // 2-week temporary storage (free tier)
+  SUPABASE_PERMANENT // Permanent storage (premium tier)
 }
 
 // Recording status lifecycle

--- a/providers/StreamProvider.tsx
+++ b/providers/StreamProvider.tsx
@@ -20,7 +20,10 @@ import { syncUserEventChannels } from "@/actions/stream/chat/event-channel.actio
 import { useUserData } from "@/hooks/useUserData";
 import { mapRoleToStream } from "@/lib/user";
 import { streamLogger } from "@/lib/stream-logger";
-import { initialSyncCompletedUsers } from "@/lib/stream-cache";
+import {
+  initialSyncCompletedUsers,
+  clearAllStreamCaches,
+} from "@/lib/stream-cache";
 import StreamErrorBoundary from "@/components/stream/StreamErrorBoundary";
 
 // Import Stream Chat CSS
@@ -32,6 +35,32 @@ const apiKey = process.env.NEXT_PUBLIC_STREAM_API_KEY;
 let globalChatClient: StreamChat | null = null;
 let globalVideoClient: StreamVideoClient | null = null;
 let currentUserId: string | null = null;
+
+/**
+ * Disconnect all Stream clients and clear global state.
+ * Call this before signing out to ensure clean disconnection.
+ */
+export async function disconnectStreamClients(): Promise<void> {
+  const promises: Promise<void>[] = [];
+
+  if (globalChatClient) {
+    promises.push(
+      globalChatClient.disconnectUser().then(() => {
+        streamLogger.debug("Chat client disconnected on logout");
+      }),
+    );
+    globalChatClient = null;
+  }
+
+  if (globalVideoClient) {
+    globalVideoClient = null;
+  }
+
+  currentUserId = null;
+  clearAllStreamCaches();
+
+  await Promise.all(promises);
+}
 
 // Connection state context
 interface StreamConnectionState {


### PR DESCRIPTION
## Summary

Comprehensive Stream.io Chat + Video SDK audit and hardening for production launch. Addresses **#400** (security audit) and **#499** (auto-channel creation).

### P0 Bug Fixes
- **Chat token expiry**: Tokens now expire after 1 hour (previously never expired — leaked tokens granted permanent access)
- **Search API auth gap**: `/api/stream/search` now requires authentication for all requests (previously unauthenticated when `relationships=false`)
- **Logout disconnect**: Stream WebSocket + global clients are now properly disconnected on sign-out across all 4 logout locations
- **Silent error failures**: Chat message edit/delete/reaction errors now show user-facing toasts instead of silent `console.error`
- **Recording stale closure**: Fixed `RecordingControls` re-subscribing to all call events on every recording state change (uses ref now)
- **console.log cleanup**: Replaced all `console.log/error` in Stream routes with `streamLogger`

### P1 Security
- **Block user**: New `POST /api/stream/users/block` endpoint — bans user in Stream Chat + creates ModerationReport in DB. UI button added to 1-on-1 DM channel info dialog.
- **Report user DB persistence**: `flagUser()` calls now also POST to `/api/report` so staff can see reports in the existing moderation dashboard (previously only flagged in Stream's queue)
- **Channel truncate permissions**: "Clear Chat" restricted in group DMs and team channels to channel creator or CONSULTANT/ADMIN/STAFF roles (1-on-1 DMs unchanged)

### P2 Features
- **Message flagging**: "More Options" dropdown now appears on other users' messages with "Report Message" option (flags in Stream + creates ModerationReport)
- **DM mute/unmute**: Mute notifications button added to Individual DM and Group DM sections (previously only available on team channels)
- **Auto-channel creation** (#499): Stream channels now auto-created on payment success (all 4 event types) and consultation/subscription approval. Fire-and-forget — never blocks payments.
- **Chat webhook handlers**: New `user.flagged` + `message.flagged` webhook processing creates ModerationReport records. Deduplicates flags from same reporter.

### Files Changed (18)
- 2 new files: `app/api/stream/users/block/route.ts`, `lib/stream/chat-moderation-handlers.ts`
- 16 modified files across actions, API routes, components, and providers

### Verified
- `npx tsc --noEmit` passes with 0 errors
- Stream SDK method signatures verified against node_modules type definitions (`client.flagMessage`, `client.banUser`, `channel.truncate`, `channel.mute/unmute`, `client.disconnectUser`)

## Test plan
- [ ] Decode chat token (jwt.io) — confirm `exp` claim present (~1hr)
- [ ] `GET /api/stream/search?term=test` without auth cookie → 401
- [ ] Sign out → verify Stream WebSocket closes in DevTools Network tab
- [ ] Edit/delete message while offline → error toast appears
- [ ] Start/stop recording → no duplicate event subscriptions
- [ ] Block user in 1-on-1 DM → verify ban via Stream MCP
- [ ] Report user from DM → check ModerationReport in DB
- [ ] "Clear Chat" hidden for consultee in group DM
- [ ] Report message → Stream flag + DB ModerationReport
- [ ] Mute/unmute in DM → notifications toggle works
- [ ] Payment success → channel appears immediately (Stream MCP)
- [ ] Approve consultation → DM channel created
- [ ] Flag user via Stream dashboard → webhook creates ModerationReport

🤖 Generated with [Claude Code](https://claude.com/claude-code)