### PR TITLE
docs: update payment, payout, refund, and dispute docs for fix sprint

### DIFF
--- a/docs/maintenance/02-degraded-vs-offline.md
+++ b/docs/maintenance/02-degraded-vs-offline.md
@@ -43,6 +43,13 @@
 | **Participants** (`/api/participants/*`)                 | Allowed                                 | Blocked                    | LOW        |
 | **Trials** (`/api/trials`, `/api/trials/[id]`)           | Allowed (gap)                           | Blocked                    | MEDIUM     |
 | **Plans** (`/api/plans/*`)                               | GET: Allowed, POST/PATCH: Allowed (gap) | Blocked                    | MEDIUM     |
+| **Slot appointments** (`/api/slots/appointments`)        | **Writes blocked (503)** (Mar 2026)     | Blocked                    | HIGH       |
+| **Waitlist** (`/api/waitlist`)                           | **Writes blocked (503)** (Mar 2026)     | Blocked                    | MEDIUM     |
+| **Referrals** (`/api/referrals`)                         | **Writes blocked (503)** (Mar 2026)     | Blocked                    | MEDIUM     |
+| **Collaborators** (`/api/collaborators`)                 | **Writes blocked (503)** (Mar 2026)     | Blocked                    | MEDIUM     |
+| **Refunds** (`/api/payments/refunds`)                    | **Writes blocked (503)** (Mar 2026)     | Blocked                    | HIGH       |
+| **Disputes** (`/api/payments/disputes`)                  | **Writes blocked (503)** (Mar 2026)     | Blocked                    | HIGH       |
+| **Admin payouts** (`/api/admin/payouts`)                 | **Writes blocked (503)** (Mar 2026)     | Blocked                    | HIGH       |
 | **User routes** (`/api/user/*`)                          | Allowed                                 | Blocked                    | LOW        |
 | **Admin routes** (`/api/admin/*`)                        | Allowed                                 | Blocked                    | LOW        |
 | **Staff routes** (`/api/staff/*`)                        | Allowed                                 | Blocked                    | LOW        |
@@ -61,13 +68,23 @@
 
 ## Current Gaps
 
-### Gap 1: DEGRADED Does Not Block Writes
+### Gap 1: DEGRADED Now Blocks Critical Writes (Partially Resolved Mar 2026)
 
-**Problem**: In DEGRADED mode, the middleware only adds informational headers (`x-maintenance-phase`, `x-maintenance-reason`, `x-maintenance-eta`). All write operations (POST, PATCH, DELETE) proceed normally.
+**Previous problem**: In DEGRADED mode, the middleware only added informational headers (`x-maintenance-phase`, `x-maintenance-reason`, `x-maintenance-eta`). All write operations (POST, PATCH, DELETE) proceeded normally.
 
-**Impact**: Users can complete checkouts, create appointments, modify events, and perform other transactional operations during DEGRADED mode.
+**Mar 2026 fix**: The following routes are now **write-blocked** (return 503) during DEGRADED mode:
 
-**When this matters**: If DEGRADED is used during a deployment that changes business logic but not the DB schema, writes could produce inconsistent data.
+| Route | Reason |
+| --- | --- |
+| `/api/slots/appointments` | Prevent slot modifications during maintenance |
+| `/api/waitlist` | Prevent waitlist mutations |
+| `/api/referrals` | Prevent referral creation |
+| `/api/collaborators` | Prevent collaborator changes |
+| `/api/payments/refunds` | Prevent refund processing |
+| `/api/payments/disputes` | Prevent dispute evidence submission |
+| `/api/admin/payouts` | Prevent payout batch creation/approval |
+
+**Remaining gap**: Checkout (`/api/checkout`), appointment cancel/reschedule, event CRUD, and trial routes are still **not** write-blocked in DEGRADED mode. These may be addressed in a future update.
 
 ### Gap 2: Cron Jobs Bypass Middleware Entirely
 

--- a/docs/maintenance/04-cron-jobs-reference.md
+++ b/docs/maintenance/04-cron-jobs-reference.md
@@ -198,7 +198,7 @@ All 27 scheduled jobs run as GitHub Actions workflows, executing standalone Node
 | -------------------- | -------------------------------------------------------------------------------------------------------------- |
 | **Schedule**         | `0 */6 * * *` (every 6 hours)                                                                                  |
 | **Script**           | `jobs/disputes/handle-lost-disputes.ts`                                                                        |
