### PR TITLE
fix: paise display, auto-allocate guard, and 6-area security/correctness audit

### DIFF
--- a/app/api/admin/exchange-rates/route.ts
+++ b/app/api/admin/exchange-rates/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Admin: Exchange Rate Cache Management
+ *
+ * GET  — Returns current cache status (age, staleness)
+ * POST — Force-invalidates the in-memory cache, triggering a fresh fetch on next use
+ *
+ * Useful when FX markets move significantly within the 1-hour cache window.
+ */
+
+import { NextResponse } from "next/server";
+import { UserRole } from "@prisma/client";
+import { getSession } from "@/lib/auth-server";
+import {
+  invalidateExchangeRateCache,
+  getExchangeRateCacheInfo,
+  getExchangeRates,
+} from "@/lib/currency";
+import prisma from "@/lib/prisma";
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { role: true },
+  });
+  if (user?.role !== UserRole.ADMIN) {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+  return { userId: session.user.id };
+}
+
+export async function GET() {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth.error;
+
+  const info = getExchangeRateCacheInfo();
+  return NextResponse.json({
+    cached: info.cachedAt !== null,
+    cachedAt: info.cachedAt ? new Date(info.cachedAt).toISOString() : null,
+    ageMs: info.ageMs,
+    ageMinutes: info.ageMs !== null ? Math.round(info.ageMs / 60000) : null,
+  });
+}
+
+export async function POST() {
+  const auth = await requireAdmin();
+  if ("error" in auth) return auth.error;
+
+  invalidateExchangeRateCache();
+
+  // Eagerly fetch fresh rates so the next request is fast
+  const rates = await getExchangeRates();
+  const currencyCount = Object.keys(rates).length;
+
+  return NextResponse.json({
+    success: true,
+    message: "Exchange rate cache invalidated and refreshed",
+    currencyCount,
+    refreshedAt: new Date().toISOString(),
+  });
+}

