### PR TITLE
fix(booking): cancelled slots, waitlist dashboard, checkout validation, status filters, planner counts

### DIFF
--- a/app/api/dashboard/consultant/[consultantId]/planner/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/planner/route.ts
@@ -81,10 +81,13 @@ interface PlannerData {
 async function getParticipantCounts(
   webinarIds: string[],
   classIds: string[],
+  excludeConsultantUserId?: string,
 ): Promise<Record<string, number>> {
   const counts: Record<string, number> = {};
 
-  // Fetch webinar participant counts in a single query
+  // FIX #556: Fetch webinar participant counts with host exclusion.
+  // Use actual user IDs (not _count) to deduplicate across multi-slot
+  // webinars and exclude the consultant host.
   if (webinarIds.length > 0) {
     const webinarCounts = await prisma.webinar.findMany({
       where: { id: { in: webinarIds } },
@@ -93,7 +96,9 @@ async function getParticipantCounts(
         appointment: {
           select: {
             slotsOfAppointment: {
-              select: { _count: { select: { user: true } } },
+              select: {
+                user: { select: { id: true } },
+              },
               where: { isTentative: false },
             },
           },
@@ -102,11 +107,15 @@ async function getParticipantCounts(
     });
 
     for (const webinar of webinarCounts) {
-      counts[webinar.id] =
-        webinar.appointment?.slotsOfAppointment.reduce(
-          (total, slot) => total + slot._count.user,
-          0,
-        ) || 0;
+      const uniqueUserIds = new Set<string>();
+      for (const slot of webinar.appointment?.slotsOfAppointment || []) {
+        for (const user of slot.user) {
+          if (user.id !== excludeConsultantUserId) {
+            uniqueUserIds.add(user.id);
+          }
+        }
+      }
+      counts[webinar.id] = uniqueUserIds.size;
     }
   }
 
@@ -133,13 +142,15 @@ async function getParticipantCounts(
 
     for (const classEvent of classCounts) {
       // Use a Set to count unique users across ALL appointments/sessions
+      // FIX #556: Exclude the consultant host from participant count
       const uniqueUserIds = new Set<string>();
 
       for (const appointment of classEvent.appointments) {
         for (const slot of appointment.slotsOfAppointment) {
-          // slot.user is an array of users connected to this slot
           for (const user of slot.user) {
-            uniqueUserIds.add(user.id);
+            if (user.id !== excludeConsultantUserId) {
+              uniqueUserIds.add(user.id);
+            }
           }
         }
       }
@@ -288,7 +299,16 @@ export async function GET(
     const webinarIds = webinars.map((w) => w.id);
     const classIds = classes.map((c) => c.id);
 
-    const participantCounts = await getParticipantCounts(webinarIds, classIds);
+    // FIX #556: Pass consultant's userId to exclude from participant counts
+    const consultantProfile = await prisma.consultantProfile.findUnique({
+      where: { id: consultantId },
+      select: { userId: true },
+    });
+    const participantCounts = await getParticipantCounts(
+      webinarIds,
+      classIds,
+      consultantProfile?.userId,
+    );
 
     const plannerData: PlannerData = {
       webinars,

--- a/app/api/dashboard/consultee/[consulteeId]/events/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/events/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { WaitlistStatus } from "@prisma/client";
 import {
   requireApiAuth,
   isPrivileged,
@@ -135,7 +136,7 @@ export async function GET(
                 waitlist: {
                   some: {
                     userId,
-                    status: { in: ["WAITING", "NOTIFIED", "BOOKED"] },
+                    status: { in: [WaitlistStatus.WAITING, WaitlistStatus.NOTIFIED, WaitlistStatus.BOOKED] },
                   },
                 },
               },
@@ -210,7 +211,7 @@ export async function GET(
                 waitlist: {
                   some: {
                     userId,
-                    status: { in: ["WAITING", "NOTIFIED", "BOOKED"] },
+                    status: { in: [WaitlistStatus.WAITING, WaitlistStatus.NOTIFIED, WaitlistStatus.BOOKED] },
                   },
                 },
               },

--- a/app/api/dashboard/consultee/[consulteeId]/events/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/events/route.ts
@@ -120,14 +120,26 @@ export async function GET(
           },
           orderBy: { requestedAt: "desc" },
         }),
-        // Webinars: User registered via waitlist or via appointment slots
+        // Webinars: User registered via appointment slots OR waitlisted
         prisma.webinar.findMany({
           where: {
-            appointment: {
-              slotsOfAppointment: {
-                some: { user: { some: { id: userId } } },
+            OR: [
+              {
+                appointment: {
+                  slotsOfAppointment: {
+                    some: { user: { some: { id: userId } } },
+                  },
+                },
               },
-            },
+              {
+                waitlist: {
+                  some: {
+                    userId,
+                    status: { in: ["WAITING", "NOTIFIED", "BOOKED"] },
+                  },
+                },
+              },
+            ],
           },
           include: {
             webinarPlan: {
@@ -181,16 +193,28 @@ export async function GET(
           },
           orderBy: { createdAt: "desc" },
         }),
-        // Classes: User registered via waitlist or via appointment slots
+        // Classes: User registered via appointment slots OR waitlisted
         prisma.class.findMany({
           where: {
-            appointments: {
-              some: {
-                slotsOfAppointment: {
-                  some: { user: { some: { id: userId } } },
+            OR: [
+              {
+                appointments: {
+                  some: {
+                    slotsOfAppointment: {
+                      some: { user: { some: { id: userId } } },
+                    },
+                  },
                 },
               },
-            },
+              {
+                waitlist: {
+                  some: {
+                    userId,
+                    status: { in: ["WAITING", "NOTIFIED", "BOOKED"] },
+                  },
+                },
+              },
+            ],
           },
           include: {
             classPlan: {

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { AppointmentsType, Prisma } from "@prisma/client";
+import { AppointmentsType, Prisma, RequestStatus } from "@prisma/client";
 import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 
 export async function GET(request: NextRequest) {
@@ -58,27 +58,42 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Validate statuses
-  const validStatuses = ["PENDING", "APPROVED", "REJECTED", "CANCELLED"];
-  if (consultationStatus && !validStatuses.includes(consultationStatus)) {
+  // Validate statuses — consultation/subscription use RequestStatus enum,
+  // webinar/class use their own event lifecycle statuses
+  const validRequestStatuses = [
+    "PENDING",
+    "APPROVED",
+    "APPROVED_PENDING_PAYMENT",
+    "SCHEDULED",
+    "REJECTED",
+    "CANCELLED",
+    "EXPIRED",
+  ];
+  const validEventStatuses = [
+    "SCHEDULED",
+    "IN_PROGRESS",
+    "COMPLETED",
+    "CANCELLED",
+  ];
+  if (consultationStatus && !validRequestStatuses.includes(consultationStatus)) {
     return NextResponse.json(
       { error: "Invalid consultation status" },
       { status: 400 },
     );
   }
-  if (subscriptionStatus && !validStatuses.includes(subscriptionStatus)) {
+  if (subscriptionStatus && !validRequestStatuses.includes(subscriptionStatus)) {
     return NextResponse.json(
       { error: "Invalid subscription status" },
       { status: 400 },
     );
   }
-  if (webinarStatus && !validStatuses.includes(webinarStatus)) {
+  if (webinarStatus && !validEventStatuses.includes(webinarStatus)) {
     return NextResponse.json(
       { error: "Invalid webinar status" },
       { status: 400 },
     );
   }
-  if (classStatus && !validStatuses.includes(classStatus)) {
+  if (classStatus && !validEventStatuses.includes(classStatus)) {
     return NextResponse.json(
       { error: "Invalid class status" },
       { status: 400 },
@@ -95,30 +110,10 @@ export async function GET(request: NextRequest) {
       consulteeProfileId,
       userId,
       {
-        consultation: consultationStatus as
-          | "PENDING"
-          | "APPROVED"
-          | "REJECTED"
-          | "CANCELLED"
-          | undefined,
-        subscription: subscriptionStatus as
-          | "PENDING"
-          | "APPROVED"
-          | "REJECTED"
-          | "CANCELLED"
-          | undefined,
-        webinar: webinarStatus as
-          | "PENDING"
-          | "APPROVED"
-          | "REJECTED"
-          | "CANCELLED"
-          | undefined,
-        class: classStatus as
-          | "PENDING"
-          | "APPROVED"
-          | "REJECTED"
-          | "CANCELLED"
-          | undefined,
+        consultation: consultationStatus || undefined,
+        subscription: subscriptionStatus || undefined,
+        webinar: webinarStatus || undefined,
+        class: classStatus || undefined,
       },
       startDate,
       endDate,
@@ -146,10 +141,10 @@ async function getAppointments(
   consulteeProfileId?: string | null,
   userId?: string | null,
   statuses?: {
-    consultation?: "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
-    subscription?: "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
-    webinar?: "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
-    class?: "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
+    consultation?: string;
+    subscription?: string;
+    webinar?: string;
+    class?: string;
   },
   startDate?: string | null,
   endDate?: string | null,
@@ -299,6 +294,41 @@ async function getAppointments(
   }
   if (eventIds?.subscriptionId) {
     whereClause.subscription = { id: eventIds.subscriptionId };
+  }
+
+  // FIX #551: Apply status filters that were previously parsed but never used.
+  // Build an OR clause so appointments matching ANY of the provided status
+  // filters are returned (allows fetching e.g., APPROVED consultations AND
+  // SCHEDULED webinars in one call).
+  const statusFilters: Prisma.AppointmentWhereInput[] = [];
+  if (statuses?.consultation) {
+    statusFilters.push({
+      consultation: { requestStatus: statuses.consultation as RequestStatus },
+    });
+  }
+  if (statuses?.subscription) {
+    statusFilters.push({
+      subscription: { requestStatus: statuses.subscription as RequestStatus },
+    });
+  }
+  if (statuses?.webinar) {
+    statusFilters.push({
+      webinar: { status: statuses.webinar as Prisma.EnumWebinarStatusFilter },
+    });
+  }
+  if (statuses?.class) {
+    statusFilters.push({
+      class: { status: statuses.class as Prisma.EnumClassStatusFilter },
+    });
+  }
+  if (statusFilters.length > 0) {
+    // Combine with existing AND clauses
+    const existingAnd = whereClause.AND
+      ? Array.isArray(whereClause.AND)
+        ? whereClause.AND
+        : [whereClause.AND]
+      : [];
+    whereClause.AND = [...existingAnd, { OR: statusFilters }];
   }
 
   const appointments = await prisma.appointment.findMany({

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -65,6 +65,7 @@ export async function GET(request: NextRequest) {
     "APPROVED",
     "APPROVED_PENDING_PAYMENT",
     "SCHEDULED",
+    "COMPLETED",
     "REJECTED",
     "CANCELLED",
     "EXPIRED",

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -24,6 +24,7 @@ import {
 } from "@/utils/appointmentlock";
 import { validateSlotTiming } from "@/lib/payments/utils/slot-validation";
 import { isMinuteWithinWeeklySlot } from "@/utils/slotAllocation/slotTimeUtils";
+import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
 import {
   countUniqueParticipants,
   isUserEnrolled,
@@ -590,6 +591,8 @@ export async function validateSlotAvailability(
   // 1. Check for confirmed overlapping appointments FOR THIS CONSULTANT ONLY
   // FIX Bug #05: Use canonical overlap predicate that catches all 4 overlap shapes
   // (partial start, partial end, full containment, and exact match)
+  // FIX #540: Only check slots belonging to occupied (active) appointments.
+  // Cancelled/rejected/expired appointment slots should NOT block new bookings.
   const existingBooking = await tx.slotOfAppointment.findFirst({
     where: {
       AND: [
@@ -608,6 +611,12 @@ export async function validateSlotAvailability(
               },
             ]
           : []),
+        // FIX #540: Only count slots from active/occupied appointments
+        {
+          appointment: {
+            OR: buildOccupiedAppointmentFilter(),
+          },
+        },
       ],
     },
   });
@@ -958,6 +967,31 @@ async function revalidateInsideLock(
 
     // BUG-E: Re-validate plan still exists (could be deleted between initial validation and lock)
     await verifyPlanExistsInsideLock(tx, data.appointmentType, data.planId);
+
+    // FIX #548: Validate waitlist entry if this checkout originates from a waitlist offer.
+    // Verify the entry belongs to this user, is in NOTIFIED status, and hasn't expired.
+    if (
+      data.fromWaitlist &&
+      (data.appointmentType === "WEBINAR" || data.appointmentType === "CLASS")
+    ) {
+      const waitlistEntry = await tx.waitlist.findUnique({
+        where: { id: data.fromWaitlist },
+      });
+      if (!waitlistEntry) {
+        throw new Error("Waitlist entry not found");
+      }
+      if (waitlistEntry.userId !== userId) {
+        throw new Error("Waitlist entry does not belong to this user");
+      }
+      if (waitlistEntry.status !== "NOTIFIED") {
+        throw new Error(
+          "Waitlist offer is no longer valid (expired, cancelled, or already used)",
+        );
+      }
+      if (waitlistEntry.expiresAt && waitlistEntry.expiresAt < new Date()) {
+        throw new Error("Waitlist offer has expired");
+      }
+    }
 
     // Re-validate slot availability based on appointment type
     switch (data.appointmentType) {


### PR DESCRIPTION
## Summary
Five booking and slot logic fixes addressing cancelled slots blocking bookings, missing waitlisted events in dashboard, unvalidated waitlist checkout, dead status filters, and inflated planner counts.

## Changes

### #540: Cancelled slots still block new bookings
**File:** `lib/payments/operations/checkout.ts`
- `validateSlotAvailability` checked `isTentative: false` but never filtered by appointment status
- Added `appointment: { OR: buildOccupiedAppointmentFilter() }` so only slots from active appointments (PENDING/APPROVED/SCHEDULED) block — cancelled/rejected/expired do not

### #546: Waitlisted webinars/classes missing from consultee dashboard
**File:** `app/api/dashboard/consultee/[consulteeId]/events/route.ts`
- Webinar/class queries only matched users in appointment slots
- Added `OR` clause to also include events where user has a WAITING/NOTIFIED/BOOKED waitlist entry

### #548: Waitlist ACCEPT flow doesn't validate during checkout
**File:** `lib/payments/operations/checkout.ts`
- When `fromWaitlist` is set during WEBINAR/CLASS checkout, `revalidateInsideLock` now validates:
  - Entry exists and belongs to the current user
  - Status is NOTIFIED (not expired/cancelled/already used)
  - Expiry hasn't passed

### #551: Status filters accepted but never applied
**File:** `app/api/slots/appointments/route.ts`
- Implemented actual status filtering in `getAppointments()` via OR clause
- Fixed webinar/class validators to use correct enum (SCHEDULED/IN_PROGRESS/COMPLETED/CANCELLED) instead of consultation-style statuses (PENDING/APPROVED)
- Consultant dashboard fetchers that send `consultationStatus=APPROVED` now actually get filtered results

### #556: Planner participant counts include hosts
**File:** `app/api/dashboard/consultant/[consultantId]/planner/route.ts`
- Webinar counts now fetch actual user IDs (not `_count`) to deduplicate across multi-slot sessions and exclude the consultant
- Class counts also exclude the consultant host
- Added `excludeConsultantUserId` parameter to `getParticipantCounts()`

## Issues
Closes #540, closes #546, closes #548, closes #551, closes #556

## Test plan
- [ ] Cancel an appointment → re-book the same slot → succeeds (not "already booked")
- [ ] Join a webinar/class waitlist → appears in consultee dashboard events
- [ ] Accept waitlist offer → checkout validates entry is yours and not expired
- [ ] Use another user's waitlist ID in checkout → rejected
- [ ] GET `/api/slots/appointments?consultationStatus=APPROVED` → only APPROVED consultations returned
- [ ] Planner shows correct participant count (without the host)
- [ ] Multi-slot webinar participant count is not inflated

🤖 Generated with [Claude Code](https://claude.com/claude-code)