-| **Description**      | Processes disputes marked as lost. Updates earnings status and sends alerts if earnings were already paid out. |
+| **Description**      | Processes disputes marked as lost. Now uses canonical `refundEarnings(paymentId, { forceRefund: true })` instead of manual logic (Mar 2026). Correctly creates TDS reversal records and decrements `totalRevenue` for PAID earnings. |
 | **DB Connection**    | Yes (Prisma)                                                                                                   |
 | **External APIs**    | Stripe                                                                                                         |
 | **Maintenance Risk** | HIGH -- May incorrectly process earnings if data is in flux                                                    |
@@ -250,7 +250,7 @@ All 27 scheduled jobs run as GitHub Actions workflows, executing standalone Node
 | -------------------- | ---------------------------------------------------------------------------------------------- |
 | **Schedule**         | `0 * * * *` (hourly)                                                                           |
 | **Script**           | `jobs/earnings/sync-payment-earnings.ts`                                                       |
-| **Description**      | Matches confirmed payments with consultant earnings records. Creates missing earnings entries. |
+| **Description**      | Matches confirmed payments with consultant earnings records. Creates missing earnings entries. Uses cursor-based pagination (Mar 2026, replacing skip-based). For WEBINAR/CLASS payments, calls `calculateRevenueSplit()` to create multi-party earnings with proper role/sharePercentage for collaborators. |
 | **DB Connection**    | Yes (Prisma)                                                                                   |
 | **External APIs**    | None                                                                                           |
 | **Maintenance Risk** | HIGH -- May create incorrect earnings if payment/earnings tables are being migrated            |

--- a/docs/payments/01-architecture.md
+++ b/docs/payments/01-architecture.md
@@ -35,6 +35,10 @@ The payment system supports multiple payment gateways (Stripe, Razorpay) with pl
 - **Two-Phase Refund Pattern**: Atomically claims amount before gateway call
 - **Reconciliation Crons**: Catch stuck records from crashes/timeouts
 - **Webhook Idempotency**: All handlers check if record already exists/processed
+- **Payout Webhook Idempotency** (Mar 2026): `handlePayoutWebhook` uses atomic `updateMany` with terminal-status guard to prevent double-applying revenue
+- **Razorpay Composite EventId** (Mar 2026): Webhook eventId formatted as `{eventType}:{entityId}` to prevent cross-event collisions
+- **Post-Commit Emails** (Mar 2026): Payment success notifications sent after transaction commits to prevent false confirmations on rollback
+- **Payout Batch Integrity** (Mar 2026): Each consultant's batch payout wrapped in `$transaction` with count-mismatch guard
 
 ---
 
@@ -672,8 +676,16 @@ RequestStatus:
                                  |
                                  v
 +-----------------------------------------------------------------------------------+
+|  Phase 1 (Transaction):                                                           |
 |  UPDATE PAYMENT STATUS = SUCCEEDED                                                |
+|  CONFIRM APPOINTMENT                                                              |
++-----------------------------------------------------------------------------------+
+                                        |
+                                        v
++-----------------------------------------------------------------------------------+
+|  Phase 2 (Post-Commit):                                                           |
 |  SEND PAYMENT SUCCESS EMAIL                                                       |
+|  (Moved outside transaction in Mar 2026 to prevent false emails on rollback)      |
 +-----------------------------------------------------------------------------------+
 ```
 

--- a/docs/payments/checkout-flow/03-payment-processing.md
+++ b/docs/payments/checkout-flow/03-payment-processing.md
@@ -631,6 +631,11 @@ export async function handlePaymentSuccess(
       `✅ Payment ${paymentIntentId} processed successfully. Appointment ID: ${appointment.id}`,
     );
   });
+
+  // Phase 2 (post-commit): Send notification emails AFTER transaction commits
+  // Moved outside the transaction in Mar 2026 to prevent false confirmation
+  // emails being sent if the transaction later rolls back.
+  await sendPaymentSuccessNotification(paymentIntentId, metadata);
 }
 ```
 

