### PR TITLE
fix(security): dispute reconciliation misclassification + verification document scoping

### DIFF
--- a/app/api/admin/verification/[verificationId]/route.ts
+++ b/app/api/admin/verification/[verificationId]/route.ts
@@ -145,11 +145,13 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
       NEEDS_INFO: "PENDING_VERIFICATION",
     };
 
-    // Prepare document feedback updates
+    // FIX #582: Scope document updates to this verification to prevent
+    // staff from accidentally/maliciously updating documents belonging
+    // to a different verification request.
     const documentUpdates =
       documentFeedback?.map((df) =>
-        prisma.profileVerificationDocument.update({
-          where: { id: df.documentId },
+        prisma.profileVerificationDocument.updateMany({
+          where: { id: df.documentId, verificationId },
           data: {
             isValid: df.isValid,
             staffFeedback: df.staffFeedback || null,

--- a/scripts/disputes/reconcile-disputes.ts
+++ b/scripts/disputes/reconcile-disputes.ts
@@ -171,7 +171,10 @@ export async function reconcileDisputes(): Promise<DisputeReconciliationResult> 
       // Also check error code as fallback for StripeError
       const errorCode = (error as { code?: string })?.code;
 
-      // Handle "dispute not found" case - check both error code and message patterns
+      // Handle "dispute not found" case - check both error code and message patterns.
+      // FIX #566: Do NOT mark as WON — a missing dispute could be a transient
+      // API error, a Stripe-side delay, or a dispute that was resolved outside
+      // our system. Log it for manual review instead.
       if (
         errorCode === "resource_missing" ||
         errorMessage.includes("resource_missing") ||
@@ -186,19 +189,17 @@ export async function reconcileDisputes(): Promise<DisputeReconciliationResult> 
         await prisma.dispute.update({
           where: { disputeId: dispute.disputeId },
           data: {
-            status: DisputeStatus.WON,
             evidence: {
               ...existingEvidence,
               reconciliation_note:
-                "Dispute no longer exists at gateway - marked as WON",
+                "Dispute not found at gateway — flagged for manual review (not auto-resolved)",
               reconciled_at: new Date().toISOString(),
             } as Prisma.InputJsonValue,
           },
         });
-        console.log(
-          `✅ Dispute ${dispute.disputeId} no longer exists at gateway - marked as WON`,
+        console.warn(
+          `⚠️ Dispute ${dispute.disputeId} not found at gateway — flagged for manual review (status unchanged)`,
         );
-        reconciledCount++;
       } else {
         errors.push(`Dispute ${dispute.disputeId}: ${errorMessage}`);
         console.error(


### PR DESCRIPTION
## Summary
Two security fixes:

### #566: Dispute reconciliation treats "not found at gateway" as merchant WON
- `scripts/disputes/reconcile-disputes.ts` auto-marked disputes as WON when Stripe returned "resource_missing" / "not found"
- A missing dispute could be a transient API error, a Stripe-side delay, or resolved outside our system
- **Fix:** Leave status unchanged, update evidence note to flag for manual review

### #582: Verification review routes can update document feedback on arbitrary document IDs
- `app/api/admin/verification/[verificationId]/route.ts` accepted any `documentId` in feedback without verifying it belongs to the current verification
- **Fix:** Changed `update` to `updateMany` with `{ id: df.documentId, verificationId }` filter — documents outside this verification are silently skipped

## Local validation
- `npx tsc --noEmit` — clean
- `npm run test` — 676/676 passed

## Issues
Closes #566, closes #582

## Test plan
- [ ] Dispute reconciliation: gateway returns "not found" → status unchanged, evidence note added
- [ ] Verification review with valid document IDs → feedback updated
- [ ] Verification review with document IDs from another verification → silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)