### PR TITLE
refactor: standardize Supabase storage file naming with UUID-based convention

### DIFF
--- a/app/api/verification/documents/route.ts
+++ b/app/api/verification/documents/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { uploadToSupabase, deleteFromSupabase } from "@/lib/supabase";
+import {
+  uploadToSupabase,
+  deleteFromSupabase,
+  generateStorageFileName,
+} from "@/lib/supabase";
 
 import { getSession } from "@/lib/auth-server";
 const ALLOWED_TYPES = [
@@ -112,14 +116,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Upload file to Supabase
-    // Use userId for onboarding mode when consultantProfile doesn't exist yet
     const fileBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(fileBuffer);
-    const ext = file.name.split(".").pop() || "pdf";
-    const fileIdentifier =
-      consultantProfile?.id || `onboarding-${session.user.id}`;
-    const fileName = `verification-${fileIdentifier}-${Date.now()}.${ext}`;
-    const storagePath = `verification-documents/${fileName}`;
+    const fileName = generateStorageFileName(file.type);
+    const storagePath = `verification/${session.user.id}/${fileName}`;
 
     const { url: fileUrl, error: uploadError } = await uploadToSupabase(
       storagePath,

--- a/lib/stream/recording-transfer-service.ts
+++ b/lib/stream/recording-transfer-service.ts
@@ -190,7 +190,9 @@ export class RecordingTransferService {
       const now = new Date();
       const year = now.getFullYear();
       const month = (now.getMonth() + 1).toString().padStart(2, "0");
-      const filename = generateStorageFileName(contentType);
+      // Strip content-type params (e.g. "video/mp4; charset=utf-8" → "video/mp4")
+      const mimeType = contentType.split(";")[0].trim();
+      const filename = generateStorageFileName(mimeType);
       const storagePath = `recordings/${year}/${month}/${recordingId}/${filename}`;
 
       // Upload to Supabase

--- a/lib/stream/recording-transfer-service.ts
+++ b/lib/stream/recording-transfer-service.ts
@@ -6,7 +6,11 @@
 import prisma from "@/lib/prisma";
 import { Recording, RecordingStatus } from "@prisma/client";
 import { streamLogger } from "@/lib/stream-logger";
-import supabase, { ensureBucketExists, supabaseAdmin } from "@/lib/supabase";
+import supabase, {
+  ensureBucketExists,
+  supabaseAdmin,
+  generateStorageFileName,
+} from "@/lib/supabase";
 
 // Recordings bucket name
 const RECORDINGS_BUCKET = "recordings";
@@ -182,11 +186,11 @@ export class RecordingTransferService {
         });
       }
 
-      // Create file path: recordings/{year}/{month}/{recordingId}/{filename}
+      // Create file path: recordings/{year}/{month}/{recordingId}/{uuid}.{ext}
       const now = new Date();
       const year = now.getFullYear();
       const month = (now.getMonth() + 1).toString().padStart(2, "0");
-      const filename = recording.streamRecordingId || `${recordingId}.mp4`;
+      const filename = generateStorageFileName(contentType);
       const storagePath = `recordings/${year}/${month}/${recordingId}/${filename}`;
 
       // Upload to Supabase

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import type { FileObject } from "@supabase/storage-js"; // Import FileObject type
 
@@ -87,6 +88,49 @@ const supabase: SupabaseClient = supabaseInstance;
 const supabaseAdmin: SupabaseClient | null = supabaseAdminInstance;
 
 /**
+ * Centralized MIME type to file extension map.
+ * Used by generateStorageFileName() to derive extensions from MIME types
+ * instead of user-controlled file.name values.
+ */
+export const MIME_TO_EXT: Record<string, string> = {
+  // Images
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  // Documents
+  "application/pdf": "pdf",
+  "application/msword": "doc",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+  "application/vnd.ms-excel": "xls",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "application/vnd.ms-powerpoint": "ppt",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "pptx",
+  "text/plain": "txt",
+  "text/csv": "csv",
+  "text/markdown": "md",
+  "application/zip": "zip",
+  "application/x-rar-compressed": "rar",
+  // Video
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+};
+
+/**
+ * Generate a UUID-based storage filename with MIME-derived extension.
+ * Guarantees uniqueness (UUID v4) and security (extension from MIME, not user input).
+ */
+export function generateStorageFileName(mimeType: string): string {
+  const ext = MIME_TO_EXT[mimeType];
+  if (!ext) throw new Error(`Unsupported MIME type: ${mimeType}`);
+  return `${crypto.randomUUID()}.${ext}`;
+}
+
+/**
  * Ensure a storage bucket exists, create it if it doesn't
  */
 const ensureBucketExists = async (bucketName: string): Promise<boolean> => {
@@ -151,8 +195,8 @@ const ensureBucketExists = async (bucketName: string): Promise<boolean> => {
 };
 
 /**
- * Ensure a folder exists in storage by creating a placeholder file if needed
- * Note: Supabase doesn't have "folders" per se, but we can simulate them with file paths
+ * @deprecated No-op function — Supabase auto-creates folder structure on file upload.
+ * All upload functions now skip this call. Kept for backward compatibility with tests.
  */
 const ensureFolderExists = async (
   bucketName: string,
@@ -280,17 +324,12 @@ const uploadAppointmentDocument = async (
       };
     }
 
-    // Generate unique filename
-    const timestamp = Date.now();
-    const safeFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
-    const fileName = `${timestamp}_${safeFileName}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
 
     // Create folder structure: appointments/{appointmentId}/consultee-{consulteeId}/
     const folderPath = `appointments/${appointmentId}/consultee-${consulteeId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    // Ensure folder structure exists (this is mostly for clarity - Supabase creates folders on upload)
-    await ensureFolderExists("documents", folderPath);
 
     // Upload file to Supabase storage
     const { data: _uploadData, error: uploadError } = await supabase.storage
@@ -456,17 +495,12 @@ const uploadPlanMaterial = async (
       };
     }
 
-    // Generate unique filename
-    const timestamp = Date.now();
-    const safeFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
-    const fileName = `${timestamp}_${safeFileName}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
 
     // Create folder structure: plans/{planType}-plans/{planId}/
     const folderPath = `plans/${planType}-plans/${planId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    // Ensure folder structure exists
-    await ensureFolderExists("documents", folderPath);
 
     // Upload file to Supabase storage
     const { error: uploadError } = await supabase.storage
@@ -592,17 +626,12 @@ const uploadConsultantDocument = async (
       };
     }
 
-    // Generate unique filename
-    const timestamp = Date.now();
-    const safeFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
-    const fileName = `${timestamp}_${safeFileName}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
 
     // Create folder structure: appointments/{appointmentId}/consultant-{consultantId}/
     const folderPath = `appointments/${appointmentId}/consultant-${consultantId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    // Ensure folder structure exists
-    await ensureFolderExists("documents", folderPath);
 
     // Upload file to Supabase storage
     const { error: uploadError } = await supabase.storage
@@ -691,17 +720,12 @@ const uploadSupportTicketAttachment = async (
       };
     }
 
-    // Generate unique filename
-    const timestamp = Date.now();
-    const safeFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
-    const fileName = `${timestamp}_${safeFileName}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
 
     // Create folder structure: support-tickets/{ticketId}/
     const folderPath = `support-tickets/${ticketId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    // Ensure folder structure exists
-    await ensureFolderExists("support-attachments", folderPath);
 
     // Upload file to Supabase storage
     const { data: _uploadData, error: uploadError } = await supabase.storage
@@ -834,9 +858,9 @@ const uploadPlanImage = async (
       };
     }
 
-    const fileExt = file.name.split(".").pop();
+    const fileName = generateStorageFileName(file.type);
     const folderPath = `${planType}/${planId}`;
-    const storagePath = `${folderPath}/cover.${fileExt}`;
+    const storagePath = `${folderPath}/${fileName}`;
 
     // Delete any existing cover images for this plan first
     try {
@@ -1008,17 +1032,12 @@ const uploadCoverImage = async (
       };
     }
 
-    // Generate unique filename
-    const timestamp = Date.now();
-    const fileExt = file.name.split(".").pop();
-    const fileName = `cover_${timestamp}.${fileExt}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
 
     // Create folder structure: covers/{userId}/
     const folderPath = `covers/${userId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    // Ensure folder structure exists
-    await ensureFolderExists("profile-images", folderPath);
 
     // Delete any existing cover images for this user first
     try {
@@ -1163,17 +1182,12 @@ const uploadProfileDisplayImage = async (
       };
     }
 
-    // Generate unique filename
-    const timestamp = Date.now();
-    const fileExt = file.name.split(".").pop();
-    const fileName = `display_${timestamp}.${fileExt}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
 
     // Create folder structure: display/{userId}/
     const folderPath = `display/${userId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    // Ensure folder structure exists
-    await ensureFolderExists("profile-images", folderPath);
 
     // Delete any existing profile display images for this user first
     try {
@@ -1312,20 +1326,10 @@ const uploadProfileImage = async (options: {
       };
     }
 
-    const MIME_TO_EXT: Record<string, string> = {
-      "image/jpeg": "jpg",
-      "image/jpg": "jpg",
-      "image/png": "png",
-      "image/webp": "webp",
-    };
-
-    const timestamp = Date.now();
-    const fileExt = MIME_TO_EXT[file.type] || "jpg";
-    const fileName = `avatar_${timestamp}.${fileExt}`;
+    // Generate unique filename using UUID + MIME-derived extension
+    const fileName = generateStorageFileName(file.type);
     const folderPath = `avatars/${userId}`;
     const storagePath = `${folderPath}/${fileName}`;
-
-    await ensureFolderExists("profile-images", folderPath);
 
     // Delete any existing avatar images for this user first
     try {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,3 @@
-import crypto from "crypto";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import type { FileObject } from "@supabase/storage-js"; // Import FileObject type
 
@@ -118,6 +117,9 @@ export const MIME_TO_EXT: Record<string, string> = {
   "video/mp4": "mp4",
   "video/webm": "webm",
   "video/quicktime": "mov",
+  "video/x-msvideo": "avi",
+  // Fallback
+  "application/octet-stream": "bin",
 };
 
 /**
@@ -127,7 +129,7 @@ export const MIME_TO_EXT: Record<string, string> = {
 export function generateStorageFileName(mimeType: string): string {
   const ext = MIME_TO_EXT[mimeType];
   if (!ext) throw new Error(`Unsupported MIME type: ${mimeType}`);
-  return `${crypto.randomUUID()}.${ext}`;
+  return `${globalThis.crypto.randomUUID()}.${ext}`;
 }
 
 /**
@@ -195,7 +197,8 @@ const ensureBucketExists = async (bucketName: string): Promise<boolean> => {
 };
 
 /**
- * @deprecated No-op function — Supabase auto-creates folder structure on file upload.
+ * @deprecated Supabase auto-creates folder structure on file upload.
+ * This function makes a storage `.list()` call but always returns `true` regardless of the result.
  * All upload functions now skip this call. Kept for backward compatibility with tests.
  */
 const ensureFolderExists = async (


### PR DESCRIPTION
## Summary
- Standardizes all 9 Supabase storage upload functions from 6 different naming patterns to a single `{uuid}.{ext}` convention
- Adds centralized `MIME_TO_EXT` map and `generateStorageFileName()` helper — extensions always derived from MIME type, never from user-controlled `file.name`
- Removes duplicated sanitization regex (4 copies), no-op `ensureFolderExists` calls (7 calls), and local MIME map from `uploadProfileImage`
- Restructures verification document path from flat `verification-documents/` to user-scoped `verification/{userId}/`

Closes #470

## Files Changed
| File | Changes |
|------|---------|
| `lib/supabase.ts` | Added `MIME_TO_EXT` + `generateStorageFileName()`. Updated all 8 upload functions. Deprecated `ensureFolderExists`. |
| `app/api/verification/documents/route.ts` | Uses new helper + user-scoped path |
| `lib/stream/recording-transfer-service.ts` | Uses UUID filename instead of `streamRecordingId` |

## Non-Breaking Migration
- Existing files keep old-format paths (URLs stored in DB)
- Delete functions are format-agnostic (use `storagePath` from DB or list-delete entire folders)
- No Prisma schema changes needed (`originalName` already exists on all document models)

## Test Plan
- [x] `tsc --noEmit` passes
- [x] Profile avatar upload → UUID filename with MIME extension
- [x] Profile display image upload → UUID filename
- [x] Plan cover image upload → UUID filename (replaces `cover.{ext}`)
- [x] Appointment document upload → UUID filename (was `{timestamp}_{sanitizedName}`)
- [x] Consultant document upload → UUID filename
- [x] Plan material upload → UUID filename
- [x] Support ticket attachment → UUID filename
- [x] Verification document → UUID filename + new `verification/{userId}/` path
- [x] Edge case: mismatched filename extension (`.txt`) with `image/png` MIME → produces `.png`
- [x] Re-upload avatar → new UUID generated, DB updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)