--- a/docs/payments/gateways/razorpay/02-architecture-and-flow.md
+++ b/docs/payments/gateways/razorpay/02-architecture-and-flow.md
@@ -181,6 +181,10 @@ In our system, these map to `PaymentStatus`: `PENDING` (created/authorized), `SU
 
 **Source**: `app/api/webhooks/razorpay/route.ts`
 
+### Webhook Idempotency (Mar 2026)
+
+Razorpay webhook eventId is now constructed as a **composite key**: `{eventType}:{entityId}` (e.g., `payment.captured:pay_abc123`). This prevents cross-event collisions where different event types for the same entity (e.g., `payment.captured` and `refund.created` both referencing the same payment) would previously share the same idempotency key and incorrectly deduplicate.
+
 ---
 
 ## Currency

--- a/docs/payments/payouts/01-architecture.md
+++ b/docs/payments/payouts/01-architecture.md
@@ -115,10 +115,10 @@ graph LR
 
 | Function                    | Purpose                                 | Trigger                  |
 | --------------------------- | --------------------------------------- | ------------------------ |
-| `createEarningsFromPayment` | Create earnings record with hold period | Webhook: payment.success |
+| `createEarningsFromPayment` | Create earnings record(s) with hold period. For WEBINAR/CLASS with collaborators, creates multi-party earnings via `calculateRevenueSplit()`. | Webhook: payment.success |
 | `releaseEarningsFromHold`   | PENDING → READY after hold period       | Cron: hourly             |
 | `getConsultantEarnings`     | Fetch earnings for dashboard            | API request              |
-| `refundEarnings`            | Mark as REFUNDED on payment refund      | Webhook: refund          |
+| `refundEarnings`            | Proportional or full reversal of earnings. Accepts `refundAmount`/`paymentAmount` for partial refunds. Tracks cumulative reversals via `refundedShareAmount`. Supports `forceRefund: true` for PAID earnings (lost disputes). | Webhook: refund, Cron: lost disputes |
 | `holdEarnings`              | READY → HELD on dispute                 | Webhook: dispute         |
 | `releaseHeldEarnings`       | HELD → READY when dispute resolved      | Admin action             |
 
@@ -159,7 +159,7 @@ graph LR
 | `approvePayout`          | Admin approves pending payout          | Admin action   |
 | `rejectPayout`           | Admin rejects with reason              | Admin action   |
 | `processApprovedPayouts` | Send to payment provider               | Cron: weekly   |
-| `handlePayoutWebhook`    | Update status from provider            | Webhook event  |
+| `handlePayoutWebhook`    | Update status from provider. Uses atomic `updateMany` with `status: { notIn: [COMPLETED, CANCELLED] }` guard for idempotency. | Webhook event  |
 
 ---
 
@@ -182,6 +182,8 @@ graph LR
     A --> IN[(Invoice)]
     IN --> C & D & E
 ```
+
+> **Invoice PDF Fix (Mar 2026):** Credit/discount calculations in generated PDFs now use `originalAmount` (immutable, set at payment creation) instead of `amount` (mutable, can change after partial refunds). This prevents discount values from drifting when partial refunds modify the payment's `amount` field.
 
 ---
 
@@ -207,6 +209,7 @@ erDiagram
         int grossAmount
         int platformFee
         int consultantShare
+        int refundedShareAmount
         enum status
         datetime holdUntil
         datetime paidAt

--- a/docs/payments/payouts/02-earnings-lifecycle.md
+++ b/docs/payments/payouts/02-earnings-lifecycle.md
@@ -172,6 +172,12 @@ gantt
 
 ---
 
+## Multi-Party Revenue Splits (Mar 2026)
+
+For WEBINAR and CLASS payments with collaborators, the `sync-payment-earnings` job and the earnings creation flow now call `calculateRevenueSplit()` to create **multiple** `ConsultantEarnings` records per payment -- one for the owner and one for each collaborator, each with their `role` and `sharePercentage`. This replaces the previous single-earnings-per-payment assumption.
+
+---
+
 ## Revenue Split Calculation
 
 ```mermaid
@@ -204,7 +210,7 @@ function calculateSplit(grossAmount: number) {
 
 ## Refund Handling
 
-When a payment is refunded, the associated earnings are marked as REFUNDED.
+When a payment is refunded, the associated earnings are reversed proportionally (partial) or fully.
 
 ```mermaid
 sequenceDiagram
@@ -213,30 +219,43 @@ sequenceDiagram
     participant DB as Database
     participant CP as ConsultantProfile
 
-    WH->>ES: refundEarnings(paymentId)
+    WH->>ES: refundEarnings(paymentId, opts)
+    Note over WH,ES: opts: { refundAmount, paymentAmount }
 
     ES->>DB: Find earnings by paymentId
     DB-->>ES: earnings record
 