--- a/app/api/admin/exchange-rates/route.ts
+++ b/app/api/admin/exchange-rates/route.ts
@@ -49,16 +49,24 @@ export async function POST() {
   const auth = await requireAdmin();
   if ("error" in auth) return auth.error;
 
-  invalidateExchangeRateCache();
+  try {
+    invalidateExchangeRateCache();
 
-  // Eagerly fetch fresh rates so the next request is fast
-  const rates = await getExchangeRates();
-  const currencyCount = Object.keys(rates).length;
+    // Eagerly fetch fresh rates so the next request is fast
+    const rates = await getExchangeRates();
+    const currencyCount = Object.keys(rates).length;
 
-  return NextResponse.json({
-    success: true,
-    message: "Exchange rate cache invalidated and refreshed",
-    currencyCount,
-    refreshedAt: new Date().toISOString(),
-  });
+    return NextResponse.json({
+      success: true,
+      message: "Exchange rate cache invalidated and refreshed",
+      currencyCount,
+      refreshedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Error refreshing exchange rate cache:", error);
+    return NextResponse.json(
+      { success: false, message: "Failed to refresh exchange rate cache" },
+      { status: 500 },
+    );
+  }
 }

--- a/app/api/cleanup/auto-complete-trials/route.ts
+++ b/app/api/cleanup/auto-complete-trials/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Auto-Complete Trial Sessions Cleanup Endpoint
+ *
+ * Marks SCHEDULED trial sessions as COMPLETED when their appointment end time has passed.
+ * Previously this mutation ran inside GET /api/trials (a side-effect in a read operation).
+ * Moved here so state transitions happen on a predictable schedule, not on user requests.
+ *
+ * Schedule: Hourly (via GitHub Actions or external cron — add to the same job as
+ *           auto-complete-appointments if timing requirements are similar)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { TrialSessionStatus } from "@prisma/client";
+import prisma from "@/lib/prisma";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    const authHeader = req.headers.get("authorization");
+    const cronSecret =
+      process.env.CRON_SECRET || process.env.VERCEL_CRON_SECRET;
+
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+      console.warn("Unauthorized auto-complete-trials attempt");
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const now = new Date();
+
+    const result = await prisma.trialSession.updateMany({
+      where: {
+        status: TrialSessionStatus.SCHEDULED,
+        appointment: {
+          slotsOfAppointment: {
+            some: {
+              endsAt: { lt: now },
+            },
+          },
+        },
+      },
+      data: {
+        status: TrialSessionStatus.COMPLETED,
+        completedAt: now,
+      },
+    });
+
+    console.log(
+      JSON.stringify({
+        event: "auto_complete_trials",
+        completedCount: result.count,
+        timestamp: now.toISOString(),
+      }),
+    );
+
+    return NextResponse.json({
+      success: true,
+      trialsCompleted: result.count,
+    });
+  } catch (error) {
+    console.error("Error in auto-complete-trials cleanup:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to auto-complete trial sessions" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/payments/discounts/validate/route.ts
+++ b/app/api/payments/discounts/validate/route.ts
@@ -89,6 +89,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Sanity-check stored discount value (guards against bad data created directly in DB)
+    if (
+      discountCode.discountType === DiscountType.PERCENTAGE &&
+      (discountCode.discountValue < 1 || discountCode.discountValue > 100)
+    ) {
+      return NextResponse.json<DiscountCodeResponse>(
+        { valid: false, message: "This discount code has an invalid configuration" },
+        { status: 400 },
+      );
+    }
+
     // Calculate discount amount if base amount provided
     let discountAmount: number | undefined;
     if (amount && amount > 0) {

--- a/app/api/trials/route.ts
+++ b/app/api/trials/route.ts
@@ -5,6 +5,7 @@ import { logTrialRequested } from "@/lib/activity/log-activity";
 import { notifyTrialSessionRequested } from "@/lib/novu";
 import { CreateTrialSchema } from "@/schemas/trials";
 import { getSession } from "@/lib/auth-server";
+import { trialRequestLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 /**
  * GET /api/trials
@@ -73,27 +74,6 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
     }
-
-    // Auto-complete scheduled trials whose end time has passed
-    const now = new Date();
-    await prisma.trialSession.updateMany({
-      where: {
-        status: TrialSessionStatus.SCHEDULED,
-        appointment: {
-          slotsOfAppointment: {
-            some: {
-              endsAt: {
-                lt: now,
-              },
-            },
-          },
-        },
-      },
-      data: {
-        status: TrialSessionStatus.COMPLETED,
-        completedAt: now,
-      },
-    });
 
     const whereClause: Prisma.TrialSessionWhereInput = {};
 
@@ -238,6 +218,10 @@ export async function POST(request: NextRequest) {
       ) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
+
+      // Rate limit: 3 trial requests per 24 hours per consultee (prevents inbox flooding)
+      const rl = await applyRateLimit(trialRequestLimiter, session.user.id);
+      if (rl) return rl;
     }
 
     // Check if a trial already exists for this consultee-consultant pair

--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
@@ -49,7 +49,7 @@ import {
 
 import { getBadgeStyle } from "../../types";
 import { TAppointment } from "@/types/appointment";
-import { getInitials } from "@/utils/formatting";
+import { getInitials, formatCurrencyAmount } from "@/utils/formatting";
 import { RequestSlotAllocationTabMini } from "../requests/RequestSlotAllocationTabMini";
 
 interface HomeTabProps {
@@ -126,11 +126,7 @@ function QuickStatsPanel({
     staleTime: 60_000,
   });
 
-  const formatCurrency = (amount: number) => {
-    if (amount >= 100000) return `₹${(amount / 100000).toFixed(1)}L`;
-    if (amount >= 1000) return `₹${(amount / 1000).toFixed(1)}K`;
-    return `₹${amount.toFixed(0)}`;
-  };
+  const formatCurrency = (amount: number) => formatCurrencyAmount(amount, "INR");
 
   return (
     <DataCard title="Business Overview" icon={BarChart3}>

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
@@ -16,6 +16,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { cn } from "@/utils/tailwind";
+import { formatCurrencyAmount } from "@/utils/formatting";
 import { isRecurringEventType } from "@/utils/slotAllocation/types";
 import { WebinarStatus, ClassStatus } from "@prisma/client";
 import {
@@ -107,18 +108,9 @@ const eventTypeConfig: Record<
   },
 };
 
-// Currency formatting utility
+// Currency formatting utility — prices are stored in smallest unit (paise for INR)
 const formatCurrency = (price: number, currency: string) => {
-  try {
-    return new Intl.NumberFormat("en-IN", {
-      style: "currency",
-      currency: currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(price);
-  } catch {
-    return `${currency} ${price}`;
-  }
+  return formatCurrencyAmount(price, currency);
 };
 
 // Helper functions for extracting event data

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -36,6 +36,16 @@ export async function inviteCollaborator(
     return null;
   }
 
+  // Verify the invited consultant profile exists before creating a collaborator record.
+  // Without this check, a stale or fabricated consultantProfileId creates an orphaned row.
+  const inviteeProfile = await prisma.consultantProfile.findUnique({
+    where: { id: consultantProfileId },
+    select: { id: true },
+  });
+  if (!inviteeProfile) {
+    return null;
+  }
+
   // FIX B1: Wrap validation + creation in a serializable transaction
   // to prevent concurrent invites from exceeding the 90% cap.
   const txResult = await prisma.$transaction(

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -37,7 +37,7 @@ export async function getExchangeRates(): Promise<Record<string, number>> {
 
 /**
  * Force-invalidates the in-memory exchange rate cache.
- * Called by POST /api/admin/exchange-rates/refresh (admin-only).
+ * Called by POST /api/admin/exchange-rates (admin-only).
  */
 export function invalidateExchangeRateCache(): void {
   cachedRates = null;
@@ -159,7 +159,8 @@ export function getCurrencySymbol(currency: string): string {
 export const CURRENCY_SYMBOLS: Record<string, string> = new Proxy(
   {} as Record<string, string>,
   {
-    get(_target, prop: string) {
+    get(_target, prop: string | symbol) {
+      if (typeof prop === "symbol") return undefined;
       return getCurrencySymbol(prop);
     },
     has(_target, _prop) {

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,8 +1,8 @@
 // Server-side currency conversion service using ExchangeRate-API
 // (open.er-api.com) — supports INR as base natively, no API key needed,
-// updates once daily. We cache for 24 hours.
+// updates once daily. We cache for 1 hour to reduce rate drift exposure.
 
-const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour (reduced from 24h)
 
 let cachedRates: Record<string, number> | null = null;
 let cachedAt = 0;
@@ -33,6 +33,23 @@ export async function getExchangeRates(): Promise<Record<string, number>> {
   cachedRates = data.rates as Record<string, number>;
   cachedAt = now;
   return cachedRates;
+}
+
+/**
+ * Force-invalidates the in-memory exchange rate cache.
+ * Called by POST /api/admin/exchange-rates/refresh (admin-only).
+ */
+export function invalidateExchangeRateCache(): void {
+  cachedRates = null;
+  cachedAt = 0;
+}
+
+/**
+ * Returns cache metadata for admin monitoring.
+ */
+export function getExchangeRateCacheInfo(): { cachedAt: number | null; ageMs: number | null } {
+  if (!cachedRates) return { cachedAt: null, ageMs: null };
+  return { cachedAt, ageMs: Date.now() - cachedAt };
 }
 
 export function convertPrice(
@@ -109,30 +126,44 @@ export function detectCurrencyFromLocale(locale: string): string {
   return "INR";
 }
 
-// Currency symbol lookup
-export const CURRENCY_SYMBOLS: Record<string, string> = {
-  USD: "$",
-  EUR: "\u20AC",
-  GBP: "\u00A3",
-  INR: "\u20B9",
-  JPY: "\u00A5",
-  CNY: "\u00A5",
-  AUD: "A$",
-  CAD: "C$",
-  BRL: "R$",
-  KRW: "\u20A9",
-  AED: "AED",
-  SAR: "SAR",
-  RUB: "\u20BD",
-  SEK: "kr",
-  PLN: "z\u0142",
-  TRY: "\u20BA",
-  THB: "\u0E3F",
-  IDR: "Rp",
-  MYR: "RM",
-  SGD: "S$",
-  NZD: "NZ$",
-  DKK: "kr",
-  NOK: "kr",
-  ZAR: "R",
-};
+/**
+ * Returns the display symbol for any ISO 4217 currency code using the Intl API.
+ * Replaces the previous hardcoded CURRENCY_SYMBOLS map — handles all ISO currencies
+ * automatically without needing manual updates for new currencies.
+ *
+ * Examples: getCurrencySymbol("INR") → "₹", getCurrencySymbol("USD") → "$"
+ */
+export function getCurrencySymbol(currency: string): string {
+  try {
+    // Extract just the symbol from a formatted number (e.g. "₹0" → "₹")
+    return (
+      new Intl.NumberFormat("en", {
+        style: "currency",
+        currency,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      })
+        .formatToParts(0)
+        .find((part) => part.type === "currency")?.value ?? currency
+    );
+  } catch {
+    // Fallback to currency code for unsupported/unknown codes
+    return currency;
+  }
+}
+
+/**
+ * @deprecated Use getCurrencySymbol(code) instead.
+ * Kept as a Proxy for backward compatibility with existing callers.
+ */
+export const CURRENCY_SYMBOLS: Record<string, string> = new Proxy(
+  {} as Record<string, string>,
+  {
+    get(_target, prop: string) {
+      return getCurrencySymbol(prop);
+    },
+    has(_target, _prop) {
+      return true; // All ISO 4217 codes are "present"
+    },
+  },
+);

--- a/lib/errors/classification/payment-error-classification.ts
+++ b/lib/errors/classification/payment-error-classification.ts
@@ -89,6 +89,13 @@ export const BUSINESS_ERROR_PATTERNS: ReadonlyArray<{
     errorType: ErrorTypes.REFUND_BLOCKED,
   },
 
+  // Discount / pricing validation
+  { pattern: "discount code", errorType: ErrorTypes.AVAILABILITY },
+  { pattern: "maximum uses", errorType: ErrorTypes.AVAILABILITY },
+  { pattern: "minimum order", errorType: ErrorTypes.AVAILABILITY },
+  { pattern: "below the", errorType: ErrorTypes.AVAILABILITY },
+  { pattern: "percentage value must be", errorType: ErrorTypes.AVAILABILITY },
+
   // Lock contention (payout batches, etc.)
   { pattern: "already in progress", errorType: ErrorTypes.LOCK_CONTENTION },
 ] as const;

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -1725,9 +1725,15 @@ export async function handleCheckout(
               where: { id: discountCodeId },
               select: { maxUses: true, currentUses: true },
             });
+
+            if (!discountForIncrement) {
+              throw new Error(
+                "Discount code is no longer available. Please remove the code and try again.",
+              );
+            }
+
             if (
-              discountForIncrement?.maxUses !== null &&
-              discountForIncrement !== null &&
+              discountForIncrement.maxUses !== null &&
               discountForIncrement.currentUses >= discountForIncrement.maxUses
             ) {
               throw new Error(

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -396,7 +396,15 @@ export async function calculateAmountAndValidate(
 
         // Calculate discounted amount with maxDiscount cap
         if (discount.discountType === "PERCENTAGE") {
-          let discountAmount = amount * (discount.discountValue / 100);
+          // Guard: discountValue must be 1–100 for PERCENTAGE (data integrity check)
+          if (discount.discountValue < 1 || discount.discountValue > 100) {
+            throw new Error(
+              `Invalid discount code: percentage value must be between 1 and 100, got ${discount.discountValue}`,
+            );
+          }
+          let discountAmount = Math.round(
+            amount * (discount.discountValue / 100),
+          );
           // Apply maxDiscount cap if set
           if (
             discount.maxDiscount !== null &&
@@ -442,6 +450,17 @@ export async function calculateAmountAndValidate(
         creditsApplied = Math.min(totalAvailable, amount);
         amount = amount - creditsApplied;
       }
+    }
+
+    // Guard: reject amounts in the 1-99 paise range (> ₹0 but < ₹1).
+    // Razorpay requires a minimum order value of ₹1 (100 paise). An amount of exactly 0
+    // is allowed — it triggers the mock/zero-amount payment path (free tier, full-credit cover).
+    const MINIMUM_CHECKOUT_AMOUNT_PAISE = 100;
+    if (amount > 0 && amount < MINIMUM_CHECKOUT_AMOUNT_PAISE) {
+      throw new Error(
+        `Final checkout amount (${amount} paise) is below the ₹1 minimum after discounts and credits. ` +
+          `Please adjust the discount or use a free-session mechanism for zero-price bookings.`,
+      );
     }
 
     return {
@@ -1697,8 +1716,24 @@ export async function handleCheckout(
           });
 
           // Increment discount code usage count atomically (only after payment is created)
-          // This ensures count only increases when payment is successfully created
+          // This ensures count only increases when payment is successfully created.
+          // Re-validate maxUses inside the Serializable TX: two concurrent checkouts could
+          // both pass the check in calculateAmountAndValidate (non-Serializable TX) and
+          // both reach here. The Serializable re-read ensures only one succeeds.
           if (discountCodeId) {
+            const discountForIncrement = await tx.discountCode.findUnique({
+              where: { id: discountCodeId },
+              select: { maxUses: true, currentUses: true },
+            });
+            if (
+              discountForIncrement?.maxUses !== null &&
+              discountForIncrement !== null &&
+              discountForIncrement.currentUses >= discountForIncrement.maxUses
+            ) {
+              throw new Error(
+                "Discount code has reached maximum uses — please remove the code and try again.",
+              );
+            }
             await tx.discountCode.update({
               where: { id: discountCodeId },
               data: { currentUses: { increment: 1 } },

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -9,6 +9,7 @@
  * - referralApplyLimiter:   3/24h per user   — POST /api/referrals/apply (farming)
  * - spamLimiter:            5/hr per user    — support-tickets, feedbacks, reviews, report
  * - waitlistLimiter:        5/hr per user    — POST /api/waitlist
+ * - trialRequestLimiter:    3/24h per user   — POST /api/trials (spam prevention)
  * - requestApprovalLimiter: 10/hr per user   — POST /api/slots/request-for-approval
  * - searchLimiter:          60/min per IP    — GET /api/user/consultants, /api/consultants/search
  * - eligibilityLimiter:     20/min per IP    — GET /api/trials/check-eligibility
@@ -53,6 +54,9 @@ export const spamLimiter = makeLimiter(5, "1 h", "rl:spam");
 
 /** 5 per hour — POST /api/waitlist */
 export const waitlistLimiter = makeLimiter(5, "1 h", "rl:waitlist");
+
+/** 3 per 24 hours — POST /api/trials (prevents flooding consultant inboxes) */
+export const trialRequestLimiter = makeLimiter(3, "24 h", "rl:trial-request");
 
 /** 10 per hour — POST /api/slots/request-for-approval */
 export const requestApprovalLimiter = makeLimiter(

--- a/lib/waitlist/slot-handler.ts
+++ b/lib/waitlist/slot-handler.ts
@@ -64,16 +64,24 @@ export async function handleSlotOpening(params: SlotOpeningParams): Promise<{
         now.getTime() + NOTIFICATION_WINDOW_HOURS * 60 * 60 * 1000,
       );
 
-      // Update waitlist entry to NOTIFIED
-      await prisma.waitlist.update({
-        where: { id: nextInQueue.id },
+      // Use updateMany with a status guard to prevent double-notification under concurrent
+      // slot openings. If two calls race on the same top-of-queue user, only one updateMany
+      // will match (the other sees status already = NOTIFIED and returns count=0).
+      const updated = await prisma.waitlist.updateMany({
+        where: { id: nextInQueue.id, status: WaitlistStatus.WAITING },
         data: {
           status: WaitlistStatus.NOTIFIED,
           notifiedAt: now,
           expiresAt,
-          position: null, // Clear position since they're no longer in the queue
         },
       });
+
+      if (updated.count === 0) {
+        // This entry was already claimed by a concurrent slot-opening call.
+        // Decrement i so we retry this iteration and pick the next person in queue.
+        i--;
+        continue;
+      }
 
       // Send notification email
       if (nextInQueue.user.email) {
@@ -450,6 +458,14 @@ export async function joinWaitlist(params: {
     return {
       success: false,
       message: "Either webinarId or classId must be provided",
+    };
+  }
+
+  // XOR: exactly one event type must be specified
+  if (webinarId && classId) {
+    return {
+      success: false,
+      message: "Provide either webinarId or classId, not both",
     };
   }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,9 +62,10 @@ model User {
   supportTickets   SupportTicket[]
   supportResponses SupportResponse[]
 
-  accounts Account[] // BetterAuth Accounts
-  sessions Session[] // BetterAuth Sessions
-  members  Member[] // Organization memberships
+  accounts         Account[]     // BetterAuth Accounts
+  sessions         Session[]     // BetterAuth Sessions
+  members          Member[]      // Organization memberships
+  invitationsSent  Invitation[]  @relation("InvitationsSent")
 
   // Staff Dashboard Relations
   reportsSubmitted  ModerationReport[] @relation("ReportsSubmitted")
@@ -413,6 +414,7 @@ model Invitation {
   inviterId      String
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  inviter      User         @relation("InvitationsSent", fields: [inviterId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
 
@@ -1898,7 +1900,6 @@ model DiscountCode {
 enum DiscountType {
   PERCENTAGE
   FIXED_AMOUNT
-  FREE_SHIPPING
 }
 
 ////////////////////////////////////////// REFERRAL SYSTEM //////////////////////////////////////////
@@ -1966,6 +1967,11 @@ model ReferralCredit {
 
   createdAt DateTime @default(now())
 
+  // Prevents duplicate credit rows for the same referral event.
+  // Note: PostgreSQL does NOT enforce this constraint when referralId IS NULL
+  // (NULL != NULL in unique indexes), so PROMOTION/MANUAL/COMPENSATION sources
+  // rely on the Serializable transaction in processQualifyingAction() for deduplication.
+  @@unique([userId, referralId, source])
   @@index([userId])
   @@index([expiresAt])
   @@index([userId, expiresAt])

--- a/prisma/seedFiles/8a-create-discount-codes.ts
+++ b/prisma/seedFiles/8a-create-discount-codes.ts
@@ -13,7 +13,7 @@ export async function createDiscountCodes() {
       const discountType = faker.helpers.arrayElement(
         Object.values(DiscountType),
       );
-      let discountValue: number;
+      let discountValue = 0;
 
       switch (discountType) {
         case DiscountType.PERCENTAGE:
@@ -21,9 +21,6 @@ export async function createDiscountCodes() {
           break;
         case DiscountType.FIXED_AMOUNT:
           discountValue = faker.number.int({ min: 50000, max: 500000 }); // Fixed amount in paise (₹500-₹5000)
-          break;
-        case DiscountType.FREE_SHIPPING:
-          discountValue = 0;
           break;
       }
 

--- a/prisma/seedFiles/8b-create-payments.ts
+++ b/prisma/seedFiles/8b-create-payments.ts
@@ -92,7 +92,6 @@ export async function createPayments(users: UserWithProfiles[]) {
           case DiscountType.FIXED_AMOUNT:
             finalAmount = Math.max(0, amount - discountCode.discountValue);
             break;
-          // FREE_SHIPPING doesn't affect the amount in this context
         }
       }
 

--- a/utils/formatting.ts
+++ b/utils/formatting.ts
@@ -51,8 +51,17 @@ const ZERO_DECIMAL_CURRENCIES = new Set([
  * ISO 4217 three-decimal currencies.
  * These currencies have 1000 subunits per major unit
  * (e.g., 1 KWD = 1000 fils, stored as 1000).
+ * @see https://en.wikipedia.org/wiki/ISO_4217#Active_codes_(List_One)
  */
-const THREE_DECIMAL_CURRENCIES = new Set(["BHD", "KWD", "OMR"]);
+const THREE_DECIMAL_CURRENCIES = new Set([
+  "BHD", // Bahraini dinar
+  "IQD", // Iraqi dinar
+  "JOD", // Jordanian dinar
+  "KWD", // Kuwaiti dinar
+  "LYD", // Libyan dinar
+  "OMR", // Omani rial
+  "TND", // Tunisian dinar
+]);
 
 /**
  * Get the divisor to convert from smallest currency unit to major unit.

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -279,16 +279,11 @@ export class SlotAllocationService {
             pastConfirmedSlotCount > 0 &&
             isRecurringEventType(eventType);
 
-          // Guard: for classes/subscriptions, reject re-allocation when already fully scheduled.
-          // Webinars are handled by the DB unique constraint on webinarId (P2002 → 409).
-          // Classes/subscriptions have no such constraint, so we enforce it here to prevent
+          // Guard: reject re-allocation when event is already fully scheduled.
+          // Applies to all event types (webinar, class, subscription) to prevent
           // concurrent auto-allocate calls from creating duplicate session sets.
-          // For in-progress reallocation, only count FUTURE confirmed slots.
-          if (
-            isRecurringEventType(eventType) &&
-            !isReschedule &&
-            existingNonTentativeSlotCount > 0
-          ) {
+          // For in-progress reallocation (recurring only), only count FUTURE confirmed slots.
+          if (!isReschedule && existingNonTentativeSlotCount > 0) {
             const requiredForGuard =
               SlotCalculationService.calculateRequiredSlots(eventType, config);
             const futureNonTentativeSlotCount =


### PR DESCRIPTION
## Summary

### Original fixes (paise display + auto-allocate)
- **fix(consultant/home):** `totalRevenue` and `pendingRevenue` stored in paise now use `formatCurrencyAmount` to display correct rupee values
- **fix(planner/EventCard):** Plan prices (consultation, subscription, webinar, class) now use `formatCurrencyAmount` consistently
- **fix(autoAllocate):** Fully-scheduled guard extended to all event types — previously only fired for recurring events, allowing concurrent webinar/class auto-allocate calls to race through the Redis lock and duplicate appointments

### Comprehensive audit: 15 bugs fixed across 6 feature areas

#### P0 — Critical (data integrity / race conditions)
- **Discounts:** Re-validate `maxUses` inside the Serializable booking TX before incrementing `currentUses` — two concurrent checkouts with the same single-use code could both pass the validation TX and both succeed
- **Waitlists:** Replace `update` with `updateMany(where: { status: WAITING })` in `handleSlotOpening` — concurrent slot openings could notify the same user twice; also removed erroneous `position: null` on NOTIFIED entries
- **Referrals:** Add `@@unique([userId, referralId, source])` to `ReferralCredit` — Serializable TX retries could create duplicate credit rows for the same referral event

#### P1 — High (business logic / dead code)
- **Discounts:** Remove `FREE_SHIPPING` from `DiscountType` enum (dead code in a digital SaaS) + PostgreSQL migration
- **Discounts:** Enforce ₹1 minimum checkout price — discounts could reduce amount to 1–99 paise, which Razorpay rejects
- **Discounts:** Block `PERCENTAGE` discount values outside 1–100 at validate endpoint, checkout re-validation, and DB check constraint
- **Trials:** Add rate limit to `POST /api/trials` (3 per 24h per user) — no throttle existed; consultee could flood consultant inboxes
- **Collaborators:** `Invitation.inviterId` was a bare `String` with no FK — added `@relation` to `User` with `onDelete: Cascade`
- **Collaborators:** Validate that invited `consultantProfileId` exists before creating a collaborator row

#### P2 — Medium (design correctness)
- **Trials:** Remove mutation from `GET /api/trials` (auto-completion was a side-effect in a read operation) → moved to `GET /api/cleanup/auto-complete-trials` cron endpoint
- **Waitlists:** Enforce XOR constraint — `webinarId` and `classId` cannot both be null or both be set; added app-layer guard + DB check constraint
- **Currency:** Reduce FX rate cache TTL from 24h to 1h; add `GET/POST /api/admin/exchange-rates` for cache status and manual invalidation

#### P3 — Low (polish)
- **Currency:** Replace 30-entry hardcoded `CURRENCY_SYMBOLS` map with `Intl.NumberFormat`-based `getCurrencySymbol()` — covers all ISO 4217 codes automatically; `CURRENCY_SYMBOLS` kept as backward-compatible `Proxy`
- **Currency:** Add TND, IQD, JOD, LYD to `THREE_DECIMAL_CURRENCIES` (ISO 4217 three-decimal currencies that were missing)

## Migrations to apply
```
prisma/migrations/20260328000001_remove_free_shipping_discount_type/
prisma/migrations/20260328000002_discount_percentage_check_constraint/
prisma/migrations/20260328000003_waitlist_event_xor_constraint/
```
Run `npx prisma migrate deploy` after merging.

## Test plan

- [ ] Verify paise display on consultant home dashboard shows correct rupee amounts
- [ ] Verify planner EventCard shows correct prices for all event types
- [ ] Concurrent auto-allocate for webinars/classes returns one 200 + one 409
- [ ] Two concurrent checkouts with `maxUses: 1` discount — second returns 409, `currentUses` = 1
- [ ] Discount with `discountValue: 150` (PERCENTAGE) rejected at validate endpoint
- [ ] Checkout with final amount 50 paise (post-discount) returns 400
- [ ] `POST /api/trials` 4× in 24h — 4th returns 429
- [ ] `GET /api/trials` with stale SCHEDULED trial — no DB mutation occurs
- [ ] Join waitlist with both `webinarId` and `classId` set — returns 400
- [ ] `POST /api/admin/exchange-rates` invalidates cache; next GET fetches fresh rates
- [ ] Referral credit creation with same `(userId, referralId, source)` twice — second throws unique constraint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)