### PR TITLE
fix(stream): revoke collaborator Stream channel access on removal

### DIFF
--- a/actions/stream/chat/event-channel.action.ts
+++ b/actions/stream/chat/event-channel.action.ts
@@ -213,6 +213,9 @@ export async function removeUserFromEventChannel(
     });
     return { success: true };
   } catch (error) {
+    // Clear membership cache regardless — if removal failed, we don't want
+    // stale "is member" cache entries preventing future add/remove operations.
+    markMembership(channelId, userId, false);
     // Channel may not exist — that's fine, user has no access anyway
     streamLogger.warn("Failed to remove user from event channel", {
       eventType,

--- a/actions/stream/chat/event-channel.action.ts
+++ b/actions/stream/chat/event-channel.action.ts
@@ -186,6 +186,45 @@ export async function addUserToEventChannel(
 }
 
 /**
+ * Remove a user from an event channel.
+ * Used when a collaborator is removed from a webinar/class plan.
+ */
+export async function removeUserFromEventChannel(
+  eventType: EventType,
+  eventId: string,
+  userId: string,
+): Promise<{ success: boolean }> {
+  eventTypeSchema.parse(eventType);
+  eventIdSchema.parse(eventId);
+  userIdSchema.parse(userId);
+
+  const channelId = getChannelId(eventType, eventId);
+  const channelType = getChannelType(eventType);
+
+  const client = getStreamChatClient();
+
+  try {
+    const channel = client.channel(channelType, channelId);
+    await channel.removeMembers([userId]);
+    markMembership(channelId, userId, false);
+    streamLogger.info("Removed user from event channel", {
+      channelId,
+      userId,
+    });
+    return { success: true };
+  } catch (error) {
+    // Channel may not exist — that's fine, user has no access anyway
+    streamLogger.warn("Failed to remove user from event channel", {
+      eventType,
+      eventId,
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { success: false };
+  }
+}
+
+/**
  * Get event data for channel creation
  */
 async function getEventData(eventType: EventType, eventId: string) {

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -10,6 +10,7 @@ import type {
   CollaboratorStatus,
 } from "@prisma/client";
 import { removeUserFromEventChannel } from "@/actions/stream/chat/event-channel.action";
+import { getStreamChatClient } from "@/lib/stream-client";
 import {
   notifyCollaboratorInvited,
   notifyCollaboratorAccepted,
@@ -345,10 +346,17 @@ export async function removeCollaborator(
           planType: "webinar",
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
-        // FIX #592: Remove collaborator from all webinar event channels
-        for (const webinar of webinars) {
-          await removeUserFromEventChannel("webinar", webinar.id, profile.userId);
-        }
+        // FIX #592: Remove collaborator from all webinar event channels + collab channel
+        await Promise.all([
+          ...webinars.map((webinar) =>
+            removeUserFromEventChannel("webinar", webinar.id, profile.userId),
+          ),
+          // Also remove from the plan-level collaborator channel
+          getStreamChatClient()
+            .channel("messaging", `collab-webinar-${planId}`)
+            .removeMembers([profile.userId])
+            .catch(() => {}), // Ignore if channel doesn't exist
+        ]);
       }
     } catch (error) {
       console.error(
@@ -391,10 +399,17 @@ export async function removeCollaborator(
           planType: "class",
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
-        // FIX #592: Remove collaborator from all class event channels
-        for (const classEvent of classes) {
-          await removeUserFromEventChannel("class", classEvent.id, profile.userId);
-        }
+        // FIX #592: Remove collaborator from all class event channels + collab channel
+        await Promise.all([
+          ...classes.map((classEvent) =>
+            removeUserFromEventChannel("class", classEvent.id, profile.userId),
+          ),
+          // Also remove from the plan-level collaborator channel
+          getStreamChatClient()
+            .channel("messaging", `collab-class-${planId}`)
+            .removeMembers([profile.userId])
+            .catch(() => {}), // Ignore if channel doesn't exist
+        ]);
       }
     } catch (error) {
       console.error(

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -325,44 +325,49 @@ export async function removeCollaborator(
     });
 
     // Fire-and-forget: notify removed collaborator + revoke Stream channel access
-    try {
-      const [profile, plan, webinars] = await Promise.all([
-        prisma.consultantProfile.findUnique({
-          where: { id: collab.consultantProfileId },
-          select: { userId: true },
-        }),
-        prisma.webinarPlan.findUnique({
+    // Fire-and-forget: notification and Stream removal are independent.
+    // Separate try/catch so a Novu outage doesn't block Stream revocation.
+    const profile = await prisma.consultantProfile
+      .findUnique({
+        where: { id: collab.consultantProfileId },
+        select: { userId: true },
+      })
+      .catch(() => null);
+
+    if (profile?.userId) {
+      // Notification — independent failure
+      try {
+        const plan = await prisma.webinarPlan.findUnique({
           where: { id: planId },
           select: { title: true },
-        }),
-        prisma.webinar.findMany({
-          where: { webinarPlanId: planId },
-          select: { id: true },
-        }),
-      ]);
-      if (profile?.userId) {
+        });
         await notifyCollaboratorRemoved(profile.userId, {
           planTitle: plan?.title ?? "Unknown Plan",
           planType: "webinar",
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
-        // FIX #592: Remove collaborator from all webinar event channels + collab channel
+      } catch (error) {
+        console.error("[collaborators] Failed to send removal notification:", error);
+      }
+
+      // Stream channel revocation — independent failure
+      try {
+        const webinars = await prisma.webinar.findMany({
+          where: { webinarPlanId: planId },
+          select: { id: true },
+        });
         await Promise.all([
           ...webinars.map((webinar) =>
             removeUserFromEventChannel("webinar", webinar.id, profile.userId),
           ),
-          // Also remove from the plan-level collaborator channel
           getStreamChatClient()
             .channel("messaging", `collab-webinar-${planId}`)
             .removeMembers([profile.userId])
-            .catch(() => {}), // Ignore if channel doesn't exist
+            .catch(() => {}),
         ]);
+      } catch (error) {
+        console.error("[collaborators] Failed to revoke Stream access:", error);
       }
-    } catch (error) {
-      console.error(
-        "[collaborators] Failed to send removal notification:",
-        error,
-      );
     }
 
     return result;
@@ -377,45 +382,48 @@ export async function removeCollaborator(
       data: { status: "REMOVED" },
     });
 
-    // Fire-and-forget: notify removed collaborator + revoke Stream channel access
-    try {
-      const [profile, plan, classes] = await Promise.all([
-        prisma.consultantProfile.findUnique({
-          where: { id: collab.consultantProfileId },
-          select: { userId: true },
-        }),
-        prisma.classPlan.findUnique({
+    // Fire-and-forget: notification and Stream removal are independent.
+    const classProfile = await prisma.consultantProfile
+      .findUnique({
+        where: { id: collab.consultantProfileId },
+        select: { userId: true },
+      })
+      .catch(() => null);
+
+    if (classProfile?.userId) {
+      // Notification — independent failure
+      try {
+        const plan = await prisma.classPlan.findUnique({
           where: { id: planId },
           select: { title: true },
-        }),
-        prisma.class.findMany({
-          where: { classPlanId: planId },
-          select: { id: true },
-        }),
-      ]);
-      if (profile?.userId) {
-        await notifyCollaboratorRemoved(profile.userId, {
+        });
+        await notifyCollaboratorRemoved(classProfile.userId, {
           planTitle: plan?.title ?? "Unknown Plan",
           planType: "class",
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
-        // FIX #592: Remove collaborator from all class event channels + collab channel
+      } catch (error) {
+        console.error("[collaborators] Failed to send removal notification:", error);
+      }
+
+      // Stream channel revocation — independent failure
+      try {
+        const classes = await prisma.class.findMany({
+          where: { classPlanId: planId },
+          select: { id: true },
+        });
         await Promise.all([
           ...classes.map((classEvent) =>
-            removeUserFromEventChannel("class", classEvent.id, profile.userId),
+            removeUserFromEventChannel("class", classEvent.id, classProfile.userId),
           ),
-          // Also remove from the plan-level collaborator channel
           getStreamChatClient()
             .channel("messaging", `collab-class-${planId}`)
-            .removeMembers([profile.userId])
-            .catch(() => {}), // Ignore if channel doesn't exist
+            .removeMembers([classProfile.userId])
+            .catch(() => {}),
         ]);
+      } catch (error) {
+        console.error("[collaborators] Failed to revoke Stream access:", error);
       }
-    } catch (error) {
-      console.error(
-        "[collaborators] Failed to send removal notification:",
-        error,
-      );
     }
 
     return result;

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -9,6 +9,7 @@ import type {
   ClassCollaborator,
   CollaboratorStatus,
 } from "@prisma/client";
+import { removeUserFromEventChannel } from "@/actions/stream/chat/event-channel.action";
 import {
   notifyCollaboratorInvited,
   notifyCollaboratorAccepted,
@@ -322,9 +323,9 @@ export async function removeCollaborator(
       data: { status: "REMOVED" },
     });
 
-    // Fire-and-forget: notify removed collaborator
+    // Fire-and-forget: notify removed collaborator + revoke Stream channel access
     try {
-      const [profile, plan] = await Promise.all([
+      const [profile, plan, webinars] = await Promise.all([
         prisma.consultantProfile.findUnique({
           where: { id: collab.consultantProfileId },
           select: { userId: true },
@@ -333,6 +334,10 @@ export async function removeCollaborator(
           where: { id: planId },
           select: { title: true },
         }),
+        prisma.webinar.findMany({
+          where: { webinarPlanId: planId },
+          select: { id: true },
+        }),
       ]);
       if (profile?.userId) {
         await notifyCollaboratorRemoved(profile.userId, {
@@ -340,6 +345,10 @@ export async function removeCollaborator(
           planType: "webinar",
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
+        // FIX #592: Remove collaborator from all webinar event channels
+        for (const webinar of webinars) {
+          await removeUserFromEventChannel("webinar", webinar.id, profile.userId);
+        }
       }
     } catch (error) {
       console.error(
@@ -360,9 +369,9 @@ export async function removeCollaborator(
       data: { status: "REMOVED" },
     });
 
-    // Fire-and-forget: notify removed collaborator
+    // Fire-and-forget: notify removed collaborator + revoke Stream channel access
     try {
-      const [profile, plan] = await Promise.all([
+      const [profile, plan, classes] = await Promise.all([
         prisma.consultantProfile.findUnique({
           where: { id: collab.consultantProfileId },
           select: { userId: true },
@@ -371,6 +380,10 @@ export async function removeCollaborator(
           where: { id: planId },
           select: { title: true },
         }),
+        prisma.class.findMany({
+          where: { classPlanId: planId },
+          select: { id: true },
+        }),
       ]);
       if (profile?.userId) {
         await notifyCollaboratorRemoved(profile.userId, {
@@ -378,6 +391,10 @@ export async function removeCollaborator(
           planType: "class",
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
+        // FIX #592: Remove collaborator from all class event channels
+        for (const classEvent of classes) {
+          await removeUserFromEventChannel("class", classEvent.id, profile.userId);
+        }
       }
     } catch (error) {
       console.error(


### PR DESCRIPTION
## Summary
When a collaborator is removed from a webinar/class plan, they lose DB access but retain full Stream chat channel membership. This means removed collaborators can still read and post in private event chat channels.

## Changes

### `actions/stream/chat/event-channel.action.ts`
- Added `removeUserFromEventChannel(eventType, eventId, userId)` — mirrors `addUserToEventChannel` but calls `channel.removeMembers()`. Gracefully handles channels that don't exist.

### `lib/collaborators/service.ts`
- In `removeCollaborator()` for both webinar and class paths: after setting status to REMOVED and sending notification, fetch all events for the plan and remove the collaborator's user from each event's Stream channel.

## Issue triage
- **#592** (removed collaborators retain Stream access): **LEGIT — fixed**
- **#580** (waitlist users get chat access before booking): **Already fixed** — channel code already filters `waitlist: { where: { status: "BOOKED" } }`. Only booked users get channel membership.

## Issues
Closes #592
Closes #580

## Test plan
- [ ] Remove collaborator from webinar plan → they lose Stream chat access immediately
- [ ] Remove collaborator from class plan → same
- [ ] If event channel doesn't exist yet (no one joined), removal still succeeds gracefully
- [ ] Waitlist join (WAITING status) → no chat channel access (already working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)