-    alt Earnings status is PENDING or READY
+    alt Full refund or refundedShareAmount exhausted
         ES->>DB: Update status to REFUNDED
-        ES->>CP: Decrement pendingRevenue
-        ES-->>WH: Refund processed
-    else Earnings status is PAID
-        ES-->>WH: Error: Already paid out
-        Note over WH: Platform absorbs loss or<br/>initiates recovery
+        ES->>DB: Increment refundedShareAmount
+        ES->>CP: Decrement pendingRevenue/totalRevenue
+        ES-->>WH: Refund processed (full)
+    else Partial refund
+        ES->>DB: Increment refundedShareAmount by proportional amount
+        ES->>CP: Decrement pendingRevenue/totalRevenue proportionally
+        ES-->>WH: Refund processed (partial)
+    else Earnings status is PAID (with forceRefund)
+        ES->>DB: Reverse via forceRefund path
+        ES->>CP: Decrement totalRevenue
+        ES-->>WH: Forced refund processed
     end
 ```
 
+### Partial Refund Support (Mar 2026)
+
+`refundEarnings()` now accepts `refundAmount`/`paymentAmount` for proportional reversal. A new `refundedShareAmount` field on `ConsultantEarnings` tracks cumulative partial refunds. Earnings auto-transition to `REFUNDED` when `refundedShareAmount >= consultantShare`.
+
 ### Refund States
 
-| Original Status | Can Refund? | Action            |
-| --------------- | ----------- | ----------------- |
-| PENDING         | Yes         | Mark as REFUNDED  |
-| READY           | Yes         | Mark as REFUNDED  |
-| HELD            | Yes         | Mark as REFUNDED  |
-| PAID            | No          | Already disbursed |
-| REFUNDED        | No          | Already refunded  |
+| Original Status | Can Refund? | Action                                             |
+| --------------- | ----------- | -------------------------------------------------- |
+| PENDING         | Yes         | Proportional or full reversal, may mark REFUNDED   |
+| READY           | Yes         | Proportional or full reversal, may mark REFUNDED   |
+| HELD            | Yes         | Proportional or full reversal, may mark REFUNDED   |
+| PAID            | Yes*        | Via `forceRefund: true` (lost disputes), decrements totalRevenue |
+| REFUNDED        | No          | Already refunded                                   |
+
+> *PAID earnings can now be refunded using `forceRefund: true`, used by the lost-dispute handler. This creates TDS reversal records and decrements `totalRevenue`.
 
 ---
 
@@ -273,9 +292,13 @@ await holdEarnings(paymentId);
 await releaseHeldEarnings(earningsId);
 // Status: HELD → READY
 
-// Resolve in customer's favor
+// Resolve in customer's favor (standard)
 await refundEarnings(paymentId);
 // Status: HELD → REFUNDED
+
+// Lost dispute on already-PAID earnings (Mar 2026)
+await refundEarnings(paymentId, { forceRefund: true });
+// Creates TDS reversal records, decrements totalRevenue
 ```
 
 ---
