### PR TITLE
fix(explore/experts): harden ConsultantCard against placeholder + duplicate data

### DIFF
--- a/app/explore/experts/components/ConsultantCard.tsx
+++ b/app/explore/experts/components/ConsultantCard.tsx
@@ -55,6 +55,19 @@ interface SubscriptionPlanCardData {
   totalSessions: number | null;
 }
 
+/**
+ * Returns true if `value` is a non-empty string that isn't one of the
+ * placeholder sentinels users/seeds sometimes leave behind ("none", "n/a", …).
+ */
+const isMeaningfulText = (
+  value: string | null | undefined,
+): value is string => {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return !/^(none|n\/?a|na|null|nil|tbd|-+|\.+)$/i.test(trimmed);
+};
+
 const SubscriptionPlanCard = ({
   plan,
   formatPrice,
@@ -88,22 +101,31 @@ const SubscriptionPlanCard = ({
         </div>
       </div>
       <div className="space-y-2.5">
-        <div className="flex items-center gap-2 text-sm">
-          <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-          <span className="text-zinc-600">{plan.callsPerWeek} calls/week</span>
-        </div>
-        <div className="flex items-center gap-2 text-sm">
-          <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-          <span className="text-zinc-600 capitalize">
-            {(plan.emailSupport ?? "no").toLowerCase()} email support
-          </span>
-        </div>
-        <div className="flex items-center gap-2 text-sm">
-          <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-          <span className="text-zinc-600">
-            {plan.totalSessions} sessions total
-          </span>
-        </div>
+        {plan.callsPerWeek != null && plan.callsPerWeek > 0 && (
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+            <span className="text-zinc-600">
+              {plan.callsPerWeek} {plan.callsPerWeek === 1 ? "call" : "calls"}/week
+            </span>
+          </div>
+        )}
+        {plan.emailSupport && (
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+            <span className="text-zinc-600 capitalize">
+              {plan.emailSupport.toLowerCase()} email support
+            </span>
+          </div>
+        )}
+        {plan.totalSessions != null && plan.totalSessions > 0 && (
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+            <span className="text-zinc-600">
+              {plan.totalSessions}{" "}
+              {plan.totalSessions === 1 ? "session" : "sessions"} total
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -120,6 +142,26 @@ export const ConsultantCard = memo(function ConsultantCard({
     consultant.subscriptionPlans
       ?.slice()
       .sort((a, b) => a.durationInMonths - b.durationInMonths) || [];
+
+  // Count how many plans share each duration so we can disambiguate labels
+  // when multiple plans have the same `durationInMonths`.
+  const durationCounts = sortedPlans.reduce<Record<number, number>>(
+    (acc, plan) => {
+      acc[plan.durationInMonths] = (acc[plan.durationInMonths] || 0) + 1;
+      return acc;
+    },
+    {},
+  );
+  const durationSeen: Record<number, number> = {};
+  const tabLabels = sortedPlans.map((plan) => {
+    const base = `${plan.durationInMonths} Mo`;
+    if (durationCounts[plan.durationInMonths] > 1) {
+      durationSeen[plan.durationInMonths] =
+        (durationSeen[plan.durationInMonths] || 0) + 1;
+      return `${base} (${durationSeen[plan.durationInMonths]})`;
+    }
+    return base;
+  });
 
   return (
     <div className="bg-white rounded-2xl border border-zinc-200 hover:border-zinc-300 hover:shadow-xl transition-all duration-300 overflow-hidden group">
@@ -166,10 +208,12 @@ export const ConsultantCard = memo(function ConsultantCard({
             </div>
           </div>
 
-          {/* Description */}
-          <p className="text-zinc-600 leading-relaxed mb-6 line-clamp-2">
-            {consultant.description}
-          </p>
+          {/* Description — only render when it's meaningful free-form text */}
+          {isMeaningfulText(consultant.description) && (
+            <p className="text-zinc-600 leading-relaxed mb-6 line-clamp-2">
+              {consultant.description.trim()}
+            </p>
+          )}
 
           {/* Meta Info */}
           <div className="space-y-3 mb-6">
@@ -229,9 +273,11 @@ export const ConsultantCard = memo(function ConsultantCard({
 
           {/* Domain & Subdomains */}
           <div className="flex flex-wrap gap-2">
-            <Badge className="bg-zinc-900 text-white hover:bg-zinc-800 px-3 py-1">
-              {consultant.domain?.name}
-            </Badge>
+            {consultant.domain?.name && (
+              <Badge className="bg-zinc-900 text-white hover:bg-zinc-800 px-3 py-1">
+                {consultant.domain.name}
+              </Badge>
+            )}
             {consultant.subDomains.slice(0, 2).map((sd) => (
               <Badge
                 key={`${consultant.id}-subdomain-${sd.id}`}
@@ -262,26 +308,22 @@ export const ConsultantCard = memo(function ConsultantCard({
         <div className="flex-shrink-0 lg:w-[380px] xl:w-[420px] space-y-4">
           <div className="bg-zinc-50 rounded-xl p-4">
             {sortedPlans.length > 0 ? (
-              <Tabs
-                defaultValue={sortedPlans[0].durationInMonths.toString()}
-                className="w-full"
-              >
+              <Tabs defaultValue={sortedPlans[0].id} className="w-full">
                 <TabsList className="w-full mb-4 bg-white p-1 rounded-lg border border-zinc-200">
-                  {sortedPlans.map((plan) => (
+                  {sortedPlans.map((plan, index) => (
                     <TabsTrigger
                       key={`${consultant.id}-tab-trigger-${plan.id}`}
-                      value={plan.durationInMonths.toString()}
+                      value={plan.id}
                       className="flex-1 data-[state=active]:bg-zinc-900 data-[state=active]:text-white rounded-md text-sm font-medium transition-all duration-200"
                     >
-                      {plan.durationInMonths}{" "}
-                      {plan.durationInMonths === 1 ? "Mo" : "Mo"}
+                      {tabLabels[index]}
                     </TabsTrigger>
                   ))}
                 </TabsList>
                 {sortedPlans.map((plan) => (
                   <TabsContent
                     key={`${consultant.id}-tab-content-${plan.id}`}
-                    value={plan.durationInMonths.toString()}
+                    value={plan.id}
                   >
                     <SubscriptionPlanCard
                       plan={plan}


### PR DESCRIPTION
## Summary
Fixes three UI bugs on the explore experts listing card, observed on Arjun Mehta's profile (DB-confirmed):

- **\"NONE\" rendered as description** — `description = \"NONE\\n\"` in the DB was shown verbatim. Added `isMeaningfulText` type guard that hides the `<p>` when the value is null/whitespace or a placeholder sentinel (`none`, `n/a`, `null`, `nil`, `tbd`, `-`, `...`).
- **Two overlapping \"3 Mo\" tabs** — `Tabs` used `durationInMonths.toString()` as the `value`, so two plans with `durationInMonths = 3` collided on the same tab. Switched `defaultValue`/`value` to `plan.id` (unique) and disambiguate labels as `3 Mo (1)` / `3 Mo (2)` when durations repeat.
- **Dead `=== 1 ? \"Mo\" : \"Mo\"` ternary** — removed.

While touching the card, also made related rendering defensive so the same shape of bad/sparse data can't regress elsewhere:
- Plan detail rows hide when `callsPerWeek` / `emailSupport` / `totalSessions` are null/0 (was rendering `null calls/week`).
- Fixed `1 calls/week` → `1 call/week` grammar.
- Empty domain badge no longer renders when `consultant.domain` is missing.

Scope: single file, `app/explore/experts/components/ConsultantCard.tsx`.

## Test plan
- [ ] Reload `/explore/experts` — Arjun Mehta's card no longer shows \"NONE\" block above headline.
- [ ] Both 3-month subscription plans are now independently selectable as `3 Mo (1)` / `3 Mo (2)`, each showing its own price and calls/sessions.
- [ ] Clicking between tabs updates the plan card content correctly.
- [ ] Other consultants with exactly one plan per duration still show plain `3 Mo`, `6 Mo`, etc.
- [ ] Consultants with legitimate multi-sentence descriptions still render the paragraph.
- [ ] Consultants with null/empty `callsPerWeek` or `totalSessions` do not render stray `null calls/week` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)