### PR TITLE
fix(security): add server-side document limit and ownership validation

### DIFF
--- a/app/api/verification/documents/route.ts
+++ b/app/api/verification/documents/route.ts
@@ -115,6 +115,24 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Enforce server-side document count limit (max 10 per verification)
+    if (verification) {
+      const existingDocCount =
+        await prisma.profileVerificationDocument.count({
+          where: { verificationId: verification.id },
+        });
+      if (existingDocCount >= 10) {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "Maximum 10 documents per verification request. Delete an existing document before uploading a new one.",
+          },
+          { status: 400 },
+        );
+      }
+    }
+
     // Upload file to Supabase
     const fileBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(fileBuffer);

--- a/app/api/verification/documents/route.ts
+++ b/app/api/verification/documents/route.ts
@@ -15,6 +15,7 @@ const ALLOWED_TYPES = [
   "application/pdf",
 ];
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_DOCS_PER_VERIFICATION = 10;
 
 /**
  * POST /api/verification/documents
@@ -115,23 +116,42 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Enforce server-side document count limit (max 10 per verification)
+    // Enforce server-side document count limit (max 10 per verification).
+    // For onboarding mode (no verification yet), count all docs owned by
+    // this user's consultant profile to prevent storage abuse via onboarding=true.
     if (verification) {
       const existingDocCount =
         await prisma.profileVerificationDocument.count({
           where: { verificationId: verification.id },
         });
-      if (existingDocCount >= 10) {
+      if (existingDocCount >= MAX_DOCS_PER_VERIFICATION) {
         return NextResponse.json(
           {
             success: false,
-            error:
-              "Maximum 10 documents per verification request. Delete an existing document before uploading a new one.",
+            error: `Maximum ${MAX_DOCS_PER_VERIFICATION} documents per verification request. Delete an existing document before uploading a new one.`,
+          },
+          { status: 400 },
+        );
+      }
+    } else if (consultantProfile) {
+      // Onboarding with existing profile but no verification yet
+      const totalDocs = await prisma.profileVerificationDocument.count({
+        where: {
+          verification: { consultantProfileId: consultantProfile.id },
+        },
+      });
+      if (totalDocs >= MAX_DOCS_PER_VERIFICATION) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `Maximum ${MAX_DOCS_PER_VERIFICATION} documents allowed. Delete an existing document before uploading a new one.`,
           },
           { status: 400 },
         );
       }
     }
+    // For pure onboarding (no profile at all), uploads are transient
+    // Supabase storage and file size limits (10MB) provide baseline protection
 
     // Upload file to Supabase
     const fileBuffer = await file.arrayBuffer();

--- a/app/api/verification/submit/route.ts
+++ b/app/api/verification/submit/route.ts
@@ -57,6 +57,28 @@ export async function POST(request: NextRequest) {
       (latestVerification.status === "PENDING" ||
         latestVerification.status === "NEEDS_INFO");
 
+    // Validate document ownership before connecting — prevents reassigning
+    // another consultant's documents to this verification request
+    if (documentIds?.length) {
+      const ownedDocs = await prisma.profileVerificationDocument.findMany({
+        where: {
+          id: { in: documentIds },
+          verification: { consultantProfileId: consultantProfile.id },
+        },
+        select: { id: true },
+      });
+      if (ownedDocs.length !== documentIds.length) {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "One or more document IDs do not belong to your verification request",
+          },
+          { status: 403 },
+        );
+      }
+    }
+
     let verification;
 
     if (shouldUpdate) {

--- a/app/api/verification/submit/route.ts
+++ b/app/api/verification/submit/route.ts
@@ -58,16 +58,20 @@ export async function POST(request: NextRequest) {
         latestVerification.status === "NEEDS_INFO");
 
     // Validate document ownership before connecting — prevents reassigning
-    // another consultant's documents to this verification request
-    if (documentIds?.length) {
+    // another consultant's documents to this verification request.
+    // Deduplicate IDs first to avoid false 403 when duplicates are passed.
+    const uniqueDocumentIds: string[] = documentIds?.length
+      ? Array.from(new Set(documentIds as string[]))
+      : [];
+    if (uniqueDocumentIds.length) {
       const ownedDocs = await prisma.profileVerificationDocument.findMany({
         where: {
-          id: { in: documentIds },
+          id: { in: uniqueDocumentIds },
           verification: { consultantProfileId: consultantProfile.id },
         },
         select: { id: true },
       });
-      if (ownedDocs.length !== documentIds.length) {
+      if (ownedDocs.length !== uniqueDocumentIds.length) {
         return NextResponse.json(
           {
             success: false,
@@ -93,10 +97,10 @@ export async function POST(request: NextRequest) {
           reviewNotes: null,
           rejectionReason: null,
           feedbackDetails: null,
-          // Connect new documents if provided
-          ...(documentIds?.length && {
+          // Connect new documents if provided (using deduplicated + validated IDs)
+          ...(uniqueDocumentIds.length && {
             documents: {
-              connect: documentIds.map((id: string) => ({ id })),
+              connect: uniqueDocumentIds.map((id) => ({ id })),
             },
           }),
         },
@@ -111,10 +115,10 @@ export async function POST(request: NextRequest) {
           consultantProfileId: consultantProfile.id,
           notes,
           status: "PENDING",
-          // Connect existing documents if provided
-          ...(documentIds?.length && {
+          // Connect existing documents if provided (using deduplicated + validated IDs)
+          ...(uniqueDocumentIds.length && {
             documents: {
-              connect: documentIds.map((id: string) => ({ id })),
+              connect: uniqueDocumentIds.map((id) => ({ id })),
             },
           }),
         },


### PR DESCRIPTION
## Summary
- **#575**: No server-side limit on verification document uploads — a malicious user could upload unlimited files. Added max 10 documents per verification request check.
- **#576**: Verification submission could connect arbitrary document IDs without proving consultant ownership — any authenticated user could reassign another consultant's documents to their own submission. Added ownership validation.

## Changes

### `app/api/verification/documents/route.ts`
- After verification is resolved, count existing documents for that verification
- If count >= 10, return 400 with clear error message
- Applies only when a verification exists (onboarding uploads without verification are transient)

### `app/api/verification/submit/route.ts`
- Before connecting `documentIds` in either the update or create path, query all provided IDs with a `verification.consultantProfileId` filter
- If any document doesn't belong to the caller's consultant profile, return 403

## Issues
Closes #575, closes #576

## Test plan
- [ ] Upload 10 documents to a verification → succeeds
- [ ] Upload 11th document → 400 "Maximum 10 documents per verification request"
- [ ] Submit with your own document IDs → succeeds
- [ ] Submit with another consultant's document IDs → 403 "do not belong to your verification request"
- [ ] Onboarding upload flow still works (no verification exists yet, limit doesn't block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)