### PR TITLE
fix(invoice): use immutable originalAmount for credit discount calculation

### DIFF
--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -42,7 +42,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
                 discountValue: true,
               },
             },
-            creditUsages: { select: { amount: true } },
+            creditUsages: { select: { amount: true, originalAmount: true } },
           },
         },
       },

--- a/lib/payments/payouts/invoice-pdf.tsx
+++ b/lib/payments/payouts/invoice-pdf.tsx
@@ -723,7 +723,7 @@ export async function getInvoicePdfData(
         discountType: string;
         discountValue: number;
       } | null;
-      creditUsages?: { amount: number }[];
+      creditUsages?: { amount: number; originalAmount?: number }[];
     } | null;
   },
   companyInfo?: {
@@ -739,8 +739,10 @@ export async function getInvoicePdfData(
   const taxAmount = invoice.taxAmount ?? 0;
   const isInternational = payment?.isInternational ?? false;
 
+  // FIX #604: Use originalAmount (immutable) instead of amount (mutable,
+  // decremented on partial refund). Prevents invoice discount drift on regeneration.
   const creditsAppliedAmount =
-    payment?.creditUsages?.reduce((sum, cu) => sum + cu.amount, 0) ?? 0;
+    payment?.creditUsages?.reduce((sum, cu) => sum + (cu.originalAmount ?? cu.amount), 0) ?? 0;
 
   const discountAmount =
     payment && payment.originalAmount > 0


### PR DESCRIPTION
## Summary
Invoice PDF credit discount calculation summed `creditUsages.amount` which is mutable — decremented when partial refunds restore credit. Regenerating an invoice after a partial refund would show a different discount total.

## Changes
### `lib/payments/payouts/invoice-pdf.tsx`
- Use `cu.originalAmount` (immutable, set at creation) instead of `cu.amount` (mutable)
- Fallback to `cu.amount` for backwards compatibility with older records
- Updated type to include `originalAmount?: number`

## Local validation
- `npx tsc --noEmit` — clean
- `npm run test` — 676/676 passed

## Issues
Closes #604

## Test plan
- [ ] Generate invoice PDF → discount shows original credit amount
- [ ] Partial refund → regenerate same invoice → discount unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)