### PR TITLE
fix: payout batch integrity, lost-dispute reversal, sync pagination, collaborator splits, CI gating

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         run: npx prisma generate
 
       - name: Unit Tests
-        run: npm run test -- --passWithNoTests
+        run: npm run test
 
       - name: Build
         run: npm run build

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -217,10 +217,12 @@ export async function createPayoutBatch(
       },
     });
 
-    // Create payouts for each eligible consultant
+    // FIX #568: Create each payout inside a transaction so the amount
+    // recorded always matches the earnings actually linked. The groupBy
+    // above gives us candidates; the transaction re-queries the exact
+    // earnings, sums them, creates the payout, and links — atomically.
     for (const consultant of eligibleConsultants) {
-      const { consultantProfileId, _sum } = consultant;
-      const amount = _sum?.consultantShare || 0;
+      const { consultantProfileId } = consultant;
 
       // Get consultant's default payout account
       const account = await prisma.payoutAccount.findFirst({
@@ -251,38 +253,57 @@ export async function createPayoutBatch(
           method = PayoutMethod.BANK_TRANSFER;
       }
 
-      // Determine if auto-approve applies
-      const shouldAutoApprove =
-        amount < PAYOUT_CONSTANTS.AUTO_APPROVE_THRESHOLD;
+      await prisma.$transaction(async (tx) => {
+        // Re-query exact READY earnings inside the transaction
+        const readyEarnings = await tx.consultantEarnings.findMany({
+          where: {
+            consultantProfileId,
+            status: EarningStatus.READY,
+            payoutId: null,
+          },
+          select: { id: true, consultantShare: true },
+        });
 
-      // Create payout record
-      const payout = await prisma.payout.create({
-        data: {
-          consultantProfileId,
-          provider: account.provider,
-          amount,
-          currency: "INR",
-          status: shouldAutoApprove
-            ? PayoutStatus.APPROVED
-            : PayoutStatus.PENDING,
-          method,
-          batchId,
-          idempotencyKey: `payout_${consultantProfileId}_${batchId}`,
-          approvedAt: shouldAutoApprove ? new Date() : undefined,
-          approvedBy: shouldAutoApprove ? "SYSTEM_AUTO_APPROVE" : undefined,
-        },
-      });
+        if (readyEarnings.length === 0) return;
 
-      // Link earnings to this payout
-      await prisma.consultantEarnings.updateMany({
-        where: {
-          consultantProfileId,
-          status: EarningStatus.READY,
-          payoutId: null,
-        },
-        data: {
-          payoutId: payout.id,
-        },
+        // Calculate amount from the actual earnings being linked
+        const amount = readyEarnings.reduce(
+          (sum, e) => sum + e.consultantShare,
+          0,
+        );
+
+        if (amount < PAYOUT_CONSTANTS.MINIMUM_PAYOUT_AMOUNT) return;
+
+        const shouldAutoApprove =
+          amount < PAYOUT_CONSTANTS.AUTO_APPROVE_THRESHOLD;
+
+        // Create payout with the exact amount
+        const payout = await tx.payout.create({
+          data: {
+            consultantProfileId,
+            provider: account.provider,
+            amount,
+            currency: "INR",
+            status: shouldAutoApprove
+              ? PayoutStatus.APPROVED
+              : PayoutStatus.PENDING,
+            method,
+            batchId,
+            idempotencyKey: `payout_${consultantProfileId}_${batchId}`,
+            approvedAt: shouldAutoApprove ? new Date() : undefined,
+            approvedBy: shouldAutoApprove ? "SYSTEM_AUTO_APPROVE" : undefined,
+          },
+        });
+
+        // Link the exact earnings we summed (by ID, not by status filter)
+        await tx.consultantEarnings.updateMany({
+          where: {
+            id: { in: readyEarnings.map((e) => e.id) },
+          },
+          data: {
+            payoutId: payout.id,
+          },
+        });
       });
     }
 

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -295,15 +295,24 @@ export async function createPayoutBatch(
           },
         });
 
-        // Link the exact earnings we summed (by ID, not by status filter)
-        await tx.consultantEarnings.updateMany({
+        // Link the exact earnings we summed, with guards against concurrent state changes
+        const linkResult = await tx.consultantEarnings.updateMany({
           where: {
             id: { in: readyEarnings.map((e) => e.id) },
+            status: EarningStatus.READY,
+            payoutId: null,
           },
           data: {
             payoutId: payout.id,
           },
         });
+
+        // If not all targeted earnings were linked, some changed state concurrently
+        if (linkResult.count !== readyEarnings.length) {
+          throw new Error(
+            `Payout linking race: expected ${readyEarnings.length} earnings, linked ${linkResult.count} for consultant ${consultantProfileId}. Rolling back.`,
+          );
+        }
       });
     }
 

--- a/scripts/disputes/handle-lost-disputes.ts
+++ b/scripts/disputes/handle-lost-disputes.ts
@@ -102,14 +102,14 @@ export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
       continue;
     }
 
