### PR TITLE
fix: quick-wins batch 1 — checkout params, activity logs, currency display, preferences

### DIFF
--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -315,8 +315,6 @@ export async function POST(
 
     return NextResponse.json(result);
   } catch (error) {
-    console.error("Error canceling appointment:", error);
-
     if (error instanceof Error && error.message === "Appointment not found") {
       return NextResponse.json(
         { error: "Appointment not found" },
@@ -324,6 +322,7 @@ export async function POST(
       );
     }
 
+    console.error("Error canceling appointment:", error);
     return NextResponse.json(
       { error: "Failed to cancel appointment" },
       { status: 500 },

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -270,7 +270,8 @@ export async function POST(
       });
     }
 
-    // Fire-and-forget: log cancellation activity for consultant dashboard
+    // Log cancellation activity for consultant dashboard (awaited — DB write
+    // that should not be dropped in serverless; logActivity swallows errors)
     const actor = {
       id: session.user.id,
       name: session.user.name || "User",
@@ -285,7 +286,7 @@ export async function POST(
       const cpId =
         appointment.consultation.consultationPlan?.consultantProfileId;
       if (cpId) {
-        void logConsultationCancelled(
+        await logConsultationCancelled(
           cpId,
           appointment.consultation.id,
           actor,
@@ -297,7 +298,7 @@ export async function POST(
       const cpId =
         appointment.subscription.subscriptionPlan?.consultantProfileId;
       if (cpId) {
-        void logSubscriptionCancelled(
+        await logSubscriptionCancelled(
           cpId,
           appointment.subscription.id,
           actor,

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -3,6 +3,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { CancellationReason } from "@prisma/client";
 import { notifyAppointmentCancelled } from "@/lib/novu";
 import { CancelAppointmentSchema } from "@/schemas/appointments";
+import {
+  logConsultationCancelled,
+  logSubscriptionCancelled,
+} from "@/lib/activity/log-activity";
 
 import { getSession } from "@/lib/auth-server";
 import { isPrivileged } from "@/lib/auth-helpers";
@@ -264,6 +268,43 @@ export async function POST(
             ? "consultant"
             : "consultee",
       });
+    }
+
+    // Fire-and-forget: log cancellation activity for consultant dashboard
+    const actor = {
+      id: session.user.id,
+      name: session.user.name || "User",
+      image: session.user.image,
+    };
+    const cancelledBy =
+      session.user.id === notificationMeta.consultantUserId
+        ? ("consultant" as const)
+        : ("consultee" as const);
+
+    if (appointment.consultation) {
+      const cpId =
+        appointment.consultation.consultationPlan?.consultantProfileId;
+      if (cpId) {
+        void logConsultationCancelled(
+          cpId,
+          appointment.consultation.id,
+          actor,
+          planTitle || "Consultation",
+          cancelledBy,
+        );
+      }
+    } else if (appointment.subscription) {
+      const cpId =
+        appointment.subscription.subscriptionPlan?.consultantProfileId;
+      if (cpId) {
+        void logSubscriptionCancelled(
+          cpId,
+          appointment.subscription.id,
+          actor,
+          planTitle || "Subscription",
+          cancelledBy,
+        );
+      }
     }
 
     // Note: This route cancels the entire event (sets parent to CANCELLED),

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -413,8 +413,6 @@ export async function POST(
 
     return NextResponse.json(result);
   } catch (error) {
-    console.error("Error requesting reschedule:", error);
-
     // Type-safe error handling using custom error classes
     if (error instanceof RescheduleAuthorizationError) {
       return NextResponse.json({ error: error.message }, { status: 403 });
@@ -432,6 +430,8 @@ export async function POST(
       return NextResponse.json({ error: error.message }, { status: 404 });
     }
 
+    // Only log unexpected errors — the known error types above are normal control flow
+    console.error("Error requesting reschedule:", error);
     return NextResponse.json(
       { error: "Failed to request reschedule" },
       { status: 500 },

--- a/app/api/events/subscriptions/[subscriptionId]/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/route.ts
@@ -731,10 +731,10 @@ export async function PATCH(
             });
           }
 
-          // Fire-and-forget: log cancellation activity for consultant dashboard
+          // Log cancellation activity (awaited — DB write should not be dropped in serverless)
           const cpId = subData.subscriptionPlan?.consultantProfileId;
           if (cpId) {
-            void logSubscriptionCancelled(
+            await logSubscriptionCancelled(
               cpId,
               subData.id,
               {

--- a/app/api/events/subscriptions/[subscriptionId]/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/route.ts
@@ -18,6 +18,7 @@ import {
   notifySubscriptionStarted,
   notifySubscriptionCancelled,
 } from "@/lib/novu";
+import { logSubscriptionCancelled } from "@/lib/activity/log-activity";
 import {
   UpdateSubscriptionSchema,
   PatchSubscriptionStatusSchema,
@@ -728,6 +729,24 @@ export async function PATCH(
               consulteeName: subData.requestedBy?.user?.name || undefined,
               dashboardUrl: "/dashboard",
             });
+          }
+
+          // Fire-and-forget: log cancellation activity for consultant dashboard
+          const cpId = subData.subscriptionPlan?.consultantProfileId;
+          if (cpId) {
+            void logSubscriptionCancelled(
+              cpId,
+              subData.id,
+              {
+                id: session.user.id,
+                name: session.user.name || "User",
+                image: session.user.image,
+              },
+              subData.subscriptionPlan?.title || "Subscription",
+              session.user.id === consultantUserId
+                ? "consultant"
+                : "consultee",
+            );
           }
         }
       }

--- a/app/api/events/subscriptions/route.ts
+++ b/app/api/events/subscriptions/route.ts
@@ -6,6 +6,7 @@ import {
   notifySubscriptionStarted,
   notifySubscriptionCancelled,
 } from "@/lib/novu";
+import { logSubscriptionCancelled } from "@/lib/activity/log-activity";
 import { UpdateSubscriptionStatusSchema } from "@/schemas/subscriptions";
 import {
   requireApiAuth,
@@ -281,6 +282,22 @@ export async function PATCH(request: NextRequest) {
             consulteeName: subscription.requestedBy?.user?.name || undefined,
             dashboardUrl: "/dashboard",
           });
+        }
+
+        // Fire-and-forget: log cancellation activity for consultant dashboard
+        const cpId = subscription.subscriptionPlan?.consultantProfileId;
+        if (cpId) {
+          void logSubscriptionCancelled(
+            cpId,
+            subscription.id,
+            {
+              id: session.user.id,
+              name: session.user.name || "User",
+              image: session.user.image,
+            },
+            subscription.subscriptionPlan?.title || "Subscription",
+            session.user.id === consultantUserId ? "consultant" : "consultee",
+          );
         }
       }
 

--- a/app/api/events/subscriptions/route.ts
+++ b/app/api/events/subscriptions/route.ts
@@ -284,10 +284,10 @@ export async function PATCH(request: NextRequest) {
           });
         }
 
-        // Fire-and-forget: log cancellation activity for consultant dashboard
+        // Log cancellation activity (awaited — DB write should not be dropped in serverless)
         const cpId = subscription.subscriptionPlan?.consultantProfileId;
         if (cpId) {
-          void logSubscriptionCancelled(
+          await logSubscriptionCancelled(
             cpId,
             subscription.id,
             {

--- a/app/api/user/cookie-preferences/route.ts
+++ b/app/api/user/cookie-preferences/route.ts
@@ -1,0 +1,86 @@
+import prisma from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/auth-helpers";
+import { z } from "zod";
+
+const UpdateCookiePreferencesSchema = z.object({
+  analytics: z.boolean(),
+  marketing: z.boolean(),
+});
+
+export async function GET() {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  try {
+    const prefs = await prisma.cookiePreference.findUnique({
+      where: { userId: session.user.id },
+    });
+
+    if (!prefs) {
+      return NextResponse.json(
+        { data: { essential: true, analytics: false, marketing: false } },
+        { status: 200 },
+      );
+    }
+
+    return NextResponse.json({
+      data: {
+        essential: prefs.essential,
+        analytics: prefs.analytics,
+        marketing: prefs.marketing,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching cookie preferences:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch cookie preferences" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  try {
+    const body = await request.json();
+    const result = UpdateCookiePreferencesSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: result.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const prefs = await prisma.cookiePreference.upsert({
+      where: { userId: session.user.id },
+      update: {
+        analytics: result.data.analytics,
+        marketing: result.data.marketing,
+      },
+      create: {
+        userId: session.user.id,
+        analytics: result.data.analytics,
+        marketing: result.data.marketing,
+      },
+    });
+
+    return NextResponse.json({
+      data: {
+        essential: prefs.essential,
+        analytics: prefs.analytics,
+        marketing: prefs.marketing,
+      },
+    });
+  } catch (error) {
+    console.error("Error updating cookie preferences:", error);
+    return NextResponse.json(
+      { error: "Failed to update cookie preferences" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/user/cookie-preferences/route.ts
+++ b/app/api/user/cookie-preferences/route.ts
@@ -46,8 +46,17 @@ export async function PUT(request: NextRequest) {
   if (authResult.error) return authResult.error;
   const { session } = authResult;
 
+  let body: unknown;
   try {
-    const body = await request.json();
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON in request body" },
+      { status: 400 },
+    );
+  }
+
+  try {
     const result = UpdateCookiePreferencesSchema.safeParse(body);
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/user/notification-preferences/route.ts
+++ b/app/api/user/notification-preferences/route.ts
@@ -56,8 +56,17 @@ export async function PUT(request: NextRequest) {
   if (authResult.error) return authResult.error;
   const { session } = authResult;
 
+  let body: unknown;
   try {
-    const body = await request.json();
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON in request body" },
+      { status: 400 },
+    );
+  }
+
+  try {
     const result = UpdateNotificationPreferencesSchema.safeParse(body);
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/user/notification-preferences/route.ts
+++ b/app/api/user/notification-preferences/route.ts
@@ -1,0 +1,101 @@
+import prisma from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+import { requireApiAuth } from "@/lib/auth-helpers";
+import { z } from "zod";
+
+const UpdateNotificationPreferencesSchema = z.object({
+  allNotifications: z.boolean(),
+  mentions: z.boolean(),
+  directMessages: z.boolean(),
+  updates: z.boolean(),
+});
+
+export async function GET() {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  try {
+    const prefs = await prisma.notificationPreference.findUnique({
+      where: { userId: session.user.id },
+    });
+
+    if (!prefs) {
+      return NextResponse.json(
+        {
+          data: {
+            allNotifications: true,
+            mentions: false,
+            directMessages: false,
+            updates: false,
+          },
+        },
+        { status: 200 },
+      );
+    }
+
+    return NextResponse.json({
+      data: {
+        allNotifications: prefs.allNotifications,
+        mentions: prefs.mentions,
+        directMessages: prefs.directMessages,
+        updates: prefs.updates,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching notification preferences:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch notification preferences" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const authResult = await requireApiAuth();
+  if (authResult.error) return authResult.error;
+  const { session } = authResult;
+
+  try {
+    const body = await request.json();
+    const result = UpdateNotificationPreferencesSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: result.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const prefs = await prisma.notificationPreference.upsert({
+      where: { userId: session.user.id },
+      update: {
+        allNotifications: result.data.allNotifications,
+        mentions: result.data.mentions,
+        directMessages: result.data.directMessages,
+        updates: result.data.updates,
+      },
+      create: {
+        userId: session.user.id,
+        allNotifications: result.data.allNotifications,
+        mentions: result.data.mentions,
+        directMessages: result.data.directMessages,
+        updates: result.data.updates,
+      },
+    });
+
+    return NextResponse.json({
+      data: {
+        allNotifications: prefs.allNotifications,
+        mentions: prefs.mentions,
+        directMessages: prefs.directMessages,
+        updates: prefs.updates,
+      },
+    });
+  } catch (error) {
+    console.error("Error updating notification preferences:", error);
+    return NextResponse.json(
+      { error: "Failed to update notification preferences" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/checkout/plans/class/[planId]/page.tsx
+++ b/app/checkout/plans/class/[planId]/page.tsx
@@ -9,11 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { useMaintenanceGuard } from "@/hooks/useMaintenanceGuard";
 import { useToast } from "@/hooks/use-toast";
 import { fetchReviews } from "@/lib/user";
-import {
-  createCheckoutData,
-  WebinarSearchParams,
-  webinarSearchParamsSchema,
-} from "@/schemas/checkout";
+import { SearchParams, searchParamsSchema, createCheckoutData } from "@/schemas/checkout";
 import { PaymentGateway } from "@prisma/client";
 import { CreditCard as CreditCardIcon } from "lucide-react";
 import { CompanyLogo } from "@/components/ui/company-logo";
@@ -29,25 +25,25 @@ import {
 } from "../../utils";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
-import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
 import type { AppliedDiscount } from "@/types/checkout";
+import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
 
 import type {
   Appointment,
+  ClassContent,
+  ClassPlan,
   ConsultantProfile,
   ConsultantReview,
   Domain,
+  Class as PrismaClass,
   Tag as PrismaTag,
   Topic as PrismaTopic,
-  Webinar as PrismaWebinar,
   SlotOfAppointment,
   SubDomain,
   User,
-  WebinarPlan,
 } from "@prisma/client";
 
-// Define a type for the fetched WebinarPlan data
-export type CheckoutWebinarPlanData = WebinarPlan & {
+export type CheckoutClassPlanData = ClassPlan & {
   consultantProfile:
     | (ConsultantProfile & {
         user: User & {
@@ -62,32 +58,30 @@ export type CheckoutWebinarPlanData = WebinarPlan & {
         tags: PrismaTag[];
       })
     | null;
-  webinars: (PrismaWebinar & {
-    appointment:
-      | (Appointment & {
-          slotsOfAppointment: SlotOfAppointment[];
-        })
-      | null;
+  classes: (PrismaClass & {
+    appointments: (Appointment & {
+      slotsOfAppointment: SlotOfAppointment[];
+    })[];
   })[];
   topics: PrismaTopic[];
-  type: "webinar";
+  classContents: ClassContent[];
+  type: "class";
   imageUrl: string;
 };
 
 type PlanResponse = {
-  data: CheckoutWebinarPlanData;
+  data: CheckoutClassPlanData;
 };
 
 type PageProps = {
-  params: Promise<{ webinarPlanId: string }>;
+  params: Promise<{ planId: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-export default function WebinarCheckoutPage({
+export default function ClassCheckoutPage({
   params,
   searchParams,
 }: Readonly<PageProps>) {
-  // Next.js 15 Synchronous params and searchParams
   const resolvedParams = use(params);
   const resolvedSearchParams = use(searchParams);
 
@@ -118,10 +112,18 @@ export default function WebinarCheckoutPage({
   } = useMaintenanceGuard();
 
   // Validate search params once with Zod — single source of truth for all checkout flows
-  const validatedSearchParams = useMemo((): WebinarSearchParams | null => {
-    const result = webinarSearchParamsSchema.safeParse(resolvedSearchParams);
+  const validatedSearchParams = useMemo((): SearchParams | null => {
+    const result = searchParamsSchema.safeParse(resolvedSearchParams);
     return result.success ? result.data : null;
   }, [resolvedSearchParams]);
+
+  // Derive the first available class ID — used by both component renders and handleCheckout
+  const availableClassId = useMemo(() => {
+    const availableClass = planData?.data?.classes?.find(
+      (c) => c.status === "SCHEDULED" || c.status === "IN_PROGRESS",
+    );
+    return availableClass?.id ?? null;
+  }, [planData]);
 
   // Apply discount code
   const handleApplyDiscount = async (code?: string) => {
@@ -188,9 +190,8 @@ export default function WebinarCheckoutPage({
     fetchCredits();
   }, []);
 
-  // Create utility functions using the toast instance
   const handleApiError = createHandleApiError(toast);
-  const handleCheckoutSuccess = createHandleCheckoutSuccess(toast, "WEBINAR");
+  const handleCheckoutSuccess = createHandleCheckoutSuccess(toast, "CLASS");
   const stripeHandlers = createStripeCheckoutHandlers(toast);
   const razorpayHandlers = createRazorpayCheckoutHandlers(toast);
 
@@ -207,57 +208,45 @@ export default function WebinarCheckoutPage({
         return;
       }
 
-      // Prevent double-clicks: ref provides synchronous guard (React state is async)
       if (isProcessingRef.current || isCheckoutProcessing) {
         return;
       }
       isProcessingRef.current = true;
 
       try {
-        // Set loading state
         setIsCheckoutProcessing(true);
         setProcessingGateway(`${gateway}-${isMockPayment ? "mock" : "real"}`);
 
-        // Use pre-validated search params
         if (!validatedSearchParams) {
-          throw new Error("Invalid webinar parameters");
+          throw new Error("Invalid class parameters");
         }
 
         if (!planData?.data?.id) {
-          throw new Error("Webinar plan not found");
+          throw new Error("Class plan not found");
         }
 
-        // Staleness check: validate the target webinar is still available
-        const targetWebinar = planData.data.webinars?.find(
-          (w) => w.id === validatedSearchParams.eventId,
-        );
-        if (!targetWebinar) {
-          throw new Error("Webinar session not found.");
-        }
-        if (targetWebinar.status === "COMPLETED") {
-          throw new Error("This webinar has already ended.");
-        }
-        if (targetWebinar.status === "CANCELLED") {
-          throw new Error("This webinar has been cancelled.");
+        if (!availableClassId) {
+          throw new Error(
+            "No available class sessions. All sessions may be full, cancelled, or completed.",
+          );
         }
 
-        // fromWaitlist is not in webinarSearchParamsSchema — read from raw params
+        // fromWaitlist is not in searchParamsSchema — read from raw params
         const fromWaitlist =
           typeof resolvedSearchParams.fromWaitlist === "string"
             ? resolvedSearchParams.fromWaitlist
             : undefined;
         const checkoutData = createCheckoutData({
-          appointmentType: "WEBINAR",
+          appointmentType: "CLASS",
           planId: planData.data.id,
-          eventId: validatedSearchParams.eventId,
+          eventId: availableClassId,
           discountCode: appliedDiscount?.code,
-          paymentGateway: gateway,
           displayCurrency: currency,
+          paymentGateway: gateway,
           fromWaitlist,
           useReferralCredits,
         });
 
-        // Handle unified checkout flow using the utility
         await handleUnifiedCheckout(
           checkoutData,
           gateway,
@@ -269,17 +258,17 @@ export default function WebinarCheckoutPage({
         console.error("Checkout error:", error);
         if (error instanceof Error) {
           // Provide more informative error messages based on the error type
-          let errorTitle = "Unable to Complete Registration";
+          let errorTitle = "Unable to Complete Enrollment";
           let errorDescription = error.message;
 
-          if (error.message.includes("Invalid webinar parameters")) {
-            errorTitle = "Registration Link Error";
+          if (error.message.includes("Invalid class parameters")) {
+            errorTitle = "Enrollment Link Error";
             errorDescription =
-              "The registration information is incomplete. Please go back to the webinar page and click 'Register Now' again to ensure all required information is included.";
-          } else if (error.message.includes("Webinar plan not found")) {
-            errorTitle = "Webinar Not Found";
+              "The enrollment information is incomplete. Please go back to the class page and click 'Enroll Now' again to ensure all required information is included.";
+          } else if (error.message.includes("Class plan not found")) {
+            errorTitle = "Class Not Found";
             errorDescription =
-              "This webinar could not be found or may no longer be available. Please go back and select a different webinar, or contact support if you believe this is an error.";
+              "This class could not be found or may no longer be available. Please go back and select a different class, or contact support if you believe this is an error.";
           } else if (
             error.message.includes("network") ||
             error.message.includes("fetch")
@@ -298,9 +287,9 @@ export default function WebinarCheckoutPage({
           });
         }
       } finally {
-        isProcessingRef.current = false;
         setIsCheckoutProcessing(false);
         setProcessingGateway(null);
+        isProcessingRef.current = false;
       }
     },
     [
@@ -309,6 +298,7 @@ export default function WebinarCheckoutPage({
       maintenanceBlockReason,
       resolvedSearchParams,
       planData?.data?.id,
+      resolvedParams.planId,
       handleApiError,
       handleCheckoutSuccess,
       toast,
@@ -321,7 +311,7 @@ export default function WebinarCheckoutPage({
     async function fetchPlanData() {
       setIsLoading(true);
       try {
-        const endpoint = `/api/plans/webinars/${resolvedParams.webinarPlanId}`;
+        const endpoint = `/api/plans/classes/${resolvedParams.planId}`;
 
         const response = await fetch(endpoint);
         if (!response.ok) {
@@ -336,7 +326,6 @@ export default function WebinarCheckoutPage({
 
         setPlanData(data);
 
-        // Fetch reviews for the consultant
         const reviewsData = await fetchReviews(
           data.data.consultantProfile?.id ?? "",
         );
@@ -354,7 +343,7 @@ export default function WebinarCheckoutPage({
     }
 
     fetchPlanData();
-  }, [resolvedParams.webinarPlanId]);
+  }, [resolvedParams.planId]);
 
   // Calculate pricing using the proper math functions
   // NOTE: This must be before early returns to maintain consistent hook order
@@ -387,44 +376,25 @@ export default function WebinarCheckoutPage({
     checkoutTaxContext.isInternational,
   ]);
 
-  // Periodic staleness check: detect if webinar has ended or been cancelled
+  // Periodic staleness check: detect if all class sessions have ended or been cancelled
   useEffect(() => {
-    if (!planData?.data?.webinars) return;
-
-    const eventId =
-      typeof resolvedSearchParams.eventId === "string"
-        ? resolvedSearchParams.eventId
-        : undefined;
+    if (!planData?.data?.classes) return;
 
     const checkStaleness = () => {
-      const targetWebinar = eventId
-        ? planData.data.webinars.find((w) => w.id === eventId)
-        : planData.data.webinars[0];
-
-      if (!targetWebinar) return;
-
-      if (targetWebinar.status === "COMPLETED") {
-        setError("This webinar has already ended.");
-      } else if (targetWebinar.status === "CANCELLED") {
-        setError("This webinar has been cancelled.");
-      } else if (targetWebinar.appointment?.slotsOfAppointment?.[0]) {
-        const firstSlotEnd = new Date(
-          targetWebinar.appointment.slotsOfAppointment[
-            targetWebinar.appointment.slotsOfAppointment.length - 1
-          ].endsAt,
+      const hasAvailable = planData.data.classes.some(
+        (c) => c.status === "SCHEDULED" || c.status === "IN_PROGRESS",
+      );
+      if (!hasAvailable) {
+        setError(
+          "No available class sessions. All sessions may be full, cancelled, or completed.",
         );
-        if (firstSlotEnd.getTime() < Date.now()) {
-          setError(
-            "This webinar session has already ended. Please go back.",
-          );
-        }
       }
     };
 
     checkStaleness();
     const intervalId = setInterval(checkStaleness, 60_000);
     return () => clearInterval(intervalId);
-  }, [planData, resolvedSearchParams.eventId]);
+  }, [planData]);
 
   if (isLoading) {
     return (
@@ -473,13 +443,13 @@ export default function WebinarCheckoutPage({
   const consultantDetails = planDetails?.consultantProfile;
   const userDetails = consultantDetails?.user;
 
-  const nextSession =
-    planDetails?.webinars?.[0]?.appointment?.slotsOfAppointment?.[0];
+  const nextClassSession =
+    planDetails?.classes?.[0]?.appointments?.[0]?.slotsOfAppointment?.[0];
 
   if (!planData || !planDetails || !consultantDetails || !userDetails) {
     return (
       <div className="flex items-center justify-center h-screen">
-        <p>Essential webinar data is missing. Please try again later.</p>
+        <p>Essential class data is missing. Please try again later.</p>
       </div>
     );
   }
@@ -512,7 +482,7 @@ export default function WebinarCheckoutPage({
                   <div className="flex items-center gap-1.5 mt-1">
                     {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
                       <CompanyLogo
-                        key={`checkout-webinar-company-${i}`}
+                        key={`checkout-class-company-${i}`}
                         companyName={exp.company}
                         companyDomain={exp.companyDomain ?? undefined}
                         size={20}
@@ -524,22 +494,22 @@ export default function WebinarCheckoutPage({
             </div>
           </div>
           <div className="text-right">
-            <div className="font-semibold">Webinar</div>
+            <div className="font-semibold">Class</div>
             <div className="text-sm text-muted-foreground">
-              {planDetails?.title || "Online Session"}
+              {planDetails?.title || "Online Class"}
             </div>
           </div>
         </div>
         <Separator className="bg-zinc-200" />
         <div className="grid gap-2">
-          <div className="font-semibold">Webinar Details</div>
+          <div className="font-semibold">Class Details</div>
           <div className="grid gap-2">
-            {nextSession && (
+            {nextClassSession && (
               <>
                 <div className="flex items-center justify-between">
-                  <div className="text-muted-foreground">Date</div>
+                  <div className="text-muted-foreground">First Session</div>
                   <div>
-                    {new Date(nextSession.startsAt).toLocaleDateString(
+                    {new Date(nextClassSession.startsAt).toLocaleDateString(
                       undefined,
                       {
                         weekday: "long",
@@ -553,8 +523,8 @@ export default function WebinarCheckoutPage({
                 <div className="flex items-center justify-between">
                   <div className="text-muted-foreground">Time</div>
                   <div>
-                    {new Date(nextSession.startsAt).toLocaleTimeString()} -{" "}
-                    {new Date(nextSession.endsAt).toLocaleTimeString()} (
+                    {new Date(nextClassSession.startsAt).toLocaleTimeString()} -{" "}
+                    {new Date(nextClassSession.endsAt).toLocaleTimeString()} (
                     {Intl.DateTimeFormat().resolvedOptions().timeZone})
                   </div>
                 </div>
@@ -562,7 +532,17 @@ export default function WebinarCheckoutPage({
             )}
             <div className="flex items-center justify-between">
               <div className="text-muted-foreground">Duration</div>
-              <div>{planDetails?.durationInHours || 1} hours</div>
+              <div>
+                {planDetails?.durationInMonths} month
+                {planDetails?.durationInMonths !== 1 ? "s" : ""} (
+                {planDetails?.totalSessions ||
+                  planDetails?.durationInMonths * 4}{" "}
+                sessions)
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="text-muted-foreground">Sessions per Week</div>
+              <div>{planDetails?.meetingsPerWeek || 2}</div>
             </div>
             <div className="flex items-center justify-between">
               <div className="text-muted-foreground">Max Participants</div>
@@ -636,17 +616,17 @@ export default function WebinarCheckoutPage({
           <div className="grid gap-2">
             <div className="flex items-center justify-between">
               <div>
-                <div className="font-medium">WEBINAR10</div>
+                <div className="font-medium">CLASS15</div>
                 <div className="text-sm text-muted-foreground">
-                  Get 10% off your webinar registration
+                  Get 15% off your class enrollment
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <div className="text-muted-foreground">10% off</div>
+                <div className="text-muted-foreground">15% off</div>
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => handleApplyDiscount("WEBINAR10")}
+                  onClick={() => handleApplyDiscount("CLASS15")}
                   disabled={isApplyingDiscount || !!appliedDiscount}
                 >
                   Apply
@@ -687,12 +667,12 @@ export default function WebinarCheckoutPage({
       <div className="flex flex-col gap-8 p-8 bg-white">
         <Card className="border-zinc-200 shadow-sm">
           <CardHeader>
-            <CardTitle className="text-zinc-900">Webinar Pricing</CardTitle>
+            <CardTitle className="text-zinc-900">Class Pricing</CardTitle>
           </CardHeader>
           <CardContent className="grid gap-4">
             <div className="grid gap-2">
               <div className="flex items-center justify-between">
-                <div>Registration Fee</div>
+                <div>Enrollment Fee</div>
                 <div>{formatPrice(planDetails?.price || 0)}</div>
               </div>
               <div className="flex items-center justify-between">
@@ -701,10 +681,23 @@ export default function WebinarCheckoutPage({
                 </div>
                 <div className="font-semibold">
                   <ul className="list-disc">
-                    <li>Live webinar access</li>
-                    <li>Q&A session</li>
-                    <li>Recording access</li>
-                    <li>Certificate of attendance</li>
+                    <li>
+                      {planDetails?.totalSessions ||
+                        (planDetails?.meetingsPerWeek || 2) *
+                          (planDetails?.durationInMonths || 1) *
+                          4}{" "}
+                      total sessions (
+                      {planDetails?.totalHours ||
+                        (planDetails?.meetingsPerWeek || 2) *
+                          (planDetails?.durationInMonths || 1) *
+                          4}{" "}
+                      hours)
+                    </li>
+                    <li>
+                      {planDetails?.meetingsPerWeek || 2} sessions per week
+                    </li>
+                    <li>Course materials</li>
+                    <li>Certificate of completion</li>
                   </ul>
                 </div>
               </div>
@@ -783,12 +776,12 @@ export default function WebinarCheckoutPage({
                   </div>
                   {gateway.isActive ? (
                     <div className="flex gap-2">
-                      {validatedSearchParams && gateway.gateway === "RAZORPAY" ? (
+                      {availableClassId && gateway.gateway === "RAZORPAY" ? (
                         <RazorpayCheckout
                           checkoutData={createCheckoutData({
-                            appointmentType: "WEBINAR",
+                            appointmentType: "CLASS",
                             planId: planDetails.id,
-                            eventId: validatedSearchParams.eventId,
+                            eventId: availableClassId,
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
                             displayCurrency: currency,
@@ -798,12 +791,12 @@ export default function WebinarCheckoutPage({
                           onPaymentError={razorpayHandlers.onPaymentError}
                           disabled={isMaintenanceBlocked}
                         />
-                      ) : validatedSearchParams && gateway.gateway === "STRIPE" ? (
+                      ) : availableClassId && gateway.gateway === "STRIPE" ? (
                         <StripeCheckout
                           checkoutData={createCheckoutData({
-                            appointmentType: "WEBINAR",
+                            appointmentType: "CLASS",
                             planId: planDetails.id,
-                            eventId: validatedSearchParams.eventId,
+                            eventId: availableClassId,
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
                             displayCurrency: currency,

--- a/app/checkout/plans/math.ts
+++ b/app/checkout/plans/math.ts
@@ -15,7 +15,7 @@ export interface PricingConfig {
   isInternational?: boolean; // If true, zero-rate tax (export of services)
   discountPercent?: number; // Applied discount percentage (0.10 = 10%)
   discountAmount?: number; // Fixed discount amount
-  creditsApplied?: number; // Referral credits applied (in major currency unit)
+  creditsApplied?: number; // Referral credits applied (same unit as baseAmount, typically paise)
 }
 
 export interface PricingBreakdown {

--- a/app/checkout/plans/webinar/[planId]/page.tsx
+++ b/app/checkout/plans/webinar/[planId]/page.tsx
@@ -9,7 +9,11 @@ import { Switch } from "@/components/ui/switch";
 import { useMaintenanceGuard } from "@/hooks/useMaintenanceGuard";
 import { useToast } from "@/hooks/use-toast";
 import { fetchReviews } from "@/lib/user";
-import { SearchParams, searchParamsSchema, createCheckoutData } from "@/schemas/checkout";
+import {
+  createCheckoutData,
+  WebinarSearchParams,
+  webinarSearchParamsSchema,
+} from "@/schemas/checkout";
 import { PaymentGateway } from "@prisma/client";
 import { CreditCard as CreditCardIcon } from "lucide-react";
 import { CompanyLogo } from "@/components/ui/company-logo";
@@ -25,25 +29,25 @@ import {
 } from "../../utils";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
-import type { AppliedDiscount } from "@/types/checkout";
 import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
+import type { AppliedDiscount } from "@/types/checkout";
 
 import type {
   Appointment,
-  ClassContent,
-  ClassPlan,
   ConsultantProfile,
   ConsultantReview,
   Domain,
-  Class as PrismaClass,
   Tag as PrismaTag,
   Topic as PrismaTopic,
+  Webinar as PrismaWebinar,
   SlotOfAppointment,
   SubDomain,
   User,
+  WebinarPlan,
 } from "@prisma/client";
 
-export type CheckoutClassPlanData = ClassPlan & {
+// Define a type for the fetched WebinarPlan data
+export type CheckoutWebinarPlanData = WebinarPlan & {
   consultantProfile:
     | (ConsultantProfile & {
         user: User & {
@@ -58,30 +62,32 @@ export type CheckoutClassPlanData = ClassPlan & {
         tags: PrismaTag[];
       })
     | null;
-  classes: (PrismaClass & {
-    appointments: (Appointment & {
-      slotsOfAppointment: SlotOfAppointment[];
-    })[];
+  webinars: (PrismaWebinar & {
+    appointment:
+      | (Appointment & {
+          slotsOfAppointment: SlotOfAppointment[];
+        })
+      | null;
   })[];
   topics: PrismaTopic[];
-  classContents: ClassContent[];
-  type: "class";
+  type: "webinar";
   imageUrl: string;
 };
 
 type PlanResponse = {
-  data: CheckoutClassPlanData;
+  data: CheckoutWebinarPlanData;
 };
 
 type PageProps = {
-  params: Promise<{ classPlanId: string }>;
+  params: Promise<{ planId: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-export default function ClassCheckoutPage({
+export default function WebinarCheckoutPage({
   params,
   searchParams,
 }: Readonly<PageProps>) {
+  // Next.js 15 Synchronous params and searchParams
   const resolvedParams = use(params);
   const resolvedSearchParams = use(searchParams);
 
@@ -112,18 +118,10 @@ export default function ClassCheckoutPage({
   } = useMaintenanceGuard();
 
   // Validate search params once with Zod — single source of truth for all checkout flows
-  const validatedSearchParams = useMemo((): SearchParams | null => {
-    const result = searchParamsSchema.safeParse(resolvedSearchParams);
+  const validatedSearchParams = useMemo((): WebinarSearchParams | null => {
+    const result = webinarSearchParamsSchema.safeParse(resolvedSearchParams);
     return result.success ? result.data : null;
   }, [resolvedSearchParams]);
-
-  // Derive the first available class ID — used by both component renders and handleCheckout
-  const availableClassId = useMemo(() => {
-    const availableClass = planData?.data?.classes?.find(
-      (c) => c.status === "SCHEDULED" || c.status === "IN_PROGRESS",
-    );
-    return availableClass?.id ?? null;
-  }, [planData]);
 
   // Apply discount code
   const handleApplyDiscount = async (code?: string) => {
@@ -190,8 +188,9 @@ export default function ClassCheckoutPage({
     fetchCredits();
   }, []);
 
+  // Create utility functions using the toast instance
   const handleApiError = createHandleApiError(toast);
-  const handleCheckoutSuccess = createHandleCheckoutSuccess(toast, "CLASS");
+  const handleCheckoutSuccess = createHandleCheckoutSuccess(toast, "WEBINAR");
   const stripeHandlers = createStripeCheckoutHandlers(toast);
   const razorpayHandlers = createRazorpayCheckoutHandlers(toast);
 
@@ -208,45 +207,57 @@ export default function ClassCheckoutPage({
         return;
       }
 
+      // Prevent double-clicks: ref provides synchronous guard (React state is async)
       if (isProcessingRef.current || isCheckoutProcessing) {
         return;
       }
       isProcessingRef.current = true;
 
       try {
+        // Set loading state
         setIsCheckoutProcessing(true);
         setProcessingGateway(`${gateway}-${isMockPayment ? "mock" : "real"}`);
 
+        // Use pre-validated search params
         if (!validatedSearchParams) {
-          throw new Error("Invalid class parameters");
+          throw new Error("Invalid webinar parameters");
         }
 
         if (!planData?.data?.id) {
-          throw new Error("Class plan not found");
+          throw new Error("Webinar plan not found");
         }
 
-        if (!availableClassId) {
-          throw new Error(
-            "No available class sessions. All sessions may be full, cancelled, or completed.",
-          );
+        // Staleness check: validate the target webinar is still available
+        const targetWebinar = planData.data.webinars?.find(
+          (w) => w.id === validatedSearchParams.eventId,
+        );
+        if (!targetWebinar) {
+          throw new Error("Webinar session not found.");
+        }
+        if (targetWebinar.status === "COMPLETED") {
+          throw new Error("This webinar has already ended.");
+        }
+        if (targetWebinar.status === "CANCELLED") {
+          throw new Error("This webinar has been cancelled.");
         }
 
-        // fromWaitlist is not in searchParamsSchema — read from raw params
+        // fromWaitlist is not in webinarSearchParamsSchema — read from raw params
         const fromWaitlist =
           typeof resolvedSearchParams.fromWaitlist === "string"
             ? resolvedSearchParams.fromWaitlist
             : undefined;
         const checkoutData = createCheckoutData({
-          appointmentType: "CLASS",
+          appointmentType: "WEBINAR",
           planId: planData.data.id,
-          eventId: availableClassId,
+          eventId: validatedSearchParams.eventId,
           discountCode: appliedDiscount?.code,
-          displayCurrency: currency,
           paymentGateway: gateway,
+          displayCurrency: currency,
           fromWaitlist,
           useReferralCredits,
         });
 
+        // Handle unified checkout flow using the utility
         await handleUnifiedCheckout(
           checkoutData,
           gateway,
@@ -258,17 +269,17 @@ export default function ClassCheckoutPage({
         console.error("Checkout error:", error);
         if (error instanceof Error) {
           // Provide more informative error messages based on the error type
-          let errorTitle = "Unable to Complete Enrollment";
+          let errorTitle = "Unable to Complete Registration";
           let errorDescription = error.message;
 
-          if (error.message.includes("Invalid class parameters")) {
-            errorTitle = "Enrollment Link Error";
+          if (error.message.includes("Invalid webinar parameters")) {
+            errorTitle = "Registration Link Error";
             errorDescription =
-              "The enrollment information is incomplete. Please go back to the class page and click 'Enroll Now' again to ensure all required information is included.";
-          } else if (error.message.includes("Class plan not found")) {
-            errorTitle = "Class Not Found";
+              "The registration information is incomplete. Please go back to the webinar page and click 'Register Now' again to ensure all required information is included.";
+          } else if (error.message.includes("Webinar plan not found")) {
+            errorTitle = "Webinar Not Found";
             errorDescription =
-              "This class could not be found or may no longer be available. Please go back and select a different class, or contact support if you believe this is an error.";
+              "This webinar could not be found or may no longer be available. Please go back and select a different webinar, or contact support if you believe this is an error.";
           } else if (
             error.message.includes("network") ||
             error.message.includes("fetch")
@@ -287,9 +298,9 @@ export default function ClassCheckoutPage({
           });
         }
       } finally {
+        isProcessingRef.current = false;
         setIsCheckoutProcessing(false);
         setProcessingGateway(null);
-        isProcessingRef.current = false;
       }
     },
     [
@@ -298,7 +309,6 @@ export default function ClassCheckoutPage({
       maintenanceBlockReason,
       resolvedSearchParams,
       planData?.data?.id,
-      resolvedParams.classPlanId,
       handleApiError,
       handleCheckoutSuccess,
       toast,
@@ -311,7 +321,7 @@ export default function ClassCheckoutPage({
     async function fetchPlanData() {
       setIsLoading(true);
       try {
-        const endpoint = `/api/plans/classes/${resolvedParams.classPlanId}`;
+        const endpoint = `/api/plans/webinars/${resolvedParams.planId}`;
 
         const response = await fetch(endpoint);
         if (!response.ok) {
@@ -326,6 +336,7 @@ export default function ClassCheckoutPage({
 
         setPlanData(data);
 
+        // Fetch reviews for the consultant
         const reviewsData = await fetchReviews(
           data.data.consultantProfile?.id ?? "",
         );
@@ -343,7 +354,7 @@ export default function ClassCheckoutPage({
     }
 
     fetchPlanData();
-  }, [resolvedParams.classPlanId]);
+  }, [resolvedParams.planId]);
 
   // Calculate pricing using the proper math functions
   // NOTE: This must be before early returns to maintain consistent hook order
@@ -376,25 +387,44 @@ export default function ClassCheckoutPage({
     checkoutTaxContext.isInternational,
   ]);
 
-  // Periodic staleness check: detect if all class sessions have ended or been cancelled
+  // Periodic staleness check: detect if webinar has ended or been cancelled
   useEffect(() => {
-    if (!planData?.data?.classes) return;
+    if (!planData?.data?.webinars) return;
+
+    const eventId =
+      typeof resolvedSearchParams.eventId === "string"
+        ? resolvedSearchParams.eventId
+        : undefined;
 
     const checkStaleness = () => {
-      const hasAvailable = planData.data.classes.some(
-        (c) => c.status === "SCHEDULED" || c.status === "IN_PROGRESS",
-      );
-      if (!hasAvailable) {
-        setError(
-          "No available class sessions. All sessions may be full, cancelled, or completed.",
+      const targetWebinar = eventId
+        ? planData.data.webinars.find((w) => w.id === eventId)
+        : planData.data.webinars[0];
+
+      if (!targetWebinar) return;
+
+      if (targetWebinar.status === "COMPLETED") {
+        setError("This webinar has already ended.");
+      } else if (targetWebinar.status === "CANCELLED") {
+        setError("This webinar has been cancelled.");
+      } else if (targetWebinar.appointment?.slotsOfAppointment?.[0]) {
+        const firstSlotEnd = new Date(
+          targetWebinar.appointment.slotsOfAppointment[
+            targetWebinar.appointment.slotsOfAppointment.length - 1
+          ].endsAt,
         );
+        if (firstSlotEnd.getTime() < Date.now()) {
+          setError(
+            "This webinar session has already ended. Please go back.",
+          );
+        }
       }
     };
 
     checkStaleness();
     const intervalId = setInterval(checkStaleness, 60_000);
     return () => clearInterval(intervalId);
-  }, [planData]);
+  }, [planData, resolvedSearchParams.eventId]);
 
   if (isLoading) {
     return (
@@ -443,13 +473,13 @@ export default function ClassCheckoutPage({
   const consultantDetails = planDetails?.consultantProfile;
   const userDetails = consultantDetails?.user;
 
-  const nextClassSession =
-    planDetails?.classes?.[0]?.appointments?.[0]?.slotsOfAppointment?.[0];
+  const nextSession =
+    planDetails?.webinars?.[0]?.appointment?.slotsOfAppointment?.[0];
 
   if (!planData || !planDetails || !consultantDetails || !userDetails) {
     return (
       <div className="flex items-center justify-center h-screen">
-        <p>Essential class data is missing. Please try again later.</p>
+        <p>Essential webinar data is missing. Please try again later.</p>
       </div>
     );
   }
@@ -482,7 +512,7 @@ export default function ClassCheckoutPage({
                   <div className="flex items-center gap-1.5 mt-1">
                     {userDetails.workExperiences.slice(0, 3).map((exp, i) => (
                       <CompanyLogo
-                        key={`checkout-class-company-${i}`}
+                        key={`checkout-webinar-company-${i}`}
                         companyName={exp.company}
                         companyDomain={exp.companyDomain ?? undefined}
                         size={20}
@@ -494,22 +524,22 @@ export default function ClassCheckoutPage({
             </div>
           </div>
           <div className="text-right">
-            <div className="font-semibold">Class</div>
+            <div className="font-semibold">Webinar</div>
             <div className="text-sm text-muted-foreground">
-              {planDetails?.title || "Online Class"}
+              {planDetails?.title || "Online Session"}
             </div>
           </div>
         </div>
         <Separator className="bg-zinc-200" />
         <div className="grid gap-2">
-          <div className="font-semibold">Class Details</div>
+          <div className="font-semibold">Webinar Details</div>
           <div className="grid gap-2">
-            {nextClassSession && (
+            {nextSession && (
               <>
                 <div className="flex items-center justify-between">
-                  <div className="text-muted-foreground">First Session</div>
+                  <div className="text-muted-foreground">Date</div>
                   <div>
-                    {new Date(nextClassSession.startsAt).toLocaleDateString(
+                    {new Date(nextSession.startsAt).toLocaleDateString(
                       undefined,
                       {
                         weekday: "long",
@@ -523,8 +553,8 @@ export default function ClassCheckoutPage({
                 <div className="flex items-center justify-between">
                   <div className="text-muted-foreground">Time</div>
                   <div>
-                    {new Date(nextClassSession.startsAt).toLocaleTimeString()} -{" "}
-                    {new Date(nextClassSession.endsAt).toLocaleTimeString()} (
+                    {new Date(nextSession.startsAt).toLocaleTimeString()} -{" "}
+                    {new Date(nextSession.endsAt).toLocaleTimeString()} (
                     {Intl.DateTimeFormat().resolvedOptions().timeZone})
                   </div>
                 </div>
@@ -532,17 +562,7 @@ export default function ClassCheckoutPage({
             )}
             <div className="flex items-center justify-between">
               <div className="text-muted-foreground">Duration</div>
-              <div>
-                {planDetails?.durationInMonths} month
-                {planDetails?.durationInMonths !== 1 ? "s" : ""} (
-                {planDetails?.totalSessions ||
-                  planDetails?.durationInMonths * 4}{" "}
-                sessions)
-              </div>
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="text-muted-foreground">Sessions per Week</div>
-              <div>{planDetails?.meetingsPerWeek || 2}</div>
+              <div>{planDetails?.durationInHours || 1} hours</div>
             </div>
             <div className="flex items-center justify-between">
               <div className="text-muted-foreground">Max Participants</div>
@@ -616,17 +636,17 @@ export default function ClassCheckoutPage({
           <div className="grid gap-2">
             <div className="flex items-center justify-between">
               <div>
-                <div className="font-medium">CLASS15</div>
+                <div className="font-medium">WEBINAR10</div>
                 <div className="text-sm text-muted-foreground">
-                  Get 15% off your class enrollment
+                  Get 10% off your webinar registration
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <div className="text-muted-foreground">15% off</div>
+                <div className="text-muted-foreground">10% off</div>
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => handleApplyDiscount("CLASS15")}
+                  onClick={() => handleApplyDiscount("WEBINAR10")}
                   disabled={isApplyingDiscount || !!appliedDiscount}
                 >
                   Apply
@@ -667,12 +687,12 @@ export default function ClassCheckoutPage({
       <div className="flex flex-col gap-8 p-8 bg-white">
         <Card className="border-zinc-200 shadow-sm">
           <CardHeader>
-            <CardTitle className="text-zinc-900">Class Pricing</CardTitle>
+            <CardTitle className="text-zinc-900">Webinar Pricing</CardTitle>
           </CardHeader>
           <CardContent className="grid gap-4">
             <div className="grid gap-2">
               <div className="flex items-center justify-between">
-                <div>Enrollment Fee</div>
+                <div>Registration Fee</div>
                 <div>{formatPrice(planDetails?.price || 0)}</div>
               </div>
               <div className="flex items-center justify-between">
@@ -681,23 +701,10 @@ export default function ClassCheckoutPage({
                 </div>
                 <div className="font-semibold">
                   <ul className="list-disc">
-                    <li>
-                      {planDetails?.totalSessions ||
-                        (planDetails?.meetingsPerWeek || 2) *
-                          (planDetails?.durationInMonths || 1) *
-                          4}{" "}
-                      total sessions (
-                      {planDetails?.totalHours ||
-                        (planDetails?.meetingsPerWeek || 2) *
-                          (planDetails?.durationInMonths || 1) *
-                          4}{" "}
-                      hours)
-                    </li>
-                    <li>
-                      {planDetails?.meetingsPerWeek || 2} sessions per week
-                    </li>
-                    <li>Course materials</li>
-                    <li>Certificate of completion</li>
+                    <li>Live webinar access</li>
+                    <li>Q&A session</li>
+                    <li>Recording access</li>
+                    <li>Certificate of attendance</li>
                   </ul>
                 </div>
               </div>
@@ -776,12 +783,12 @@ export default function ClassCheckoutPage({
                   </div>
                   {gateway.isActive ? (
                     <div className="flex gap-2">
-                      {availableClassId && gateway.gateway === "RAZORPAY" ? (
+                      {validatedSearchParams && gateway.gateway === "RAZORPAY" ? (
                         <RazorpayCheckout
                           checkoutData={createCheckoutData({
-                            appointmentType: "CLASS",
+                            appointmentType: "WEBINAR",
                             planId: planDetails.id,
-                            eventId: availableClassId,
+                            eventId: validatedSearchParams.eventId,
                             paymentGateway: "RAZORPAY",
                             discountCode: appliedDiscount?.code,
                             displayCurrency: currency,
@@ -791,12 +798,12 @@ export default function ClassCheckoutPage({
                           onPaymentError={razorpayHandlers.onPaymentError}
                           disabled={isMaintenanceBlocked}
                         />
-                      ) : availableClassId && gateway.gateway === "STRIPE" ? (
+                      ) : validatedSearchParams && gateway.gateway === "STRIPE" ? (
                         <StripeCheckout
                           checkoutData={createCheckoutData({
-                            appointmentType: "CLASS",
+                            appointmentType: "WEBINAR",
                             planId: planDetails.id,
-                            eventId: availableClassId,
+                            eventId: validatedSearchParams.eventId,
                             paymentGateway: "STRIPE",
                             discountCode: appliedDiscount?.code,
                             displayCurrency: currency,

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -197,7 +197,7 @@ export class AllocationAlgorithms {
         strategy: "manual",
       };
     } catch (error) {
-      console.error("Manual allocation error:", error);
+      console.warn("Manual allocation error:", error);
       return {
         success: false,
         selectedSlots: [],
@@ -337,7 +337,7 @@ export class AllocationAlgorithms {
         strategy,
       };
     } catch (error) {
-      console.error("Auto allocation error:", error);
+      console.warn("Auto allocation error:", error);
       return {
         success: false,
         selectedSlots: [],
@@ -404,7 +404,7 @@ export class AllocationAlgorithms {
         strategy: "requested-slots",
       };
     } catch (error) {
-      console.error("Pre-allocation error:", error);
+      console.warn("Pre-allocation error:", error);
       return {
         success: false,
         selectedSlots: [],

--- a/app/dashboard/consultee/[consulteeId]/(features)/home/PendingPaymentsWidget.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/home/PendingPaymentsWidget.tsx
@@ -13,7 +13,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
-import { formatCurrencyFromMajorUnit } from "@/utils/formatting";
+import { useCurrency } from "@/hooks/useCurrency";
 import { cn } from "@/utils/tailwind";
 
 interface PendingPayment {
@@ -43,6 +43,7 @@ interface PendingPaymentsWidgetProps {
 export function PendingPaymentsWidget({
   consulteeId,
 }: PendingPaymentsWidgetProps) {
+  const { formatPrice } = useCurrency();
   const router = useRouter();
   const [pendingPayments, setPendingPayments] = useState<PendingPayment[]>([]);
   const [loading, setLoading] = useState(true);
@@ -157,10 +158,7 @@ export function PendingPaymentsWidget({
                   </p>
                 </div>
                 <span className="text-sm font-semibold text-zinc-900 tabular-nums shrink-0">
-                  {formatCurrencyFromMajorUnit(
-                    payment.amount,
-                    payment.currency,
-                  )}
+                  {formatPrice(payment.amount)}
                 </span>
               </div>
               <div className="flex items-center justify-between mt-2.5">

--- a/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
@@ -3,10 +3,7 @@
 import { useMemo, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { motion } from "framer-motion";
-import {
-  formatCurrencyAmount,
-  formatCurrencyFromMajorUnit,
-} from "@/utils/formatting";
+import { useCurrency } from "@/hooks/useCurrency";
 import { cn } from "@/utils/tailwind";
 import {
   CreditCard,
@@ -213,6 +210,8 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
+  const { formatPrice } = useCurrency();
+
   // Build a map from paymentId → invoice for quick lookup
   const invoiceByPaymentId = useMemo(() => {
     if (!data) return new Map<string, InvoiceItem>();
@@ -285,7 +284,7 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
             </Tooltip>
           </TooltipProvider>
           <p className="text-2xl font-bold text-zinc-900">
-            {formatCurrencyFromMajorUnit(totalSpent, "INR")}
+            {formatPrice(totalSpent)}
           </p>
           <p className="text-xs text-zinc-400 mt-1">
             {(() => {
@@ -298,16 +297,16 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
         <div className="bg-white rounded-xl border border-zinc-200 p-4">
           <p className="text-sm text-zinc-500">Credits Earned</p>
           <p className="text-2xl font-bold text-zinc-900">
-            {formatCurrencyAmount(data.creditSummary.total, "INR")}
+            {formatPrice(data.creditSummary.total)}
           </p>
           <p className="text-xs text-zinc-400 mt-1">
-            {formatCurrencyAmount(data.creditSummary.used, "INR")} used
+            {formatPrice(data.creditSummary.used)} used
           </p>
         </div>
         <div className="bg-white rounded-xl border border-zinc-200 p-4">
           <p className="text-sm text-zinc-500">Credit Balance</p>
           <p className="text-2xl font-bold text-emerald-600">
-            {formatCurrencyAmount(data.creditSummary.remaining, "INR")}
+            {formatPrice(data.creditSummary.remaining)}
           </p>
           <p className="text-xs text-zinc-400 mt-1">Available to use</p>
         </div>
@@ -431,18 +430,12 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                           </td>
                           <td className="px-4 py-3 text-right whitespace-nowrap">
                             <span className="font-medium text-zinc-900">
-                              {formatCurrencyFromMajorUnit(
-                                payment.amount,
-                                payment.currency,
-                              )}
+                              {formatPrice(payment.amount)}
                             </span>
                             {payment.taxAmount && payment.taxAmount > 0 && (
                               <span className="block text-xs text-zinc-400">
                                 incl.{" "}
-                                {formatCurrencyFromMajorUnit(
-                                  payment.taxAmount,
-                                  payment.currency,
-                                )}{" "}
+                                {formatPrice(payment.taxAmount ?? 0)}{" "}
                                 GST
                               </span>
                             )}
@@ -460,7 +453,7 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                                       {" \u2014 "}
                                       {payment.discount.type === "PERCENTAGE"
                                         ? `${payment.discount.value}% off`
-                                        : `${formatCurrencyFromMajorUnit(payment.discount.value, payment.currency)} off`}
+                                        : `${formatPrice(payment.discount.value)} off`}
                                     </p>
                                   </TooltipContent>
                                 </Tooltip>
@@ -595,13 +588,10 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                             {credit.source.toLowerCase().replace(/_/g, " ")}
                           </td>
                           <td className="px-4 py-3 text-right font-medium text-zinc-900">
-                            {formatCurrencyAmount(credit.amount, "INR")}
+                            {formatPrice(credit.amount)}
                           </td>
                           <td className="px-4 py-3 text-right font-medium text-emerald-600">
-                            {formatCurrencyAmount(
-                              credit.remainingAmount,
-                              "INR",
-                            )}
+                            {formatPrice(credit.remainingAmount)}
                           </td>
                           <td className="px-4 py-3 text-zinc-500">
                             {credit.expiresAt
@@ -650,7 +640,7 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                                 .replace(/_/g, " ")}
                             </td>
                             <td className="px-4 py-3 text-right font-medium text-red-600">
-                              -{formatCurrencyAmount(usage.amount, "INR")}
+                              -{formatPrice(usage.amount)}
                             </td>
                           </tr>
                         ))}

--- a/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
@@ -16,6 +16,7 @@ import {
   QUALIFICATION_WINDOW_DAYS,
   CREDIT_EXPIRY_MONTHS,
 } from "@/lib/referrals/constants";
+import { useCurrency } from "@/hooks/useCurrency";
 
 interface ReferralCode {
   id: string;
@@ -59,6 +60,7 @@ export default function ConsulteeReferralsPage({
 }) {
   use(params);
   const { toast } = useToast();
+  const { formatPrice } = useCurrency();
   const [copied, setCopied] = useState(false);
 
   const { data: codeData } = useQuery<{ data: ReferralCode }>({
@@ -99,13 +101,13 @@ export default function ConsulteeReferralsPage({
     : "";
 
   const shareMessage = referralLink
-    ? `Hey! I've been using Familiarise and it's been great. Use my referral link to get ${formatAmount(code?.refereeReward ?? 0)} off your first booking: ${referralLink}`
+    ? `Hey! I've been using Familiarise and it's been great. Use my referral link to get ${formatPrice(code?.refereeReward ?? 0)} off your first booking: ${referralLink}`
     : "";
   const whatsappUrl = referralLink
     ? `https://wa.me/?text=${encodeURIComponent(shareMessage)}`
     : "";
   const emailUrl = referralLink
-    ? `mailto:?subject=${encodeURIComponent(`Get ${formatAmount(code?.refereeReward ?? 0)} off your first booking on Familiarise`)}&body=${encodeURIComponent(shareMessage)}`
+    ? `mailto:?subject=${encodeURIComponent(`Get ${formatPrice(code?.refereeReward ?? 0)} off your first booking on Familiarise`)}&body=${encodeURIComponent(shareMessage)}`
     : "";
 
   const handleCopy = () => {
@@ -115,12 +117,7 @@ export default function ConsulteeReferralsPage({
     setTimeout(() => setCopied(false), 2000);
   };
 
-  function formatAmount(paise: number) {
-    return new Intl.NumberFormat("en-IN", {
-      style: "currency",
-      currency: "INR",
-    }).format(paise / 100);
-  }
+  // formatPrice from useCurrency handles paise→display conversion with currency preference
 
   return (
     <>
@@ -144,7 +141,7 @@ export default function ConsulteeReferralsPage({
           />
           <StatCard
             title="Credit Balance"
-            value={formatAmount(credits?.totalAvailable ?? 0)}
+            value={formatPrice(credits?.totalAvailable ?? 0)}
             icon={IndianRupee}
             variant="info"
             tooltip="Credits earned from referrals. Applied at checkout."
@@ -158,8 +155,8 @@ export default function ConsulteeReferralsPage({
           </h3>
           {code && (
             <div className="mb-3 rounded-lg bg-emerald-50 border border-emerald-200 px-4 py-3 text-sm text-emerald-800">
-              Earn {formatAmount(code.referrerReward)} for each friend who
-              books. Your friend gets {formatAmount(code.refereeReward)} off
+              Earn {formatPrice(code.referrerReward)} for each friend who
+              books. Your friend gets {formatPrice(code.refereeReward)} off
               their first booking!
             </div>
           )}
@@ -281,7 +278,7 @@ export default function ConsulteeReferralsPage({
                     </td>
                     <td className="px-6 py-3 text-right">
                       {ref.status === "REWARDED"
-                        ? formatAmount(ref.referrerRewardAmount)
+                        ? formatPrice(ref.referrerRewardAmount)
                         : "-"}
                     </td>
                   </tr>
@@ -317,9 +314,9 @@ export default function ConsulteeReferralsPage({
                     <td className="px-6 py-3">
                       {credit.source.replace(/_/g, " ")}
                     </td>
-                    <td className="px-6 py-3">{formatAmount(credit.amount)}</td>
+                    <td className="px-6 py-3">{formatPrice(credit.amount)}</td>
                     <td className="px-6 py-3">
-                      {formatAmount(credit.remainingAmount)}
+                      {formatPrice(credit.remainingAmount)}
                     </td>
                     <td className="px-6 py-3 text-zinc-500">
                       {credit.expiresAt

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -122,25 +122,31 @@ export default function Profile() {
   // Load cookie and notification preferences
   useEffect(() => {
     async function loadPreferences() {
-      try {
-        const [cookieRes, notifRes] = await Promise.all([
-          fetch("/api/user/cookie-preferences"),
-          fetch("/api/user/notification-preferences"),
-        ]);
-        if (cookieRes.ok) {
-          const { data } = await cookieRes.json();
+      const [cookieResult, notifResult] = await Promise.allSettled([
+        fetch("/api/user/cookie-preferences"),
+        fetch("/api/user/notification-preferences"),
+      ]);
+
+      if (cookieResult.status === "fulfilled" && cookieResult.value.ok) {
+        try {
+          const { data } = await cookieResult.value.json();
           setCookieAnalytics(data.analytics);
           setCookieMarketing(data.marketing);
+        } catch (e) {
+          console.error("Failed to parse cookie preferences:", e);
         }
-        if (notifRes.ok) {
-          const { data } = await notifRes.json();
+      }
+
+      if (notifResult.status === "fulfilled" && notifResult.value.ok) {
+        try {
+          const { data } = await notifResult.value.json();
           setNotifAll(data.allNotifications);
           setNotifMentions(data.mentions);
           setNotifDirect(data.directMessages);
           setNotifUpdates(data.updates);
+        } catch (e) {
+          console.error("Failed to parse notification preferences:", e);
         }
-      } catch (error) {
-        console.error("Failed to load preferences:", error);
       }
     }
     loadPreferences();
@@ -162,10 +168,13 @@ export default function Profile() {
         title: "Cookie preferences saved",
         description: "Your cookie preferences have been updated.",
       });
-    } catch {
+    } catch (error) {
       toast({
         title: "Error",
-        description: "Failed to save cookie preferences. Please try again.",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to save cookie preferences. Please try again.",
         variant: "destructive",
       });
     } finally {
@@ -191,11 +200,13 @@ export default function Profile() {
         title: "Notification preferences saved",
         description: "Your notification preferences have been updated.",
       });
-    } catch {
+    } catch (error) {
       toast({
         title: "Error",
         description:
-          "Failed to save notification preferences. Please try again.",
+          error instanceof Error
+            ? error.message
+            : "Failed to save notification preferences. Please try again.",
         variant: "destructive",
       });
     } finally {

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -98,6 +98,18 @@ export default function Profile() {
   const [deleteConfirmEmail, setDeleteConfirmEmail] = useState("");
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 
+  // Cookie preferences state
+  const [cookieAnalytics, setCookieAnalytics] = useState(false);
+  const [cookieMarketing, setCookieMarketing] = useState(false);
+  const [isSavingCookies, setIsSavingCookies] = useState(false);
+
+  // Notification preferences state
+  const [notifAll, setNotifAll] = useState(true);
+  const [notifMentions, setNotifMentions] = useState(false);
+  const [notifDirect, setNotifDirect] = useState(false);
+  const [notifUpdates, setNotifUpdates] = useState(false);
+  const [isSavingNotifs, setIsSavingNotifs] = useState(false);
+
   // Sync form state when session loads
   useEffect(() => {
     if (session?.user) {
@@ -106,6 +118,90 @@ export default function Profile() {
       setAddress(session.user.address ?? "");
     }
   }, [session?.user]);
+
+  // Load cookie and notification preferences
+  useEffect(() => {
+    async function loadPreferences() {
+      try {
+        const [cookieRes, notifRes] = await Promise.all([
+          fetch("/api/user/cookie-preferences"),
+          fetch("/api/user/notification-preferences"),
+        ]);
+        if (cookieRes.ok) {
+          const { data } = await cookieRes.json();
+          setCookieAnalytics(data.analytics);
+          setCookieMarketing(data.marketing);
+        }
+        if (notifRes.ok) {
+          const { data } = await notifRes.json();
+          setNotifAll(data.allNotifications);
+          setNotifMentions(data.mentions);
+          setNotifDirect(data.directMessages);
+          setNotifUpdates(data.updates);
+        }
+      } catch (error) {
+        console.error("Failed to load preferences:", error);
+      }
+    }
+    loadPreferences();
+  }, []);
+
+  const saveCookiePreferences = async () => {
+    setIsSavingCookies(true);
+    try {
+      const res = await fetch("/api/user/cookie-preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          analytics: cookieAnalytics,
+          marketing: cookieMarketing,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save");
+      toast({
+        title: "Cookie preferences saved",
+        description: "Your cookie preferences have been updated.",
+      });
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to save cookie preferences. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSavingCookies(false);
+    }
+  };
+
+  const saveNotificationPreferences = async () => {
+    setIsSavingNotifs(true);
+    try {
+      const res = await fetch("/api/user/notification-preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          allNotifications: notifAll,
+          mentions: notifMentions,
+          directMessages: notifDirect,
+          updates: notifUpdates,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save");
+      toast({
+        title: "Notification preferences saved",
+        description: "Your notification preferences have been updated.",
+      });
+    } catch {
+      toast({
+        title: "Error",
+        description:
+          "Failed to save notification preferences. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSavingNotifs(false);
+    }
+  };
 
   // Load linked accounts
   const loadLinkedAccounts = useCallback(async () => {
@@ -907,7 +1003,11 @@ export default function Profile() {
                     >
                       Analytics
                     </Label>
-                    <Switch id="analytics" />
+                    <Switch
+                      id="analytics"
+                      checked={cookieAnalytics}
+                      onCheckedChange={setCookieAnalytics}
+                    />
                   </div>
                   <p className="text-sm text-zinc-500">
                     Help us improve site performance
@@ -921,7 +1021,11 @@ export default function Profile() {
                     >
                       Marketing
                     </Label>
-                    <Switch id="marketing" />
+                    <Switch
+                      id="marketing"
+                      checked={cookieMarketing}
+                      onCheckedChange={setCookieMarketing}
+                    />
                   </div>
                   <p className="text-sm text-zinc-500">
                     Personalized recommendations
@@ -929,6 +1033,22 @@ export default function Profile() {
                 </div>
               </div>
             </CardContent>
+            <CardFooter className="pt-0">
+              <Button
+                className="ml-auto bg-zinc-900 hover:bg-zinc-800 text-white"
+                onClick={saveCookiePreferences}
+                disabled={isSavingCookies}
+              >
+                {isSavingCookies ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save Preferences"
+                )}
+              </Button>
+            </CardFooter>
           </Card>
         </motion.div>
 
@@ -966,7 +1086,11 @@ export default function Profile() {
                       </p>
                     </div>
                   </div>
-                  <Switch id="all" />
+                  <Switch
+                    id="all"
+                    checked={notifAll}
+                    onCheckedChange={setNotifAll}
+                  />
                 </div>
                 <div className="flex items-center justify-between p-4 rounded-xl border border-zinc-100 hover:border-zinc-200 transition-colors">
                   <div className="flex items-center gap-3">
@@ -980,7 +1104,11 @@ export default function Profile() {
                       </p>
                     </div>
                   </div>
-                  <Switch id="mentions" />
+                  <Switch
+                    id="mentions"
+                    checked={notifMentions}
+                    onCheckedChange={setNotifMentions}
+                  />
                 </div>
                 <div className="flex items-center justify-between p-4 rounded-xl border border-zinc-100 hover:border-zinc-200 transition-colors">
                   <div className="flex items-center gap-3">
@@ -996,7 +1124,11 @@ export default function Profile() {
                       </p>
                     </div>
                   </div>
-                  <Switch id="direct-messages" />
+                  <Switch
+                    id="direct-messages"
+                    checked={notifDirect}
+                    onCheckedChange={setNotifDirect}
+                  />
                 </div>
                 <div className="flex items-center justify-between p-4 rounded-xl border border-zinc-100 hover:border-zinc-200 transition-colors">
                   <div className="flex items-center gap-3">
@@ -1012,13 +1144,28 @@ export default function Profile() {
                       </p>
                     </div>
                   </div>
-                  <Switch id="updates" />
+                  <Switch
+                    id="updates"
+                    checked={notifUpdates}
+                    onCheckedChange={setNotifUpdates}
+                  />
                 </div>
               </div>
             </CardContent>
             <CardFooter className="pt-0">
-              <Button className="ml-auto bg-zinc-900 hover:bg-zinc-800 text-white">
-                Save Preferences
+              <Button
+                className="ml-auto bg-zinc-900 hover:bg-zinc-800 text-white"
+                onClick={saveNotificationPreferences}
+                disabled={isSavingNotifs}
+              >
+                {isSavingNotifs ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save Preferences"
+                )}
               </Button>
             </CardFooter>
           </Card>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,13 +1,1 @@
 import "@testing-library/jest-dom";
-
-// Suppress console.error/warn noise from code paths that intentionally throw
-// (auth rejections, validation failures, missing mocks). Tests that need to
-// assert on console output can spy on these individually.
-beforeAll(() => {
-  jest.spyOn(console, "error").mockImplementation(() => {});
-  jest.spyOn(console, "warn").mockImplementation(() => {});
-});
-
-afterAll(() => {
-  jest.restoreAllMocks();
-});

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,13 @@
 import "@testing-library/jest-dom";
+
+// Suppress console.error/warn noise from code paths that intentionally throw
+// (auth rejections, validation failures, missing mocks). Tests that need to
+// assert on console output can spy on these individually.
+beforeAll(() => {
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});

--- a/lib/activity/log-activity.ts
+++ b/lib/activity/log-activity.ts
@@ -51,8 +51,8 @@ export async function logActivity({
       },
     });
   } catch (error) {
-    // Log but don't throw - activity logging should not break main flows
-    console.error("Failed to log activity:", error);
+    // Non-fatal — activity logging should not break main flows
+    console.warn("Failed to log activity:", error);
     return null;
   }
 }

--- a/utils/slotAllocation/SlotValidationService.ts
+++ b/utils/slotAllocation/SlotValidationService.ts
@@ -421,7 +421,7 @@ export class SlotValidationService {
       }
 
       if (hasInvalidSlots) {
-        console.error("[SlotValidationService] Invalid slots found:", {
+        console.warn("[SlotValidationService] Invalid slots found:", {
           invalidSlots: invalidSlotsList,
         });
 


### PR DESCRIPTION
## Summary

Batch of 5 quick-win fixes from the GitHub issues triage (68 open issues categorized):

- **#251** — Standardize checkout route params: rename `[webinarPlanId]` and `[classPlanId]` to `[planId]` for consistency with consultation/subscription routes
- **#488 (Bugs 1+2)** — Wire `logConsultationCancelled()` and `logSubscriptionCancelled()` into all 3 cancellation routes. These functions existed in `lib/activity/log-activity.ts` but had zero call sites — consultants had no audit trail for cancellations on their dashboard
- **#523 (Bug 2)** — Fix 100x currency inflation in consultee dashboard. `formatCurrencyFromMajorUnit` treated paise values as rupees (e.g. ₹14,798 displayed as ₹14,79,894). Replaced with `useCurrency().formatPrice()` across PaymentsTab, PendingPaymentsWidget, and referrals page — also enables multi-currency display
- **#520** — Zero-amount payment handling was already implemented. Fixed remaining stale JSDoc in `math.ts` (`creditsApplied` comment said "major currency unit" but values are in paise)
- **#468** — Wire cookie & notification preferences on profile page. Created `GET`/`PUT` API routes for both preference types. Connected all `<Switch>` components to controlled state with DB persistence and save buttons with loading states

## Files changed

| Area | Files | Change |
|------|-------|--------|
| Checkout routes | `app/checkout/plans/webinar/[planId]/page.tsx`, `app/checkout/plans/class/[planId]/page.tsx` | Renamed from `[webinarPlanId]`/`[classPlanId]`, updated param refs |
| Cancellation logging | 3 cancel/subscription route files | Added `logConsultationCancelled`/`logSubscriptionCancelled` calls |
| Currency display | `PaymentsTab.tsx`, `PendingPaymentsWidget.tsx`, `referrals/page.tsx` | Replaced deprecated formatters with `useCurrency().formatPrice()` |
| Preferences API | `app/api/user/cookie-preferences/route.ts`, `app/api/user/notification-preferences/route.ts` | New GET/PUT routes |
| Profile page | `app/profile/page.tsx` | Wired switches to controlled state, added save handlers |
| JSDoc | `app/checkout/plans/math.ts` | Fixed stale comment |

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally, zero errors)
- [ ] Navigate to `/checkout/plans/webinar/<id>` and `/checkout/plans/class/<id>` — pages load correctly with new `[planId]` param
- [ ] Cancel a consultation and subscription — verify activity log entries appear on consultant dashboard Home tab
- [ ] Open consultee Payments tab — amounts should display correctly (not 100x inflated)
- [ ] Change currency via navbar selector — PaymentsTab and referrals amounts should convert
- [ ] Profile page: toggle cookie/notification switches, click Save, refresh — preferences persist
- [ ] Profile page: Save button shows loading spinner during save

🤖 Generated with [Claude Code](https://claude.com/claude-code)