### PR TITLE
fix(trials): implement CONVERTED handler with subscription linkage and activity logging

### DIFF
--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   logTrialCompleted,
   logTrialScheduled,
+  logTrialConverted,
 } from "@/lib/activity/log-activity";
 import {
   lockTrialSlot,
@@ -157,7 +158,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         { status: 400 },
       );
     }
-    const { status, scheduledTime, slotData, notes } = parseResult.data;
+    const { status, scheduledTime, slotData, notes, subscriptionId } =
+      parseResult.data;
 
     // Fetch the existing trial session
     const existingTrial = await prisma.trialSession.findUnique({
@@ -510,6 +512,77 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             });
           });
         }
+      }
+
+      // Handle trial conversion — requires a linked subscription
+      if (status === TrialSessionStatus.CONVERTED) {
+        if (!subscriptionId) {
+          return NextResponse.json(
+            {
+              error:
+                "subscriptionId is required when converting a trial to a subscription",
+            },
+            { status: 400 },
+          );
+        }
+
+        // Validate the subscription exists and belongs to the same plan/consultee
+        const subscription = await prisma.subscription.findUnique({
+          where: { id: subscriptionId },
+          select: {
+            id: true,
+            subscriptionPlan: { select: { id: true } },
+            requestedById: true,
+          },
+        });
+
+        if (!subscription) {
+          return NextResponse.json(
+            { error: "Subscription not found" },
+            { status: 404 },
+          );
+        }
+
+        if (
+          subscription.subscriptionPlan.id !==
+          existingTrial.subscriptionPlan.id
+        ) {
+          return NextResponse.json(
+            {
+              error:
+                "Subscription must belong to the same plan as the trial",
+            },
+            { status: 400 },
+          );
+        }
+
+        if (subscription.requestedById !== existingTrial.consulteeProfileId) {
+          return NextResponse.json(
+            {
+              error:
+                "Subscription must belong to the same consultee as the trial",
+            },
+            { status: 400 },
+          );
+        }
+
+        // Link the subscription to the trial
+        updateData.convertedToSubscription = {
+          connect: { id: subscriptionId },
+        };
+
+        // Log the conversion activity
+        void logTrialConverted(
+          existingTrial.consultantProfileId,
+          trialId,
+          subscriptionId,
+          {
+            id: existingTrial.consulteeProfile.user.id,
+            name: existingTrial.consulteeProfile.user.name || "User",
+            image: existingTrial.consulteeProfile.user.image,
+          },
+          existingTrial.subscriptionPlan.title,
+        );
       }
     }
 

--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -531,7 +531,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
           where: { id: subscriptionId },
           select: {
             id: true,
-            subscriptionPlan: { select: { id: true } },
+            subscriptionPlanId: true,
             requestedById: true,
           },
         });
@@ -544,8 +544,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         if (
-          subscription.subscriptionPlan.id !==
-          existingTrial.subscriptionPlan.id
+          subscription.subscriptionPlanId !==
+          existingTrial.subscriptionPlanId
         ) {
           return NextResponse.json(
             {

--- a/schemas/trials.ts
+++ b/schemas/trials.ts
@@ -20,6 +20,8 @@ export const UpdateTrialSchema = z.object({
     })
     .optional(),
   notes: z.string().optional(),
+  // Required when status = CONVERTED — the subscription created via checkout
+  subscriptionId: z.string().optional(),
 });
 
 export type CreateTrialInput = z.infer<typeof CreateTrialSchema>;


### PR DESCRIPTION
## Summary
The trial PATCH API accepted `status: CONVERTED` but had no handler — the status was set without creating or linking a subscription, and the `TRIAL_CONVERTED` activity event was never recorded.

## Changes

### `schemas/trials.ts`
- Added optional `subscriptionId` field to `UpdateTrialSchema`

### `app/api/trials/[trialId]/route.ts`
- Added CONVERTED handler that:
  - Requires `subscriptionId` in request body (400 if missing)
  - Validates subscription exists, belongs to same plan and consultee
  - Links via `convertedToSubscription: { connect: { id } }`
- Calls `logTrialConverted()` (was defined in `lib/activity/log-activity.ts` but never used)

## Design note
Trials are subscription-only by design — the schema has `subscriptionPlanId` (required) and `convertedToSubscription` (optional outcome). The checkout flow creates the subscription first, then the trial is marked CONVERTED with the subscription ID.

## Local validation
- `npx tsc --noEmit` — clean
- `npm run test` — 676/676 passed

## Issues
Closes #601, closes #602

## Test plan
- [ ] PATCH trial with `status: CONVERTED` without `subscriptionId` → 400
- [ ] PATCH with `subscriptionId` from wrong plan → 400
- [ ] PATCH with `subscriptionId` from wrong consultee → 400
- [ ] PATCH with valid `subscriptionId` → 200, trial linked, activity logged
- [ ] Activity log shows TRIAL_CONVERTED event

🤖 Generated with [Claude Code](https://claude.com/claude-code)