-    // Check if any earnings are already PAID (for logging)
-    const hasPaidEarnings = earningsList.some(
+    // Count PAID earnings for summary reporting
+    const paidEarningsCount = earningsList.filter(
       (e) => e.status === EarningStatus.PAID,
-    );
-    if (hasPaidEarnings) {
-      alreadyPaidCount++;
+    ).length;
+    if (paidEarningsCount > 0) {
+      alreadyPaidCount += paidEarningsCount;
       console.warn(
-        `⚠️ Dispute ${dispute.disputeId} has PAID earnings — forceRefund will reverse revenue + TDS`,
+        `⚠️ Dispute ${dispute.disputeId} has ${paidEarningsCount} PAID earnings — forceRefund will reverse revenue + TDS`,
       );
     }
 

--- a/scripts/disputes/handle-lost-disputes.ts
+++ b/scripts/disputes/handle-lost-disputes.ts
@@ -21,6 +21,7 @@
 
 import prisma from "../../lib/prisma";
 import { DisputeStatus, EarningStatus } from "@prisma/client";
+import { refundEarnings } from "../../lib/payments/payouts/earnings-service";
 
 export interface LostDisputeHandlerResult {
   success: boolean;
@@ -89,73 +90,45 @@ export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
       continue;
     }
 
-    for (const earnings of earningsList) {
-      // Check if earnings were already paid out
-      if (earnings.status === EarningStatus.PAID) {
-        // This is a critical situation - earnings were paid but dispute was lost
-        console.error(
-          `⚠️ CRITICAL: Dispute ${dispute.disputeId} lost but earnings ${earnings.id} already PAID!`,
-        );
-        console.error(
-          `   Consultant: ${earnings.consultantProfile.user.name || "Unknown"} (${earnings.consultantProfile.user.email})`,
-        );
-        console.error(
-          `   Amount: ₹${(earnings.consultantShare / 100).toFixed(2)}`,
-        );
-        console.error(`   Manual recovery required!`);
+    // FIX #567: Use the canonical refundEarnings() path instead of reimplementing.
+    // This ensures TDS reversal for PAID earnings, correct revenue field
+    // (totalRevenue for PAID, pendingRevenue for non-PAID), and refundedShareAmount tracking.
+    const paymentId = dispute.payment?.id;
+    if (!paymentId) {
+      console.warn(
+        `⏭️ Skipping dispute ${dispute.disputeId} - no payment linked`,
+      );
+      skippedCount++;
+      continue;
+    }
 
-        // Still mark as REFUNDED to prevent double-payout, but flag for manual review
-        try {
-          await prisma.consultantEarnings.update({
-            where: { id: earnings.id },
-            data: {
-              status: EarningStatus.REFUNDED,
-            },
-          });
+    // Check if any earnings are already PAID (for logging)
+    const hasPaidEarnings = earningsList.some(
+      (e) => e.status === EarningStatus.PAID,
+    );
+    if (hasPaidEarnings) {
+      alreadyPaidCount++;
+      console.warn(
+        `⚠️ Dispute ${dispute.disputeId} has PAID earnings — forceRefund will reverse revenue + TDS`,
+      );
+    }
 
-          alreadyPaidCount++;
-          updatedCount++;
-        } catch (error) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error);
-          errors.push(`Earnings ${earnings.id} (PAID): ${errorMessage}`);
-          errorCount++;
-        }
-        continue;
-      }
-
-      try {
-        // Update earnings status to REFUNDED
-        await prisma.consultantEarnings.update({
-          where: { id: earnings.id },
-          data: {
-            status: EarningStatus.REFUNDED,
-          },
-        });
-
-        // Decrease consultant's pending revenue
-        await prisma.consultantProfile.update({
-          where: { id: earnings.consultantProfileId },
-          data: {
-            pendingRevenue: { decrement: earnings.consultantShare },
-          },
-        });
-
-        console.log(
-          `✅ Updated earnings ${earnings.id} to REFUNDED (dispute: ${dispute.disputeId}, amount: ₹${(earnings.consultantShare / 100).toFixed(2)})`,
-        );
-        updatedCount++;
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        errors.push(`Earnings ${earnings.id}: ${errorMessage}`);
-        console.error(
-          `❌ Error updating earnings ${earnings.id}:`,
-          errorMessage,
-        );
-        errorCount++;
-      }
-    } // end for earnings
+    try {
+      await refundEarnings(paymentId, { forceRefund: true });
+      updatedCount += earningsList.length;
+      console.log(
+        `✅ Refunded earnings for dispute ${dispute.disputeId} (${earningsList.length} records via refundEarnings)`,
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      errors.push(`Dispute ${dispute.disputeId}: ${errorMessage}`);
+      console.error(
+        `❌ Error refunding earnings for dispute ${dispute.disputeId}:`,
+        errorMessage,
+      );
+      errorCount++;
+    }
   }
 
   // Log summary of critical cases

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -20,7 +20,7 @@
  */
 
 import prisma from "../../lib/prisma";
