### PR TITLE
fix(payments): Razorpay integration audit — 10 security & operational fixes

### DIFF
--- a/app/api/checkout/verify-signature/route.ts
+++ b/app/api/checkout/verify-signature/route.ts
@@ -1,0 +1,115 @@
+/**
+ * POST /api/checkout/verify-signature
+ *
+ * H2 FIX: Server-side verification of Razorpay payment signature.
+ * Verifies HMAC-SHA256(order_id|payment_id, RAZORPAY_SECRET) returned by
+ * the Razorpay checkout modal, providing defense-in-depth alongside webhooks
+ * and enabling instant UI feedback without waiting for the webhook.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/auth-server";
+import { z } from "zod";
+
+const verifySignatureSchema = z.object({
+  razorpay_order_id: z.string().min(1),
+  razorpay_payment_id: z.string().min(1),
+  razorpay_signature: z.string().min(1),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { razorpay_order_id, razorpay_payment_id, razorpay_signature } =
+      verifySignatureSchema.parse(body);
+
+    const keySecret = process.env.RAZORPAY_SECRET;
+    if (!keySecret) {
+      console.error("RAZORPAY_SECRET not configured for signature verification");
+      return NextResponse.json(
+        { error: "Payment verification unavailable" },
+        { status: 500 },
+      );
+    }
+
+    // Verify: HMAC-SHA256(order_id + "|" + payment_id, key_secret)
+    const expectedSignature = crypto
+      .createHmac("sha256", keySecret)
+      .update(`${razorpay_order_id}|${razorpay_payment_id}`)
+      .digest("hex");
+
+    const sigBuf = Buffer.from(razorpay_signature, "hex");
+    const expectedBuf = Buffer.from(expectedSignature, "hex");
+
+    if (
+      sigBuf.length !== expectedBuf.length ||
+      !crypto.timingSafeEqual(sigBuf, expectedBuf)
+    ) {
+      return NextResponse.json(
+        { verified: false, error: "Invalid payment signature" },
+        { status: 400 },
+      );
+    }
+
+    // Signature valid — find the payment and verify ownership
+    const payment = await prisma.payment.findUnique({
+      where: { paymentIntent: razorpay_order_id },
+    });
+
+    if (!payment) {
+      return NextResponse.json(
+        { verified: false, error: "Payment not found" },
+        { status: 404 },
+      );
+    }
+
+    if (payment.userId !== session.user.id) {
+      return NextResponse.json(
+        { verified: false, error: "Unauthorized" },
+        { status: 403 },
+      );
+    }
+
+    // If payment is still PENDING, mark as SUCCEEDED (webhook will be idempotent)
+    if (payment.paymentStatus === "PENDING") {
+      await prisma.payment.update({
+        where: { id: payment.id },
+        data: {
+          paymentStatus: "SUCCEEDED",
+          paymentMethod: "razorpay",
+          description: `Verified via signature (payment: ${razorpay_payment_id})`,
+        },
+      });
+      console.log(
+        `✅ Payment ${payment.id} marked SUCCEEDED via signature verification (before webhook)`,
+      );
+    }
+
+    return NextResponse.json({
+      verified: true,
+      paymentStatus: "SUCCEEDED",
+      orderId: razorpay_order_id,
+      paymentId: razorpay_payment_id,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { verified: false, error: "Invalid request", details: error.errors },
+        { status: 400 },
+      );
+    }
+
+    console.error("Signature verification error:", error);
+    return NextResponse.json(
+      { verified: false, error: "Verification failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/checkout/verify-signature/route.ts
+++ b/app/api/checkout/verify-signature/route.ts
@@ -14,9 +14,9 @@ import { getSession } from "@/lib/auth-server";
 import { z } from "zod";
 
 const verifySignatureSchema = z.object({
-  razorpay_order_id: z.string().min(1),
-  razorpay_payment_id: z.string().min(1),
-  razorpay_signature: z.string().min(1),
+  razorpay_order_id: z.string().startsWith("order_"),
+  razorpay_payment_id: z.string().startsWith("pay_"),
+  razorpay_signature: z.string().length(64).regex(/^[0-9a-fA-F]+$/),
 });
 
 export async function POST(req: NextRequest) {
@@ -77,16 +77,20 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // If payment is still PENDING, mark as SUCCEEDED (webhook will be idempotent)
-    if (payment.paymentStatus === "PENDING") {
-      await prisma.payment.update({
-        where: { id: payment.id },
-        data: {
-          paymentStatus: "SUCCEEDED",
-          paymentMethod: "razorpay",
-          description: `Verified via signature (payment: ${razorpay_payment_id})`,
-        },
-      });
+    // Atomically update only if still PENDING (prevents race with webhook handler)
+    const updated = await prisma.payment.updateMany({
+      where: {
+        id: payment.id,
+        paymentStatus: "PENDING",
+      },
+      data: {
+        paymentStatus: "SUCCEEDED",
+        paymentMethod: "razorpay",
+        description: `Verified via signature (payment: ${razorpay_payment_id})`,
+      },
+    });
+
+    if (updated.count > 0) {
       console.log(
         `✅ Payment ${payment.id} marked SUCCEEDED via signature verification (before webhook)`,
       );

--- a/app/api/checkout/verify/route.ts
+++ b/app/api/checkout/verify/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
+import { razorpayClient } from "@/lib/payments/core/razorpay";
+
 export async function GET(req: NextRequest) {
   try {
     // Check authentication
@@ -12,12 +14,39 @@ export async function GET(req: NextRequest) {
     // Get payment intent from query parameters
     const { searchParams } = new URL(req.url);
     const paymentIntent = searchParams.get("payment_intent");
+    // L4 FIX: Optional sync=true to fetch latest status from Razorpay
+    const shouldSync = searchParams.get("sync") === "true";
 
     if (!paymentIntent) {
       return NextResponse.json(
         { error: "Payment intent ID is required" },
         { status: 400 },
       );
+    }
+
+    // If sync requested and this is a Razorpay order, fetch latest status
+    if (shouldSync && paymentIntent.startsWith("order_") && razorpayClient) {
+      try {
+        const rzpOrder = await razorpayClient.orders.fetch(paymentIntent);
+        if (rzpOrder.status === "paid") {
+          // Update our DB if still PENDING
+          await prisma.payment.updateMany({
+            where: {
+              paymentIntent,
+              paymentStatus: "PENDING",
+            },
+            data: {
+              paymentStatus: "SUCCEEDED",
+              description: "Synced from Razorpay API (on-demand)",
+            },
+          });
+        }
+      } catch (syncError) {
+        console.warn(
+          `Failed to sync payment status from Razorpay for ${paymentIntent}:`,
+          syncError,
+        );
+      }
     }
 
     // Find payment record with appointment details

--- a/app/api/checkout/verify/route.ts
+++ b/app/api/checkout/verify/route.ts
@@ -24,31 +24,6 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    // If sync requested and this is a Razorpay order, fetch latest status
-    if (shouldSync && paymentIntent.startsWith("order_") && razorpayClient) {
-      try {
-        const rzpOrder = await razorpayClient.orders.fetch(paymentIntent);
-        if (rzpOrder.status === "paid") {
-          // Update our DB if still PENDING
-          await prisma.payment.updateMany({
-            where: {
-              paymentIntent,
-              paymentStatus: "PENDING",
-            },
-            data: {
-              paymentStatus: "SUCCEEDED",
-              description: "Synced from Razorpay API (on-demand)",
-            },
-          });
-        }
-      } catch (syncError) {
-        console.warn(
-          `Failed to sync payment status from Razorpay for ${paymentIntent}:`,
-          syncError,
-        );
-      }
-    }
-
     // Find payment record with appointment details
     const payment = await prisma.payment.findUnique({
       where: { paymentIntent },
@@ -94,6 +69,40 @@ export async function GET(req: NextRequest) {
         { error: "Unauthorized access to payment" },
         { status: 403 },
       );
+    }
+
+    // L4 FIX: On-demand sync — fetch latest status from Razorpay API
+    // Placed AFTER ownership check to prevent unauthorized status updates
+    if (
+      shouldSync &&
+      payment.paymentStatus === "PENDING" &&
+      paymentIntent.startsWith("order_") &&
+      razorpayClient
+    ) {
+      try {
+        const rzpOrder = await razorpayClient.orders.fetch(paymentIntent);
+        if (rzpOrder.status === "paid") {
+          await prisma.payment.updateMany({
+            where: { paymentIntent, paymentStatus: "PENDING" },
+            data: {
+              paymentStatus: "SUCCEEDED",
+              description: "Synced from Razorpay API (on-demand)",
+            },
+          });
+          // Re-read payment to reflect updated status
+          const updated = await prisma.payment.findUnique({
+            where: { paymentIntent },
+          });
+          if (updated) {
+            (payment as typeof updated).paymentStatus = updated.paymentStatus;
+          }
+        }
+      } catch (syncError) {
+        console.warn(
+          `Failed to sync payment status from Razorpay for ${paymentIntent}:`,
+          syncError,
+        );
+      }
     }
 
     // Check payment status

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -42,9 +42,24 @@ export async function POST(req: NextRequest) {
   );
 
   if (!isValid) {
-    // If a separate RazorpayX secret is configured, try re-verifying.
-    // We still have the raw body from the failed attempt and the signature header.
-    if (razorpayXSecret && razorpayXSecret !== secret) {
+    // M2 FIX: Only allow RazorpayX secret fallback for payout.* events.
+    // Parse the body to check event type before re-verifying — this prevents
+    // non-payout events from being accepted with the RazorpayX secret.
+    let isPossiblyPayoutEvent = false;
+    try {
+      const parsed = JSON.parse(body);
+      isPossiblyPayoutEvent =
+        typeof parsed.event === "string" &&
+        parsed.event.startsWith("payout.");
+    } catch {
+      // Can't parse — not a valid webhook, reject
+    }
+
+    if (
+      isPossiblyPayoutEvent &&
+      razorpayXSecret &&
+      razorpayXSecret !== secret
+    ) {
       const signature = req.headers.get("x-razorpay-signature");
       if (signature) {
         const crypto = await import("crypto");
@@ -64,7 +79,7 @@ export async function POST(req: NextRequest) {
             { status: 400 },
           );
         }
-        // RazorpayX signature valid — continue processing
+        // RazorpayX signature valid for payout event — continue processing
       } else {
         return NextResponse.json(
           { error: "Invalid signature" },

--- a/app/api/webhooks/razorpay/route.ts
+++ b/app/api/webhooks/razorpay/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { after } from "next/server";
 import {
   handlePaymentFailure,
   handlePaymentSuccess,
@@ -29,13 +30,53 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // M2 FIX: RazorpayX payout webhooks may use a separate secret.
+  // Try the main Razorpay secret first. If that fails and a RazorpayX secret
+  // is configured, re-verify with it (for payout.* events).
+  const razorpayXSecret = process.env.RAZORPAYX_WEBHOOK_SECRET;
+
   const { isValid, body } = await verifyWebhookSignature(
     req,
     secret,
     "razorpay",
   );
+
   if (!isValid) {
-    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+    // If a separate RazorpayX secret is configured, try re-verifying.
+    // We still have the raw body from the failed attempt and the signature header.
+    if (razorpayXSecret && razorpayXSecret !== secret) {
+      const signature = req.headers.get("x-razorpay-signature");
+      if (signature) {
+        const crypto = await import("crypto");
+        const expectedSig = crypto
+          .createHmac("sha256", razorpayXSecret)
+          .update(body)
+          .digest("hex");
+        const sigBuf = Buffer.from(signature, "hex");
+        const expectedBuf = Buffer.from(expectedSig, "hex");
+        const isRazorpayXValid =
+          sigBuf.length === expectedBuf.length &&
+          crypto.timingSafeEqual(sigBuf, expectedBuf);
+
+        if (!isRazorpayXValid) {
+          return NextResponse.json(
+            { error: "Invalid signature" },
+            { status: 400 },
+          );
+        }
+        // RazorpayX signature valid — continue processing
+      } else {
+        return NextResponse.json(
+          { error: "Invalid signature" },
+          { status: 400 },
+        );
+      }
+    } else {
+      return NextResponse.json(
+        { error: "Invalid signature" },
+        { status: 400 },
+      );
+    }
   }
 
   // DB health check — return 503 if DB is unreachable so Razorpay retries
@@ -49,213 +90,244 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // M3 FIX: Parse, log, and idempotency-check synchronously (fast path),
+  // then return 200 immediately and process the event asynchronously via
+  // Next.js `after()` to stay within Razorpay's 5-second webhook timeout.
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let event: any;
+  let eventType: string;
+  let eventId: string;
+
   try {
-    const event = JSON.parse(body);
-    const { event: eventType } = razorpayBaseEventSchema.parse(event);
-
-    // Log webhook event for audit trail (idempotency check).
-    // Use composite key (eventType + entityId) to prevent collisions between
-    // different lifecycle events for the same entity (e.g., payment.captured
-    // vs refund.created both referencing the same payment ID).
-    const entityId =
-      event.payload?.payment?.entity?.id ||
-      event.payload?.order?.entity?.id ||
-      event.payload?.refund?.entity?.id ||
-      event.payload?.dispute?.entity?.id ||
-      event.payload?.payout?.entity?.id ||
-      event.account_id ||
-      `noid_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    const eventId = `${eventType}:${entityId}`;
-
-    const { isNew } = await logWebhookEvent(
-      "razorpay",
-      eventId,
-      eventType,
-      event.payload,
-      req.headers.get("x-razorpay-signature") || undefined,
-    );
-
-    if (!isNew) {
-      console.log(`⚠️ Duplicate webhook event ${eventId}, returning OK`);
-      return NextResponse.json({ status: "ok", duplicate: true });
-    }
-
-    console.log(`🔔 Razorpay Webhook Event: ${eventType}`, {
-      payload: event.payload,
-    });
-
-    let processingError: string | undefined;
-
-    try {
-      switch (eventType) {
-        case "payment.captured": {
-          const capturedEvent = razorpayPaymentCapturedEventSchema.parse(event);
-          await handlePaymentSuccess(
-            capturedEvent.payload.payment.entity.order_id,
-            capturedEvent.payload.payment.entity.notes || {},
-          );
-          break;
-        }
-
-        case "order.paid": {
-          const paidEvent = razorpayOrderPaidEventSchema.parse(event);
-          await handlePaymentSuccess(
-            paidEvent.payload.order.entity.id,
-            paidEvent.payload.order.entity.notes || {},
-          );
-          break;
-        }
-
-        case "payment.failed": {
-          const failedEvent = razorpayPaymentFailedEventSchema.parse(event);
-          await handlePaymentFailure(
-            failedEvent.payload.payment.entity.order_id,
-          );
-          break;
-        }
-
-        // Refund events
-        // FIX #5: Razorpay refunds use payment_id, but our DB stores order_id as
-        // paymentIntent. Resolve payment_id → order_id via Razorpay API first.
-        case "refund.created":
-        case "refund.processed": {
-          const refundEvent = event.payload.refund.entity;
-          let paymentIntentId = refundEvent.payment_id;
-
-          if (razorpayClient) {
-            try {
-              const rzpPayment = await razorpayClient.payments.fetch(
-                refundEvent.payment_id,
-              );
-              if (rzpPayment.order_id) {
-                paymentIntentId = rzpPayment.order_id;
-              }
-            } catch (lookupError) {
-              console.error(
-                `Failed to resolve Razorpay payment_id ${refundEvent.payment_id} to order_id:`,
-                lookupError,
-              );
-            }
-          }
-
-          await handleRefundCreated(
-            refundEvent.id,
-            paymentIntentId,
-            refundEvent.amount,
-            refundEvent.currency || "INR",
-            refundEvent.status,
-            "RAZORPAY",
-          );
-          break;
-        }
-
-        case "refund.failed": {
-          const failedRefundEvent = event.payload.refund.entity;
-          let failedPaymentIntentId = failedRefundEvent.payment_id;
-
-          if (razorpayClient) {
-            try {
-              const rzpPayment = await razorpayClient.payments.fetch(
-                failedRefundEvent.payment_id,
-              );
-              if (rzpPayment.order_id) {
-                failedPaymentIntentId = rzpPayment.order_id;
-              }
-            } catch (lookupError) {
-              console.error(
-                `Failed to resolve Razorpay payment_id ${failedRefundEvent.payment_id} to order_id:`,
-                lookupError,
-              );
-            }
-          }
-
-          await handleRefundCreated(
-            failedRefundEvent.id,
-            failedPaymentIntentId,
-            failedRefundEvent.amount,
-            failedRefundEvent.currency || "INR",
-            "failed",
-            "RAZORPAY",
-          );
-          break;
-        }
-
-        // Dispute events
-        case "payment.dispute.created": {
-          const disputeCreatedEvent = event.payload.dispute.entity;
-          await handleDisputeCreated(
-            disputeCreatedEvent.id,
-            disputeCreatedEvent.payment_id,
-            disputeCreatedEvent.amount,
-            disputeCreatedEvent.currency || "INR",
-            disputeCreatedEvent.reason_description ||
-              disputeCreatedEvent.reason_code,
-            disputeCreatedEvent.status,
-            disputeCreatedEvent.respond_by || null,
-            disputeCreatedEvent.deduct_at_onset === false,
-            "RAZORPAY",
-          );
-          break;
-        }
-
-        case "payment.dispute.won": {
-          const disputeWonEvent = event.payload.dispute.entity;
-          await handleDisputeUpdated(disputeWonEvent.id, "won", null);
-          break;
-        }
-
-        case "payment.dispute.lost": {
-          const disputeLostEvent = event.payload.dispute.entity;
-          await handleDisputeUpdated(disputeLostEvent.id, "lost", null);
-          break;
-        }
-
-        case "payment.dispute.closed": {
-          const disputeClosedEvent = event.payload.dispute.entity;
-          await handleDisputeUpdated(
-            disputeClosedEvent.id,
-            disputeClosedEvent.status,
-            null,
-          );
-          break;
-        }
-
-        // RazorpayX Payout events
-        case "payout.processed":
-        case "payout.reversed":
-        case "payout.rejected":
-        case "payout.queued":
-        case "payout.pending":
-        case "payout.cancelled": {
-          const payoutEvent = event.payload.payout.entity;
-          await handleRazorpayPayoutWebhook(eventType, {
-            id: payoutEvent.id,
-            status: payoutEvent.status,
-            failure_reason: payoutEvent.failure_reason,
-          });
-          break;
-        }
-
-        default:
-          console.log(`📄 Unhandled Razorpay event type: ${eventType}`);
-      }
-    } catch (handlerError) {
-      processingError =
-        handlerError instanceof Error
-          ? handlerError.message
-          : String(handlerError);
-      throw handlerError;
-    } finally {
-      // Mark event as processed
-      await markWebhookEventProcessed(eventId, processingError);
-    }
-
-    return NextResponse.json({ status: "ok" });
-  } catch (error) {
-    console.error("Razorpay webhook error:", error);
+    event = JSON.parse(body);
+    ({ event: eventType } = razorpayBaseEventSchema.parse(event));
+  } catch (parseError) {
+    console.error("Razorpay webhook parse error:", parseError);
     return NextResponse.json(
-      { error: "Webhook handler failed" },
-      { status: 500 },
+      { error: "Invalid webhook payload" },
+      { status: 400 },
     );
+  }
+
+  // Composite key prevents collisions between different lifecycle events
+  // for the same entity (e.g., payment.captured vs refund.created).
+  const entityId =
+    event.payload?.payment?.entity?.id ||
+    event.payload?.order?.entity?.id ||
+    event.payload?.refund?.entity?.id ||
+    event.payload?.dispute?.entity?.id ||
+    event.payload?.payout?.entity?.id ||
+    event.account_id ||
+    `noid_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  eventId = `${eventType}:${entityId}`;
+
+  // Idempotency check (synchronous — must complete before returning 200)
+  const { isNew } = await logWebhookEvent(
+    "razorpay",
+    eventId,
+    eventType,
+    event.payload,
+    req.headers.get("x-razorpay-signature") || undefined,
+  );
+
+  if (!isNew) {
+    console.log(`⚠️ Duplicate webhook event ${eventId}, returning OK`);
+    return NextResponse.json({ status: "ok", duplicate: true });
+  }
+
+  // Return 200 immediately — process the event asynchronously
+  after(async () => {
+    await processWebhookEvent(event, eventType, eventId);
+  });
+
+  return NextResponse.json({ status: "ok" });
+}
+
+/**
+ * Process a webhook event asynchronously (called via next/server `after()`).
+ * Errors here are logged and recorded on the webhook event record for retry.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function processWebhookEvent(
+  event: any,
+  eventType: string,
+  eventId: string,
+): Promise<void> {
+  console.log(`🔔 Razorpay Webhook Event: ${eventType}`, {
+    payload: event.payload,
+  });
+
+  let processingError: string | undefined;
+
+  try {
+    switch (eventType) {
+      case "payment.captured": {
+        const capturedEvent = razorpayPaymentCapturedEventSchema.parse(event);
+        await handlePaymentSuccess(
+          capturedEvent.payload.payment.entity.order_id,
+          capturedEvent.payload.payment.entity.notes || {},
+        );
+        break;
+      }
+
+      case "order.paid": {
+        const paidEvent = razorpayOrderPaidEventSchema.parse(event);
+        await handlePaymentSuccess(
+          paidEvent.payload.order.entity.id,
+          paidEvent.payload.order.entity.notes || {},
+        );
+        break;
+      }
+
+      case "payment.failed": {
+        const failedEvent = razorpayPaymentFailedEventSchema.parse(event);
+        await handlePaymentFailure(
+          failedEvent.payload.payment.entity.order_id,
+        );
+        break;
+      }
+
+      // Refund events
+      // FIX #5: Razorpay refunds use payment_id, but our DB stores order_id as
+      // paymentIntent. Resolve payment_id → order_id via Razorpay API first.
+      case "refund.created":
+      case "refund.processed": {
+        const refundEvent = event.payload.refund.entity;
+        let paymentIntentId = refundEvent.payment_id;
+
+        if (razorpayClient) {
+          try {
+            const rzpPayment = await razorpayClient.payments.fetch(
+              refundEvent.payment_id,
+            );
+            if (rzpPayment.order_id) {
+              paymentIntentId = rzpPayment.order_id;
+            }
+          } catch (lookupError) {
+            console.error(
+              `Failed to resolve Razorpay payment_id ${refundEvent.payment_id} to order_id:`,
+              lookupError,
+            );
+          }
+        }
+
+        await handleRefundCreated(
+          refundEvent.id,
+          paymentIntentId,
+          refundEvent.amount,
+          refundEvent.currency || "INR",
+          refundEvent.status,
+          "RAZORPAY",
+        );
+        break;
+      }
+
+      case "refund.failed": {
+        const failedRefundEvent = event.payload.refund.entity;
+        let failedPaymentIntentId = failedRefundEvent.payment_id;
+
+        if (razorpayClient) {
+          try {
+            const rzpPayment = await razorpayClient.payments.fetch(
+              failedRefundEvent.payment_id,
+            );
+            if (rzpPayment.order_id) {
+              failedPaymentIntentId = rzpPayment.order_id;
+            }
+          } catch (lookupError) {
+            console.error(
+              `Failed to resolve Razorpay payment_id ${failedRefundEvent.payment_id} to order_id:`,
+              lookupError,
+            );
+          }
+        }
+
+        await handleRefundCreated(
+          failedRefundEvent.id,
+          failedPaymentIntentId,
+          failedRefundEvent.amount,
+          failedRefundEvent.currency || "INR",
+          "failed",
+          "RAZORPAY",
+        );
+        break;
+      }
+
+      // L1 FIX: Handle refund.speed_changed (informational only)
+      case "refund.speed_changed": {
+        console.log(
+          `📄 Refund speed changed: ${event.payload?.refund?.entity?.id}`,
+        );
+        break;
+      }
+
+      // Dispute events
+      case "payment.dispute.created": {
+        const disputeCreatedEvent = event.payload.dispute.entity;
+        await handleDisputeCreated(
+          disputeCreatedEvent.id,
+          disputeCreatedEvent.payment_id,
+          disputeCreatedEvent.amount,
+          disputeCreatedEvent.currency || "INR",
+          disputeCreatedEvent.reason_description ||
+            disputeCreatedEvent.reason_code,
+          disputeCreatedEvent.status,
+          disputeCreatedEvent.respond_by || null,
+          disputeCreatedEvent.deduct_at_onset === false,
+          "RAZORPAY",
+        );
+        break;
+      }
+
+      case "payment.dispute.won": {
+        const disputeWonEvent = event.payload.dispute.entity;
+        await handleDisputeUpdated(disputeWonEvent.id, "won", null);
+        break;
+      }
+
+      case "payment.dispute.lost": {
+        const disputeLostEvent = event.payload.dispute.entity;
+        await handleDisputeUpdated(disputeLostEvent.id, "lost", null);
+        break;
+      }
+
+      case "payment.dispute.closed": {
+        const disputeClosedEvent = event.payload.dispute.entity;
+        await handleDisputeUpdated(
+          disputeClosedEvent.id,
+          disputeClosedEvent.status,
+          null,
+        );
+        break;
+      }
+
+      // RazorpayX Payout events
+      case "payout.processed":
+      case "payout.reversed":
+      case "payout.rejected":
+      case "payout.queued":
+      case "payout.pending":
+      case "payout.cancelled": {
+        const payoutEvent = event.payload.payout.entity;
+        await handleRazorpayPayoutWebhook(eventType, {
+          id: payoutEvent.id,
+          status: payoutEvent.status,
+          failure_reason: payoutEvent.failure_reason,
+        });
+        break;
+      }
+
+      default:
+        console.log(`📄 Unhandled Razorpay event type: ${eventType}`);
+    }
+  } catch (handlerError) {
+    processingError =
+      handlerError instanceof Error
+        ? handlerError.message
+        : String(handlerError);
+    console.error(`Razorpay webhook processing error for ${eventId}:`, handlerError);
+  } finally {
+    await markWebhookEventProcessed(eventId, processingError);
   }
 }

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -3,12 +3,7 @@ import { Prisma, PaymentGateway } from "@prisma/client";
 import crypto from "crypto";
 import { stripeClient } from "@/lib/payments/core/stripe";
 import { razorpayClient } from "@/lib/payments/core/razorpay";
-import {
-  handlePayoutWebhook,
-  refundEarnings,
-  holdEarnings,
-  releaseHeldEarnings,
-} from "@/lib/payments/payouts";
+import { handlePayoutWebhook, refundEarnings } from "@/lib/payments/payouts";
 import {
   notifyRefundProcessed,
   notifyDisputeCreated,
@@ -72,6 +67,10 @@ export async function verifyWebhookSignature(
         .update(body)
         .digest("hex");
       // H1 FIX: Use timing-safe comparison to prevent timing attacks on HMAC
+      // Validate hex length before Buffer.from (odd-length strings get truncated)
+      if (signature.length !== 64) {
+        return { isValid: false, body };
+      }
       const sigBuf = Buffer.from(signature, "hex");
       const expectedBuf = Buffer.from(expectedSignature, "hex");
       if (sigBuf.length !== expectedBuf.length) {
@@ -344,24 +343,16 @@ export async function handleDisputeCreated(
     console.log(`✅ Dispute ${disputeId} created for payment ${payment.id}`);
 
     // M1 FIX: Hold consultant earnings to prevent payout of disputed funds
-    const earningsToHold = await tx.consultantEarnings.findMany({
+    const heldResult = await tx.consultantEarnings.updateMany({
       where: {
         paymentId: payment.id,
         status: { in: ["PENDING", "READY"] },
       },
-      select: { id: true },
+      data: { status: "HELD" },
     });
-    // holdEarnings runs outside the transaction (uses global prisma)
-    // so we collect IDs here and hold after the transaction commits.
-    // For now, hold inline — the function is fast (single update per earning).
-    for (const earning of earningsToHold) {
-      // Update directly inside the transaction for atomicity
-      await tx.consultantEarnings.update({
-        where: { id: earning.id },
-        data: { status: "HELD" },
-      });
+    if (heldResult.count > 0) {
       console.log(
-        `🔒 Earnings ${earning.id} held due to dispute ${disputeId}`,
+        `🔒 ${heldResult.count} earnings held due to dispute ${disputeId}`,
       );
     }
 
@@ -395,51 +386,64 @@ export async function handleDisputeUpdated(
       return;
     }
 
+    const mappedStatus = mapDisputeStatus(status);
+
     await tx.dispute.update({
       where: { disputeId },
       data: {
-        status: mapDisputeStatus(status),
+        status: mappedStatus,
         ...(evidence && { evidence: evidence as Prisma.InputJsonValue }),
         updatedAt: new Date(),
       },
     });
 
-    console.log(`✅ Dispute ${disputeId} updated to status ${status}`);
+    console.log(`✅ Dispute ${disputeId} updated to status ${mappedStatus}`);
 
     // M1 FIX: Release or refund earnings based on dispute resolution
-    const mappedStatus = mapDisputeStatus(status);
     if (mappedStatus === "WON" || mappedStatus === "WARNING_CLOSED") {
       // Dispute resolved in platform's favor — release held earnings back to READY
-      const heldEarnings = await tx.consultantEarnings.findMany({
+      const released = await tx.consultantEarnings.updateMany({
         where: { paymentId: dispute.paymentId, status: "HELD" },
-        select: { id: true },
+        data: { status: "READY" },
       });
-      for (const earning of heldEarnings) {
-        await tx.consultantEarnings.update({
-          where: { id: earning.id },
-          data: { status: "READY" },
-        });
-        console.log(`🔓 Earnings ${earning.id} released — dispute ${disputeId} won`);
+      if (released.count > 0) {
+        console.log(`🔓 ${released.count} earnings released — dispute ${disputeId} won`);
       }
     } else if (mappedStatus === "LOST" || mappedStatus === "CHARGE_REFUNDED") {
-      // Dispute lost — mark held earnings as REFUNDED
+      // Dispute lost — mark held earnings as REFUNDED, accounting for partial refunds
       const heldEarnings = await tx.consultantEarnings.findMany({
         where: { paymentId: dispute.paymentId, status: "HELD" },
-        select: { id: true, consultantShare: true, consultantProfileId: true },
+        select: {
+          id: true,
+          consultantShare: true,
+          refundedShareAmount: true,
+          consultantProfileId: true,
+        },
       });
       for (const earning of heldEarnings) {
+        const alreadyRefunded = earning.refundedShareAmount ?? 0;
+        const remainingRefundable = Math.max(
+          earning.consultantShare - alreadyRefunded,
+          0,
+        );
+
         await tx.consultantEarnings.update({
           where: { id: earning.id },
           data: {
             status: "REFUNDED",
-            refundedShareAmount: earning.consultantShare,
+            ...(remainingRefundable > 0
+              ? { refundedShareAmount: { increment: remainingRefundable } }
+              : {}),
           },
         });
-        await tx.consultantProfile.update({
-          where: { id: earning.consultantProfileId },
-          data: { pendingRevenue: { decrement: earning.consultantShare } },
-        });
-        console.log(`💸 Earnings ${earning.id} refunded — dispute ${disputeId} lost`);
+
+        if (remainingRefundable > 0) {
+          await tx.consultantProfile.update({
+            where: { id: earning.consultantProfileId },
+            data: { pendingRevenue: { decrement: remainingRefundable } },
+          });
+        }
+        console.log(`💸 Earnings ${earning.id} refunded (${remainingRefundable} paise) — dispute ${disputeId} lost`);
       }
     }
 
@@ -558,7 +562,28 @@ export async function logWebhookEvent(
         return { isNew: true, eventRecordId: existing.id };
       }
 
-      // Currently being processed (processed=false, no error) — skip
+      // Currently being processed (processed=false, no error).
+      // Add staleness check: if the event has been "in progress" for > 5 minutes,
+      // treat it as abandoned (e.g., after() callback didn't run due to crash)
+      // and allow reprocessing.
+      const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+      const age = Date.now() - new Date(existing.receivedAt).getTime();
+      if (age > STALE_THRESHOLD_MS) {
+        console.log(
+          `🔄 Webhook event ${eventId} stale (in-progress for ${Math.round(age / 1000)}s), allowing retry`,
+        );
+        await prisma.webhookEvent.update({
+          where: { eventId },
+          data: {
+            processed: false,
+            processedAt: null,
+            error: null,
+            payload: payload as Prisma.InputJsonValue,
+          },
+        });
+        return { isNew: true, eventRecordId: existing.id };
+      }
+
       console.log(
         `⚠️ Webhook event ${eventId} currently being processed, skipping`,
       );

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -3,7 +3,12 @@ import { Prisma, PaymentGateway } from "@prisma/client";
 import crypto from "crypto";
 import { stripeClient } from "@/lib/payments/core/stripe";
 import { razorpayClient } from "@/lib/payments/core/razorpay";
-import { handlePayoutWebhook, refundEarnings } from "@/lib/payments/payouts";
+import {
+  handlePayoutWebhook,
+  refundEarnings,
+  holdEarnings,
+  releaseHeldEarnings,
+} from "@/lib/payments/payouts";
 import {
   notifyRefundProcessed,
   notifyDisputeCreated,
@@ -66,7 +71,13 @@ export async function verifyWebhookSignature(
         .createHmac("sha256", secret)
         .update(body)
         .digest("hex");
-      return { isValid: signature === expectedSignature, body };
+      // H1 FIX: Use timing-safe comparison to prevent timing attacks on HMAC
+      const sigBuf = Buffer.from(signature, "hex");
+      const expectedBuf = Buffer.from(expectedSignature, "hex");
+      if (sigBuf.length !== expectedBuf.length) {
+        return { isValid: false, body };
+      }
+      return { isValid: crypto.timingSafeEqual(sigBuf, expectedBuf), body };
     }
   } catch (error) {
     console.error(
@@ -332,6 +343,28 @@ export async function handleDisputeCreated(
 
     console.log(`✅ Dispute ${disputeId} created for payment ${payment.id}`);
 
+    // M1 FIX: Hold consultant earnings to prevent payout of disputed funds
+    const earningsToHold = await tx.consultantEarnings.findMany({
+      where: {
+        paymentId: payment.id,
+        status: { in: ["PENDING", "READY"] },
+      },
+      select: { id: true },
+    });
+    // holdEarnings runs outside the transaction (uses global prisma)
+    // so we collect IDs here and hold after the transaction commits.
+    // For now, hold inline — the function is fast (single update per earning).
+    for (const earning of earningsToHold) {
+      // Update directly inside the transaction for atomicity
+      await tx.consultantEarnings.update({
+        where: { id: earning.id },
+        data: { status: "HELD" },
+      });
+      console.log(
+        `🔒 Earnings ${earning.id} held due to dispute ${disputeId}`,
+      );
+    }
+
     // --- Novu notification (fire-and-forget) ---
     void notifyDisputeCreated([payment.userId], {
       disputeId,
@@ -373,6 +406,43 @@ export async function handleDisputeUpdated(
 
     console.log(`✅ Dispute ${disputeId} updated to status ${status}`);
 
+    // M1 FIX: Release or refund earnings based on dispute resolution
+    const mappedStatus = mapDisputeStatus(status);
+    if (mappedStatus === "WON" || mappedStatus === "WARNING_CLOSED") {
+      // Dispute resolved in platform's favor — release held earnings back to READY
+      const heldEarnings = await tx.consultantEarnings.findMany({
+        where: { paymentId: dispute.paymentId, status: "HELD" },
+        select: { id: true },
+      });
+      for (const earning of heldEarnings) {
+        await tx.consultantEarnings.update({
+          where: { id: earning.id },
+          data: { status: "READY" },
+        });
+        console.log(`🔓 Earnings ${earning.id} released — dispute ${disputeId} won`);
+      }
+    } else if (mappedStatus === "LOST" || mappedStatus === "CHARGE_REFUNDED") {
+      // Dispute lost — mark held earnings as REFUNDED
+      const heldEarnings = await tx.consultantEarnings.findMany({
+        where: { paymentId: dispute.paymentId, status: "HELD" },
+        select: { id: true, consultantShare: true, consultantProfileId: true },
+      });
+      for (const earning of heldEarnings) {
+        await tx.consultantEarnings.update({
+          where: { id: earning.id },
+          data: {
+            status: "REFUNDED",
+            refundedShareAmount: earning.consultantShare,
+          },
+        });
+        await tx.consultantProfile.update({
+          where: { id: earning.consultantProfileId },
+          data: { pendingRevenue: { decrement: earning.consultantShare } },
+        });
+        console.log(`💸 Earnings ${earning.id} refunded — dispute ${disputeId} lost`);
+      }
+    }
+
     // --- Novu notification for resolved disputes (fire-and-forget) ---
     const resolvedStatuses = [
       "WON",
@@ -380,7 +450,7 @@ export async function handleDisputeUpdated(
       "CHARGE_REFUNDED",
       "WARNING_CLOSED",
     ];
-    if (resolvedStatuses.includes(mapDisputeStatus(status))) {
+    if (resolvedStatuses.includes(mappedStatus)) {
       const disputePayment = await tx.payment.findUnique({
         where: { id: dispute.paymentId },
       });
@@ -391,7 +461,7 @@ export async function handleDisputeUpdated(
           amount: dispute.amount,
           currency: dispute.currency,
           reason: dispute.reason || undefined,
-          status: mapDisputeStatus(status),
+          status: mappedStatus,
           dashboardUrl: `${getAppUrl()}/dashboard`,
         });
       }

--- a/app/checkout/components/RazorpayCheckout.tsx
+++ b/app/checkout/components/RazorpayCheckout.tsx
@@ -162,9 +162,15 @@ export default function RazorpayCheckout({
             if (!verifyRes.ok) {
               const err = await verifyRes.json();
               console.error("Payment signature verification failed:", err);
-              // Still call success — webhook is authoritative; log the failure
+              onPaymentError({
+                description:
+                  "Payment verification failed. Our team will review this transaction.",
+                code: "VERIFICATION_FAILED",
+              });
+              return;
             }
           } catch (verifyErr) {
+            // Network failure — don't block; webhook is the ultimate authority
             console.error("Signature verification request failed:", verifyErr);
           }
           onPaymentSuccess(response);

--- a/app/checkout/components/RazorpayCheckout.tsx
+++ b/app/checkout/components/RazorpayCheckout.tsx
@@ -147,7 +147,26 @@ export default function RazorpayCheckout({
         name: "Familiarise",
         description: description || "Service Payment",
         order_id: data.paymentIntent.id,
-        handler: function (response: RazorpayPaymentResponse) {
+        handler: async function (response: RazorpayPaymentResponse) {
+          // H2 FIX: Verify Razorpay signature server-side before signaling success
+          try {
+            const verifyRes = await fetch("/api/checkout/verify-signature", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                razorpay_order_id: response.razorpay_order_id,
+                razorpay_payment_id: response.razorpay_payment_id,
+                razorpay_signature: response.razorpay_signature,
+              }),
+            });
+            if (!verifyRes.ok) {
+              const err = await verifyRes.json();
+              console.error("Payment signature verification failed:", err);
+              // Still call success — webhook is authoritative; log the failure
+            }
+          } catch (verifyErr) {
+            console.error("Signature verification request failed:", verifyErr);
+          }
           onPaymentSuccess(response);
         },
         ...(userName || userEmail || userPhone

--- a/lib/payments/core/razorpay.ts
+++ b/lib/payments/core/razorpay.ts
@@ -13,13 +13,11 @@ import { RefundStatus } from "@prisma/client";
 // Razorpay Client Initialization
 // ============================================================================
 
+// L2 FIX: Removed module-load console.warn — per-call errors are more actionable
 const initializeRazorpayClient = () => {
   const keyId = process.env.RAZORPAY_KEY_ID;
   const keySecret = process.env.RAZORPAY_SECRET;
   if (!keyId || !keySecret) {
-    console.warn(
-      "RAZORPAY_KEY_ID or RAZORPAY_SECRET not found in environment variables",
-    );
     return null;
   }
   return new Razorpay({

--- a/lib/payments/index.ts
+++ b/lib/payments/index.ts
@@ -146,7 +146,7 @@ export async function createRefund(
     return {
       refundId: mockRefund.refundId,
       amount: mockRefund.amount,
-      currency: "USD",
+      currency: "INR", // L3 FIX: Platform operates in INR
       status: "SUCCEEDED",
     };
   }

--- a/lib/payments/payouts/razorpay-payouts.ts
+++ b/lib/payments/payouts/razorpay-payouts.ts
@@ -440,8 +440,9 @@ export class RazorpayPayoutsService {
   /**
    * Generate idempotency key for payout
    */
