### PR TITLE
fix(consultant-dashboard): production-grade join button with proper time-window logic

### DIFF
--- a/app/api/dashboard/consultant/[consultantId]/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/route.ts
@@ -18,6 +18,7 @@ const userSelectFields = {
 
 const appointmentInclude = {
   slotsOfAppointment: {
+    orderBy: { startsAt: "asc" as const },
     include: {
       user: {
         select: userSelectFields,

--- a/app/api/dashboard/consultant/[consultantId]/route.ts
+++ b/app/api/dashboard/consultant/[consultantId]/route.ts
@@ -22,6 +22,9 @@ const appointmentInclude = {
       user: {
         select: userSelectFields,
       },
+      meetingSession: {
+        select: { id: true, endedAt: true },
+      },
     },
   },
   consultation: {
@@ -435,9 +438,11 @@ export async function GET(
         appointmentType: appointment.appointmentType,
         slotsOfAppointment: appointment.slotsOfAppointment.map((slot) => ({
           id: slot.id,
-          slotStartTimeInUTC: new Date(slot.startsAt),
-          slotEndTimeInUTC: slot.endsAt ? new Date(slot.endsAt) : null,
+          startsAt: slot.startsAt,
+          endsAt: slot.endsAt,
           isTentative: slot.isTentative,
+          completionStatus: slot.completionStatus,
+          meetingSession: slot.meetingSession ?? null,
           user: Array.isArray(slot.user)
             ? slot.user.map((u) => ({
                 id: u.id,

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -336,6 +336,7 @@ async function getAppointments(
     where: whereClause,
     include: {
       slotsOfAppointment: {
+        orderBy: { startsAt: "asc" },
         include: {
           user: true,
           meetingSession: {

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -338,6 +338,9 @@ async function getAppointments(
       slotsOfAppointment: {
         include: {
           user: true,
+          meetingSession: {
+            select: { id: true, endedAt: true },
+          },
         },
       },
       consultation: {

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -64,6 +64,7 @@ import {
   getParticipantManagementUrl,
   supportsParticipantManagement,
 } from "./utils/participantHelpers";
+import { getJoinableSlot } from "../../utils/joinState";
 
 export function AppointmentsTab({
   appointments,
@@ -164,7 +165,10 @@ export function AppointmentsTab({
     return getBadgeStyle(status);
   };
 
-  const handleJoinMeeting = async (appointment: TAppointment) => {
+  const handleJoinMeeting = async (
+    appointment: TAppointment,
+    joinableSlot?: TAppointment["slotsOfAppointment"][number],
+  ) => {
     if (!client) {
       console.warn("Stream client not ready");
       toast({
@@ -175,7 +179,8 @@ export function AppointmentsTab({
       });
       return;
     }
-    const relevantSlot = appointment.slotsOfAppointment?.[0];
+    const relevantSlot =
+      joinableSlot ?? appointment.slotsOfAppointment?.[0];
     if (!relevantSlot) {
       toast({
         title: "Error",
@@ -815,11 +820,16 @@ export function AppointmentsTab({
                               {visibleAppointments.map((appointment) => {
                                 const status =
                                   getAppointmentStatus(appointment);
-                                const isJoinable =
-                                  status === "Meeting in 5 min";
-                                const joinButtonStyle = isJoinable
-                                  ? "bg-black text-white hover:bg-gray-800"
-                                  : "bg-gray-400 text-white cursor-not-allowed";
+                                const joinableSlot = getJoinableSlot(
+                                  appointment.slotsOfAppointment ?? [],
+                                );
+                                const isJoinable = joinableSlot !== null;
+                                const isDev =
+                                  process.env.NODE_ENV !== "production";
+                                const joinButtonStyle =
+                                  isDev || isJoinable
+                                    ? "bg-black text-white hover:bg-gray-800"
+                                    : "bg-gray-400 text-white cursor-not-allowed";
 
                                 // Check if this is a one-off event (consultation or webinar)
                                 const isOneOffEvent =
@@ -976,14 +986,21 @@ export function AppointmentsTab({
                                               variant="default"
                                               size="sm"
                                               className={`${joinButtonStyle} h-8 px-4 text-xs`}
-                                              disabled={!isJoinable}
+                                              disabled={
+                                                isDev ? false : !isJoinable
+                                              }
                                               onClick={() =>
-                                                handleJoinMeeting(appointment)
+                                                handleJoinMeeting(
+                                                  appointment,
+                                                  joinableSlot ?? undefined,
+                                                )
                                               }
                                             >
-                                              {isJoinable
-                                                ? "Join meet"
-                                                : "Not available"}
+                                              {isDev
+                                                ? "Join (Dev)"
+                                                : isJoinable
+                                                  ? "Join Meeting"
+                                                  : "Not available"}
                                             </Button>
                                           )}
                                       </div>

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/PaginatedAppointments.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/PaginatedAppointments.tsx
@@ -17,6 +17,7 @@ import {
   getStartTime,
 } from "../../utils/appointmentHelpers";
 import { canManageAppointmentTimings } from "./utils/appointmentTimingHelpers";
+import { getJoinableSlot } from "../../utils/joinState";
 
 interface PaginatedAppointmentsProps {
   appointments: TAppointment[];
@@ -67,7 +68,11 @@ export function PaginatedAppointments({
         {paginatedData.map((appointment) => {
           const userName = getConsumeeName(appointment);
           const status = getAppointmentStatus(appointment);
-          const isJoinable = status === "Meeting in 5 min";
+          const joinableSlot = getJoinableSlot(
+            appointment.slotsOfAppointment ?? [],
+          );
+          const isJoinable = joinableSlot !== null;
+          const isDev = process.env.NODE_ENV !== "production";
 
           return (
             <div
@@ -128,13 +133,17 @@ export function PaginatedAppointments({
                       variant="default"
                       size="sm"
                       className={
-                        isJoinable
+                        isDev || isJoinable
                           ? "bg-blue-600 text-white hover:bg-blue-700"
                           : "bg-gray-400 text-white cursor-not-allowed"
                       }
-                      disabled={!isJoinable}
+                      disabled={isDev ? false : !isJoinable}
                     >
-                      {isJoinable ? "Join" : "Chat"}
+                      {isDev
+                        ? "Join (Dev)"
+                        : isJoinable
+                          ? "Join Meeting"
+                          : "Not available"}
                     </Button>
                   </div>
                 </div>

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/PaginatedAppointments.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/PaginatedAppointments.tsx
@@ -3,7 +3,7 @@
 import { usePagination } from "@/hooks/usePagination";
 import { Pagination } from "@/components/Pagination";
 import { BADGE_STYLES, getBadgeStyle } from "../../types";
-import { TAppointment } from "@/types/appointment";
+import { TAppointment, TSlotOfAppointment } from "@/types/appointment";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -23,12 +23,14 @@ interface PaginatedAppointmentsProps {
   appointments: TAppointment[];
   badgeStyles: typeof BADGE_STYLES;
   onManageTimings?: (appointment: TAppointment) => void;
+  onJoinMeeting?: (appointment: TAppointment, slot?: TSlotOfAppointment) => void;
 }
 
 export function PaginatedAppointments({
   appointments,
   badgeStyles,
   onManageTimings,
+  onJoinMeeting,
 }: PaginatedAppointmentsProps) {
   const expandedAppointments = appointments;
 
@@ -138,6 +140,12 @@ export function PaginatedAppointments({
                           : "bg-gray-400 text-white cursor-not-allowed"
                       }
                       disabled={isDev ? false : !isJoinable}
+                      onClick={() =>
+                        onJoinMeeting?.(
+                          appointment,
+                          joinableSlot ?? undefined,
+                        )
+                      }
                     >
                       {isDev
                         ? "Join (Dev)"

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/types/event.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/types/event.ts
@@ -6,8 +6,8 @@ export interface User {
 
 export interface SlotOfAppointment {
   id: string;
-  slotStartTimeInUTC: Date;
-  slotEndTimeInUTC: Date;
+  startsAt: Date;
+  endsAt: Date;
   user: User[];
 }
 

--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
@@ -58,6 +58,7 @@ import {
 
 import { getBadgeStyle } from "../../types";
 import { TAppointment } from "@/types/appointment";
+import { getJoinableSlot } from "../../utils/joinState";
 import { getInitials, formatCurrencyAmount } from "@/utils/formatting";
 import { RequestSlotAllocationTabMini } from "../requests/RequestSlotAllocationTabMini";
 
@@ -275,12 +276,16 @@ export function HomeTab({
   const client = useStreamVideoClient();
   const { toast } = useToast();
 
-  const handleJoinMeeting = async (appointment: TAppointment) => {
+  const handleJoinMeeting = async (
+    appointment: TAppointment,
+    joinableSlot?: TAppointment["slotsOfAppointment"][number],
+  ) => {
     if (!client) {
       toast({ title: "Error", description: "Meeting client not ready." });
       return;
     }
-    const relevantSlot = appointment.slotsOfAppointment?.[0];
+    const relevantSlot =
+      joinableSlot ?? appointment.slotsOfAppointment?.[0];
     if (!relevantSlot) {
       toast({
         title: "Error",
@@ -451,7 +456,12 @@ export function HomeTab({
                       const userName = getConsumeeName(appointment);
                       const status = getAppointmentStatus(appointment);
                       const startTime = getStartTime(appointment);
-                      const isJoinable = status === "Meeting in 5 min";
+                      const joinableSlot = getJoinableSlot(
+                        appointment.slotsOfAppointment ?? [],
+                      );
+                      const isJoinable = joinableSlot !== null;
+                      const isDev =
+                        process.env.NODE_ENV !== "production";
 
                       return (
                         <div
@@ -507,17 +517,25 @@ export function HomeTab({
                             {status}
                           </Badge>
 
-                          {isJoinable && (
+                          {(isDev || isJoinable) && (
                             <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <Button
-                                    onClick={() => handleJoinMeeting(appointment)}
+                                    onClick={() =>
+                                      handleJoinMeeting(
+                                        appointment,
+                                        joinableSlot ?? undefined,
+                                      )
+                                    }
                                     className="flex-shrink-0 bg-zinc-900 hover:bg-zinc-800 text-white gap-1.5"
                                     size="sm"
+                                    disabled={isDev ? false : !isJoinable}
                                   >
                                     <Video className="h-3.5 w-3.5" />
-                                    Join
+                                    {isDev
+                                      ? "Join (Dev)"
+                                      : "Join"}
                                   </Button>
                                 </TooltipTrigger>
                                 <TooltipContent>

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/types/calendar.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/types/calendar.ts
@@ -9,8 +9,8 @@ export interface TimeSlot {
 }
 
 export interface AppointmentSlot {
-  slotStartTimeInUTC: string | Date;
-  slotEndTimeInUTC: string | Date;
+  startsAt: string | Date;
+  endsAt: string | Date;
 }
 
 export interface Appointment {

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -152,8 +152,7 @@ function countCompletedCallsForWeek(
     if (slots.some((s: any) => s.isTentative)) return false;
     // A completed call is an appointment that has exactly the per-call slot count
     if (slots.length !== slotsPerCall) return false;
-    // FIX: Use correct field names from API (startsAt, not slotStartTimeInUTC)
-    const start = new Date(slots[0].startsAt || slots[0].slotStartTimeInUTC);
+    const start = new Date(slots[0].startsAt);
     return start >= weekStart && start <= weekEnd;
   }).length;
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useCalendarData.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useCalendarData.ts
@@ -54,9 +54,6 @@ export interface Appointment {
   slotsOfAppointment?: {
     startsAt: string;
     endsAt: string;
-    // Legacy field names for backwards compatibility
-    slotStartTimeInUTC?: string;
-    slotEndTimeInUTC?: string;
   }[];
   consultation?: any;
   subscription?: any;
@@ -331,12 +328,7 @@ export function useCalendarData(
         if (appt.slotsOfAppointment && Array.isArray(appt.slotsOfAppointment)) {
           appt.slotsOfAppointment = appt.slotsOfAppointment.filter(
             (slot: any) => {
-              // FIX: Check for BOTH new field names (startsAt/endsAt) AND old field names (slotStartTimeInUTC/slotEndTimeInUTC)
-              const hasNewFields = slot && slot.startsAt && slot.endsAt;
-              const hasOldFields =
-                slot && slot.slotStartTimeInUTC && slot.slotEndTimeInUTC;
-
-              if (!hasNewFields && !hasOldFields) {
+              if (!slot || !slot.startsAt || !slot.endsAt) {
                 console.warn(
                   `⚠️ fetchExistingAppointments: Filtering out invalid slot in appointment ${appt.id}`,
                   { slot },
@@ -435,9 +427,8 @@ export function useCalendarData(
           (appointment.slotsOfAppointment || [])
             .filter((slot: any) => !slot.isTentative)
             .flatMap((slot: any): TimeSlot[] => {
-              // FIX: Use correct field names from API (startsAt/endsAt)
-              const start = new Date(slot.startsAt || slot.slotStartTimeInUTC);
-              const end = new Date(slot.endsAt || slot.slotEndTimeInUTC);
+              const start = new Date(slot.startsAt);
+              const end = new Date(slot.endsAt);
               const durationMinutes =
                 (end.getTime() - start.getTime()) / (1000 * 60);
               const numIntervals = Math.round(durationMinutes / 30);
@@ -553,8 +544,8 @@ export function useCalendarData(
   const parsedAppointmentSlots = useMemo(() => {
     return existingAppointments.flatMap((appointment) =>
       (appointment.slotsOfAppointment || []).map((slt: any) => ({
-        start: new Date(slt.startsAt || slt.slotStartTimeInUTC).getTime(),
-        end: new Date(slt.endsAt || slt.slotEndTimeInUTC).getTime(),
+        start: new Date(slt.startsAt).getTime(),
+        end: new Date(slt.endsAt).getTime(),
         appointmentId: appointment.id,
         appointmentType: appointment.appointmentType,
         title: extractAppointmentTitle(appointment),

--- a/app/dashboard/consultant/[consultantId]/types.ts
+++ b/app/dashboard/consultant/[consultantId]/types.ts
@@ -198,6 +198,8 @@ export type BadgeStyleMap = { [key: string]: string };
 export const BADGE_STYLES: BadgeStyleMap = {
   Completed: "bg-gray-400 text-white",
   Cancelled: "bg-stone-400 text-white",
+  "In Progress": "bg-emerald-600 text-white",
+  "Starting soon": "bg-amber-500 text-white",
   "Meeting in 5 min": "bg-red-500 text-white",
   Today: "bg-blue-600 text-white",
   Tomorrow: "bg-purple-500 text-white",

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -73,16 +73,6 @@ export function getRoleBadgeStyle(role: string): string {
   return "bg-purple-100 text-purple-800";
 }
 
-/**
- * Type for appointment slot that supports both API response formats
- * - startsAt: Standard Prisma field from direct queries
- * - slotStartTimeInUTC: Legacy field from transformed dashboard API responses
- */
-type AppointmentSlot = {
-  startsAt?: string | Date;
-  slotStartTimeInUTC?: string | Date;
-};
-
 // Get the relevant name based on appointment type
 // For consultations/subscriptions: returns the consultee (requester) name
 // For webinars/classes: returns the consultant (host) name
@@ -187,20 +177,8 @@ export const getSlotTimes = (appointment: TAppointment): Date[] => {
   }
 
   return appointment.slotsOfAppointment
-    .map((slot: AppointmentSlot) => {
-      // Support both field names: startsAt (from API) and slotStartTimeInUTC (from dashboard API transformation)
-      const time = slot.startsAt || slot.slotStartTimeInUTC;
-      // Handle both Date objects and string timestamps
-      if (time instanceof Date) {
-        return time;
-      }
-      if (typeof time === "string" || typeof time === "number") {
-        const date = new Date(time);
-        return isNaN(date.getTime()) ? null : date;
-      }
-      return null;
-    })
-    .filter((date): date is Date => date !== null);
+    .map((slot) => new Date(slot.startsAt))
+    .filter((date) => !isNaN(date.getTime()));
 };
 
 /**
@@ -317,6 +295,20 @@ export const getAppointmentStatus = (appointment: TAppointment): string => {
     return "Completed";
   }
 
+  // Check if a slot is currently in progress
+  const currentSlot = appointment?.slotsOfAppointment?.find((slot) => {
+    if (slot.isTentative) return false;
+    if (
+      slot.completionStatus === "CANCELLED" ||
+      slot.completionStatus === "RESCHEDULED"
+    )
+      return false;
+    const start = new Date(slot.startsAt).getTime();
+    const end = new Date(slot.endsAt).getTime();
+    return start <= now.getTime() && now.getTime() <= end;
+  });
+  if (currentSlot) return "In Progress";
+
   // Check if all slots are in the past
   const slotTimes = getSlotTimes(appointment);
   if (slotTimes.length > 0 && slotTimes.every((time) => new Date(time) < now)) {
@@ -347,6 +339,7 @@ export const getAppointmentStatus = (appointment: TAppointment): string => {
 
   // Upcoming appointments with more precise timing
   if (diffMinutes <= 5 && diffMinutes > 0) return "Meeting in 5 min";
+  if (diffMinutes <= 15 && diffMinutes > 5) return "Starting soon";
 
   // Check if appointment is today (same calendar day)
   if (appointmentDate >= todayStart && appointmentDate < tomorrowStart) {

--- a/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/appointmentHelpers.ts
@@ -295,7 +295,7 @@ export const getAppointmentStatus = (appointment: TAppointment): string => {
     return "Completed";
   }
 
-  // Check if a slot is currently in progress
+  // Check if a slot is currently in progress (not ended early)
   const currentSlot = appointment?.slotsOfAppointment?.find((slot) => {
     if (slot.isTentative) return false;
     if (
@@ -303,8 +303,11 @@ export const getAppointmentStatus = (appointment: TAppointment): string => {
       slot.completionStatus === "RESCHEDULED"
     )
       return false;
+    if (slot.meetingSession?.endedAt) return false;
     const start = new Date(slot.startsAt).getTime();
-    const end = new Date(slot.endsAt).getTime();
+    const end = slot.endsAt
+      ? new Date(slot.endsAt).getTime()
+      : start + 60 * 60 * 1000;
     return start <= now.getTime() && now.getTime() <= end;
   });
   if (currentSlot) return "In Progress";

--- a/app/dashboard/consultant/[consultantId]/utils/joinState.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/joinState.ts
@@ -1,0 +1,32 @@
+import type { TSlotOfAppointment } from "@/types/appointment";
+
+const JOIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes before start
+
+export type JoinState = "disabled" | "countdown" | "joinable" | "ended";
+
+export function getSlotJoinState(slot: TSlotOfAppointment): JoinState {
+  if (slot.isTentative) return "disabled";
+  if (
+    slot.completionStatus === "CANCELLED" ||
+    slot.completionStatus === "RESCHEDULED"
+  )
+    return "disabled";
+
+  const now = Date.now();
+  const start = new Date(slot.startsAt).getTime();
+  const end = new Date(slot.endsAt).getTime();
+  const joinWindow = start - JOIN_WINDOW_MS;
+
+  if (now > end) return "ended";
+  if (now >= joinWindow) return "joinable";
+  return "countdown";
+}
+
+export function getJoinableSlot(
+  slots: TSlotOfAppointment[],
+): TSlotOfAppointment | null {
+  for (const slot of slots) {
+    if (getSlotJoinState(slot) === "joinable") return slot;
+  }
+  return null;
+}

--- a/app/dashboard/consultant/[consultantId]/utils/joinState.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/joinState.ts
@@ -1,6 +1,7 @@
 import type { TSlotOfAppointment } from "@/types/appointment";
 
 const JOIN_WINDOW_MS = 15 * 60 * 1000; // 15 minutes before start
+const DEFAULT_MEETING_DURATION_MS = 60 * 60 * 1000; // 1 hour fallback
 
 export type JoinState = "disabled" | "countdown" | "joinable" | "ended";
 
@@ -12,9 +13,14 @@ export function getSlotJoinState(slot: TSlotOfAppointment): JoinState {
   )
     return "disabled";
 
+  // Session manually ended early by consultant
+  if (slot.meetingSession?.endedAt) return "ended";
+
   const now = Date.now();
   const start = new Date(slot.startsAt).getTime();
-  const end = new Date(slot.endsAt).getTime();
+  const end = slot.endsAt
+    ? new Date(slot.endsAt).getTime()
+    : start + DEFAULT_MEETING_DURATION_MS;
   const joinWindow = start - JOIN_WINDOW_MS;
 
   if (now > end) return "ended";
@@ -25,7 +31,11 @@ export function getSlotJoinState(slot: TSlotOfAppointment): JoinState {
 export function getJoinableSlot(
   slots: TSlotOfAppointment[],
 ): TSlotOfAppointment | null {
-  for (const slot of slots) {
+  const sorted = [...slots].sort(
+    (a, b) =>
+      new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
+  );
+  for (const slot of sorted) {
     if (getSlotJoinState(slot) === "joinable") return slot;
   }
   return null;

--- a/types/appointment.ts
+++ b/types/appointment.ts
@@ -22,6 +22,9 @@ export type TConsultation = Prisma.ConsultationGetPayload<{
         slotsOfAppointment: {
           include: {
             user: true;
+            meetingSession: {
+              select: { id: true; endedAt: true };
+            };
           };
         };
         payment: true;
@@ -52,6 +55,9 @@ export type TSubscription = Prisma.SubscriptionGetPayload<{
         slotsOfAppointment: {
           include: {
             user: true;
+            meetingSession: {
+              select: { id: true; endedAt: true };
+            };
           };
         };
         payment: true;
@@ -78,6 +84,9 @@ export type TWebinar = Prisma.WebinarGetPayload<{
         slotsOfAppointment: {
           include: {
             user: true;
+            meetingSession: {
+              select: { id: true; endedAt: true };
+            };
           };
         };
         payment: true;
@@ -112,6 +121,9 @@ export type TClass = Prisma.ClassGetPayload<{
         slotsOfAppointment: {
           include: {
             user: true;
+            meetingSession: {
+              select: { id: true; endedAt: true };
+            };
           };
         };
         payment: true;
@@ -191,6 +203,9 @@ export type TAppointment = Prisma.AppointmentGetPayload<{
     slotsOfAppointment: {
       include: {
         user: true;
+        meetingSession: {
+          select: { id: true; endedAt: true };
+        };
       };
     };
   };


### PR DESCRIPTION
## Summary
- **Bug:** Join button only enabled during a 5-minute window before session start, disabled once session was in progress
- **Fix:** Created `joinState.ts` utility mirroring the consultee dashboard's proven 15-min join window pattern, decoupled from display-status string comparison
- **Cleanup:** Eliminated dual field naming (`slotStartTimeInUTC` → `startsAt`) across 7 consumer files, added `meetingSession` to `TAppointment` type

## Changes
| Area | What |
|------|------|
| **New utility** | `joinState.ts` — `getSlotJoinState()` + `getJoinableSlot()` with 15-min pre-join window |
| **API** | Consultant dashboard API stops renaming `startsAt`/`endsAt`, adds `meetingSession` include |
| **Types** | `TAppointment` slots now include `meetingSession { id, endedAt }` |
| **Components** | AppointmentsTab, HomeTab, PaginatedAppointments use `getJoinableSlot()` instead of string matching |
| **Display** | New "In Progress" (emerald) and "Starting soon" (amber) badge statuses |
| **Dev mode** | All join buttons always enabled with "Join (Dev)" label |

## Join Window Logic (Production)
```
──────────────────────────────────
  -15min    startsAt        endsAt
    │          │               │
    ├──────────┼───────────────┤
    │  JOINABLE (enabled)      │
────┘                          └────
 NOT AVAILABLE           NOT AVAILABLE
```

## Test plan
- [ ] TypeScript compiles clean (`tsc --noEmit` passes)
- [ ] Dev mode: all appointments show "Join (Dev)" button, always clickable
- [ ] Prod: button enables 15 min before start, stays enabled through session end
- [ ] Tentative slots: join button disabled
- [ ] Cancelled/Rescheduled slots: excluded from join logic
- [ ] Multi-session subscriptions: only current/next session joinable
- [ ] Planner EventCard unchanged (already has correct pattern)
- [ ] "In Progress" and "Starting soon" badges render with correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)