### PR TITLE
fix: zero-amount checkout, Stripe webhook, referral anti-gaming, invoice PDFs

### DIFF
--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -1,0 +1,162 @@
+/**
+ * Invoice PDF Download API
+ * GET /api/invoices/[id]/pdf
+ * Generates and returns a GST-compliant PDF invoice
+ * Caches generated PDFs in Supabase Storage for repeat downloads
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import {
+  generateInvoicePdf,
+  getInvoicePdfData,
+} from "@/lib/payments/payouts/invoice-pdf";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    // Fetch invoice with payment + user data
+    const invoice = await prisma.invoice.findFirst({
+      where: {
+        OR: [{ id }, { invoiceNumber: id }],
+      },
+      include: {
+        payment: {
+          include: {
+            user: { select: { name: true, email: true } },
+          },
+        },
+      },
+    });
+
+    if (!invoice) {
+      return NextResponse.json(
+        { error: "Invoice not found" },
+        { status: 404 },
+      );
+    }
+
+    // Authorization: user must own the payment, or be admin/staff
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { role: true, email: true },
+    });
+
+    const isOwner = invoice.payment?.user?.email === user?.email;
+    const isAdmin = user?.role === "ADMIN" || user?.role === "STAFF";
+
+    if (!isOwner && !isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    // If we already have a cached PDF URL, redirect to it
+    if (invoice.pdfUrl) {
+      return NextResponse.redirect(invoice.pdfUrl);
+    }
+
+    // Build PDF data from invoice record
+    const pdfData = await getInvoicePdfData(invoice);
+
+    // Generate PDF buffer
+    const pdfBuffer = await generateInvoicePdf(pdfData);
+
+    // Try to upload to Supabase Storage for caching (fire-and-forget)
+    uploadToStorage(invoice.id, invoice.invoiceNumber, pdfBuffer).catch(
+      (err) => {
+        console.error(
+          `Failed to cache PDF for invoice ${invoice.id}:`,
+          err,
+        );
+      },
+    );
+
+    // Return PDF response
+    return new Response(new Uint8Array(pdfBuffer), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${invoice.invoiceNumber}.pdf"`,
+        "Cache-Control": "private, max-age=3600",
+      },
+    });
+  } catch (error) {
+    console.error("Error generating invoice PDF:", error);
+    return NextResponse.json(
+      { error: "Failed to generate invoice PDF" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * Upload generated PDF to Supabase Storage and update Invoice.pdfUrl
+ * Best-effort — failures are logged but don't block the response
+ */
+async function uploadToStorage(
+  invoiceId: string,
+  invoiceNumber: string,
+  pdfBuffer: Buffer,
+): Promise<void> {
+  // Dynamic import to avoid breaking if supabase isn't configured
+  let supabase;
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      console.warn(
+        "[invoice-pdf] Supabase credentials not configured, skipping PDF caching",
+      );
+      return;
+    }
+
+    const { createClient } = await import("@supabase/supabase-js");
+    supabase = createClient(supabaseUrl, supabaseServiceKey);
+  } catch {
+    return; // Supabase not available
+  }
+
+  const bucketName = "invoices";
+  const filePath = `${invoiceId}/${invoiceNumber}.pdf`;
+
+  // Ensure bucket exists (create if missing)
+  const { data: buckets } = await supabase.storage.listBuckets();
+  if (!buckets?.find((b: { name: string }) => b.name === bucketName)) {
+    await supabase.storage.createBucket(bucketName, { public: false });
+  }
+
+  // Upload PDF
+  const { error: uploadError } = await supabase.storage
+    .from(bucketName)
+    .upload(filePath, pdfBuffer, {
+      contentType: "application/pdf",
+      upsert: true,
+    });
+
+  if (uploadError) {
+    console.error(`[invoice-pdf] Upload failed: ${uploadError.message}`);
+    return;
+  }
+
+  // Get signed URL (1 year expiry)
+  const { data: urlData } = await supabase.storage
+    .from(bucketName)
+    .createSignedUrl(filePath, 60 * 60 * 24 * 365);
+
+  if (urlData?.signedUrl) {
+    await prisma.invoice.update({
+      where: { id: invoiceId },
+      data: { pdfUrl: urlData.signedUrl },
+    });
+  }
+}

--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -35,6 +35,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         payment: {
           include: {
             user: { select: { name: true, email: true } },
+            discountCode: {
+              select: {
+                code: true,
+                discountType: true,
+                discountValue: true,
+              },
+            },
+            creditUsages: { select: { amount: true } },
           },
         },
       },