+  // M4 FIX: Deterministic key so retries hit the same RazorpayX idempotency slot
   generateIdempotencyKey(payoutId: string): string {
-    return `payout_${payoutId}_${Date.now()}`;
+    return `payout_${payoutId}`;
   }
 
   /**


### PR DESCRIPTION
## Summary

End-to-end audit of the Razorpay payment integration identified 2 HIGH, 4 MEDIUM, and 4 LOW severity issues (plus 13 well-handled patterns). All 10 fixes implemented:

### HIGH
- **H1**: Webhook signature comparison changed from `===` to `crypto.timingSafeEqual` (prevents timing attacks on HMAC)
- **H2**: New `POST /api/checkout/verify-signature` endpoint verifies Razorpay payment signature server-side after checkout modal closes (defense-in-depth + instant UI feedback)

### MEDIUM
- **M1**: Dispute webhook handler now holds consultant earnings on `payment.dispute.created` and releases/refunds on resolution (prevents paying out disputed funds)
- **M2**: Webhook route falls back to `RAZORPAYX_WEBHOOK_SECRET` for payout events when configured separately
- **M3**: Webhook processing restructured to use `next/server after()` — returns 200 immediately after idempotency check, processes event asynchronously (stays within Razorpay's 5-second timeout)
- **M4**: Payout idempotency key made deterministic by removing `Date.now()` (prevents duplicate payouts on retry)

### LOW
- **L1**: Added `refund.speed_changed` event handler (log only)
- **L2**: Removed dual warning on missing Razorpay env vars
- **L3**: Fixed mock refund currency hardcode `USD` → `INR`
- **L4**: Added `?sync=true` parameter to `/api/checkout/verify` that fetches latest status from Razorpay API

### Files changed (8)
- `app/api/webhooks/utils.ts` — H1, M1
- `app/api/webhooks/razorpay/route.ts` — M2, M3, L1
- `lib/payments/payouts/razorpay-payouts.ts` — M4
- `app/checkout/components/RazorpayCheckout.tsx` — H2
- New: `app/api/checkout/verify-signature/route.ts` — H2
- `app/api/checkout/verify/route.ts` — L4
- `lib/payments/core/razorpay.ts` — L2
- `lib/payments/index.ts` — L3

## Test plan
- [ ] Verify webhook signature accepts valid signatures and rejects invalid ones
- [ ] Complete a test payment and confirm signature verification endpoint works
- [ ] Simulate `payment.dispute.created` webhook and verify earnings status → HELD
- [ ] Verify payout idempotency key is deterministic (`generateIdempotencyKey` returns same value for same input)
- [ ] Confirm webhook returns 200 within 5 seconds (async processing via `after()`)
- [ ] Test `?sync=true` on `/api/checkout/verify` with a Razorpay order ID
- [ ] TypeScript: `npx tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)