@@ -341,6 +364,7 @@ model ConsultantEarnings {
   grossAmount          Int                // Total payment amount
   platformFee          Int                // 20% platform cut
   consultantShare      Int                // 80% consultant share
+  refundedShareAmount  Int  @default(0)   // Cumulative partial refund amount (Mar 2026)
 
   // Status tracking
   status               EarningStatus      @default(PENDING)

--- a/docs/payments/payouts/03-payout-processing.md
+++ b/docs/payments/payouts/03-payout-processing.md
@@ -58,8 +58,9 @@ sequenceDiagram
     DB-->>PS: consultant list
 
     loop For each consultant
-        PS->>DB: Get consultant's READY earnings
-        DB-->>PS: earnings list
+        PS->>DB: BEGIN $transaction
+        PS->>DB: Re-query exact READY earnings (inside TX)
+        DB-->>PS: earnings list (authoritative)
 
         PS->>PS: Sum consultantShare amounts
 
@@ -83,14 +84,19 @@ sequenceDiagram
                     Note over DB: Needs admin approval
                 end
 
-                PS->>DB: Link earnings to payout
+                PS->>DB: Link earnings to payout by ID
                 Note over DB: Set payoutId on each earning
+                PS->>PS: Count-mismatch guard
+                Note over PS: Verify linked count == expected count
             end
         end
+        PS->>DB: COMMIT $transaction
     end
 
     PS-->>GH: Batch complete
 ```
+
+> **Batch Integrity (Mar 2026):** Each consultant's payout is now wrapped in a `$transaction` that re-queries exact READY earnings, sums them, creates the payout, and links earnings by ID -- all atomically. A count-mismatch guard ensures the number of linked earnings matches expectations, preventing partial batches from concurrent modifications.
 
 ### Eligibility Criteria
 
@@ -273,6 +279,8 @@ sequenceDiagram
     DB-->>PS: payout record
 
     alt Status: processed/succeeded
+        PS->>DB: Atomic updateMany with guard
+        Note over DB: WHERE status NOT IN<br/>(COMPLETED, CANCELLED)
         PS->>DB: Update payout status to COMPLETED
         PS->>DB: Set processedAt
         PS->>DB: Update linked earnings to PAID
@@ -289,6 +297,8 @@ sequenceDiagram
     PS-->>WH: Handled
     WH-->>PG: 200 OK
 ```
+
+> **Idempotency (Mar 2026):** `handlePayoutWebhook` now uses atomic `updateMany` with a `status: { notIn: [COMPLETED, CANCELLED] }` guard to prevent double-applying revenue on duplicate webhooks. If the payout has already reached a terminal state, the duplicate webhook is safely ignored.
 
 ### Webhook Events
 

--- a/docs/payments/payouts/05-api-reference.md
+++ b/docs/payments/payouts/05-api-reference.md
@@ -613,6 +613,12 @@ All endpoints return consistent error formats:
 
 ---
 
+## Currency Display (Mar 2026)
+
+All amounts in the API and database are stored in **paise** (smallest currency unit). Admin dashboard pages now use `formatCurrencyAmount()` (which divides by 100) instead of the previous `formatCurrencyFromMajorUnit()` when displaying DB-sourced values. This ensures correct rendering -- e.g., a DB value of `80000` (paise) is displayed as "800.00 INR" rather than "80,000.00 INR".
+
+---
+
 ## Authentication
 
 All endpoints require authentication via NextAuth session.

--- a/docs/payments/payouts/07-razorpay-implementation.md
+++ b/docs/payments/payouts/07-razorpay-implementation.md
@@ -691,11 +691,22 @@ export async function handlePayoutWebhook(event: RazorpayTransferEvent) {
 }
 
 async function handleTransferProcessed(payout: any) {
+  // Idempotency guard (Mar 2026): Use updateMany with status guard
+  // to prevent double-applying revenue on duplicate webhooks
+  const result = await prisma.payout.updateMany({
+    where: {
+      id: payout.id,
+      status: { notIn: [PayoutStatus.SUCCEEDED, PayoutStatus.CANCELLED] },
+    },
+    data: { status: PayoutStatus.SUCCEEDED },
+  });
+
+  if (result.count === 0) {
+    console.log(`Payout ${payout.id} already in terminal state, skipping`);
+    return;
+  }
+
   await prisma.$transaction([
-    prisma.payout.update({
-      where: { id: payout.id },
-      data: { status: PayoutStatus.SUCCEEDED },
-    }),
     prisma.consultantEarnings.updateMany({
       where: { payoutId: payout.id },
       data: { status: EarningStatus.PAID },

--- a/docs/payments/refunds-disputes/02-refund-flow.md
+++ b/docs/payments/refunds-disputes/02-refund-flow.md
@@ -288,6 +288,29 @@ Available balance is calculated as:
 availableBalance = payment.amount - SUM(SUCCEEDED refunds) - SUM(PENDING refunds)
 ```
 
+### Proportional Earnings Reversal (Mar 2026)
+
+When a partial refund is processed, `refundEarnings()` now accepts `refundAmount` and `paymentAmount` to compute proportional reversal of consultant earnings:
+
+```typescript
+// Example: $100 payment, $30 partial refund
+refundEarnings(paymentId, {
+  refundAmount: 3000,   // $30.00
+  paymentAmount: 10000, // $100.00
+});
+
+// Result: 30% of consultantShare is reversed
+// refundedShareAmount += proportional amount
+```
+
+A new `refundedShareAmount` field on `ConsultantEarnings` tracks the cumulative amount reversed across partial refunds. When `refundedShareAmount` reaches the full `consultantShare`, the earnings record auto-transitions to `REFUNDED` status.
+
+| Scenario | Behavior |
+| --- | --- |
+| Partial refund (e.g., 30%) | Proportional share deducted, earnings remain in current status |
+| Full refund (100%) | Earnings auto-transition to REFUNDED |
+| Multiple partial refunds totalling 100% | Earnings auto-transition to REFUNDED on final refund |
+
 ---
 
 ## Code References

--- a/docs/payments/refunds-disputes/03-dispute-flow.md
+++ b/docs/payments/refunds-disputes/03-dispute-flow.md
@@ -325,6 +325,18 @@ const urgentDisputes = await prisma.dispute.count({
 
 ---
 
+## Lost Dispute Handling (Mar 2026)
+
+When a dispute is resolved in the customer's favor (status: `LOST`), the `handle-lost-disputes` cron job now uses the canonical `refundEarnings(paymentId, { forceRefund: true })` path instead of manual inline logic. This ensures:
+
+1. **TDS reversal records** are correctly created for already-paid earnings
+2. **`totalRevenue`** is decremented on the consultant profile for PAID earnings
+3. **Consistent behavior** with the refund flow (proportional reversal, `refundedShareAmount` tracking)
+
+Previously, lost-dispute handling used manual logic that could miss TDS reversals and leave `totalRevenue` stale.
+
+---
+
 ## Best Practices
 
 1. **Respond Quickly**: Don't wait until the deadline

--- a/docs/payments/refunds-disputes/README.md
+++ b/docs/payments/refunds-disputes/README.md
@@ -2,7 +2,7 @@
 
 Documentation for the Familiarise refund and dispute handling system.
 
-**Last Updated**: 2025-12-11
+**Last Updated**: 2026-03-31
 
 ---
 
@@ -45,6 +45,10 @@ Phase 1 (Transaction): Create PENDING refund → Claims the amount
 Phase 2 (No TX):       Call payment gateway → Process refund
 Phase 3 (No TX):       Update status → SUCCEEDED or FAILED
 ```
+
+### Partial Refund Earnings (Mar 2026)
+
+`refundEarnings()` now supports proportional reversal via `refundAmount`/`paymentAmount` parameters. A new `refundedShareAmount` field tracks cumulative partial refunds on `ConsultantEarnings`. Earnings auto-transition to REFUNDED when fully exhausted.
 
 ### Dispute Lifecycle
 

--- a/docs/payments/webhooks/01-monitoring.md
+++ b/docs/payments/webhooks/01-monitoring.md
@@ -219,6 +219,7 @@ SKIP_PAYMENT=true # Remove for production
 - ✅ Use HTTPS for webhook URLs
 - ✅ Keep webhook secrets secure
 - ✅ Implement idempotency for webhook processing
+- ✅ **Razorpay composite eventId** (Mar 2026): eventId is now formatted as `{eventType}:{entityId}` to prevent cross-event collisions (e.g., a `payment.captured` and `refund.created` for the same entity no longer share an idempotency key)
 
 ### 2. Error Handling
 


### PR DESCRIPTION
## Summary
Updates 14 documentation files across `docs/payments/` and `docs/maintenance/` to reflect the payment/payout/refund/dispute fix sprint.

## Files Updated
- `docs/payments/01-architecture.md` — Phase 1/Phase 2 split, invoice originalAmount note
- `docs/payments/checkout-flow/03-payment-processing.md` — email moved to Phase 2
- `docs/payments/gateways/razorpay/02-architecture-and-flow.md` — composite webhook eventId
- `docs/payments/payouts/01-architecture.md` — ER diagram, function descriptions, partial refunds
- `docs/payments/payouts/02-earnings-lifecycle.md` — refundedShareAmount, multi-party splits
- `docs/payments/payouts/03-payout-processing.md` — atomic batch creation, webhook idempotency
- `docs/payments/payouts/05-api-reference.md` — currency display (formatCurrencyAmount)
- `docs/payments/payouts/07-razorpay-implementation.md` — atomic updateMany guard
- `docs/payments/refunds-disputes/02-refund-flow.md` — proportional earnings reversal
- `docs/payments/refunds-disputes/03-dispute-flow.md` — lost dispute handling via refundEarnings
- `docs/payments/refunds-disputes/README.md` — key concepts updated
- `docs/payments/webhooks/01-monitoring.md` — composite eventId best practice
- `docs/maintenance/02-degraded-vs-offline.md` — 7 new write-blocked routes
- `docs/maintenance/04-cron-jobs-reference.md` — sync-earnings cursor pagination, lost-dispute handler

No code changes — only .md files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)