@@ -129,19 +137,23 @@ async function uploadToStorage(
   const bucketName = "invoices";
   const filePath = `${invoiceId}/${invoiceNumber}.pdf`;
 
-  // Ensure bucket exists (create if missing)
-  const { data: buckets } = await supabase.storage.listBuckets();
-  if (!buckets?.find((b: { name: string }) => b.name === bucketName)) {
-    await supabase.storage.createBucket(bucketName, { public: false });
-  }
-
-  // Upload PDF
-  const { error: uploadError } = await supabase.storage
+  // Try upload directly; create bucket only if it doesn't exist
+  let { error: uploadError } = await supabase.storage
     .from(bucketName)
     .upload(filePath, pdfBuffer, {
       contentType: "application/pdf",
       upsert: true,
     });
+
+  if (uploadError?.message?.includes("Bucket not found")) {
+    await supabase.storage.createBucket(bucketName, { public: false });
+    ({ error: uploadError } = await supabase.storage
+      .from(bucketName)
+      .upload(filePath, pdfBuffer, {
+        contentType: "application/pdf",
+        upsert: true,
+      }));
+  }
 
   if (uploadError) {
     console.error(`[invoice-pdf] Upload failed: ${uploadError.message}`);

--- a/app/api/referrals/apply/route.ts
+++ b/app/api/referrals/apply/route.ts
@@ -38,7 +38,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       data: referral,
-      message: "Referral code applied successfully",
+      // FIX #437: Credits are now deferred to first booking, not given on signup
+      message:
+        "Referral code applied successfully! You'll receive your bonus credits after your first booking.",
     });
   } catch (error) {
     console.error("Error applying referral code:", error);

--- a/app/api/referrals/code/check/[code]/route.ts
+++ b/app/api/referrals/code/check/[code]/route.ts
@@ -59,6 +59,8 @@ export async function GET(
         valid: true,
         referrerName: user?.name ?? null,
         refereeReward: referralCode.refereeReward,
+        // FIX #437: Credits are now given after first booking, not on signup
+        rewardTiming: "after_first_booking",
       },
     });
   } catch (error) {

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -15,6 +15,8 @@ import {
   stripeBaseEventSchema,
   stripePaymentIntentSucceededEventSchema,
   stripePaymentIntentFailedEventSchema,
+  stripeCheckoutSessionCompletedEventSchema,
+  stripeCheckoutSessionExpiredEventSchema,
 } from "../../../../schemas/webhooks/stripe";
 
 export async function POST(req: NextRequest) {
@@ -71,7 +73,32 @@ export async function POST(req: NextRequest) {
 
     try {
       switch (eventType) {
-        // Payment events
+        // FIX CF-3: Checkout Session events — primary handler for Stripe Checkout flow.
+        // createStripeCheckoutSession stores session.id (cs_...) in Payment.paymentIntent,
+        // so we must handle checkout.session.completed to match by cs_... ID.
+        // NOTE: Ensure these events are enabled in the Stripe Dashboard webhook settings.
+        case "checkout.session.completed": {
+          const sessionEvent =
+            stripeCheckoutSessionCompletedEventSchema.parse(event);
+          const session = sessionEvent.data.object;
+          // Use session.id (cs_...) which matches Payment.paymentIntent
+          await handlePaymentSuccess(
+            session.id,
+            session.metadata || {},
+          );
+          break;
+        }
+
+        case "checkout.session.expired": {
+          const sessionEvent =
+            stripeCheckoutSessionExpiredEventSchema.parse(event);
+          await handlePaymentFailure(sessionEvent.data.object.id);
+          break;
+        }
+
+        // Payment Intent events — kept for backward compatibility.
+        // If a payment was stored with pi_... (legacy flow), this handler catches it.
+        // Idempotency: handlePaymentSuccess is a no-op if already SUCCEEDED.
         case "payment_intent.succeeded": {
           const succeededEvent =
             stripePaymentIntentSucceededEventSchema.parse(event);

--- a/app/checkout/components/RazorpayCheckout.tsx
+++ b/app/checkout/components/RazorpayCheckout.tsx
@@ -80,6 +80,16 @@ export default function RazorpayCheckout({
         return;
       }
 
+      // FIX #520: Zero-amount payments (credits covered full cost) — no gateway needed
+      if (data.isZeroAmountPayment) {
+        onPaymentSuccess({
+          message:
+            data.message ||
+            "Payment completed via referral credits. Appointment booked successfully.",
+        });
+        return;
+      }
+
       if (!process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID) {
         toast({
           title: "Payment System Configuration Error",

--- a/app/checkout/components/StripeCheckout.tsx
+++ b/app/checkout/components/StripeCheckout.tsx
@@ -101,6 +101,16 @@ export default function StripeCheckout({
         return;
       }
 
+      // FIX #520: Zero-amount payments (credits covered full cost) — no gateway redirect needed
+      if (data.isZeroAmountPayment) {
+        onPaymentSuccess({
+          message:
+            data.message ||
+            "Payment completed via referral credits. Appointment booked successfully.",
+        });
+        return;
+      }
+
       // Handle payment based on what the server returns
       if (data.checkoutUrl) {
         // For hosted checkout sessions, redirect directly

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -337,12 +337,15 @@ export default function ConsultationCheckoutPage({
 
         // handleCheckout is only invoked by the dev-only Mock Pay button (isMockPayment=true).
         // Real payments go through StripeCheckout/RazorpayCheckout components.
-        if (data.skipPayment || data.isMockPayment) {
+        // FIX #520: Also handle zero-amount payments (credits covered full cost)
+        if (data.skipPayment || data.isMockPayment || data.isZeroAmountPayment) {
           toast({
             title: "✅ Consultation Booked Successfully!",
-            description: data.isMockPayment
-              ? "Mock payment processed. Your consultation has been confirmed. Check your dashboard for details."
-              : "Your consultation has been confirmed. Check your dashboard for details.",
+            description: data.isZeroAmountPayment
+              ? "Payment completed via referral credits. Your consultation has been confirmed."
+              : data.isMockPayment
+                ? "Mock payment processed. Your consultation has been confirmed. Check your dashboard for details."
+                : "Your consultation has been confirmed. Check your dashboard for details.",
             variant: "default",
           });
 

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -270,12 +270,18 @@ export default function SubscriptionCheckoutPage({
 
         // handleCheckout is only invoked by the dev-only Mock Pay button (isMockPayment=true).
         // Real payments go through StripeCheckout/RazorpayCheckout components.
-        if (data.success && (data.skipPayment || data.isMockPayment)) {
+        // FIX #520: Also handle zero-amount payments (credits covered full cost)
+        if (
+          data.success &&
+          (data.skipPayment || data.isMockPayment || data.isZeroAmountPayment)
+        ) {
           toast({
             title: "✅ Subscription Activated Successfully!",
-            description: data.isMockPayment
-              ? "Mock payment processed. Your subscription is now active. Check your dashboard for details."
-              : "Your subscription is now active. Check your dashboard for details.",
+            description: data.isZeroAmountPayment
+              ? "Payment completed via referral credits. Your subscription is now active."
+              : data.isMockPayment
+                ? "Mock payment processed. Your subscription is now active. Check your dashboard for details."
+                : "Your subscription is now active. Check your dashboard for details.",
             variant: "default",
           });
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
@@ -396,10 +396,9 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                                       size="sm"
                                       className="text-zinc-500 hover:text-zinc-900"
                                       onClick={() => {
-                                        // TODO: Replace with actual PDF download when @react-pdf/renderer is integrated
-                                        // Will call: GET /api/invoices/{invoice.id}/pdf
-                                        window.alert(
-                                          `PDF download coming soon.\n\nInvoice: ${invoice.invoiceNumber}\nAmount: ${formatCurrencyFromMajorUnit(invoice.amount, "INR")}`,
+                                        window.open(
+                                          `/api/invoices/${invoice.id}/pdf`,
+                                          "_blank",
                                         );
                                       }}
                                     >

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -510,17 +510,35 @@ export async function validateSlotAvailability(
     const slotDurationMinutes = Math.round(
       (slotEnd.getTime() - slotStart.getTime()) / (60 * 1000),
     );
-    if (
-      !isMinuteWithinWeeklySlot(
-        candidateDay,
-        candidateMinutes,
-        slotDurationMinutes,
-        avail.startDay,
-        avail.startTimeUtc,
-        avail.endTimeUtc,
-        avail.utcOffsetMinutes,
-      )
-    ) {
+
+    // FIX #520 Bug 2: Diagnostic logging for intermittent slot validation failures
+    const slotValidationResult = isMinuteWithinWeeklySlot(
+      candidateDay,
+      candidateMinutes,
+      slotDurationMinutes,
+      avail.startDay,
+      avail.startTimeUtc,
+      avail.endTimeUtc,
+      avail.utcOffsetMinutes,
+    );
+
+    if (!slotValidationResult) {
+      console.error(
+        JSON.stringify({
+          event: "slot_validation_failed",
+          candidateDay,
+          candidateMinutes,
+          slotDurationMinutes,
+          availStartDay: avail.startDay,
+          availStartTimeUtc: avail.startTimeUtc,
+          availEndTimeUtc: avail.endTimeUtc,
+          utcOffsetMinutes: avail.utcOffsetMinutes,
+          slotStartISO: data.slotStartTimeInUTC,
+          slotEndISO: data.slotEndTimeInUTC,
+          availId: data.slotOfAvailabilityWeeklyId,
+          timestamp: new Date().toISOString(),
+        }),
+      );
       throw new Error(
         "Selected slot does not fall within the specified availability window",
       );
@@ -1545,20 +1563,39 @@ export async function handleCheckout(
       }),
     );
 
+    // FIX #520: Detect zero-amount payments (credits fully cover cost)
+    // Both Stripe and Razorpay reject amount <= 0, so we skip the gateway
+    // entirely and treat this like a "free" payment that succeeds immediately.
+    const isZeroAmountPayment = amount === 0 && creditsApplied > 0;
+
     // STEP 4: Create payment intent (INSIDE LOCK)
-    try {
-      paymentResponse = await PaymentIntentManager.createWithCleanup({
-        amount,
-        currency,
-        metadata: buildPaymentMetadata(validatedData, userId),
-        paymentGateway: validatedData.paymentGateway,
-        isMockPayment,
-      });
-    } catch (paymentError) {
-      console.error("Payment intent creation failed:", paymentError);
-      throw new Error(
-        "Failed to create payment intent. Please try again later.",
+    if (isZeroAmountPayment) {
+      const freePaymentId = `free_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+      paymentResponse = { id: freePaymentId, client_secret: null };
+      console.log(
+        JSON.stringify({
+          event: "zero_amount_payment_detected",
+          creditsApplied,
+          originalAmount,
+          userId,
+          timestamp: new Date().toISOString(),
+        }),
       );
+    } else {
+      try {
+        paymentResponse = await PaymentIntentManager.createWithCleanup({
+          amount,
+          currency,
+          metadata: buildPaymentMetadata(validatedData, userId),
+          paymentGateway: validatedData.paymentGateway,
+          isMockPayment,
+        });
+      } catch (paymentError) {
+        console.error("Payment intent creation failed:", paymentError);
+        throw new Error(
+          "Failed to create payment intent. Please try again later.",
+        );
+      }
     }
 
     // STEP 5: Create tentative appointment + payment record (INSIDE LOCK)
@@ -1568,6 +1605,10 @@ export async function handleCheckout(
         async (tx) => {
           let createdAppointment;
 
+          // FIX #520: Zero-amount payments (credits cover full cost) skip the
+          // gateway, so slots should be confirmed immediately just like mock payments.
+          const skipPayment = isMockPayment || isZeroAmountPayment;
+
           // Create appointment based on type (with isTentative flag)
           switch (validatedData.appointmentType) {
             case "CONSULTATION": {
@@ -1576,7 +1617,7 @@ export async function handleCheckout(
                 validatedData,
                 consulteeProfileId,
                 userId,
-                isMockPayment, // skipPayment = isMockPayment
+                skipPayment,
               );
               createdAppointment = consultationResult.appointment;
               break;
@@ -1587,7 +1628,7 @@ export async function handleCheckout(
                 tx,
                 validatedData,
                 consulteeProfileId,
-                isMockPayment,
+                skipPayment,
               );
               // Use placeholder appointment for payment linkage
               // This ensures webhook uses NEW FLOW (confirm) not LEGACY FLOW (create duplicate)
@@ -1600,7 +1641,7 @@ export async function handleCheckout(
                 tx,
                 validatedData,
                 userId,
-                isMockPayment,
+                skipPayment,
               );
               createdAppointment = webinarResult.appointment;
               break;
@@ -1611,7 +1652,7 @@ export async function handleCheckout(
                 tx,
                 validatedData,
                 userId,
-                isMockPayment,
+                skipPayment,
               );
               // Class creates slots across multiple appointments
               // Use first appointment for payment linkage
@@ -1633,29 +1674,26 @@ export async function handleCheckout(
               originalAmount,
               taxAmount,
               currency,
-              paymentMethod: "CARD",
+              paymentMethod: isZeroAmountPayment ? "CREDITS" : "CARD",
               paymentIntent: paymentResponse!.id,
               paymentGateway: validatedData.paymentGateway,
-              paymentStatus: PaymentStatus.PENDING,
-              isMockPayment,
+              // FIX #520: Zero-amount and mock payments succeed immediately (no webhook)
+              paymentStatus: skipPayment
+                ? PaymentStatus.SUCCEEDED
+                : PaymentStatus.PENDING,
+              isMockPayment: isMockPayment || isZeroAmountPayment,
               userId: userId,
               appointmentId: createdAppointment?.id || null,
               discountCodeId,
-              expiresAt: new Date(Date.now() + 30 * 60 * 1000), // 30 minutes
+              expiresAt: skipPayment
+                ? null
+                : new Date(Date.now() + 30 * 60 * 1000), // 30 minutes
               buyerCountry: detectedBuyerCountry,
               isInternational,
               displayCurrencyAtCheckout,
               exchangeRateAtCheckout,
             },
           });
-
-          // FIX Issue #6: Update mock payment status directly (no webhook for mock payments)
-          if (isMockPayment) {
-            await tx.payment.update({
-              where: { id: payment.id },
-              data: { paymentStatus: PaymentStatus.SUCCEEDED },
-            });
-          }
 
           // Increment discount code usage count atomically (only after payment is created)
           // This ensures count only increases when payment is successfully created
@@ -1718,9 +1756,11 @@ export async function handleCheckout(
         },
       );
 
-      const logMessage = isMockPayment
-        ? `🎭 Mock payment + tentative appointment created: ${paymentResponse.id}`
-        : `💳 Payment intent + tentative appointment created: ${paymentResponse.id} - Waiting for payment confirmation`;
+      const logMessage = isZeroAmountPayment
+        ? `🎁 Zero-amount payment (credits covered full cost) + appointment created: ${paymentResponse.id}`
+        : isMockPayment
+          ? `🎭 Mock payment + tentative appointment created: ${paymentResponse.id}`
+          : `💳 Payment intent + tentative appointment created: ${paymentResponse.id} - Waiting for payment confirmation`;
 
       console.log(logMessage);
       console.log(
@@ -1733,10 +1773,10 @@ export async function handleCheckout(
         }),
       );
 
-      // Mock payment post-processing: referral qualifying action + waitlist
+      // Mock/zero-amount payment post-processing: referral qualifying action + waitlist
       // Real payments handle this via handlePaymentSuccess() in the webhook,
-      // but mock payments bypass webhooks entirely.
-      if (isMockPayment) {
+      // but mock and zero-amount payments bypass webhooks entirely.
+      if (isMockPayment || isZeroAmountPayment) {
         // Trigger referral reward if this is the user's first paid booking
         try {
           await processQualifyingAction(userId, "first_paid_booking");
@@ -1855,6 +1895,77 @@ export async function handleCheckout(
           );
         }
 
+        // FIX #437: Consultant qualifying action (receiving first paid booking)
+        try {
+          const paymentForConsultantRef = await prisma.payment.findUnique({
+            where: { paymentIntent: paymentResponse!.id },
+            include: {
+              appointment: {
+                include: {
+                  consultation: {
+                    include: {
+                      consultationPlan: {
+                        select: {
+                          consultantProfile: { select: { userId: true } },
+                        },
+                      },
+                    },
+                  },
+                  subscription: {
+                    include: {
+                      subscriptionPlan: {
+                        select: {
+                          consultantProfile: { select: { userId: true } },
+                        },
+                      },
+                    },
+                  },
+                  webinar: {
+                    select: {
+                      webinarPlan: {
+                        select: {
+                          consultantProfile: { select: { userId: true } },
+                        },
+                      },
+                    },
+                  },
+                  class: {
+                    select: {
+                      classPlan: {
+                        select: {
+                          consultantProfile: { select: { userId: true } },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          const consultantUserId =
+            paymentForConsultantRef?.appointment?.consultation?.consultationPlan
+              ?.consultantProfile?.userId ||
+            paymentForConsultantRef?.appointment?.subscription?.subscriptionPlan
+              ?.consultantProfile?.userId ||
+            paymentForConsultantRef?.appointment?.webinar?.webinarPlan
+              ?.consultantProfile?.userId ||
+            paymentForConsultantRef?.appointment?.class?.classPlan
+              ?.consultantProfile?.userId;
+
+          if (consultantUserId && consultantUserId !== userId) {
+            await processQualifyingAction(
+              consultantUserId,
+              "first_paid_booking_received",
+            );
+          }
+        } catch (consultantRefError) {
+          console.error(
+            `⚠️ Failed to process consultant referral qualifying action:`,
+            consultantRefError,
+          );
+        }
+
         // Update waitlist status if coming from waitlist flow
         if (validatedData.fromWaitlist) {
           try {
@@ -1876,18 +1987,22 @@ export async function handleCheckout(
       return {
         success: true,
         paymentIntent: paymentResponse,
-        message: isMockPayment
-          ? "Mock payment completed and appointment created successfully"
-          : "Payment intent created. Complete payment to book appointment.",
+        message: isZeroAmountPayment
+          ? "Payment completed via referral credits. Appointment booked successfully."
+          : isMockPayment
+            ? "Mock payment completed and appointment created successfully"
+            : "Payment intent created. Complete payment to book appointment.",
         amount,
         currency,
-        isMockPayment,
+        isMockPayment: isMockPayment || isZeroAmountPayment,
+        isZeroAmountPayment,
       };
     } catch (dbError) {
       console.error("Failed to create payment record:", dbError);
 
       // CRITICAL: Cancel payment intent since DB operation failed
-      if (paymentResponse) {
+      // (Skip cleanup for zero-amount payments — they have no real gateway intent)
+      if (paymentResponse && !isZeroAmountPayment) {
         await PaymentIntentManager.cleanup(
           paymentResponse.id,
           "Database operation failed - preventing orphaned payment intent",

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -35,6 +35,7 @@ import {
   applyCreditsToPayment,
   getUserCredits,
   processQualifyingAction,
+  processConsultantBookingReferral,
 } from "@/lib/referrals/service";
 import { TAX_CONSTANTS } from "@/lib/payments/payouts/constants";
 import {
@@ -1897,68 +1898,10 @@ export async function handleCheckout(
 
         // FIX #437: Consultant qualifying action (receiving first paid booking)
         try {
-          const paymentForConsultantRef = await prisma.payment.findUnique({
-            where: { paymentIntent: paymentResponse!.id },
-            include: {
-              appointment: {
-                include: {
-                  consultation: {
-                    include: {
-                      consultationPlan: {
-                        select: {
-                          consultantProfile: { select: { userId: true } },
-                        },
-                      },
-                    },
-                  },
-                  subscription: {
-                    include: {
-                      subscriptionPlan: {
-                        select: {
-                          consultantProfile: { select: { userId: true } },
-                        },
-                      },
-                    },
-                  },
-                  webinar: {
-                    select: {
-                      webinarPlan: {
-                        select: {
-                          consultantProfile: { select: { userId: true } },
-                        },
-                      },
-                    },
-                  },
-                  class: {
-                    select: {
-                      classPlan: {
-                        select: {
-                          consultantProfile: { select: { userId: true } },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          });
-
-          const consultantUserId =
-            paymentForConsultantRef?.appointment?.consultation?.consultationPlan
-              ?.consultantProfile?.userId ||
-            paymentForConsultantRef?.appointment?.subscription?.subscriptionPlan
-              ?.consultantProfile?.userId ||
-            paymentForConsultantRef?.appointment?.webinar?.webinarPlan
-              ?.consultantProfile?.userId ||
-            paymentForConsultantRef?.appointment?.class?.classPlan
-              ?.consultantProfile?.userId;
-
-          if (consultantUserId && consultantUserId !== userId) {
-            await processQualifyingAction(
-              consultantUserId,
-              "first_paid_booking_received",
-            );
-          }
+          await processConsultantBookingReferral(
+            { paymentIntent: paymentResponse!.id },
+            userId,
+          );
         } catch (consultantRefError) {
           console.error(
             `⚠️ Failed to process consultant referral qualifying action:`,

--- a/lib/payments/payouts/invoice-pdf.tsx
+++ b/lib/payments/payouts/invoice-pdf.tsx
@@ -2,9 +2,34 @@
  * Invoice PDF Generator
  * Generates GST-compliant PDF invoices using @react-pdf/renderer
  * Server-side only — used by the /api/invoices/[id]/pdf route
+ *
+ * REACT COMPATIBILITY NOTE
+ * ─────────────────────────────────────────────────────────────────────────
+ * In Next.js 15 App Router, `import React from "react"` inside route-handler
+ * modules resolves to Next.js's vendored RSC React 19 canary
+ * (next/dist/.../rsc/react.js). That canary's createElement stamps elements
+ * with Symbol("react.transitional.element"), but react-pdf's reconciler-23
+ * (used when React.version is "18.x") only accepts Symbol("react.element").
+ *
+ * Fix: use __non_webpack_require__("react") for element creation.
+ * Next.js defines __non_webpack_require__ as the native Node.js require in
+ * its webpack config, so it bypasses the RSC module alias and loads the
+ * actual React 18.3.1 from node_modules — whose createElement produces
+ * Symbol("react.element") that reconciler-23 accepts.
+ *
+ * We keep `import React from "react"` for TypeScript type information only.
+ * All JSX is written as createElement calls (no JSX syntax) to avoid the
+ * RSC jsx-dev-runtime transform which would also create transitional elements.
  */
 
+// TypeScript types only — the actual runtime React is loaded below.
 import React from "react";
+
+// Load React 18.3.1 from node_modules via native require, bypassing the RSC
+// webpack alias that would otherwise give us the Next.js vendored canary.
+declare const __non_webpack_require__: NodeRequire;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pdfReact = __non_webpack_require__("react") as typeof React;
 import {
   Document,
   Page,
@@ -13,50 +38,61 @@ import {
   StyleSheet,
   renderToBuffer,
 } from "@react-pdf/renderer";
+import { z } from "zod";
 import { TAX_CONSTANTS } from "./constants";
-import type { InvoiceItem } from "./invoice-service";
 
 // ============================================
-// Types
+// Zod Schemas & Types
 // ============================================
 
-export interface InvoicePdfData {
-  invoiceNumber: string;
-  invoiceDate: Date;
-  dueDate?: Date;
-  paidAt?: Date;
-  status: string;
+const InvoiceItemSchema = z.object({
+  description: z.string(),
+  quantity: z.number().int().positive(),
+  unitPrice: z.number().int().nonnegative(),
+  amount: z.number().int().nonnegative(),
+  hsnCode: z.string().optional(),
+});
+
+const InvoicePdfDataSchema = z.object({
+  invoiceNumber: z.string(),
+  invoiceDate: z.date(),
+  dueDate: z.date().optional(),
+  paidAt: z.date().optional(),
+  status: z.string(),
 
   // Company (seller)
-  companyName: string;
-  companyAddress: string;
-  companyGstin?: string;
+  companyName: z.string(),
+  companyAddress: z.string(),
+  companyGstin: z.string().optional(),
 
   // Customer (buyer)
-  customerName: string;
-  customerEmail: string;
-  customerAddress?: string;
-  customerGstin?: string;
+  customerName: z.string(),
+  customerEmail: z.string().email(),
+  customerAddress: z.string().optional(),
+  customerGstin: z.string().optional(),
 
   // Line items
-  items: InvoiceItem[];
+  items: z.array(InvoiceItemSchema).min(1),
 
   // Amounts (in paise)
-  subtotal: number;
-  taxRate: number;
-  taxAmount: number;
-  discountAmount?: number;
-  creditsApplied?: number;
-  total: number;
-  currency: string;
-  isInternational: boolean;
+  subtotal: z.number().int().nonnegative(),
+  taxRate: z.number().nonnegative(),
+  taxAmount: z.number().int().nonnegative(),
+  discountAmount: z.number().int().nonnegative().optional(),
+  creditsApplied: z.number().int().nonnegative().optional(),
+  total: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  isInternational: z.boolean(),
 
   // Service info
-  hsnCode: string;
-  paymentMethod?: string;
-  transactionId?: string;
-  notes?: string;
-}
+  hsnCode: z.string(),
+  paymentMethod: z.string().optional(),
+  transactionId: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+export type InvoicePdfData = z.infer<typeof InvoicePdfDataSchema>;
+type InvoiceItem = z.infer<typeof InvoiceItemSchema>;
 
 // ============================================
 // Helpers
@@ -132,7 +168,6 @@ function amountInWords(paise: number): string {
         " Hundred" +
         (n % 100 ? " and " + convertToWords(n % 100) : "")
       );
-    // Indian numbering: lakh (100,000), crore (10,000,000)
     if (n < 100000)
       return (
         convertToWords(Math.floor(n / 1000)) +
@@ -171,7 +206,6 @@ const styles = StyleSheet.create({
     fontFamily: "Helvetica",
     color: "#1a1a1a",
   },
-  // Header
   header: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -200,7 +234,6 @@ const styles = StyleSheet.create({
     textAlign: "right",
     marginTop: 4,
   },
-  // Status badge
   statusBadge: {
     marginTop: 6,
     paddingHorizontal: 8,
@@ -218,7 +251,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#fef3c7",
     color: "#92400e",
   },
-  // Info sections
   infoRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -238,7 +270,6 @@ const styles = StyleSheet.create({
     fontSize: 10,
     lineHeight: 1.5,
   },
-  // Table
   table: {
     marginBottom: 20,
   },
@@ -260,7 +291,6 @@ const styles = StyleSheet.create({
   colQty: { width: "10%", textAlign: "center" },
   colRate: { width: "17.5%", textAlign: "right" },
   colAmount: { width: "17.5%", textAlign: "right" },
-  // Totals
   totalsContainer: {
     flexDirection: "row",
     justifyContent: "flex-end",
@@ -303,7 +333,6 @@ const styles = StyleSheet.create({
     color: "#ffffff",
     textAlign: "right",
   },
-  // Amount in words
   amountInWords: {
     fontSize: 9,
     fontStyle: "italic",
@@ -311,7 +340,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
     textAlign: "right",
   },
-  // Notes and footer
   notesSection: {
     marginTop: 10,
     padding: 10,
@@ -346,220 +374,299 @@ const styles = StyleSheet.create({
 // ============================================
 
 function InvoiceDocument({ data }: { data: InvoicePdfData }) {
+  const ce = pdfReact.createElement;
   const halfGstRate = data.taxRate / 2;
 
-  return (
-    <Document>
-      <Page size="A4" style={styles.page}>
-        {/* Header */}
-        <View style={styles.header}>
-          <View>
-            <Text style={styles.companyName}>{data.companyName}</Text>
-            <Text style={styles.companyDetails}>{data.companyAddress}</Text>
-            {data.companyGstin && (
-              <Text style={styles.companyDetails}>
-                GSTIN: {data.companyGstin}
-              </Text>
-            )}
-          </View>
-          <View>
-            <Text style={styles.invoiceTitle}>
-              {data.isInternational ? "EXPORT INVOICE" : "TAX INVOICE"}
-            </Text>
-            <Text style={styles.invoiceNumber}>{data.invoiceNumber}</Text>
-            <View
-              style={[
+  // Tax rows: zero-rated export OR CGST+SGST split OR nothing
+  const taxRows = data.isInternational
+    ? ce(
+        View,
+        { style: styles.totalRow },
+        ce(Text, { style: styles.totalLabel }, "GST (Zero-rated export)"),
+        ce(Text, { style: styles.totalValue }, formatAmount(0, data.currency)),
+      )
+    : data.taxAmount > 0
+      ? [
+          ce(
+            View,
+            { style: styles.totalRow, key: "cgst" },
+            ce(Text, { style: styles.totalLabel }, `CGST (${halfGstRate}%)`),
+            ce(
+              Text,
+              { style: styles.totalValue },
+              formatAmount(Math.floor(data.taxAmount / 2), data.currency),
+            ),
+          ),
+          ce(
+            View,
+            { style: styles.totalRow, key: "sgst" },
+            ce(Text, { style: styles.totalLabel }, `SGST (${halfGstRate}%)`),
+            ce(
+              Text,
+              { style: styles.totalValue },
+              formatAmount(Math.ceil(data.taxAmount / 2), data.currency),
+            ),
+          ),
+        ]
+      : null;
+
+  return ce(
+    Document,
+    null,
+    ce(
+      Page,
+      { size: "A4", style: styles.page },
+
+      // ── Header ──────────────────────────────────────────────────────────
+      ce(
+        View,
+        { style: styles.header },
+        // Left: company info
+        ce(
+          View,
+          null,
+          ce(Text, { style: styles.companyName }, data.companyName),
+          ce(Text, { style: styles.companyDetails }, data.companyAddress),
+          data.companyGstin
+            ? ce(
+                Text,
+                { style: styles.companyDetails },
+                `GSTIN: ${data.companyGstin}`,
+              )
+            : null,
+        ),
+        // Right: invoice title + number + status badge
+        ce(
+          View,
+          null,
+          ce(
+            Text,
+            { style: styles.invoiceTitle },
+            data.isInternational ? "EXPORT INVOICE" : "TAX INVOICE",
+          ),
+          ce(Text, { style: styles.invoiceNumber }, data.invoiceNumber),
+          ce(
+            View,
+            {
+              style: [
                 styles.statusBadge,
                 data.status === "SUCCEEDED"
                   ? styles.statusPaid
                   : styles.statusPending,
-              ]}
-            >
-              <Text>
-                {data.status === "SUCCEEDED" ? "PAID" : data.status}
-              </Text>
-            </View>
-          </View>
-        </View>
+              ],
+            },
+            ce(
+              Text,
+              null,
+              data.status === "SUCCEEDED" ? "PAID" : data.status,
+            ),
+          ),
+        ),
+      ),
 
-        {/* Invoice & Customer Info */}
-        <View style={styles.infoRow}>
-          <View style={styles.infoBlock}>
-            <Text style={styles.infoLabel}>Bill To</Text>
-            <Text style={styles.infoValue}>{data.customerName}</Text>
-            <Text style={styles.infoValue}>{data.customerEmail}</Text>
-            {data.customerAddress && (
-              <Text style={styles.infoValue}>{data.customerAddress}</Text>
-            )}
-            {data.customerGstin && (
-              <Text style={styles.infoValue}>
-                GSTIN: {data.customerGstin}
-              </Text>
-            )}
-          </View>
-          <View style={styles.infoBlock}>
-            <Text style={styles.infoLabel}>Invoice Details</Text>
-            <Text style={styles.infoValue}>
-              Date: {formatDate(data.invoiceDate)}
-            </Text>
-            {data.dueDate && (
-              <Text style={styles.infoValue}>
-                Due: {formatDate(data.dueDate)}
-              </Text>
-            )}
-            {data.paidAt && (
-              <Text style={styles.infoValue}>
-                Paid: {formatDate(data.paidAt)}
-              </Text>
-            )}
-            {data.transactionId && (
-              <Text style={styles.infoValue}>
-                Txn: {data.transactionId}
-              </Text>
-            )}
-            {data.paymentMethod && (
-              <Text style={styles.infoValue}>
-                Method: {data.paymentMethod}
-              </Text>
-            )}
-          </View>
-        </View>
+      // ── Bill To + Invoice Details ────────────────────────────────────────
+      ce(
+        View,
+        { style: styles.infoRow },
+        ce(
+          View,
+          { style: styles.infoBlock },
+          ce(Text, { style: styles.infoLabel }, "Bill To"),
+          ce(Text, { style: styles.infoValue }, data.customerName),
+          ce(Text, { style: styles.infoValue }, data.customerEmail),
+          data.customerAddress
+            ? ce(Text, { style: styles.infoValue }, data.customerAddress)
+            : null,
+          data.customerGstin
+            ? ce(
+                Text,
+                { style: styles.infoValue },
+                `GSTIN: ${data.customerGstin}`,
+              )
+            : null,
+        ),
+        ce(
+          View,
+          { style: styles.infoBlock },
+          ce(Text, { style: styles.infoLabel }, "Invoice Details"),
+          ce(
+            Text,
+            { style: styles.infoValue },
+            `Date: ${formatDate(data.invoiceDate)}`,
+          ),
+          data.dueDate
+            ? ce(
+                Text,
+                { style: styles.infoValue },
+                `Due: ${formatDate(data.dueDate)}`,
+              )
+            : null,
+          data.paidAt
+            ? ce(
+                Text,
+                { style: styles.infoValue },
+                `Paid: ${formatDate(data.paidAt)}`,
+              )
+            : null,
+          data.transactionId
+            ? ce(
+                Text,
+                { style: styles.infoValue },
+                `Txn: ${data.transactionId}`,
+              )
+            : null,
+          data.paymentMethod
+            ? ce(
+                Text,
+                { style: styles.infoValue },
+                `Method: ${data.paymentMethod}`,
+              )
+            : null,
+        ),
+      ),
 
-        {/* Items Table */}
-        <View style={styles.table}>
-          <View style={styles.tableHeader}>
-            <Text style={styles.colDescription}>Description</Text>
-            <Text style={styles.colHsn}>HSN/SAC</Text>
-            <Text style={styles.colQty}>Qty</Text>
-            <Text style={styles.colRate}>Unit Price</Text>
-            <Text style={styles.colAmount}>Amount</Text>
-          </View>
-          {data.items.map((item, index) => (
-            <View style={styles.tableRow} key={index}>
-              <Text style={styles.colDescription}>{item.description}</Text>
-              <Text style={styles.colHsn}>
-                {item.hsnCode || data.hsnCode}
-              </Text>
-              <Text style={styles.colQty}>{item.quantity}</Text>
-              <Text style={styles.colRate}>
-                {formatAmount(item.unitPrice, data.currency)}
-              </Text>
-              <Text style={styles.colAmount}>
-                {formatAmount(item.amount, data.currency)}
-              </Text>
-            </View>
-          ))}
-        </View>
+      // ── Items Table ──────────────────────────────────────────────────────
+      ce(
+        View,
+        { style: styles.table },
+        ce(
+          View,
+          { style: styles.tableHeader },
+          ce(Text, { style: styles.colDescription }, "Description"),
+          ce(Text, { style: styles.colHsn }, "HSN/SAC"),
+          ce(Text, { style: styles.colQty }, "Qty"),
+          ce(Text, { style: styles.colRate }, "Unit Price"),
+          ce(Text, { style: styles.colAmount }, "Amount"),
+        ),
+        data.items.map((item: InvoiceItem, index: number) =>
+          ce(
+            View,
+            { style: styles.tableRow, key: index },
+            ce(Text, { style: styles.colDescription }, item.description),
+            ce(
+              Text,
+              { style: styles.colHsn },
+              item.hsnCode ?? data.hsnCode,
+            ),
+            ce(Text, { style: styles.colQty }, String(item.quantity)),
+            ce(
+              Text,
+              { style: styles.colRate },
+              formatAmount(item.unitPrice, data.currency),
+            ),
+            ce(
+              Text,
+              { style: styles.colAmount },
+              formatAmount(item.amount, data.currency),
+            ),
+          ),
+        ),
+      ),
 
-        {/* Totals */}
-        <View style={styles.totalsContainer}>
-          <View style={styles.totalsBlock}>
-            <View style={styles.totalRow}>
-              <Text style={styles.totalLabel}>Subtotal</Text>
-              <Text style={styles.totalValue}>
-                {formatAmount(data.subtotal, data.currency)}
-              </Text>
-            </View>
+      // ── Totals ───────────────────────────────────────────────────────────
+      ce(
+        View,
+        { style: styles.totalsContainer },
+        ce(
+          View,
+          { style: styles.totalsBlock },
+          ce(
+            View,
+            { style: styles.totalRow },
+            ce(Text, { style: styles.totalLabel }, "Subtotal"),
+            ce(
+              Text,
+              { style: styles.totalValue },
+              formatAmount(data.subtotal, data.currency),
+            ),
+          ),
+          taxRows,
+          data.discountAmount && data.discountAmount > 0
+            ? ce(
+                View,
+                { style: styles.totalRow },
+                ce(Text, { style: styles.totalLabel }, "Discount"),
+                ce(
+                  Text,
+                  { style: styles.totalValue },
+                  `-${formatAmount(data.discountAmount, data.currency)}`,
+                ),
+              )
+            : null,
+          data.creditsApplied && data.creditsApplied > 0
+            ? ce(
+                View,
+                { style: styles.totalRow },
+                ce(Text, { style: styles.totalLabel }, "Referral Credits"),
+                ce(
+                  Text,
+                  { style: styles.totalValue },
+                  `-${formatAmount(data.creditsApplied, data.currency)}`,
+                ),
+              )
+            : null,
+          ce(
+            View,
+            { style: styles.grandTotalRow },
+            ce(Text, { style: styles.grandTotalLabel }, "Total"),
+            ce(
+              Text,
+              { style: styles.grandTotalValue },
+              formatAmount(data.total, data.currency),
+            ),
+          ),
+        ),
+      ),
 
-            {data.isInternational ? (
-              <View style={styles.totalRow}>
-                <Text style={styles.totalLabel}>GST (Zero-rated export)</Text>
-                <Text style={styles.totalValue}>
-                  {formatAmount(0, data.currency)}
-                </Text>
-              </View>
-            ) : data.taxAmount > 0 ? (
-              <>
-                <View style={styles.totalRow}>
-                  <Text style={styles.totalLabel}>
-                    CGST ({halfGstRate}%)
-                  </Text>
-                  <Text style={styles.totalValue}>
-                    {formatAmount(
-                      Math.floor(data.taxAmount / 2),
-                      data.currency,
-                    )}
-                  </Text>
-                </View>
-                <View style={styles.totalRow}>
-                  <Text style={styles.totalLabel}>
-                    SGST ({halfGstRate}%)
-                  </Text>
-                  <Text style={styles.totalValue}>
-                    {formatAmount(
-                      Math.ceil(data.taxAmount / 2),
-                      data.currency,
-                    )}
-                  </Text>
-                </View>
-              </>
-            ) : null}
+      // ── Amount in Words ──────────────────────────────────────────────────
+      data.currency === "INR"
+        ? ce(
+            Text,
+            { style: styles.amountInWords },
+            amountInWords(data.total),
+          )
+        : null,
 
-            {data.discountAmount && data.discountAmount > 0 ? (
-              <View style={styles.totalRow}>
-                <Text style={styles.totalLabel}>Discount</Text>
-                <Text style={styles.totalValue}>
-                  -{formatAmount(data.discountAmount, data.currency)}
-                </Text>
-              </View>
-            ) : null}
+      // ── Notes ────────────────────────────────────────────────────────────
+      data.notes
+        ? ce(
+            View,
+            { style: styles.notesSection },
+            ce(Text, { style: styles.notesTitle }, "Notes"),
+            ce(Text, { style: styles.notesText }, data.notes),
+          )
+        : null,
 
-            {data.creditsApplied && data.creditsApplied > 0 ? (
-              <View style={styles.totalRow}>
-                <Text style={styles.totalLabel}>Referral Credits</Text>
-                <Text style={styles.totalValue}>
-                  -{formatAmount(data.creditsApplied, data.currency)}
-                </Text>
-              </View>
-            ) : null}
+      // ── Export declaration ───────────────────────────────────────────────
+      data.isInternational
+        ? ce(
+            View,
+            { style: styles.notesSection },
+            ce(Text, { style: styles.notesTitle }, "Export Declaration"),
+            ce(
+              Text,
+              { style: styles.notesText },
+              "Export of services \u2014 Zero-rated supply under Section 16 of IGST Act, 2017 read with Section 2(6) of IGST Act. Supply meant for export on payment of IGST.",
+            ),
+          )
+        : null,
 
-            <View style={styles.grandTotalRow}>
-              <Text style={styles.grandTotalLabel}>Total</Text>
-              <Text style={styles.grandTotalValue}>
-                {formatAmount(data.total, data.currency)}
-              </Text>
-            </View>
-          </View>
-        </View>
-
-        {/* Amount in Words */}
-        {data.currency === "INR" && (
-          <Text style={styles.amountInWords}>
-            {amountInWords(data.total)}
-          </Text>
-        )}
-
-        {/* Notes */}
-        {data.notes && (
-          <View style={styles.notesSection}>
-            <Text style={styles.notesTitle}>Notes</Text>
-            <Text style={styles.notesText}>{data.notes}</Text>
-          </View>
-        )}
-
-        {data.isInternational && (
-          <View style={styles.notesSection}>
-            <Text style={styles.notesTitle}>Export Declaration</Text>
-            <Text style={styles.notesText}>
-              Export of services — Zero-rated supply under Section 16 of IGST
-              Act, 2017 read with Section 2(6) of IGST Act. Supply meant for
-              export on payment of IGST.
-            </Text>
-          </View>
-        )}
-
-        {/* Footer */}
-        <View style={styles.footer}>
-          <Text>
-            This is a computer-generated invoice and does not require a
-            signature.
-          </Text>
-          <Text style={{ marginTop: 2 }}>
-            Familiarise — Expert Services Marketplace | familiarise.com
-          </Text>
-        </View>
-      </Page>
-    </Document>
+      // ── Footer ───────────────────────────────────────────────────────────
+      ce(
+        View,
+        { style: styles.footer },
+        ce(
+          Text,
+          null,
+          "This is a computer-generated invoice and does not require a signature.",
+        ),
+        ce(
+          Text,
+          { style: { marginTop: 2 } },
+          "Familiarise \u2014 Expert Services Marketplace | familiarise.com",
+        ),
+      ),
+    ),
   );
 }
 
@@ -568,20 +675,23 @@ function InvoiceDocument({ data }: { data: InvoicePdfData }) {
 // ============================================
 
 /**
- * Generate a PDF buffer for an invoice
- * Uses @react-pdf/renderer's server-side renderToBuffer
+ * Generate a PDF buffer for an invoice.
+ * Validates data with Zod before rendering.
  */
 export async function generateInvoicePdf(
   data: InvoicePdfData,
 ): Promise<Buffer> {
+  const validated = InvoicePdfDataSchema.parse(data);
   const buffer = await renderToBuffer(
-    <InvoiceDocument data={data} /> as React.ReactElement,
+    pdfReact.createElement(InvoiceDocument, {
+      data: validated,
+    }) as React.ReactElement,
   );
   return Buffer.from(buffer);
 }
 
 /**
- * Build InvoicePdfData from a database invoice record
+ * Build InvoicePdfData from a database invoice record.
  */
 export async function getInvoicePdfData(
   invoice: {
@@ -630,16 +740,19 @@ export async function getInvoicePdfData(
   const taxAmount = invoice.taxAmount ?? 0;
   const isInternational = payment?.isInternational ?? false;
 
-  // Separate credits from discounts using actual relation data
-  const creditsAppliedAmount = payment?.creditUsages?.reduce(
-    (sum, cu) => sum + cu.amount,
-    0,
-  ) ?? 0;
+  const creditsAppliedAmount =
+    payment?.creditUsages?.reduce((sum, cu) => sum + cu.amount, 0) ?? 0;
 
-  // Derive discount from the difference: originalAmount + tax - credits - finalAmount
-  const discountAmount = payment && payment.originalAmount > 0
-    ? Math.max(0, payment.originalAmount + taxAmount - creditsAppliedAmount - invoice.amount)
-    : 0;
+  const discountAmount =
+    payment && payment.originalAmount > 0
+      ? Math.max(
+          0,
+          payment.originalAmount +
+            taxAmount -
+            creditsAppliedAmount -
+            invoice.amount,
+        )
+      : 0;
 
   return {
     invoiceNumber: invoice.invoiceNumber,
@@ -661,7 +774,8 @@ export async function getInvoicePdfData(
     taxRate: invoice.taxRate ?? (isInternational ? 0 : TAX_CONSTANTS.GST_RATE),
     taxAmount,
     discountAmount: discountAmount > 0 ? discountAmount : undefined,
-    creditsApplied: creditsAppliedAmount > 0 ? creditsAppliedAmount : undefined,
+    creditsApplied:
+      creditsAppliedAmount > 0 ? creditsAppliedAmount : undefined,
     total: invoice.amount,
     currency: invoice.currency,
     isInternational,

--- a/lib/payments/payouts/invoice-pdf.tsx
+++ b/lib/payments/payouts/invoice-pdf.tsx
@@ -1,0 +1,664 @@
+/**
+ * Invoice PDF Generator
+ * Generates GST-compliant PDF invoices using @react-pdf/renderer
+ * Server-side only — used by the /api/invoices/[id]/pdf route
+ */
+
+import React from "react";
+import {
+  Document,
+  Page,
+  View,
+  Text,
+  StyleSheet,
+  renderToBuffer,
+} from "@react-pdf/renderer";
+import { TAX_CONSTANTS } from "./constants";
+import type { InvoiceItem } from "./invoice-service";
+
+// ============================================
+// Types
+// ============================================
+
+export interface InvoicePdfData {
+  invoiceNumber: string;
+  invoiceDate: Date;
+  dueDate?: Date;
+  paidAt?: Date;
+  status: string;
+
+  // Company (seller)
+  companyName: string;
+  companyAddress: string;
+  companyGstin?: string;
+
+  // Customer (buyer)
+  customerName: string;
+  customerEmail: string;
+  customerAddress?: string;
+  customerGstin?: string;
+
+  // Line items
+  items: InvoiceItem[];
+
+  // Amounts (in paise)
+  subtotal: number;
+  taxRate: number;
+  taxAmount: number;
+  discountAmount?: number;
+  creditsApplied?: number;
+  total: number;
+  currency: string;
+  isInternational: boolean;
+
+  // Service info
+  hsnCode: string;
+  paymentMethod?: string;
+  transactionId?: string;
+  notes?: string;
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+/** Convert paise to rupees formatted string */
+function formatAmount(paise: number, currency: string = "INR"): string {
+  const symbols: Record<string, string> = {
+    INR: "\u20B9",
+    USD: "$",
+    EUR: "\u20AC",
+    GBP: "\u00A3",
+  };
+  const symbol = symbols[currency] || currency + " ";
+  const amount = (paise / 100).toFixed(2);
+  return `${symbol}${amount}`;
+}
+
+/** Format date to DD/MM/YYYY */
+function formatDate(date: Date): string {
+  const d = new Date(date);
+  return `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}/${d.getFullYear()}`;
+}
+
+/** Convert number to words (Indian numbering) */
+function amountInWords(paise: number): string {
+  const rupees = Math.floor(paise / 100);
+  const paiseRemainder = paise % 100;
+
+  const ones = [
+    "",
+    "One",
+    "Two",
+    "Three",
+    "Four",
+    "Five",
+    "Six",
+    "Seven",
+    "Eight",
+    "Nine",
+    "Ten",
+    "Eleven",
+    "Twelve",
+    "Thirteen",
+    "Fourteen",
+    "Fifteen",
+    "Sixteen",
+    "Seventeen",
+    "Eighteen",
+    "Nineteen",
+  ];
+  const tens = [
+    "",
+    "",
+    "Twenty",
+    "Thirty",
+    "Forty",
+    "Fifty",
+    "Sixty",
+    "Seventy",
+    "Eighty",
+    "Ninety",
+  ];
+
+  function convertToWords(n: number): string {
+    if (n === 0) return "";
+    if (n < 20) return ones[n];
+    if (n < 100)
+      return tens[Math.floor(n / 10)] + (n % 10 ? " " + ones[n % 10] : "");
+    if (n < 1000)
+      return (
+        ones[Math.floor(n / 100)] +
+        " Hundred" +
+        (n % 100 ? " and " + convertToWords(n % 100) : "")
+      );
+    // Indian numbering: lakh (100,000), crore (10,000,000)
+    if (n < 100000)
+      return (
+        convertToWords(Math.floor(n / 1000)) +
+        " Thousand" +
+        (n % 1000 ? " " + convertToWords(n % 1000) : "")
+      );
+    if (n < 10000000)
+      return (
+        convertToWords(Math.floor(n / 100000)) +
+        " Lakh" +
+        (n % 100000 ? " " + convertToWords(n % 100000) : "")
+      );
+    return (
+      convertToWords(Math.floor(n / 10000000)) +
+      " Crore" +
+      (n % 10000000 ? " " + convertToWords(n % 10000000) : "")
+    );
+  }
+
+  let result = "Rupees " + (rupees === 0 ? "Zero" : convertToWords(rupees));
+  if (paiseRemainder > 0) {
+    result += " and " + convertToWords(paiseRemainder) + " Paise";
+  }
+  result += " Only";
+  return result;
+}
+
+// ============================================
+// Styles
+// ============================================
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 40,
+    fontSize: 10,
+    fontFamily: "Helvetica",
+    color: "#1a1a1a",
+  },
+  // Header
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 30,
+    borderBottom: "2px solid #2563EB",
+    paddingBottom: 15,
+  },
+  companyName: {
+    fontSize: 22,
+    fontFamily: "Helvetica-Bold",
+    color: "#2563EB",
+  },
+  companyDetails: {
+    fontSize: 8,
+    color: "#666",
+    marginTop: 4,
+  },
+  invoiceTitle: {
+    fontSize: 16,
+    fontFamily: "Helvetica-Bold",
+    textAlign: "right",
+    color: "#2563EB",
+  },
+  invoiceNumber: {
+    fontSize: 10,
+    textAlign: "right",
+    marginTop: 4,
+  },
+  // Status badge
+  statusBadge: {
+    marginTop: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 4,
+    alignSelf: "flex-end",
+    fontSize: 9,
+    fontFamily: "Helvetica-Bold",
+  },
+  statusPaid: {
+    backgroundColor: "#dcfce7",
+    color: "#166534",
+  },
+  statusPending: {
+    backgroundColor: "#fef3c7",
+    color: "#92400e",
+  },
+  // Info sections
+  infoRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 25,
+  },
+  infoBlock: {
+    width: "48%",
+  },
+  infoLabel: {
+    fontSize: 8,
+    color: "#666",
+    textTransform: "uppercase",
+    marginBottom: 4,
+    fontFamily: "Helvetica-Bold",
+  },
+  infoValue: {
+    fontSize: 10,
+    lineHeight: 1.5,
+  },
+  // Table
+  table: {
+    marginBottom: 20,
+  },
+  tableHeader: {
+    flexDirection: "row",
+    backgroundColor: "#f1f5f9",
+    padding: 8,
+    borderBottom: "1px solid #e2e8f0",
+    fontFamily: "Helvetica-Bold",
+    fontSize: 9,
+  },
+  tableRow: {
+    flexDirection: "row",
+    padding: 8,
+    borderBottom: "1px solid #f1f5f9",
+  },
+  colDescription: { width: "40%" },
+  colHsn: { width: "15%", textAlign: "center" },
+  colQty: { width: "10%", textAlign: "center" },
+  colRate: { width: "17.5%", textAlign: "right" },
+  colAmount: { width: "17.5%", textAlign: "right" },
+  // Totals
+  totalsContainer: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginBottom: 15,
+  },
+  totalsBlock: {
+    width: "45%",
+  },
+  totalRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  totalLabel: {
+    fontSize: 10,
+    color: "#666",
+  },
+  totalValue: {
+    fontSize: 10,
+    textAlign: "right",
+  },
+  grandTotalRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    backgroundColor: "#2563EB",
+    borderRadius: 4,
+    marginTop: 4,
+  },
+  grandTotalLabel: {
+    fontSize: 11,
+    fontFamily: "Helvetica-Bold",
+    color: "#ffffff",
+  },
+  grandTotalValue: {
+    fontSize: 11,
+    fontFamily: "Helvetica-Bold",
+    color: "#ffffff",
+    textAlign: "right",
+  },
+  // Amount in words
+  amountInWords: {
+    fontSize: 9,
+    fontStyle: "italic",
+    color: "#666",
+    marginBottom: 20,
+    textAlign: "right",
+  },
+  // Notes and footer
+  notesSection: {
+    marginTop: 10,
+    padding: 10,
+    backgroundColor: "#f8fafc",
+    borderRadius: 4,
+  },
+  notesTitle: {
+    fontSize: 9,
+    fontFamily: "Helvetica-Bold",
+    marginBottom: 4,
+  },
+  notesText: {
+    fontSize: 8,
+    color: "#666",
+    lineHeight: 1.5,
+  },
+  footer: {
+    position: "absolute",
+    bottom: 30,
+    left: 40,
+    right: 40,
+    borderTop: "1px solid #e2e8f0",
+    paddingTop: 10,
+    fontSize: 8,
+    color: "#999",
+    textAlign: "center",
+  },
+});
+
+// ============================================
+// PDF Document Component
+// ============================================
+
+function InvoiceDocument({ data }: { data: InvoicePdfData }) {
+  const halfGstRate = data.taxRate / 2;
+
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {/* Header */}
+        <View style={styles.header}>
+          <View>
+            <Text style={styles.companyName}>{data.companyName}</Text>
+            <Text style={styles.companyDetails}>{data.companyAddress}</Text>
+            {data.companyGstin && (
+              <Text style={styles.companyDetails}>
+                GSTIN: {data.companyGstin}
+              </Text>
+            )}
+          </View>
+          <View>
+            <Text style={styles.invoiceTitle}>
+              {data.isInternational ? "EXPORT INVOICE" : "TAX INVOICE"}
+            </Text>
+            <Text style={styles.invoiceNumber}>{data.invoiceNumber}</Text>
+            <View
+              style={[
+                styles.statusBadge,
+                data.status === "SUCCEEDED"
+                  ? styles.statusPaid
+                  : styles.statusPending,
+              ]}
+            >
+              <Text>
+                {data.status === "SUCCEEDED" ? "PAID" : data.status}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Invoice & Customer Info */}
+        <View style={styles.infoRow}>
+          <View style={styles.infoBlock}>
+            <Text style={styles.infoLabel}>Bill To</Text>
+            <Text style={styles.infoValue}>{data.customerName}</Text>
+            <Text style={styles.infoValue}>{data.customerEmail}</Text>
+            {data.customerAddress && (
+              <Text style={styles.infoValue}>{data.customerAddress}</Text>
+            )}
+            {data.customerGstin && (
+              <Text style={styles.infoValue}>
+                GSTIN: {data.customerGstin}
+              </Text>
+            )}
+          </View>
+          <View style={styles.infoBlock}>
+            <Text style={styles.infoLabel}>Invoice Details</Text>
+            <Text style={styles.infoValue}>
+              Date: {formatDate(data.invoiceDate)}
+            </Text>
+            {data.dueDate && (
+              <Text style={styles.infoValue}>
+                Due: {formatDate(data.dueDate)}
+              </Text>
+            )}
+            {data.paidAt && (
+              <Text style={styles.infoValue}>
+                Paid: {formatDate(data.paidAt)}
+              </Text>
+            )}
+            {data.transactionId && (
+              <Text style={styles.infoValue}>
+                Txn: {data.transactionId}
+              </Text>
+            )}
+            {data.paymentMethod && (
+              <Text style={styles.infoValue}>
+                Method: {data.paymentMethod}
+              </Text>
+            )}
+          </View>
+        </View>
+
+        {/* Items Table */}
+        <View style={styles.table}>
+          <View style={styles.tableHeader}>
+            <Text style={styles.colDescription}>Description</Text>
+            <Text style={styles.colHsn}>HSN/SAC</Text>
+            <Text style={styles.colQty}>Qty</Text>
+            <Text style={styles.colRate}>Unit Price</Text>
+            <Text style={styles.colAmount}>Amount</Text>
+          </View>
+          {data.items.map((item, index) => (
+            <View style={styles.tableRow} key={index}>
+              <Text style={styles.colDescription}>{item.description}</Text>
+              <Text style={styles.colHsn}>
+                {item.hsnCode || data.hsnCode}
+              </Text>
+              <Text style={styles.colQty}>{item.quantity}</Text>
+              <Text style={styles.colRate}>
+                {formatAmount(item.unitPrice, data.currency)}
+              </Text>
+              <Text style={styles.colAmount}>
+                {formatAmount(item.amount, data.currency)}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Totals */}
+        <View style={styles.totalsContainer}>
+          <View style={styles.totalsBlock}>
+            <View style={styles.totalRow}>
+              <Text style={styles.totalLabel}>Subtotal</Text>
+              <Text style={styles.totalValue}>
+                {formatAmount(data.subtotal, data.currency)}
+              </Text>
+            </View>
+
+            {data.isInternational ? (
+              <View style={styles.totalRow}>
+                <Text style={styles.totalLabel}>GST (Zero-rated export)</Text>
+                <Text style={styles.totalValue}>
+                  {formatAmount(0, data.currency)}
+                </Text>
+              </View>
+            ) : data.taxAmount > 0 ? (
+              <>
+                <View style={styles.totalRow}>
+                  <Text style={styles.totalLabel}>
+                    CGST ({halfGstRate}%)
+                  </Text>
+                  <Text style={styles.totalValue}>
+                    {formatAmount(
+                      Math.floor(data.taxAmount / 2),
+                      data.currency,
+                    )}
+                  </Text>
+                </View>
+                <View style={styles.totalRow}>
+                  <Text style={styles.totalLabel}>
+                    SGST ({halfGstRate}%)
+                  </Text>
+                  <Text style={styles.totalValue}>
+                    {formatAmount(
+                      Math.ceil(data.taxAmount / 2),
+                      data.currency,
+                    )}
+                  </Text>
+                </View>
+              </>
+            ) : null}
+
+            {data.discountAmount && data.discountAmount > 0 ? (
+              <View style={styles.totalRow}>
+                <Text style={styles.totalLabel}>Discount</Text>
+                <Text style={styles.totalValue}>
+                  -{formatAmount(data.discountAmount, data.currency)}
+                </Text>
+              </View>
+            ) : null}
+
+            {data.creditsApplied && data.creditsApplied > 0 ? (
+              <View style={styles.totalRow}>
+                <Text style={styles.totalLabel}>Referral Credits</Text>
+                <Text style={styles.totalValue}>
+                  -{formatAmount(data.creditsApplied, data.currency)}
+                </Text>
+              </View>
+            ) : null}
+
+            <View style={styles.grandTotalRow}>
+              <Text style={styles.grandTotalLabel}>Total</Text>
+              <Text style={styles.grandTotalValue}>
+                {formatAmount(data.total, data.currency)}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Amount in Words */}
+        {data.currency === "INR" && (
+          <Text style={styles.amountInWords}>
+            {amountInWords(data.total)}
+          </Text>
+        )}
+
+        {/* Notes */}
+        {data.notes && (
+          <View style={styles.notesSection}>
+            <Text style={styles.notesTitle}>Notes</Text>
+            <Text style={styles.notesText}>{data.notes}</Text>
+          </View>
+        )}
+
+        {data.isInternational && (
+          <View style={styles.notesSection}>
+            <Text style={styles.notesTitle}>Export Declaration</Text>
+            <Text style={styles.notesText}>
+              Export of services — Zero-rated supply under Section 16 of IGST
+              Act, 2017 read with Section 2(6) of IGST Act. Supply meant for
+              export on payment of IGST.
+            </Text>
+          </View>
+        )}
+
+        {/* Footer */}
+        <View style={styles.footer}>
+          <Text>
+            This is a computer-generated invoice and does not require a
+            signature.
+          </Text>
+          <Text style={{ marginTop: 2 }}>
+            Familiarise — Expert Services Marketplace | familiarise.com
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}
+
+// ============================================
+// PDF Generation
+// ============================================
+
+/**
+ * Generate a PDF buffer for an invoice
+ * Uses @react-pdf/renderer's server-side renderToBuffer
+ */
+export async function generateInvoicePdf(
+  data: InvoicePdfData,
+): Promise<Buffer> {
+  const buffer = await renderToBuffer(
+    <InvoiceDocument data={data} /> as React.ReactElement,
+  );
+  return Buffer.from(buffer);
+}
+
+/**
+ * Build InvoicePdfData from a database invoice record
+ */
+export async function getInvoicePdfData(
+  invoice: {
+    id: string;
+    invoiceNumber: string;
+    amount: number;
+    currency: string;
+    status: string;
+    items: unknown;
+    taxAmount: number | null;
+    taxRate: number | null;
+    hsnCode: string | null;
+    paidAt: Date | null;
+    dueDate: Date | null;
+    pdfUrl: string | null;
+    createdAt: Date;
+    payment: {
+      id: string;
+      paymentIntent: string | null;
+      paymentMethod: string;
+      originalAmount: number;
+      amount: number;
+      isInternational: boolean;
+      user: {
+        name: string | null;
+        email: string;
+      };
+    } | null;
+  },
+  companyInfo?: {
+    companyName?: string;
+    companyAddress?: string;
+    companyGstin?: string;
+  },
+): Promise<InvoicePdfData> {
+  const items = (invoice.items as InvoiceItem[]) || [];
+  const payment = invoice.payment;
+
+  const subtotal = items.reduce((sum, item) => sum + item.amount, 0);
+  const taxAmount = invoice.taxAmount ?? 0;
+  const isInternational = payment?.isInternational ?? false;
+
+  // Calculate credits/discount from difference between original and final
+  const creditsOrDiscount =
+    payment && payment.originalAmount > 0
+      ? payment.originalAmount + taxAmount - invoice.amount
+      : 0;
+
+  return {
+    invoiceNumber: invoice.invoiceNumber,
+    invoiceDate: invoice.createdAt,
+    dueDate: invoice.dueDate ?? undefined,
+    paidAt: invoice.paidAt ?? undefined,
+    status: invoice.status,
+
+    companyName: companyInfo?.companyName ?? "Familiarise",
+    companyAddress:
+      companyInfo?.companyAddress ?? "Expert Services Marketplace",
+    companyGstin: companyInfo?.companyGstin,
+
+    customerName: payment?.user.name ?? "Customer",
+    customerEmail: payment?.user.email ?? "",
+
+    items,
+    subtotal,
+    taxRate: invoice.taxRate ?? (isInternational ? 0 : TAX_CONSTANTS.GST_RATE),
+    taxAmount,
+    creditsApplied: creditsOrDiscount > 0 ? creditsOrDiscount : undefined,
+    total: invoice.amount,
+    currency: invoice.currency,
+    isInternational,
+
+    hsnCode: invoice.hsnCode ?? TAX_CONSTANTS.HSN_CODES.CONSULTING,
+    paymentMethod: payment?.paymentMethod,
+    transactionId: payment?.paymentIntent ?? undefined,
+    notes: isInternational
+      ? "Export of services \u2014 Zero-rated under IGST Act Section 2(6)"
+      : undefined,
+  };
+}

--- a/lib/payments/payouts/invoice-pdf.tsx
+++ b/lib/payments/payouts/invoice-pdf.tsx
@@ -609,6 +609,12 @@ export async function getInvoicePdfData(
         name: string | null;
         email: string;
       };
+      discountCode?: {
+        code: string;
+        discountType: string;
+        discountValue: number;
+      } | null;
+      creditUsages?: { amount: number }[];
     } | null;
   },
   companyInfo?: {
@@ -624,11 +630,16 @@ export async function getInvoicePdfData(
   const taxAmount = invoice.taxAmount ?? 0;
   const isInternational = payment?.isInternational ?? false;
 
-  // Calculate credits/discount from difference between original and final
-  const creditsOrDiscount =
-    payment && payment.originalAmount > 0
-      ? payment.originalAmount + taxAmount - invoice.amount
-      : 0;
+  // Separate credits from discounts using actual relation data
+  const creditsAppliedAmount = payment?.creditUsages?.reduce(
+    (sum, cu) => sum + cu.amount,
+    0,
+  ) ?? 0;
+
+  // Derive discount from the difference: originalAmount + tax - credits - finalAmount
+  const discountAmount = payment && payment.originalAmount > 0
+    ? Math.max(0, payment.originalAmount + taxAmount - creditsAppliedAmount - invoice.amount)
+    : 0;
 
   return {
     invoiceNumber: invoice.invoiceNumber,
@@ -649,7 +660,8 @@ export async function getInvoicePdfData(
     subtotal,
     taxRate: invoice.taxRate ?? (isInternational ? 0 : TAX_CONSTANTS.GST_RATE),
     taxAmount,
-    creditsApplied: creditsOrDiscount > 0 ? creditsOrDiscount : undefined,
+    discountAmount: discountAmount > 0 ? discountAmount : undefined,
+    creditsApplied: creditsAppliedAmount > 0 ? creditsAppliedAmount : undefined,
     total: invoice.amount,
     currency: invoice.currency,
     isInternational,

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -26,7 +26,10 @@ import {
   notifyPaymentFailed,
   notifyAppointmentBooked,
 } from "@/lib/novu";
-import { processQualifyingAction } from "@/lib/referrals/service";
+import {
+  processQualifyingAction,
+  processConsultantBookingReferral,
+} from "@/lib/referrals/service";
 import { addUserToEventChannel } from "@/actions/stream/chat/event-channel.action";
 import { createDirectMessageChannel } from "@/actions/stream/chat/channel.action";
 import { streamLogger } from "@/lib/stream-logger";
@@ -398,60 +401,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   // referral scenario where consultants never trigger qualification because they don't
   // make bookings, they receive them.
   try {
-    const paymentForConsultant = await prisma.payment.findUnique({
-      where: { id: paymentId },
-      include: {
-        appointment: {
-          include: {
-            consultation: {
-              include: {
-                consultationPlan: {
-                  select: { consultantProfile: { select: { userId: true } } },
-                },
-              },
-            },
-            subscription: {
-              include: {
-                subscriptionPlan: {
-                  select: { consultantProfile: { select: { userId: true } } },
-                },
-              },
-            },
-            webinar: {
-              select: {
-                webinarPlan: {
-                  select: { consultantProfile: { select: { userId: true } } },
-                },
-              },
-            },
-            class: {
-              select: {
-                classPlan: {
-                  select: { consultantProfile: { select: { userId: true } } },
-                },
-              },
-            },
-          },
-        },
-      },
-    });
-
-    const consultantUserId =
-      paymentForConsultant?.appointment?.consultation?.consultationPlan
-        ?.consultantProfile?.userId ||
-      paymentForConsultant?.appointment?.subscription?.subscriptionPlan
-        ?.consultantProfile?.userId ||
-      paymentForConsultant?.appointment?.webinar?.webinarPlan
-        ?.consultantProfile?.userId ||
-      paymentForConsultant?.appointment?.class?.classPlan?.consultantProfile
-        ?.userId;
-
-    if (consultantUserId && consultantUserId !== userId) {
-      await processQualifyingAction(
-        consultantUserId,
-        "first_paid_booking_received",
-      );
-    }
+    await processConsultantBookingReferral({ id: paymentId }, userId);
   } catch (consultantReferralError) {
     console.error(
       `⚠️ Failed to process consultant referral qualifying action:`,

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -382,13 +382,80 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
     );
   }
 
-  // --- Referral qualifying action (first paid booking triggers referrer reward) ---
+  // --- Referral qualifying action (first paid booking triggers both bonuses) ---
+  // FIX #437: Process for the buyer (consultee) — their first paid booking qualifies their referral
   try {
     await processQualifyingAction(userId, "first_paid_booking");
   } catch (referralError) {
     console.error(
       `⚠️ Failed to process referral qualifying action for user ${userId}:`,
       referralError,
+    );
+  }
+
+  // FIX #437: Also process for the consultant (service provider) — receiving their first
+  // paid booking qualifies their referral too. This fixes the broken Consultant→Consultant
+  // referral scenario where consultants never trigger qualification because they don't
+  // make bookings, they receive them.
+  try {
+    const paymentForConsultant = await prisma.payment.findUnique({
+      where: { id: paymentId },
+      include: {
+        appointment: {
+          include: {
+            consultation: {
+              include: {
+                consultationPlan: {
+                  select: { consultantProfile: { select: { userId: true } } },
+                },
+              },
+            },
+            subscription: {
+              include: {
+                subscriptionPlan: {
+                  select: { consultantProfile: { select: { userId: true } } },
+                },
+              },
+            },
+            webinar: {
+              select: {
+                webinarPlan: {
+                  select: { consultantProfile: { select: { userId: true } } },
+                },
+              },
+            },
+            class: {
+              select: {
+                classPlan: {
+                  select: { consultantProfile: { select: { userId: true } } },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const consultantUserId =
+      paymentForConsultant?.appointment?.consultation?.consultationPlan
+        ?.consultantProfile?.userId ||
+      paymentForConsultant?.appointment?.subscription?.subscriptionPlan
+        ?.consultantProfile?.userId ||
+      paymentForConsultant?.appointment?.webinar?.webinarPlan
+        ?.consultantProfile?.userId ||
+      paymentForConsultant?.appointment?.class?.classPlan?.consultantProfile
+        ?.userId;
+
+    if (consultantUserId && consultantUserId !== userId) {
+      await processQualifyingAction(
+        consultantUserId,
+        "first_paid_booking_received",
+      );
+    }
+  } catch (consultantReferralError) {
+    console.error(
+      `⚠️ Failed to process consultant referral qualifying action:`,
+      consultantReferralError,
     );
   }
 

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -172,24 +172,10 @@ export async function applyReferralCode(
           data: { totalReferrals: { increment: 1 } },
         });
 
-        // Give referee immediate welcome bonus
-        const refereeReward = ref.refereeRewardAmount;
-        if (refereeReward && refereeReward > 0) {
-          const expiresAt = new Date();
-          expiresAt.setMonth(expiresAt.getMonth() + CREDIT_EXPIRY_MONTHS);
-
-          await tx.referralCredit.create({
-            data: {
-              userId: newUserId,
-              amount: refereeReward,
-              currency: "INR",
-              source: "REFEREE_BONUS",
-              referralId: ref.id,
-              remainingAmount: refereeReward,
-              expiresAt,
-            },
-          });
-        }
+        // FIX #437: Referee bonus is NO LONGER given immediately on signup.
+        // Both referee (₹200) and referrer (₹500) bonuses are now deferred
+        // until the referred user's first paid booking via processQualifyingAction().
+        // This eliminates fake account farming (previously ₹200/account with zero revenue).
 
         return ref;
       },
@@ -244,6 +230,8 @@ export async function processQualifyingAction(
             qualifiedAt: new Date(),
             qualifyingAction: action,
             referrerRewardPaidAt: new Date(),
+            // FIX #437: Both bonuses awarded together on first paid booking
+            refereeRewardPaidAt: new Date(),
           },
         });
 
@@ -274,6 +262,27 @@ export async function processQualifyingAction(
             data: {
               successfulReferrals: { increment: 1 },
               totalEarned: { increment: referrerReward },
+            },
+          });
+        }
+
+        // FIX #437: Give referee their bonus (deferred from signup)
+        // Previously given immediately in applyReferralCode, now deferred to
+        // first paid booking to prevent fake account farming.
+        const refereeReward = referral.refereeRewardAmount;
+        if (refereeReward && refereeReward > 0) {
+          const expiresAt = new Date();
+          expiresAt.setMonth(expiresAt.getMonth() + CREDIT_EXPIRY_MONTHS);
+
+          await tx.referralCredit.create({
+            data: {
+              userId: referral.referredUserId,
+              amount: refereeReward,
+              currency: "INR",
+              source: "REFEREE_BONUS",
+              referralId: referral.id,
+              remainingAmount: refereeReward,
+              expiresAt,
             },
           });
         }

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -593,3 +593,72 @@ export async function expireStaleCredits(): Promise<number> {
 
   return result.count;
 }
+
+/**
+ * Process consultant referral qualifying action when they receive a paid booking.
+ * Looks up the consultant userId from the payment's appointment chain and triggers
+ * processQualifyingAction for "first_paid_booking_received".
+ *
+ * Used by both checkout.ts (mock/zero-amount) and handlers.ts (webhook-confirmed).
+ */
+export async function processConsultantBookingReferral(
+  paymentLookup: { id?: string; paymentIntent?: string },
+  buyerUserId: string,
+): Promise<void> {
+  const where = paymentLookup.id
+    ? { id: paymentLookup.id }
+    : { paymentIntent: paymentLookup.paymentIntent! };
+
+  const payment = await prisma.payment.findUnique({
+    where,
+    include: {
+      appointment: {
+        include: {
+          consultation: {
+            include: {
+              consultationPlan: {
+                select: { consultantProfile: { select: { userId: true } } },
+              },
+            },
+          },
+          subscription: {
+            include: {
+              subscriptionPlan: {
+                select: { consultantProfile: { select: { userId: true } } },
+              },
+            },
+          },
+          webinar: {
+            select: {
+              webinarPlan: {
+                select: { consultantProfile: { select: { userId: true } } },
+              },
+            },
+          },
+          class: {
+            select: {
+              classPlan: {
+                select: { consultantProfile: { select: { userId: true } } },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const consultantUserId =
+    payment?.appointment?.consultation?.consultationPlan?.consultantProfile
+      ?.userId ||
+    payment?.appointment?.subscription?.subscriptionPlan?.consultantProfile
+      ?.userId ||
+    payment?.appointment?.webinar?.webinarPlan?.consultantProfile?.userId ||
+    payment?.appointment?.class?.classPlan?.consultantProfile?.userId;
+
+  if (consultantUserId && consultantUserId !== buyerUserId) {
+    await processQualifyingAction(
+      consultantUserId,
+      "first_paid_booking_received",
+    );
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,6 +37,7 @@ const nextConfig = {
     "@prisma/adapter-pg",
     "pg-pool",
     "pg-connection-string",
+    "@react-pdf/renderer",
   ],
 
   images: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-email/components": "^1.0.6",
         "@react-email/render": "^2.0.4",
+        "@react-pdf/renderer": "^4.3.2",
         "@stream-io/node-sdk": "^0.7.36",
         "@stream-io/video-react-sdk": "^1.31.5",
         "@stripe/stripe-js": "^8.6.4",
@@ -5140,6 +5141,180 @@
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.4.tgz",
+      "integrity": "sha512-8YtgGtL511txIEc9AjiilpZ7yjid8uCd8OGUl6jaL3LIHnrToUupSN4IzsMQpVTCMYiDLFnDNQzpZsOYtRS/Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^4.1.0",
+        "@react-pdf/types": "^2.9.2",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.4.tgz",
+      "integrity": "sha512-z0ogVQE0bKqgXQ5smgzIU857rLV7bMgVdrYsu3UfXDDLSzI7QPvzf6MFTFllX6Dx2rcsF13E01dqKPtJEM799g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/png-js": "^3.0.0",
+        "jay-peg": "^1.1.1"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.2.tgz",
+      "integrity": "sha512-gNu2oh8MiGR+NJZYTJ4c4q0nWCESBI6rKFiodVhE7OeVAjtzZzd6l65wsN7HXdWJqOZD3ttD97iE+tf5SOd/Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/image": "^3.0.4",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.2",
+        "@react-pdf/textkit": "^6.1.0",
+        "@react-pdf/types": "^2.9.2",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.1.0.tgz",
+      "integrity": "sha512-Wm/IOAv0h/U5Ra94c/PltFJGcpTUd/fwVMVeFD6X9tTTPCttIwg0teRG1Lqq617J8K4W7jpL/B0HTH0mjp3QpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^3.0.0",
+        "browserify-zlib": "^0.2.0",
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "linebreak": "^1.1.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/png-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
+      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
+      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.2.tgz",
+      "integrity": "sha512-el5KYM1sH/PKcO4tRCIm8/AIEmhtraaONbwCrBhFdehoGv6JtgnXiMxHGAvZbI5kEg051GbyP+XIU6f6YbOu6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/textkit": "^6.1.0",
+        "@react-pdf/types": "^2.9.2",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^1.9.1",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.2.tgz",
+      "integrity": "sha512-EhPkj35gO9rXIyyx29W3j3axemvVY5RigMmlK4/6Ku0pXB8z9PEE/sz4ZBOShu2uot6V4xiCR3aG+t9IjJJlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/font": "^4.0.4",
+        "@react-pdf/layout": "^4.4.2",
+        "@react-pdf/pdfkit": "^4.1.0",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.3.2",
+        "@react-pdf/types": "^2.9.2",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.2.tgz",
+      "integrity": "sha512-E3ftGRYUQGKiN3JOgtGsLDo0hGekA6dmkmi/MYACytmPTKxQRBSO3126MebmCq+t1rgU9uRlREIEawJ+8nzSbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.2",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.1.0.tgz",
+      "integrity": "sha512-sFlzDC9CDFrJsnL3B/+NHrk9+Advqk7iJZIStiYQDdskbow8GF/AGYrpIk+vWSnh35YxaGbHkqXq53XOxnyrjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.2.tgz",
+      "integrity": "sha512-dufvpKId9OajLLbgn9q7VLUmyo1Jf+iyGk2ZHmCL8nIDtL8N1Ejh9TH7+pXXrR0tdie1nmnEb5Bz9U7g4hI4/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.4",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.2"
+      }
+    },
     "node_modules/@react-stately/flags": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
@@ -6611,6 +6786,12 @@
       "integrity": "sha512-iirJNv92A1ZWxoOHHDYW/1KPoi83939o83iUBQHIim0i3tMeSKEh+bxhJdTHQ86Mr4uXx9xGUTq69cp52ZP8Xw==",
       "license": "MIT"
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -7391,6 +7572,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7424,6 +7614,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -7804,6 +8012,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7864,8 +8081,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -7941,6 +8167,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -8280,6 +8512,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -8506,6 +8744,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -9098,6 +9342,15 @@
       "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9207,7 +9460,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9376,6 +9628,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/for-each": {
@@ -10006,6 +10275,21 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -10115,6 +10399,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/i18next": {
       "version": "25.7.4",
@@ -10252,7 +10542,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -10750,6 +11039,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -10931,6 +11226,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
       }
     },
     "node_modules/jest": {
@@ -12425,6 +12729,25 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -12961,6 +13284,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -13917,6 +14246,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
       }
     },
     "node_modules/npm": {
@@ -16138,6 +16476,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16194,6 +16538,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -16953,6 +17303,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -17449,6 +17808,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resend": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/resend/-/resend-6.8.0.tgz",
@@ -17519,6 +17887,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -17962,6 +18336,21 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -18297,6 +18686,15 @@
         "emoji-mart": {
           "optional": true
         }
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -18660,6 +19058,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/svix": {
       "version": "1.84.1",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
@@ -18924,6 +19328,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -19372,6 +19782,32 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -19739,6 +20175,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -20232,6 +20682,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zeptomatch": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-email/components": "^1.0.6",
     "@react-email/render": "^2.0.4",
+    "@react-pdf/renderer": "^4.3.2",
     "@stream-io/node-sdk": "^0.7.36",
     "@stream-io/video-react-sdk": "^1.31.5",
     "@stripe/stripe-js": "^8.6.4",

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -226,6 +226,7 @@ export const checkoutSuccessResponseSchema = z.object({
   message: z.string().optional(),
   skipPayment: z.boolean().optional(),
   isMockPayment: z.boolean().optional(), // Mock payment flag
+  isZeroAmountPayment: z.boolean().optional(), // Credits fully covered payment
   // Production flow fields
   paymentIntent: z
     .object({

--- a/schemas/webhooks/stripe.ts
+++ b/schemas/webhooks/stripe.ts
@@ -90,6 +90,38 @@ export const stripeSubscriptionCreatedEventSchema =
     }),
   });
 
+// Checkout Session schema (session.id is the cs_... stored in Payment.paymentIntent)
+const checkoutSessionSchema = z.object({
+  id: z.string(), // cs_... ID — matches Payment.paymentIntent
+  object: z.literal("checkout.session"),
+  payment_intent: z.string().nullable(), // pi_... ID — the underlying PaymentIntent
+  payment_status: z.string(), // "paid", "unpaid", "no_payment_required"
+  status: z.string(), // "complete", "expired", "open"
+  metadata: metadataSchema,
+  amount_total: z.number().nullable(),
+  currency: z.string().nullable(),
+});
+
+// FIX CF-3: Checkout Session Completed event
+// This is the correct event for Stripe Checkout Sessions.
+// The session.id (cs_...) is what we store in Payment.paymentIntent.
+export const stripeCheckoutSessionCompletedEventSchema =
+  stripeBaseEventSchema.extend({
+    type: z.literal("checkout.session.completed"),
+    data: z.object({
+      object: checkoutSessionSchema,
+    }),
+  });
+
+// Checkout Session Expired event (session timed out without payment)
+export const stripeCheckoutSessionExpiredEventSchema =
+  stripeBaseEventSchema.extend({
+    type: z.literal("checkout.session.expired"),
+    data: z.object({
+      object: checkoutSessionSchema,
+    }),
+  });
+
 export type StripePaymentIntentSucceededEvent = z.infer<
   typeof stripePaymentIntentSucceededEventSchema
 >;
@@ -101,4 +133,10 @@ export type StripeInvoicePaidEvent = z.infer<
 >;
 export type StripeSubscriptionCreatedEvent = z.infer<
   typeof stripeSubscriptionCreatedEventSchema
+>;
+export type StripeCheckoutSessionCompletedEvent = z.infer<
+  typeof stripeCheckoutSessionCompletedEventSchema
+>;
+export type StripeCheckoutSessionExpiredEvent = z.infer<
+  typeof stripeCheckoutSessionExpiredEventSchema
 >;


### PR DESCRIPTION
## Summary

- Fix zero-amount checkout crash when referral credits fully cover payment cost (#520)
- Fix Stripe webhook never confirming payments due to session/intent ID mismatch (CF-3 from #456)
- Harden referral system against gaming by deferring all bonuses to first paid booking (#437)
- Implement GST-compliant invoice PDF generation with download and storage (#438)
- Add diagnostic logging for intermittent slot validation failures (#520 Bug 2)

## Changes

### Zero-Amount Payment Bypass (#520 Bug 1)
When referral credits fully cover the checkout amount, the system now skips the payment gateway entirely (both Stripe and Razorpay reject amount=0). Instead, it creates a `free_...` payment record marked as `SUCCEEDED`, confirms the appointment immediately, and runs all post-processing (earnings, referral qualification, waitlist). Both `StripeCheckout` and `RazorpayCheckout` client components handle `isZeroAmountPayment` to show success without a gateway redirect.

### Stripe Webhook Fix (CF-3 from #456)
Added `checkout.session.completed` and `checkout.session.expired` handlers to the Stripe webhook route. The existing flow stored Checkout Session IDs (`cs_...`) in `Payment.paymentIntent`, but only handled `payment_intent.succeeded` events which carry PaymentIntent IDs (`pi_...`). The DB lookup would always fail silently. Existing `payment_intent.succeeded` handler is kept for backward compatibility with idempotency protection.

**NOTE:** Ensure `checkout.session.completed` and `checkout.session.expired` events are enabled in the Stripe Dashboard webhook endpoint settings.

### Referral Anti-Gaming (#437)
Referee bonus (₹200) is no longer given immediately on signup. Both referee and referrer bonuses are now awarded together when the referred user completes their first paid booking. This eliminates fake account farming (previously cost ₹200/fake account with zero revenue). Also adds consultant qualifying action (`first_paid_booking_received`) so Consultant→Consultant referrals work correctly — consultants who receive their first paid booking as a service provider now trigger referral qualification.

### Invoice PDF Generation (#438)
Implements full GST-compliant invoice PDF generation using `@react-pdf/renderer`:
- Server-side PDF rendering via `renderToBuffer()`
- New API endpoint: `GET /api/invoices/[id]/pdf`
- Branded template with line items, HSN/SAC codes, CGST/SGST breakdown
- International invoices show zero-rated export notes
- PDFs cached in Supabase Storage with signed URLs
- Download button wired up in consultee payments dashboard

### Slot Validation Diagnostics (#520 Bug 2)
Adds structured JSON logging around weekly slot availability checking. When validation fails, logs capture all candidate day/minutes, availability parameters, and UTC offset — enabling root cause analysis of the intermittent timezone edge case.

## Issues Audited & Confirmed Fixed (No Action Needed)
- #432 (earnings with credits) — already fixed
- #431 (tax mismatch) — fixed in PR #498
- #433 (currency units) — fixed in PRs #498/#500
- CF-1 (Stripe dispute auto-close) — already uses `disputes.update()`
- CF-2 (mock payment bypass) — already gated by `NODE_ENV === "development"`
- CF-6 (cancellation hard-delete) — already uses soft-cancel

## Test plan
- [ ] Zero-amount checkout: credits fully cover cost → appointment created, credits deducted, no gateway call
- [ ] Zero-amount checkout: credits partially cover cost → normal payment flow (unchanged)
- [ ] Zero-amount: consultant earnings created based on `originalAmount`, not 0
- [ ] Stripe webhook: `checkout.session.completed` → payment found by `cs_...` ID, marked SUCCEEDED
- [ ] Stripe webhook: duplicate event → idempotent no-op
- [ ] Stripe webhook: `checkout.session.expired` → payment marked FAILED
- [ ] Referral signup: user gets 0 credits on signup (no immediate bonus)
- [ ] Referral first booking: buyer makes first booking → both bonuses awarded (₹200 referee + ₹500 referrer)
- [ ] Consultant referral: consultant receives first paid booking → referral qualified
- [ ] Invoice PDF: `GET /api/invoices/{id}/pdf` returns valid PDF with correct GST layout
- [ ] Invoice PDF: international invoice shows "Zero-rated export" note, 0% GST
- [ ] Invoice PDF: subsequent requests serve cached PDF from Supabase Storage
- [ ] Invoice PDF: download button works in consultee payments dashboard
- [ ] Slot validation: diagnostic logs appear when validation fails in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)