-import { EarningStatus, PaymentStatus, AppointmentsType } from "@prisma/client";
+import { EarningStatus, EarningRole, PaymentStatus, AppointmentsType } from "@prisma/client";
 import {
   PAYOUT_CONSTANTS,
   AppointmentType,
@@ -232,6 +232,8 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
       consultantShare: number;
       status: EarningStatus;
       holdUntil: Date;
+      role?: EarningRole;
+      sharePercentage?: number;
     }> = [];
     const revenueUpdates: Map<string, number> = new Map();
 
@@ -306,12 +308,22 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
 
       if (splits.length > 0) {
         // Multi-party earnings (collaborator splits)
+        // Owner gets full grossAmount/platformFee; collaborators get 0 for those fields.
         for (const split of splits) {
-          const splitEarnings = calculateEarningsData(payment, split.consultantProfileId);
-          splitEarnings.consultantShare = split.share;
-          splitEarnings.platformFee = baseEarnings.platformFee;
-          splitEarnings.grossAmount = baseEarnings.grossAmount;
-          earningsToCreate.push(splitEarnings);
+          const isOwner = split.role === "OWNER";
+          const splitBase = calculateEarningsData(payment, split.consultantProfileId);
+          const sharePercentage = totalConsultantPool > 0
+            ? Math.round((split.share / totalConsultantPool) * 10000) / 100
+            : 0;
+
+          earningsToCreate.push({
+            ...splitBase,
+            consultantShare: split.share,
+            grossAmount: isOwner ? baseEarnings.grossAmount : 0,
+            platformFee: isOwner ? baseEarnings.platformFee : 0,
+            role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
+            sharePercentage,
+          });
 
           const currentRevenue = revenueUpdates.get(split.consultantProfileId) || 0;
           revenueUpdates.set(
@@ -321,7 +333,11 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
         }
       } else {
         // Single-party earnings (owner only, or no collaborators)
-        earningsToCreate.push(baseEarnings);
+        earningsToCreate.push({
+          ...baseEarnings,
+          role: EarningRole.OWNER,
+          sharePercentage: 100,
+        });
 
         const currentRevenue = revenueUpdates.get(consultantProfileId) || 0;
         revenueUpdates.set(

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -25,6 +25,7 @@ import {
   PAYOUT_CONSTANTS,
   AppointmentType,
 } from "../../lib/payments/payouts/constants";
+import { calculateRevenueSplit } from "../../lib/collaborators/service";
 
 // Only sync payments within the last 30 days
 const SYNC_WINDOW_DAYS = 30;
@@ -135,11 +136,14 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
     Date.now() - SYNC_WINDOW_DAYS * 24 * 60 * 60 * 1000,
   );
 
-  let skip = 0;
+  // FIX #571: Use cursor-based pagination instead of skip-based.
+  // Skip-based pagination on a mutating result set (earnings: { none: {} })
+  // can silently skip payments when items are removed from the set mid-iteration.
+  let cursor: string | undefined;
   let hasMore = true;
 
   while (hasMore) {
-    // Fetch batch with limit
+    // Fetch batch with cursor-based pagination
     const payments = await prisma.payment.findMany({
       where: {
         paymentStatus: PaymentStatus.SUCCEEDED,
@@ -147,7 +151,9 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
         earnings: { none: {} }, // No linked earnings
       },
       take: BATCH_SIZE,
-      skip,
+      ...(cursor
+        ? { cursor: { id: cursor }, skip: 1 } // skip the cursor item itself
+        : {}),
       include: {
         appointment: {
           include: {
@@ -168,27 +174,35 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
             webinar: {
               include: {
                 webinarPlan: {
-                  select: { consultantProfileId: true },
+                  select: {
+                    id: true,
+                    consultantProfileId: true,
+                  },
                 },
               },
             },
             class: {
               include: {
                 classPlan: {
-                  select: { consultantProfileId: true },
+                  select: {
+                    id: true,
+                    consultantProfileId: true,
+                  },
                 },
               },
             },
           },
         },
       },
-      orderBy: { createdAt: "asc" },
+      orderBy: { id: "asc" },
     });
 
     if (payments.length < BATCH_SIZE) {
       hasMore = false;
     }
-    skip += BATCH_SIZE;
+    if (payments.length > 0) {
+      cursor = payments[payments.length - 1].id;
+    }
     totalProcessed += payments.length;
 
     if (payments.length === 0) {
@@ -247,15 +261,74 @@ export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
         continue;
       }
 
-      const earningsData = calculateEarningsData(payment, consultantProfileId);
-      earningsToCreate.push(earningsData);
+      // FIX #572: For webinar/class payments, check for collaborator revenue splits
+      // instead of giving 100% to the plan owner.
+      const appointmentType = appointment?.appointmentType;
+      const webinarPlanId = appointment?.webinar?.webinarPlan?.id;
+      const classPlanId = appointment?.class?.classPlan?.id;
 
-      // Accumulate revenue updates per consultant
-      const currentRevenue = revenueUpdates.get(consultantProfileId) || 0;
-      revenueUpdates.set(
-        consultantProfileId,
-        currentRevenue + earningsData.consultantShare,
-      );
+      const baseEarnings = calculateEarningsData(payment, consultantProfileId);
+      const totalConsultantPool = baseEarnings.consultantShare;
+
+      let splits: Array<{
+        consultantProfileId: string;
+        share: number;
+        role: string;
+      }> = [];
+
+      if (
+        appointmentType === AppointmentsType.WEBINAR &&
+        webinarPlanId
+      ) {
+        try {
+          splits = await calculateRevenueSplit(
+            "webinar",
+            webinarPlanId,
+            totalConsultantPool,
+          );
+        } catch {
+          // Fallback to owner-only if split calculation fails
+        }
+      } else if (
+        appointmentType === AppointmentsType.CLASS &&
+        classPlanId
+      ) {
+        try {
+          splits = await calculateRevenueSplit(
+            "class",
+            classPlanId,
+            totalConsultantPool,
+          );
+        } catch {
+          // Fallback to owner-only if split calculation fails
+        }
+      }
+
+      if (splits.length > 0) {
+        // Multi-party earnings (collaborator splits)
+        for (const split of splits) {
+          const splitEarnings = calculateEarningsData(payment, split.consultantProfileId);
+          splitEarnings.consultantShare = split.share;
+          splitEarnings.platformFee = baseEarnings.platformFee;
+          splitEarnings.grossAmount = baseEarnings.grossAmount;
+          earningsToCreate.push(splitEarnings);
+
+          const currentRevenue = revenueUpdates.get(split.consultantProfileId) || 0;
+          revenueUpdates.set(
+            split.consultantProfileId,
+            currentRevenue + split.share,
+          );
+        }
+      } else {
+        // Single-party earnings (owner only, or no collaborators)
+        earningsToCreate.push(baseEarnings);
+
+        const currentRevenue = revenueUpdates.get(consultantProfileId) || 0;
+        revenueUpdates.set(
+          consultantProfileId,
+          currentRevenue + baseEarnings.consultantShare,
+        );
+      }
     }
 
     // Batch create earnings


### PR DESCRIPTION
## Summary
Five fixes targeting the lowest-scoring audit areas (payouts 63%, disputes 70%, refunds 68%). These are the last 5 open ChatGPT-5.4 Codex issues from the Checkpoint 1 audit (#613).

## Changes

### #567: Lost-dispute handler missing TDS reversal + wrong revenue field
**File:** `scripts/disputes/handle-lost-disputes.ts`
- Replaced manual earnings reversal with `refundEarnings(paymentId, { forceRefund: true })`
- Now correctly: creates TDS reversal for PAID earnings, decrements `totalRevenue` (not `pendingRevenue`), tracks `refundedShareAmount`

### #568: Payout batch amount diverges from linked earnings (TOCTOU)
**File:** `lib/payments/payouts/payout-service.ts`
- Wrapped each consultant's payout in a `$transaction` that: re-queries READY earnings by ID → sums → creates payout → links by exact IDs
- Eliminates race where the set of READY earnings changes between sum and link

### #571: Skip-based pagination misses payments in mutating result set
**File:** `scripts/earnings/sync-payment-earnings.ts`
- Replaced `skip`-based pagination with cursor-based (`cursor: { id: lastId }, skip: 1`)
- Result set filtered by `earnings: { none: {} }` shrinks as earnings are created; skip-based would silently miss items

### #572: Sync-earnings ignores collaborator revenue splits for webinar/class
**File:** `scripts/earnings/sync-payment-earnings.ts`
- For WEBINAR/CLASS payments, calls `calculateRevenueSplit()` to create multi-party earnings
- Falls back to single-party if no accepted collaborators or if split calculation fails

### #545: CI passes with zero tests
**File:** `.github/workflows/ci.yaml`
- Removed `--passWithNoTests` flag — tests must now actually pass

## Local validation
- `npx tsc --noEmit` — clean
- `npm run test` — 676/676 passed

## Issues
Closes #567, closes #568, closes #571, closes #572, closes #545

## Test plan
- [ ] Lost dispute with PAID earnings → TDS reversal created, totalRevenue decremented
- [ ] Payout batch → amount exactly matches sum of linked earnings
- [ ] Sync script with >100 payments → no payments silently skipped
- [ ] Webinar payment with 70/30 collaborator split → sync creates 2 earnings records
- [ ] CI with failing test → build fails (no silent pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)