### PR TITLE
fix(trials): consistent cancellation behavior between PATCH and DELETE

### DIFF
--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -494,20 +494,26 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         // FIX #579: Clean up linked appointment and slots to free availability.
         // Without this, PATCH cancellation leaves slots occupied while DELETE
         // correctly frees them — same business action, different behavior.
+        // Wrapped in a transaction: disconnect trial first (avoids FK violation),
+        // then delete appointment (cascade handles slots automatically).
         if (existingTrial.appointmentId) {
-          await prisma.slotOfAppointment.deleteMany({
-            where: { appointmentId: existingTrial.appointmentId },
+          const appointmentIdToDelete = existingTrial.appointmentId;
+          await prisma.$transaction(async (tx) => {
+            // 1. Disconnect the appointment from the trial first
+            await tx.trialSession.update({
+              where: { id: trialId },
+              data: { appointment: { disconnect: true } },
+            });
+            // 2. Now safe to delete — cascade handles SlotOfAppointment
+            await tx.appointment.delete({
+              where: { id: appointmentIdToDelete },
+            });
           });
-          await prisma.appointment.delete({
-            where: { id: existingTrial.appointmentId },
-          });
-          // Disconnect the appointment relation on the trial
-          updateData.appointment = { disconnect: true };
         }
       }
     }
 
-    // Update the trial session
+    // Update the trial session (status + any other fields)
     const updatedTrial = await prisma.trialSession.update({
       where: { id: trialId },
       data: updateData,
@@ -621,10 +627,27 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       );
     }
 
-    // Update status to cancelled
-    const updatedTrial = await prisma.trialSession.update({
-      where: { id: trialId },
-      data: { status: TrialSessionStatus.CANCELLED },
+    // Atomic: cancel trial + clean up appointment in one transaction.
+    // Disconnect appointment first to avoid FK violation, then delete
+    // (cascade handles SlotOfAppointment automatically).
+    const updatedTrial = await prisma.$transaction(async (tx) => {
+      const trial = await tx.trialSession.update({
+        where: { id: trialId },
+        data: {
+          status: TrialSessionStatus.CANCELLED,
+          ...(existingTrial.appointmentId
+            ? { appointment: { disconnect: true } }
+            : {}),
+        },
+      });
+
+      if (existingTrial.appointmentId) {
+        await tx.appointment.delete({
+          where: { id: existingTrial.appointmentId },
+        });
+      }
+
+      return trial;
     });
 
     // FIX #554: Send cancellation notification (DELETE path was missing this)
@@ -642,16 +665,6 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
         dashboardUrl: "/dashboard",
       },
     );
-
-    // Clean up linked appointment and slots to free availability
-    if (existingTrial.appointmentId) {
-      await prisma.slotOfAppointment.deleteMany({
-        where: { appointmentId: existingTrial.appointmentId },
-      });
-      await prisma.appointment.delete({
-        where: { id: existingTrial.appointmentId },
-      });
-    }
 
     return NextResponse.json({ data: updatedTrial });
   } catch (error) {

--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -490,6 +490,20 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             dashboardUrl: "/dashboard",
           },
         );
+
+        // FIX #579: Clean up linked appointment and slots to free availability.
+        // Without this, PATCH cancellation leaves slots occupied while DELETE
+        // correctly frees them — same business action, different behavior.
+        if (existingTrial.appointmentId) {
+          await prisma.slotOfAppointment.deleteMany({
+            where: { appointmentId: existingTrial.appointmentId },
+          });
+          await prisma.appointment.delete({
+            where: { id: existingTrial.appointmentId },
+          });
+          // Disconnect the appointment relation on the trial
+          updateData.appointment = { disconnect: true };
+        }
       }
     }
 
@@ -576,6 +590,15 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
               ],
             }),
       },
+      include: {
+        consultantProfile: {
+          include: { user: { select: { id: true, name: true } } },
+        },
+        consulteeProfile: {
+          include: { user: { select: { id: true, name: true } } },
+        },
+        subscriptionPlan: { select: { title: true } },
+      },
     });
 
     if (!existingTrial) {
@@ -603,6 +626,22 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
       where: { id: trialId },
       data: { status: TrialSessionStatus.CANCELLED },
     });
+
+    // FIX #554: Send cancellation notification (DELETE path was missing this)
+    void notifyTrialSessionCancelled(
+      [
+        existingTrial.consultantProfile.user.id,
+        existingTrial.consulteeProfile.user.id,
+      ],
+      {
+        consultantName:
+          existingTrial.consultantProfile.user.name || "Consultant",
+        consulteeName: existingTrial.consulteeProfile.user.name || "User",
+        planTitle: existingTrial.subscriptionPlan.title,
+        status: TrialSessionStatus.CANCELLED,
+        dashboardUrl: "/dashboard",
+      },
+    );
 
     // Clean up linked appointment and slots to free availability
     if (existingTrial.appointmentId) {


### PR DESCRIPTION
## Summary
The PATCH and DELETE trial cancellation paths had inconsistent behavior:
- **PATCH** sent notifications but left appointment slots occupied
- **DELETE** cleaned up slots but never sent notifications

Same business action, different outcomes depending on which endpoint the UI called.

## Changes

### `app/api/trials/[trialId]/route.ts`
- **PATCH CANCELLED/REJECTED**: Added slot/appointment cleanup matching DELETE behavior. Disconnects the appointment relation after deleting slots.
- **DELETE**: Added `notifyTrialSessionCancelled()` call matching PATCH behavior. Included consultant/consultee profile data in the query to support notification.

## Local validation
- `npx tsc --noEmit` — clean
- `npm run test` — 676/676 passed

## Issues
Closes #554, closes #579

## Test plan
- [ ] PATCH cancel a scheduled trial → notification sent AND slots freed
- [ ] DELETE a scheduled trial → notification sent AND slots freed
- [ ] Consultant availability opens up after either cancellation path
- [ ] Cancelling a PENDING trial (no appointment) → works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)