### PR TITLE
ci: add lint summary to GitHub Actions job output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,12 +27,42 @@ jobs:
         run: npm ci
 
       - name: Prettier Check
-        run: npm run format:check
+        id: prettier
+        run: npm run format:check 2>&1 | tee /tmp/prettier.txt; exit ${PIPESTATUS[0]}
         continue-on-error: true
 
       - name: ESLint Check
-        run: npx eslint .
+        id: eslint
+        run: npx eslint . --format stylish 2>&1 | tee /tmp/eslint.txt; exit ${PIPESTATUS[0]}
         continue-on-error: true
+
+      - name: Lint Summary
+        if: always()
+        run: |
+          {
+            echo "## Lint Results"
+            echo ""
+
+            if [ "${{ steps.prettier.outcome }}" = "failure" ]; then
+              echo "### ❌ Prettier — formatting issues found"
+              echo '```'
+              cat /tmp/prettier.txt | head -50
+              echo '```'
+            else
+              echo "### ✅ Prettier — no formatting issues"
+            fi
+
+            echo ""
+
+            if [ "${{ steps.eslint.outcome }}" = "failure" ]; then
+              echo "### ⚠️ ESLint — errors/warnings found (non-blocking)"
+              echo '```'
+              cat /tmp/eslint.txt | head -100
+              echo '```'
+            else
+              echo "### ✅ ESLint — no issues"
+            fi
+          } >> $GITHUB_STEP_SUMMARY
 
   test-and-build:
     name: TypeScript, Tests & Build


### PR DESCRIPTION
## Summary
- Pipes Prettier and ESLint output to temp files during CI
- Writes a formatted markdown pass/fail report to `$GITHUB_STEP_SUMMARY`
- Both lint steps remain non-blocking (`continue-on-error: true`)
- Lint issues are now visible in the Actions UI job summary tab

## Test plan
- [ ] Trigger CI on a PR with a formatting issue — confirm ❌ Prettier section appears in job summary
- [ ] Trigger CI on clean code — confirm ✅ lines appear in job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)