### PR TITLE
[codex] Add CSMO launch strategy docs

### DIFF
--- a/docs/sales-marketing/csmo-2026-launch/00-executive-csmo-strategy.md
+++ b/docs/sales-marketing/csmo-2026-launch/00-executive-csmo-strategy.md
@@ -1,0 +1,131 @@
+# Familiarise CSMO Strategy - India Tech Mentor Launch
+
+**Status:** Launch operating strategy  
+**Date:** 2026-04-30  
+**Audience:** Founder, sales interns, marketing interns, list-building contractors  
+**Stage assumed:** Pre-launch / beta  
+
+## Executive Thesis
+
+Familiarise should not launch as a generic consulting marketplace. It should launch as the India-first business platform for credible tech mentors who want to monetize expertise through 1:1 calls, ongoing mentorship, webinars, classes, document review, integrated video, and trusted payouts.
+
+The first 90 days are a supply-first campaign. Recruit enough high-trust Indian tech mentors that demand generation has something worth converting into bookings. Broad marketplace marketing before credible profiles, availability, and reviews exist will waste time and cash.
+
+The public promise:
+
+> Familiarise helps Indian tech experts run a real mentoring business with 10% commission, integrated video and chat, UPI/Razorpay payments, document review, and multiple service formats in one platform.
+
+The internal operating rule:
+
+> Every rupee and every hour must either recruit credible supply, create proof, or convert proof into first paid bookings.
+
+## Strategic Decisions
+
+| Decision | Choice |
+| --- | --- |
+| First wedge | Indian tech mentors: system design, DSA, backend, DevOps, cloud, ML, SDE career growth |
+| Launch posture | Pre-launch / beta, founder-led and intern-assisted |
+| Monetization | 10% commission from day one; future range can expand to 10-15% after proof |
+| Budget | ₹25K-50K/month, excluding founder time |
+| Hiring | India intern-first; Upwork only for list building and enrichment |
+| Channel center | LinkedIn manual outreach and content |
+| Supporting tests | Cold email, X/Twitter, Instagram, Facebook, Reddit, webinars, SEO, WhatsApp follow-up, light offline events |
+| Competitor tone | Math-first comparisons, no public mudslinging |
+
+## Market Positioning
+
+### To Consultants
+
+"Stop stitching together scheduling, payments, Zoom, WhatsApp, documents, and spreadsheets. Familiarise gives you one place to sell 1:1 calls, subscriptions, webinars, and classes with integrated video, chat, document review, payments, reviews, and payouts. The platform fee is 10% because the platform runs the operating layer for your expert business."
+
+### To Consultees
+
+"Book credible Indian tech mentors for interview prep, system design, resume review, career strategy, and ongoing mentorship. Everything happens in one app, from payment and scheduling to video and document review."
+
+### To Organizations Later
+
+"Sponsor expert-led learning for your team or students with Indian billing, program controls, SSO-ready architecture, and auditability."
+
+Enterprise is a real product capability in the schema and app, but it is not the first campaign wedge. Keep enterprise as founder-led design partner sales only until B2C consultant supply shows proof.
+
+## Why We Can Win
+
+Familiarise has a product-depth advantage over link-in-bio and single-format mentorship products:
+
+- Four sellable formats: consultations, subscriptions, webinars, and classes.
+- Built-in video and chat through Stream.
+- Document upload and consultant response workflows.
+- Trial sessions and trial-to-paid conversion tracking.
+- Referral credits.
+- Reviews and profile trust signals.
+- Indian payment and payout architecture with Razorpay, Stripe, refunds, disputes, earnings, payout accounts, TDS, and invoices.
+- Organization layer for future B2B: memberships, programs, wallet/license/invoice funding, rate cards, SSO settings, audit logs.
+
+The wedge is not "we have more features." The wedge is "a serious tech mentor can run more of their business on Familiarise, and keep the workflow professional."
+
+## Competitive Narrative
+
+Use competitors to educate, not attack.
+
+| Competitor | Public-safe comparison |
+| --- | --- |
+| Topmate | Strong default creator storefront. Familiarise should contrast on integrated expert-service operations: video/chat, document review, subscriptions/classes, India-first payment workflows, and 10% commission. Topmate's own 2026 guide describes 1:1 sessions, webinars, digital products, priority DMs, service bundles, Zoom/Calendar/WhatsApp integrations, 300K+ creators, 1M+ professionals, and $1.13M raised. |
+| Preplaced | Strong long-term career mentorship brand. Preplaced publicly positions around 1:1 long-term mentorship, free trial, verified mentors, 600+ mentors, and career outcomes. Familiarise should not out-Preplaced Preplaced; it should own tech expert business infrastructure and broader service formats. |
+| ProPeers | App-first peer/expert guidance and achievement network. Compete on serious monetization, payments, bookings, and expert-service workflows. |
+
+Sources: [Topmate 2026 guide](https://topmate.io/blog/topmate.io-in-2026-the-honest-guide-for-creators-coaches-and-experts-thinking-about-monetizing-their-time), [Preplaced homepage](https://www.preplaced.in/), [ProPeers App Store listing](https://apps.apple.com/us/app/propeers/id6446427356).
+
+## 90-Day Objectives
+
+| Objective | Target |
+| --- | --- |
+| Qualified consultant list | 1,000 Indian tech mentor prospects |
+| Personalized outreach | 600 total messages across LinkedIn, email, X, and warm intros |
+| Qualified replies | 90 |
+| Demo calls | 35 |
+| Consultant signups | 25 |
+| Fully activated consultants | 15 with profile, service, availability, payout readiness |
+| First paid bookings | 25 |
+| Reviews | 15 public reviews |
+| Free webinars | 6 founder-supported webinars |
+| Monthly GMV by day 90 | ₹1L-2L stretch |
+
+## Budget Allocation
+
+Stay inside ₹25K-50K/month unless an item is explicitly optional.
+
+| Item | Monthly cost | Notes |
+| --- | ---: | --- |
+| Sales / CS intern | ₹10K-12K | Own CRM, outreach support, onboarding coordination |
+| Marketing intern | ₹10K-12K | Own content, social clips, community, SEO drafts |
+| Upwork list builder | ₹5K-10K | Fixed-scope list enrichment only |
+| Tools | ₹3K-8K | Sales Navigator trial or month, email verification, Buffer/Canva/Apollo free/low tiers |
+| Offline events | ₹2K-5K | Meetups, travel, QR leaflets |
+| Reserve | ₹0-5K | Small experiments |
+
+Do not spend on paid ads in the first 60 days. Paid ads amplify proof; they do not create it.
+
+## Operating Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Empty marketplace | Supply-first launch, founder-curated first 15 active consultants |
+| Weak consultant activation | Mandatory onboarding call and first-link-share commitment |
+| 10% fee resistance | Sell workflow, payments, review trust, service variety, and operational support |
+| Interns send spam | Founder-approved templates, daily review, CRM quality gates |
+| LinkedIn limits | Manual outreach, high personalization, mix with email/X/warm intros. LinkedIn states Sales Navigator users receive 50 InMail credits/month and can accumulate up to 150. |
+| Contractor quality risk | Upwork contractors only build lists; they do not message prospects from founder accounts |
+| Broad-channel distraction | Every channel has a 2-week test window and kill criteria |
+
+LinkedIn source: [Sales Navigator InMail credits](https://www.linkedin.com/help/linkedin/answer/a101030/inmail-crediting-and-renewal-process-in-sales-navigator).
+
+## What Not To Do
+
+- Do not launch as "Topmate but cheaper."
+- Do not recruit every type of expert.
+- Do not hire a full-time marketer before the founder-led message works.
+- Do not give Upwork contractors control of LinkedIn DMs.
+- Do not spend on ads before there are activated profiles and proof.
+- Do not promise discovery to consultants. Say: "We help you convert and operate professionally; discovery will compound as the marketplace grows."
+- Do not publicly claim competitor weaknesses unless sourced and phrased carefully.
+

--- a/docs/sales-marketing/csmo-2026-launch/01-product-subsystems-and-selling-points.md
+++ b/docs/sales-marketing/csmo-2026-launch/01-product-subsystems-and-selling-points.md
@@ -1,0 +1,113 @@
+# Product Subsystems And Selling Points
+
+**Purpose:** Convert the app's real capabilities into honest sales language for consultants, consultees, and future organizations.
+
+This document is based on the current app surface, Prisma schema, and existing docs. Use it as the source of truth for what the sales team can safely say.
+
+## Core Product Map
+
+| Subsystem | Product reality | Selling point |
+| --- | --- | --- |
+| Consultant profiles | `ConsultantProfile`, domains, subdomains, tags, reviews, verification, work/education/certifications at user level | "Build a credible expert profile with domain tags, credentials, reviews, and verification signals." |
+| 1:1 consultations | `ConsultationPlan`, `Consultation`, request status, payment URL, cancellation tracking, appointment link | "Sell focused calls for system design, DSA, resume review, career strategy, code review, or startup tech advisory." |
+| Subscriptions | `SubscriptionPlan`, `Subscription`, recurring schedule period, calls/week, total sessions, trial conversion | "Turn one-off advice into ongoing mentorship programs with recurring sessions." |
+| Trial sessions | `TrialSession`, trial appointment, status, conversion to subscription | "Offer a free trial for high-trust mentorship without losing conversion tracking." |
+| Webinars | `WebinarPlan`, `Webinar`, max participants, recording settings, waitlist | "Run live group sessions and convert attendees into 1:1 or subscription clients." |
+| Classes | `ClassPlan`, `Class`, class content, multi-session scheduling, max participants | "Package structured multi-week learning, not just ad hoc calls." |
+| Appointments | Unified `Appointment` model for consultations, subscriptions, webinars, classes, trials | "One scheduling backbone across every service format." |
+| Availability | Weekly and custom slots, UTC-aware storage, booking allocation services | "Timezone-aware scheduling built for real calendars." |
+| Documents | `AppointmentDocument`, review status, consultant response documents | "Let clients upload resumes, portfolios, architecture docs, or code notes before sessions, and respond with reviewed material." |
+| Video and chat | Stream meeting and channel APIs, recordings, meeting sessions | "Integrated video and chat instead of external Zoom-link juggling." |
+| Payments | Razorpay, Stripe, payment legs, discounts, refunds, disputes, invoices | "Payments, discounts, refunds, disputes, receipts, and invoices are part of the platform workflow." |
+| Earnings and payouts | Consultant earnings, payout accounts, payout batches, TDS records, hold/release states | "Consultants can see earnings and payout status instead of reconciling money manually." |
+| Referrals | Referral codes, referral credits, credit usage, referral landing route | "Referral credits can reduce acquisition cost and bring repeat bookings back into the platform." |
+| Reviews | Consultant reviews and ratings | "Verified social proof can compound profile conversion." |
+| Support/admin | Support tickets, moderation, refunds, disputes, system jobs, maintenance | "There is an operating layer behind sessions, not just a booking page." |
+| Enterprise/org layer | Organizations, memberships, programs, billing accounts, contracts, wallets, invoices, SSO settings, audit logs | "Future-ready for sponsored learning, company experts, GST-style invoicing, org programs, and SSO." |
+
+## Consultant-Facing Claims
+
+Use these claims in sales scripts, landing pages, and onboarding:
+
+- "You can sell more than calls: 1:1 consultations, ongoing subscriptions, webinars, and classes."
+- "Your client journey can happen inside Familiarise: booking, payment, reminders, video, chat, document review, and reviews."
+- "The 10% commission is paying for the operating layer: scheduling, payments, video, document workflows, support, trust signals, and admin."
+- "You do not need to leave your existing platform on day one. Start by running one offer on Familiarise and compare conversion, workflow, and client experience."
+- "Familiarise is built for Indian professional services, with Razorpay and compliance-oriented payout/invoice foundations."
+
+Do not say:
+
+- "We will bring you guaranteed clients."
+- "You will earn more automatically."
+- "We are cheaper than everyone in every case."
+- "We replace your audience-building work."
+- "Payouts are instant" unless product operations explicitly support it.
+
+## Consultee-Facing Claims
+
+Use these for demand-side campaigns after credible supply exists:
+
+- "Book Indian tech mentors for system design, DSA, resume review, career strategy, mock interviews, and startup tech advice."
+- "Upload context before the session so the expert can review your resume, portfolio, or technical notes."
+- "Choose one-off help or longer mentorship."
+- "Attend free or paid webinars before booking deeper 1:1 guidance."
+- "Payments, scheduling, video, chat, and documents stay in one place."
+
+Do not say:
+
+- "Guaranteed job."
+- "Guaranteed referral."
+- "Guaranteed interview conversion."
+- "Official FAANG mentorship" unless the mentor and employer relationship permits that wording.
+
+## Organization-Facing Claims
+
+Use only in founder-led conversations until B2B motion is intentionally activated:
+
+- "Familiarise has an organization layer for sponsored learning and expert programs."
+- "The model can support buyer organizations, provider organizations, or hybrid organizations."
+- "The schema supports memberships, programs, billing accounts, contracts, invoices, rate cards, SSO settings, audit logs, and HRIS stubs."
+- "The first few B2B deals should be design partnerships with manual support."
+
+Do not say:
+
+- "Fully self-serve enterprise is ready" unless that has been tested end to end.
+- "We support every HRIS/SSO scenario today."
+- "We are an LMS replacement." The better phrase is "expert-led mentoring and consultation layer."
+
+## Feature-To-Offer Translation
+
+| Tech mentor offer | Product features to use | Suggested price floor |
+| --- | --- | ---: |
+| System design mock interview | Consultation, appointment, document upload, review, video | ₹1,499-₹4,999 |
+| Resume and LinkedIn review | Consultation, document upload, consultant response document | ₹799-₹2,499 |
+| SDE career strategy call | Consultation, notes, review request | ₹999-₹2,999 |
+| 4-week interview mentorship | Subscription, trial session, recurring appointments, chat | ₹4,999-₹19,999 |
+| Live system design webinar | Webinar, waitlist, recording, email follow-up | Free to ₹499 |
+| Multi-week backend class | Class, class content, appointments, recordings, materials | ₹3,999-₹24,999 |
+| Startup CTO office hours | Consultation or subscription, document review, recurring support | ₹2,999-₹15,000 |
+
+## Proof Assets To Collect
+
+Every activated consultant should produce at least three proof assets:
+
+1. Public profile with headline, expertise tags, proof points, and one paid offer.
+2. One LinkedIn post announcing the offer and explaining who it helps.
+3. One short testimonial, review, or session outcome after the first booking.
+
+The marketing intern should turn these into:
+
+- Consultant spotlight posts.
+- Short clips or carousels.
+- SEO profile blurbs.
+- Webinar recap posts.
+- Case study snippets after 3+ successful sessions.
+
+## Messaging Guardrails
+
+Use "business platform for expert services" more than "marketplace" when selling consultants. "Marketplace" makes people expect discovery. "Business platform" makes the operating value clear.
+
+Use "tech mentor launch cohort" more than "all experts welcome." This keeps supply quality high.
+
+Use "10% platform fee" or "10% commission" consistently. Avoid "only 10%" in contexts where competitors may also claim 10%; explain what is included in the 10%.
+

--- a/docs/sales-marketing/csmo-2026-launch/02-90-day-launch-plan.md
+++ b/docs/sales-marketing/csmo-2026-launch/02-90-day-launch-plan.md
@@ -1,0 +1,227 @@
+# 90-Day Launch Plan
+
+**Goal:** Build the first credible supply base of Indian tech mentors, convert early sessions, collect reviews, and create repeatable sales and onboarding motions.
+
+## North Star
+
+Monthly active consultants: consultants who complete at least one paid session in the month.
+
+Day 90 target: 15 activated consultants, 25 paid bookings, 15 reviews, and a CRM that proves which channel creates qualified consultant conversations.
+
+## Team Assumption
+
+| Role | Owner | Time |
+| --- | --- | --- |
+| Founder | Closing calls, positioning, demos, first partnerships | 10-15 hrs/week sales and marketing |
+| Sales / CS intern | CRM, list QA, outreach drafting, onboarding coordination, support notes | 25-30 hrs/week |
+| Marketing intern | Content, profile polishing, social repurposing, webinar assets, SEO briefs | 25-30 hrs/week |
+| Upwork list builder | Lead list enrichment only | 5-10 hrs/week equivalent |
+
+## Week-By-Week Plan
+
+### Weeks 1-2: Foundation And Lead List
+
+Outcomes:
+
+- 300 qualified tech mentor prospects in CRM.
+- 30 priority targets with personalization notes.
+- Consultant onboarding checklist ready.
+- Demo Loom recorded.
+- First 20 outreach messages sent by founder.
+
+Actions:
+
+- Build CRM columns from `07-kpi-dashboard-and-operating-cadence.md`.
+- Use LinkedIn, Topmate public profiles, Preplaced mentor browsing, tech conference speaker lists, GitHub, X/Twitter, Hashnode, and YouTube to source prospects.
+- Score each prospect on expertise, audience, engagement, monetization signal, and platform fit.
+- Founder records a 5-minute demo: profile, service creation, booking, video/chat, document review, payments/earnings overview.
+- Marketing intern prepares 5 social posts: founder story, product workflow, tech mentor use cases, why 10%, call for beta mentors.
+
+Targets:
+
+- 150 prospects/week added.
+- 10 founder messages/week.
+- 5 qualified replies by end of week 2.
+
+### Weeks 3-4: Founder-Led Outreach And First Demos
+
+Outcomes:
+
+- 100 personalized outreach messages sent.
+- 10 demo calls booked.
+- 5 consultants signed up.
+- 3 consultants fully activated.
+
+Actions:
+
+- Founder sends messages to top 50 prospects.
+- Sales intern drafts and logs personalization, but founder approves messages.
+- Run 15-20 minute demo calls.
+- Onboard each signed consultant live: profile, first offer, price, availability, payout readiness, and first link-share.
+- Marketing intern polishes consultant profile copy and creates first spotlight posts.
+
+Targets:
+
+- Outreach reply rate: 15%+.
+- Demo show rate: 70%+.
+- Signup from demo: 40%+.
+- Activation from signup: 60%+.
+
+### Weeks 5-6: Activation And First Paid Bookings
+
+Outcomes:
+
+- 10 consultants signed.
+- 7 activated.
+- 5 paid bookings.
+- 3 reviews.
+
+Actions:
+
+- Every activated consultant posts their Familiarise link on LinkedIn or sends it to 5 warm contacts.
+- Founder helps each consultant choose one narrow offer. Avoid vague "career mentorship."
+- Launch 2 free webinars as demand capture: "System Design Mock Interview Live" and "Resume Review Live."
+- Follow up attendees with 1:1 booking CTAs.
+- Sales intern runs 48-hour check-ins after every first booking.
+
+Targets:
+
+- 70% of activated consultants share link publicly or with warm list.
+- 5-10% webinar attendee to booking interest.
+- 50%+ first-session review request completion.
+
+### Weeks 7-8: Channel Tests
+
+Outcomes:
+
+- LinkedIn baseline established.
+- Cold email test launched.
+- X/Twitter and Reddit tests launched.
+- Instagram/Facebook content tests started.
+
+Actions:
+
+- Send 150 additional LinkedIn/manual messages.
+- Send a 100-person cold email test with verified email only.
+- Post 2 Reddit value posts per week without hard selling.
+- Publish 2 X/Twitter threads around tech mentorship offers.
+- Publish 4 Instagram/Facebook short assets: clips, carousels, consultant proof.
+- Keep WhatsApp only for opt-in or warm follow-up.
+
+Targets:
+
+- LinkedIn qualified reply rate: 12%+.
+- Cold email reply rate: 3%+.
+- X/Twitter qualified conversations: 3+.
+- Instagram/Facebook qualified inbound: 2+ or keep as proof channel only.
+
+### Weeks 9-10: Proof And Referral Loop
+
+Outcomes:
+
+- 15 consultants signed.
+- 10 activated.
+- 15 paid bookings.
+- 8 reviews.
+- First case study drafted.
+
+Actions:
+
+- Ask every consultant with a successful session for one referral to another mentor.
+- Ask every happy consultee for a review and one friend referral.
+- Publish first public case study if permission is available.
+- Host 2 more webinars with activated consultants.
+- Build "Top 10 Indian System Design Mentors To Watch" style SEO draft if enough profiles exist.
+
+Targets:
+
+- 20 consultant referrals requested.
+- 5 referred consultant conversations.
+- 5 referred consultee signups.
+- 1 public case study or anonymized proof post.
+
+### Weeks 11-12: Tighten The Machine
+
+Outcomes:
+
+- 25 consultants signed.
+- 15 activated.
+- 25 paid bookings.
+- 15 reviews.
+- Channel report with keep/kill decisions.
+
+Actions:
+
+- Audit every channel using `07-kpi-dashboard-and-operating-cadence.md`.
+- Double down on channels that produced qualified replies under acceptable cost.
+- Kill or pause channels that only produced vanity engagement.
+- Prepare next 90-day plan: either deepen tech vertical or add adjacent product management/startup tech advisory.
+- Identify whether the sales intern should continue, convert, or be replaced.
+
+Targets:
+
+- Cost per activated consultant: under ₹2,000 excluding founder time.
+- Consultant activation rate: 60%+.
+- Consultant 30-day activity: 50%+.
+- Session review collection: 40%+.
+
+## Daily Operating Cadence
+
+Founder:
+
+- 5 high-quality outbound messages.
+- 1-2 demo or onboarding calls when available.
+- 15 minutes reviewing intern CRM and message quality.
+
+Sales / CS intern:
+
+- Add 15-25 leads.
+- Draft 10 personalized openers.
+- Update CRM statuses.
+- Follow up accepted LinkedIn connections or warm replies.
+- Coordinate onboarding calls.
+
+Marketing intern:
+
+- Publish or schedule 1 social asset.
+- Improve 1 consultant profile or proof asset.
+- Write or update 1 SEO/content brief.
+- Repurpose webinar/session proof.
+
+## Weekly Review
+
+Every Friday, review:
+
+- New leads added.
+- Outreach sent by channel.
+- Replies and qualified replies.
+- Demo calls booked and completed.
+- Signups.
+- Activations.
+- Bookings.
+- Reviews.
+- Top objections.
+- Product blockers.
+- Next week's top 20 target accounts.
+
+## 90-Day Kill Rules
+
+Kill or pause a channel if it fails for 2 consecutive weeks:
+
+- LinkedIn: below 8% qualified reply rate after 100 well-personalized messages.
+- Cold email: below 2% reply rate or deliverability issues after 100 verified emails.
+- Instagram/Facebook: no qualified consultant or consultee conversations after 20 posts.
+- Reddit: negative moderation or no qualified conversations after 8 value posts.
+- Offline events: no qualified follow-up conversations after 2 events.
+- Webinars: below 20 registrants or below 3 qualified booking interests for 2 events.
+
+## Success Definition
+
+The launch is successful if Familiarise exits day 90 with:
+
+- A repeatable way to recruit Indian tech mentors.
+- A small but credible set of active consultants.
+- Real paid bookings and reviews.
+- Proof assets that support SEO and social.
+- Clear evidence of which channels deserve the next ₹50K.
+

--- a/docs/sales-marketing/csmo-2026-launch/03-channel-playbooks.md
+++ b/docs/sales-marketing/csmo-2026-launch/03-channel-playbooks.md
@@ -1,0 +1,438 @@
+# Channel Playbooks
+
+**Operating principle:** LinkedIn is the daily center. Every other channel is a controlled test with a clear owner, cost, KPI, and kill rule.
+
+## Channel Summary
+
+| Channel | Role | Priority |
+| --- | --- | --- |
+| LinkedIn manual | Primary consultant recruiting and founder credibility | P0 |
+| Sales Navigator | Targeting, saved searches, limited InMail | P1 |
+| Cold email | Scaled backup for consultant outreach | P1 |
+| X/Twitter | Tech community conversations and founder POV | P1 |
+| Webinars | Demand capture and consultant proof | P1 |
+| SEO | Long-term compounding profile and content discovery | P1 |
+| Reddit | Value-led community listening and demand testing | P2 |
+| Instagram | Visual proof, clips, carousels, creator confidence | P2 |
+| Facebook | Retargeting later, groups only if high-signal | P3 |
+| WhatsApp | Warm follow-up and onboarding, not cold blast | P1 |
+| Offline events | Trust-building and local sourcing | P2 |
+
+## LinkedIn Manual Outreach
+
+Target audience:
+
+- Senior Software Engineers, Staff Engineers, EMs, architects, DevOps leads, ML engineers, backend leads, SDE interview coaches.
+- India-based or India-serving.
+- Signals: 1K+ followers/connections, posts about mentoring/careers, Topmate/Preplaced/ADPList profile, conference talks, GitHub/blog proof.
+
+Daily activity:
+
+- Founder sends 5 high-quality messages.
+- Sales intern drafts 10 openers and logs personalization.
+- Comment on 10 target posts before sending connection requests.
+- Follow up accepted connections within 24 hours.
+
+Weekly activity:
+
+- 50-70 new prospects reviewed.
+- 25-35 connection requests.
+- 15 follow-up messages.
+- 3-5 demo calls targeted.
+
+Tools:
+
+- LinkedIn free account.
+- Google Sheets or Zoho CRM.
+- Optional Sales Navigator for search filters.
+
+Expected cost:
+
+- ₹0 at start.
+- Optional Sales Navigator when the CRM has 300+ prospects and search quality matters.
+
+KPIs:
+
+- Connection acceptance: 25%+.
+- Qualified reply rate: 12%+.
+- Demo booked per accepted connection: 8%+.
+- Signup per demo: 40%+.
+
+Kill criteria:
+
+- If qualified reply rate stays below 8% after 100 personalized messages, pause and rewrite ICP, opener, and offer.
+
+Do:
+
+- Reference a specific post, project, talk, or offer.
+- Lead with founder curiosity and product fit.
+- Ask for feedback or a 15-minute demo.
+
+Do not:
+
+- Batch-send generic pitches.
+- Claim guaranteed discovery or earnings.
+- Attack Topmate, Preplaced, or any other platform.
+
+## Sales Navigator
+
+Target audience:
+
+- Same as LinkedIn manual, with tighter filters by geography, current title, seniority, industry, and posted content.
+
+Daily activity:
+
+- Save 10 qualified leads.
+- Review alerts and job/title changes.
+- Send InMail only to top-tier prospects with no connection path.
+
+Weekly activity:
+
+- Build 2 saved searches.
+- Export/search manually into CRM.
+- Use 10-15 InMails max for highest-fit prospects.
+
+Tools:
+
+- LinkedIn Sales Navigator.
+
+Expected cost:
+
+- Optional. Use a trial or one paid month only after manual outreach messaging is proven.
+
+KPIs:
+
+- Saved lead to qualified prospect: 50%+.
+- InMail response: 15%+.
+- Demo booked from InMail: 5%+.
+
+Kill criteria:
+
+- Cancel if it does not improve lead quality or demo volume within 30 days.
+
+Source:
+
+- LinkedIn states Sales Navigator users receive 50 InMail credits/month, can accumulate up to 150, and get credits back when an InMail receives a response within 90 days: [LinkedIn Sales Navigator InMail credits](https://www.linkedin.com/help/linkedin/answer/a101030/inmail-crediting-and-renewal-process-in-sales-navigator).
+
+## Cold Email
+
+Target audience:
+
+- Tech mentors with public professional emails or emails sourced from compliant B2B databases.
+- Conference speakers, newsletter writers, GitHub maintainers, engineering coaches, startup tech advisors.
+
+Daily activity:
+
+- Verify 15 emails.
+- Send 10 highly targeted emails from founder or brand domain.
+- Log opens, replies, bounces, and unsubscribes.
+
+Weekly activity:
+
+- 50-75 emails.
+- 3-step sequence: day 0, day 4, day 10.
+- Clean bounced contacts.
+
+Tools:
+
+- Apollo free/low tier, Snov.io, Hunter, Google Sheets.
+- Saleshandy/Instantly only after sender domain basics are configured.
+
+Expected cost:
+
+- ₹0-₹5K/month in the first 90 days.
+
+KPIs:
+
+- Bounce rate under 3%.
+- Open rate above 35%.
+- Reply rate above 3%.
+- Qualified reply rate above 2%.
+
+Kill criteria:
+
+- Pause if bounce rate exceeds 5%, spam complaints appear, or reply rate stays below 2% after 100 verified emails.
+
+Compliance notes:
+
+- Include a clear sender identity and opt-out line.
+- Do not scrape sensitive personal data.
+- Use public/business context only.
+- Store only necessary outreach data.
+
+## X/Twitter
+
+Target audience:
+
+- Indian tech Twitter: engineering managers, startup engineers, DSA creators, system design educators, indie builders.
+
+Daily activity:
+
+- Reply to 10 high-signal posts.
+- DM 3 warm prospects only after engagement.
+- Post one founder insight or build-in-public update.
+
+Weekly activity:
+
+- 2 threads: one product/workflow insight, one tech mentorship/business insight.
+- 1 consultant spotlight after activation.
+
+Tools:
+
+- Native X.
+- Typefully or Buffer optional.
+
+Expected cost:
+
+- ₹0.
+
+KPIs:
+
+- Profile visits.
+- Meaningful replies.
+- Qualified DMs.
+- Demo calls from X.
+
+Kill criteria:
+
+- If 4 weeks produce no qualified consultant conversation, reduce to founder presence only.
+
+## Instagram
+
+Target audience:
+
+- Younger tech professionals, career switchers, students, creators who respond to visual proof.
+
+Daily activity:
+
+- Engage with 5 relevant creator/student posts.
+- Repurpose one proof asset as story/reel/carousel when available.
+
+Weekly activity:
+
+- 3 reels or carousels.
+- 1 consultant spotlight.
+- 1 webinar clip.
+
+Tools:
+
+- Instagram, Canva, CapCut.
+
+Expected cost:
+
+- ₹0-₹2K/month for editing templates if needed.
+
+KPIs:
+
+- Saves and shares.
+- Profile clicks.
+- Webinar registrations.
+- Qualified DMs.
+
+Kill criteria:
+
+- If 20 posts generate no qualified conversations or webinar signups, keep Instagram as proof archive only.
+
+## Facebook
+
+Target audience:
+
+- Tech groups, college alumni groups, job prep groups, later retargeting audiences.
+
+Daily activity:
+
+- None by default.
+
+Weekly activity:
+
+- Test 2 value posts in relevant groups if group rules allow it.
+- Republish webinar/event announcements.
+
+Tools:
+
+- Facebook groups.
+- Meta ads only after proof exists.
+
+Expected cost:
+
+- ₹0 in first 90 days.
+
+KPIs:
+
+- Group post approvals.
+- Comments/questions.
+- Webinar registrations.
+- Qualified DMs.
+
+Kill criteria:
+
+- If posts get removed, ignored, or attract low-quality spam, stop.
+
+## Reddit
+
+Target audience:
+
+- Indian developers, students, career switchers, interview preppers.
+
+Daily activity:
+
+- Listen and comment, no pitching.
+
+Weekly activity:
+
+- 2 value posts or comments with practical advice.
+- Use founder identity transparently when mentioning Familiarise.
+
+Tools:
+
+- Reddit.
+
+Expected cost:
+
+- ₹0.
+
+KPIs:
+
+- Helpful replies.
+- DMs.
+- Webinar registrations.
+- Topic insights for content.
+
+Kill criteria:
+
+- Stop if moderation feedback is negative or if 8 value posts produce no insight or qualified conversation.
+
+## Webinars
+
+Target audience:
+
+- Consultees: SDE candidates, early-career engineers, students, career switchers.
+- Consultants: mentors who want to see Familiarise's webinar workflow.
+
+Weekly activity:
+
+- Weeks 5-12: one webinar every two weeks minimum.
+- Founder helps consultant define topic, title, CTA, and follow-up.
+
+Tools:
+
+- Familiarise webinar flow.
+- LinkedIn events/posts.
+- WhatsApp opt-in reminders.
+- Email follow-up.
+
+Expected cost:
+
+- ₹0-₹2K/event for design and small logistics.
+
+KPIs:
+
+- Registrations: 20+ early, 50+ stretch.
+- Attendance: 40%+.
+- Booking interest: 5-10% of attendees.
+- Reviews/testimonials from attendees.
+
+Kill criteria:
+
+- Rework if two webinars in a row have under 20 registrations or under 3 qualified booking leads.
+
+## SEO
+
+Target audience:
+
+- Searchers looking for system design mentors, DSA mock interviews, resume review, career mentorship, Topmate alternatives, Preplaced alternatives.
+
+Weekly activity:
+
+- Publish or draft 2 SEO pages/posts.
+- Optimize every consultant profile for title, domain, outcome, price, proof, and FAQ.
+- Intern maintains internal links from blogs to profiles.
+
+Tools:
+
+- Google Search Console.
+- Ahrefs free tools or Ubersuggest optional.
+- Next.js metadata and sitemap support.
+
+Expected cost:
+
+- ₹0-₹3K/month.
+
+KPIs:
+
+- Indexed profiles.
+- Impressions.
+- Top 20 keyword count.
+- Organic signups.
+- Profile page conversion.
+
+Kill criteria:
+
+- Do not kill SEO in 90 days. Rework topics if impressions are flat after indexing.
+
+## WhatsApp Follow-Up
+
+Target audience:
+
+- Accepted prospects, demo attendees, webinar registrants, activated consultants, customers who opted in.
+
+Daily activity:
+
+- Follow up warm conversations.
+- Send onboarding reminders.
+- Ask for reviews after sessions.
+
+Tools:
+
+- WhatsApp Business manually at first.
+- AiSensy/WATI only after opt-in volume exists.
+
+Expected cost:
+
+- ₹0 at first.
+- Optional ₹1.5K-₹4K/month later.
+
+KPIs:
+
+- Response rate.
+- Onboarding completion.
+- Review completion.
+- Webinar attendance uplift.
+
+Kill criteria:
+
+- Stop any cold or bulk use that risks spam complaints.
+
+## Light Offline Events
+
+Target audience:
+
+- Tech meetups, startup events, college tech clubs, engineering communities.
+
+Monthly activity:
+
+- Attend 1-2 events.
+- Identify 5 targets before the event.
+- Connect on LinkedIn within 24 hours.
+- Send demo link within 48 hours.
+
+Tools:
+
+- QR landing page.
+- One-page leaflet.
+- LinkedIn QR.
+
+Expected cost:
+
+- ₹2K-₹5K/month.
+
+KPIs:
+
+- Qualified conversations per event: 5+.
+- Demo calls from event: 2+.
+- Consultant signups from event: 1+.
+
+Kill criteria:
+
+- Pause if 2 events produce no qualified follow-up calls.
+

--- a/docs/sales-marketing/csmo-2026-launch/04-scripts-and-sequences.md
+++ b/docs/sales-marketing/csmo-2026-launch/04-scripts-and-sequences.md
@@ -1,0 +1,305 @@
+# Scripts And Sequences
+
+**Rule:** These are templates, not copy-paste blasts. Every outbound message must include at least one real personalization field.
+
+## Personalization Fields
+
+Collect these before messaging:
+
+- `name`
+- `current_role`
+- `company`
+- `city_or_market`
+- `expertise`
+- `recent_post_or_project`
+- `existing_offer_or_platform`
+- `audience_signal`
+- `why_they_fit_familiarise`
+- `suggested_first_offer`
+
+## Cold LinkedIn Connection Request
+
+Use when:
+
+- Prospect is not connected.
+- You have a specific reason for reaching out.
+
+Template:
+
+> Hi `name`, I saw your work on `recent_post_or_project`. I am building Familiarise for Indian tech mentors who want to sell 1:1s, subscriptions, webinars, and classes with integrated video, documents, and payments. Would love to connect and get your feedback.
+
+Do not say:
+
+- "Hope you are doing well."
+- "We are the best Topmate alternative."
+- "I can help you get clients."
+- "Dear sir/madam."
+
+## LinkedIn Follow-Up After Acceptance
+
+Template:
+
+> Thanks for connecting, `name`. Your `expertise` work stood out because `specific_reason`.
+>
+> I am recruiting a small beta group of Indian tech mentors for Familiarise. The idea is simple: 10% commission, but the platform handles the serious operating layer: booking, payments, integrated video/chat, document review, reviews, webinars/classes, and payouts.
+>
+> I think your first offer could be `suggested_first_offer`. Would you be open to a 15-minute demo this week? I would value blunt feedback even if you do not join.
+
+Do not say:
+
+- "Only 10%" without explaining what is included.
+- "You should leave your current platform."
+- "We guarantee discovery."
+
+## Topmate / Existing Creator Outreach
+
+Use when:
+
+- Prospect already monetizes expertise on Topmate, SuperProfile, ADPList, Preplaced-like profiles, or own booking page.
+
+Template:
+
+> Hi `name`, I noticed your `existing_offer_or_platform` offer around `expertise`. It looks like you are already doing the hard part: earning trust from an audience.
+>
+> I am building Familiarise for Indian expert businesses that need more than a booking link. You can run 1:1 consultations, subscriptions, webinars, and classes with integrated video/chat, document review, Indian payments, reviews, and payout tracking.
+>
+> We charge 10% from day one. The pitch is not "free"; it is that the 10% should remove operational friction and make the client experience more professional.
+>
+> Would you be open to testing one offer on Familiarise in parallel?
+
+Do not say:
+
+- "Topmate is bad."
+- "You are losing money" unless you have sourced and precise math for that prospect.
+- "Deactivate your current profile."
+
+## Cold Email Sequence
+
+### Email 1 - Founder Feedback Ask
+
+Subject options:
+
+- `name`, quick feedback on a tech mentor platform?
+- Your `expertise` mentoring offer
+- Familiarise beta for Indian tech mentors
+
+Body:
+
+> Hi `name`,
+>
+> I found your work on `recent_post_or_project` and thought your `expertise` background could fit what we are building.
+>
+> Familiarise is an India-first platform for tech mentors to run 1:1 calls, ongoing mentorship, webinars, and classes with integrated video/chat, document review, payments, reviews, and payout tracking.
+>
+> We charge 10% commission from day one. The goal is to make that fee earn itself through better operations and client experience.
+>
+> Would you be open to a 15-minute feedback call? I think your first offer could be `suggested_first_offer`.
+>
+> - `sender_name`
+>
+> If this is not relevant, reply "no" and I will not follow up.
+
+Do not say:
+
+- "Revolutionary platform."
+- "Guaranteed revenue."
+- "Massive opportunity" without specifics.
+
+### Email 2 - Workflow Angle
+
+Send 4 days later.
+
+> Hi `name`, quick follow-up.
+>
+> The reason I thought of you: most tech mentors end up stitching together calendar links, payment links, Zoom, WhatsApp, Google Drive, and manual review notes.
+>
+> Familiarise combines those workflows so a mentor can sell `suggested_first_offer` without that operational mess.
+>
+> Worth a quick look, or should I close the loop?
+
+Do not say:
+
+- "Just checking in" by itself.
+- "Circling back."
+
+### Email 3 - Breakup
+
+Send 10 days after first email.
+
+> Last note from me, `name`.
+>
+> I am curating a small beta group of Indian tech mentors. Your `expertise` background seemed like a strong fit, but timing may be wrong.
+>
+> I will close this out unless you want the demo link.
+>
+> Either way, enjoyed your `recent_post_or_project`.
+
+Do not say:
+
+- "This is your last chance."
+- "Spots are almost gone" unless true.
+
+## X/Twitter DM
+
+Use only after engaging with their content.
+
+Template:
+
+> Hey `name`, your post on `recent_post_or_project` was sharp. I am building Familiarise for Indian tech mentors who want to sell calls, subscriptions, webinars, and classes without duct-taping Zoom/payments/docs. I think `suggested_first_offer` would fit your audience. Open to a 15-min feedback demo?
+
+Do not say:
+
+- "I loved your content" without naming the content.
+- "Can I pick your brain?"
+
+## Demo Call Script - 15 Minutes
+
+Minute 0-2: context
+
+> Thanks for taking this, `name`. I am not here to hard sell. I want to see if Familiarise can support the kind of expert business you may want to run.
+
+Ask:
+
+- What advice do people already ask you for?
+- Have you charged for it before?
+- What is annoying about your current workflow?
+
+Minute 3-8: tailored demo
+
+Show only the relevant path:
+
+- 1:1 plan if they do mock interviews or reviews.
+- Subscription if they do longer mentorship.
+- Webinar if they have audience.
+- Document review if they review resumes/code/architecture.
+
+Minute 9-12: first offer design
+
+> If we had to launch one offer this week, I would suggest `suggested_first_offer` at `price_range`. Does that feel sellable to your audience?
+
+Minute 13-15: close
+
+> The next step is simple: create your profile, add one offer, set availability, and share it with 5 warm people. I can help you do that live.
+
+Do not say:
+
+- "Let me show you everything."
+- "We have enterprise and every other feature" unless relevant.
+
+## Consultant Onboarding Call - 30 Minutes
+
+Goal:
+
+- Profile complete.
+- One offer live.
+- Availability set.
+- First link-share committed.
+
+Script:
+
+1. Goal:
+
+> What would make this worth your time in the next 30 days?
+
+2. Offer:
+
+> We need one narrow offer first. A narrow offer sells better than a broad profile.
+
+3. Price:
+
+> Your price should reflect the outcome, not just the hour. For `expertise`, I would start at `price_range` and adjust after 3-5 bookings.
+
+4. Activation:
+
+> Who are 5 people who already trust you enough to test this?
+
+5. Commitment:
+
+> Before we end, let us send or schedule one post/message with your link.
+
+Do not say:
+
+- "You can set it up later."
+- "Add every possible service."
+
+## Objection Handling
+
+### "Why pay 10%?"
+
+Response:
+
+> Fair question. Familiarise should earn the 10%. The fee covers the operating layer: booking, payments, integrated video/chat, document review, reviews, support workflows, earnings tracking, and room to build demand. If all you need is a payment link, you do not need us. If you want to run a professional expert-service workflow, that is where we fit.
+
+Do not say:
+
+- "It is only 10%."
+
+### "I am already on Topmate."
+
+Response:
+
+> That is fine. I would not ask you to rip anything out. Run one offer on Familiarise in parallel and compare the workflow. We are stronger when the service needs integrated video, document review, subscriptions/classes, and a more professional session lifecycle.
+
+Do not say:
+
+- "Topmate is unreliable."
+- "Switch completely today."
+
+### "I do not have an audience."
+
+Response:
+
+> Then we should start carefully. Familiarise will not magically create an audience. It can help you convert trust once you have it. I would start with one warm-network offer and one webinar, then use the response to decide whether to keep going.
+
+Do not say:
+
+- "We will bring you leads."
+
+### "Platform is too new."
+
+Response:
+
+> True. The upside of joining early is direct founder support and influence over the product. The risk is that we are still proving the market. That is why I suggest starting with one offer and a small warm test, not moving your whole business.
+
+Do not say:
+
+- "There is no risk."
+
+## Referral Ask
+
+Use after a positive onboarding or first booking.
+
+Template:
+
+> `name`, quick ask. Who is one Indian tech mentor you respect who already gives great advice and might want to monetize it more professionally? I would rather speak to one high-fit person you trust than scrape 100 random profiles.
+
+Do not say:
+
+- "Can you send this to everyone?"
+
+## Webinar Invite
+
+Template:
+
+> Hi `name`, we are hosting a live session on `topic` with `consultant_name`. It is built for `audience` who want `outcome`. You can join free here: `link`.
+>
+> If you want deeper help after the session, the mentor will also share a 1:1 booking option.
+
+Do not say:
+
+- "Limited seats" unless capacity is actually limited.
+- "Guaranteed job/interview/referral."
+
+## Post-Session Review Ask
+
+Template:
+
+> Hi `name`, hope the session with `consultant_name` was useful. Could you leave a quick review while it is fresh? Two honest lines about what changed or became clearer would help future learners choose the right mentor.
+>
+> Review link: `link`
+
+Do not say:
+
+- "Please leave 5 stars."
+- "Positive review."
+

--- a/docs/sales-marketing/csmo-2026-launch/05-hiring-and-upwork-plan.md
+++ b/docs/sales-marketing/csmo-2026-launch/05-hiring-and-upwork-plan.md
@@ -1,0 +1,278 @@
+# Hiring And Upwork Plan
+
+**Decision:** Intern-first India team. Upwork is only for lead-list research and enrichment in the first 90 days.
+
+## Hiring Philosophy
+
+The first sales and marketing hires are not strategists. They are operators who help the founder increase throughput without damaging brand trust.
+
+Founder owns:
+
+- Positioning.
+- Final outbound quality.
+- Demo calls.
+- Closing.
+- High-stakes customer conversations.
+
+Interns own:
+
+- CRM hygiene.
+- Drafting.
+- Follow-up coordination.
+- Content production.
+- Onboarding support.
+- Weekly reporting.
+
+Upwork contractors own:
+
+- Finding and enriching lead lists.
+- Never sending messages from founder accounts.
+- Never making unapproved claims.
+
+## Monthly Budget
+
+Stay inside ₹25K-50K/month.
+
+| Role/item | Budget |
+| --- | ---: |
+| Sales / CS intern | ₹10K-12K/month |
+| Marketing intern | ₹10K-12K/month |
+| Upwork list builder | ₹5K-10K/month |
+| Tools | ₹3K-8K/month |
+| Offline/events reserve | ₹2K-5K/month |
+| Total | ₹30K-47K/month |
+
+Optional above-budget items must be approved separately.
+
+## Role 1: Sales / Customer Success Intern
+
+Compensation:
+
+- ₹10K-12K/month stipend.
+- Optional ₹300 per activated consultant, capped at ₹3K/month.
+
+Responsibilities:
+
+- Maintain CRM.
+- Add 15-25 prospects/day.
+- Draft 10 personalized LinkedIn/email openers/day.
+- Track replies and follow-ups.
+- Coordinate demo and onboarding calls.
+- Maintain objection notes.
+- Send review requests after sessions.
+- Create weekly funnel report.
+
+90-day scorecard:
+
+| Metric | Target |
+| --- | ---: |
+| Qualified prospects added | 600 |
+| Founder-approved message drafts | 300 |
+| Qualified replies supported | 60 |
+| Demo calls scheduled | 25 |
+| Consultants activated | 10 |
+| CRM completeness | 95% required fields |
+| First-response time for warm leads | Under 1 business day |
+
+Trial task:
+
+- Build a list of 25 Indian tech mentors.
+- For each, include LinkedIn URL, expertise, proof link, existing monetization signal, one personalization line, and one suggested Familiarise offer.
+- Draft 5 outreach messages.
+
+Reject if:
+
+- Uses generic personalization.
+- Cannot distinguish tech mentor ICP from generic influencer.
+- Overpromises discovery/revenue.
+- Poor CRM hygiene.
+
+## Role 2: Marketing / Content Intern
+
+Compensation:
+
+- ₹10K-12K/month stipend.
+- Optional ₹500 per content-attributed activated consultant, capped at ₹3K/month.
+
+Responsibilities:
+
+- Publish/schedule LinkedIn, X, Instagram proof content.
+- Turn consultant proof into spotlights.
+- Draft SEO articles and profile copy.
+- Create webinar posters, recap posts, and clips.
+- Monitor competitor messaging.
+- Maintain content calendar.
+
+90-day scorecard:
+
+| Metric | Target |
+| --- | ---: |
+| Social posts shipped | 60 |
+| SEO drafts | 12 |
+| Consultant spotlights | 10 |
+| Webinar assets | 6 events |
+| Case studies/proof posts | 3 |
+| Qualified inbound conversations | 10 |
+
+Trial task:
+
+- Rewrite one consultant profile headline and bio.
+- Create 3 LinkedIn posts: founder POV, consultant spotlight, webinar invite.
+- Draft one SEO outline: "System design mentor India."
+
+Reject if:
+
+- Writes generic AI-sounding copy.
+- Uses hype instead of proof.
+- Cannot write for Indian tech professionals.
+- Does not understand outcomes and specificity.
+
+## Upwork Use Case: Lead List Builder
+
+Why only list-building:
+
+- Upwork is useful for research throughput.
+- It is risky for high-trust founder messaging.
+- Contractors do not understand product nuance early.
+- LinkedIn account safety and brand tone matter more than volume.
+
+Scope:
+
+- Build and enrich prospect lists.
+- Find public profile links.
+- Add proof signals.
+- Identify existing offers.
+- No outreach.
+- No scraping behind login walls.
+- No sensitive personal data.
+
+Expected pay:
+
+- Fixed project preferred: $50-$120 for 150-300 researched leads depending on depth.
+- Hourly acceptable: $5-$12/hour for India/Philippines-based researchers with strong QA.
+
+Benchmark sources:
+
+- Upwork lists lead generation experts at $13-$45/hr: [Upwork lead generation rates](https://www.upwork.com/hire/lead-generation-specialists/cost/).
+- Upwork lists sales representatives at $13-$40/hr: [Upwork sales representative rates](https://www.upwork.com/hire/sales-representatives/cost/).
+- Upwork lists virtual assistants at $10-$20/hr: [Upwork virtual assistant rates](https://www.upwork.com/hire/virtual-assistants/cost/).
+- Upwork lists content writers at $15-$40/hr: [Upwork content writer rates](https://www.upwork.com/hire/content-writers/cost//).
+
+Use these benchmarks to avoid overpaying. For first 90 days, Familiarise should hire below full specialist rates because the task is bounded research, not sales ownership.
+
+## Upwork Job Post
+
+Title:
+
+> Lead Researcher For Indian Tech Mentor Marketplace
+
+Description:
+
+> We are building Familiarise, an India-first platform for tech mentors to sell 1:1 consultations, subscriptions, webinars, and classes.
+>
+> We need a detail-oriented researcher to build a list of Indian tech mentors and senior engineers who may be a fit for our beta launch.
+>
+> You will not send messages. This is research only.
+>
+> Required fields per lead:
+>
+> - Name
+> - LinkedIn URL
+> - Current role/company
+> - Location/market
+> - Expertise area
+> - Proof link: post, talk, GitHub, blog, YouTube, or profile
+> - Existing monetization signal: Topmate, Preplaced, ADPList, own booking link, paid cohort, webinar, newsletter, or public mentoring post
+> - Audience signal: followers, engagement, community, or credibility proof
+> - Suggested Familiarise offer
+> - One personalization line
+>
+> First paid test: 25 leads. If quality is strong, we will extend to 200-300 leads.
+
+Screening questions:
+
+- Share 3 sample leads for "Indian system design mentor."
+- What makes a lead high quality for a mentorship platform?
+- How would you avoid adding generic software engineers who are not mentor prospects?
+
+Acceptance criteria:
+
+- 80%+ leads match ICP.
+- 95%+ links work.
+- No duplicate leads.
+- Personalization lines are specific and usable.
+- No fabricated follower counts or proof.
+
+## Cost-Saving Plan
+
+Use this order:
+
+1. Founder and intern build first 100 leads manually. This teaches quality.
+2. Hire Upwork for a 25-lead paid test.
+3. If 80%+ pass QA, expand to 200 leads.
+4. Intern reviews every lead before founder messages.
+5. Stop contractor if more than 20% are generic, duplicate, or low-fit.
+
+Do not buy large lead databases before the first 300 prospects teach the ICP.
+
+## Hiring Timeline
+
+Week 1:
+
+- Post intern roles.
+- Assign trial tasks.
+- Founder builds first CRM template.
+
+Week 2:
+
+- Select sales/CS intern and marketing intern.
+- Start 25-lead Upwork test.
+
+Weeks 3-4:
+
+- Interns shadow founder outreach and demos.
+- Contractor expands list only if test passed.
+
+Weeks 5-8:
+
+- Interns own daily operating cadence.
+- Founder audits quality daily.
+
+Weeks 9-12:
+
+- Decide continue/replace/convert based on scorecards.
+
+## Interview Questions
+
+Sales / CS intern:
+
+- Explain how you would personalize a message to a senior engineer.
+- What would you track in a CRM?
+- How would you respond if someone says, "I already use Topmate"?
+- Tell me about a time you followed up without being annoying.
+
+Marketing intern:
+
+- Rewrite "Book mentorship calls with experts" for a system design mentor.
+- What makes a LinkedIn post credible?
+- How would you turn one webinar into five content pieces?
+- What is the difference between traffic and qualified demand?
+
+Upwork researcher:
+
+- Show a sample lead list.
+- Explain your research process.
+- How do you verify that someone is open to mentoring?
+- How do you avoid duplicates?
+
+## Red Lines
+
+Do not hire anyone who:
+
+- Wants to run aggressive automation from founder LinkedIn.
+- Measures success by message volume only.
+- Cannot write specific personalization.
+- Wants to promise guaranteed income.
+- Cannot explain the tech mentor ICP.
+- Uses fabricated data.
+

--- a/docs/sales-marketing/csmo-2026-launch/06-competitor-battlecards.md
+++ b/docs/sales-marketing/csmo-2026-launch/06-competitor-battlecards.md
@@ -1,0 +1,180 @@
+# Competitor Battlecards
+
+**Positioning rule:** Compare with math, workflow, and product fit. Do not attack competitors.
+
+## Source Notes
+
+Use sourced claims only.
+
+- Topmate's 2026 guide describes 1:1 sessions, webinars/group sessions, digital products/courses, service bundles, priority DMs, Instagram Auto-DM automation, Google Calendar/Zoom/WhatsApp integrations, 1M+ professionals, 300K+ creators, $1M+ creator earnings, and $1.13M raised: [Topmate 2026 guide](https://topmate.io/blog/topmate.io-in-2026-the-honest-guide-for-creators-coaches-and-experts-thinking-about-monetizing-their-time).
+- Preplaced publicly positions around 1:1 long-term mentorship, free trial, verified mentors, rescheduling, 600+ mentors, and career outcomes: [Preplaced homepage](https://www.preplaced.in/).
+- ProPeers App Store listing describes expert advice, peer updates, and showcasing skills/achievements: [ProPeers App Store listing](https://apps.apple.com/us/app/propeers/id6446427356).
+
+Any claim not in those sources or repo docs must be marked as an assumption.
+
+## Familiarise Position
+
+Familiarise is not just a profile link. It is an India-first expert-service operating platform.
+
+Core contrast:
+
+- 1:1 consultations.
+- Ongoing subscriptions.
+- Webinars.
+- Multi-week classes.
+- Integrated video/chat.
+- Document review.
+- Trial-to-paid tracking.
+- Reviews.
+- Referrals.
+- Payments, refunds, disputes, earnings, payouts, invoices.
+- Organization layer for future B2B.
+
+The 10% commission is positioned as payment for that operating infrastructure.
+
+## Against Topmate
+
+### What They Are Good At
+
+- Strong brand recall among creators.
+- Fast creator storefront setup.
+- Broad monetization surface: sessions, webinars, digital products, bundles, priority DMs.
+- Large reported scale.
+- Social proof from being the default "book a call" link in many bios.
+
+### Familiarise Opening
+
+> Topmate is a strong creator storefront. Familiarise is for Indian tech mentors who want a deeper service workflow: integrated video/chat, document review, subscriptions, webinars/classes, reviews, payouts, and Indian operating foundations.
+
+### Say
+
+- "You do not need to leave Topmate to test Familiarise. Run one high-value offer in parallel."
+- "If your product is a simple paid call link, Topmate may be enough. If your offer needs documents, video, recurring mentorship, webinars/classes, and tighter operations, Familiarise is built for that."
+- "Our fee is 10% from day one. The question is whether the operating layer earns that fee for you."
+
+### Do Not Say
+
+- "Topmate is bad."
+- "Topmate will lose your money."
+- "Everyone is switching."
+- "We are cheaper in every scenario."
+
+### Best Prospect Type
+
+- Existing Topmate creator who sells mock interviews, resume reviews, system design prep, or high-touch consulting.
+- Creator with audience but operational mess.
+- Mentor who wants to launch subscriptions/classes, not just calls.
+
+### Objection
+
+"I already use Topmate."
+
+Response:
+
+> That is exactly why I reached out. You already know people will pay for your expertise. I would not ask you to move everything. Test one offer on Familiarise where the workflow matters, like document-heavy resume review, system design mock interview, or a 4-week mentorship subscription.
+
+## Against Preplaced
+
+### What They Are Good At
+
+- Clear career outcome positioning.
+- Long-term mentorship focus.
+- Free trial hook.
+- Verified mentor trust language.
+- Publicly shows 600+ mentors and coverage across engineering, data, product, business, and more.
+
+### Familiarise Opening
+
+> Preplaced is strong for job-oriented long-term mentorship. Familiarise gives independent tech experts a broader business platform to sell calls, subscriptions, webinars, classes, and document review under their own expert brand.
+
+### Say
+
+- "Preplaced is career-outcome focused. Familiarise is expert-business focused."
+- "If you want to be part of a mentorship program, Preplaced may fit. If you want to run your own services across multiple formats, Familiarise fits better."
+- "We support trial sessions, but the broader play is helping mentors package multiple service types."
+
+### Do Not Say
+
+- "Preplaced mentors are worse."
+- "Preplaced is only for beginners."
+- "We guarantee better outcomes."
+
+### Best Prospect Type
+
+- Senior engineer who does not want to be boxed into long-term mentorship only.
+- Mentor who wants 1:1 plus webinars or classes.
+- Tech expert with startup advisory or document review offers.
+
+### Objection
+
+"Preplaced has stronger career mentorship branding."
+
+Response:
+
+> Yes, and that is why we are not trying to copy their exact lane. Familiarise is better when the mentor wants to run multiple expert-service formats under their own brand: consultations, subscriptions, webinars, classes, and document review.
+
+## Against ProPeers
+
+### What They Are Good At
+
+- App-based peer/expert discovery framing.
+- Community and achievement language.
+- Mobile app presence.
+
+### Familiarise Opening
+
+> ProPeers feels closer to a peer guidance and achievement network. Familiarise is a monetization and operations platform for paid expert services.
+
+### Say
+
+- "Familiarise is built around paid appointments, service plans, payments, video, documents, reviews, and payouts."
+- "For serious tech mentors, the business workflow matters more than social discovery alone."
+
+### Do Not Say
+
+- "ProPeers is not a competitor."
+- "They have no value."
+
+### Best Prospect Type
+
+- Expert who wants professional monetization.
+- Mentor who needs bookings and payout workflow.
+- Consultant who wants to sell structured offers.
+
+## Comparison Table
+
+| Dimension | Familiarise | Topmate | Preplaced | ProPeers |
+| --- | --- | --- | --- | --- |
+| Best public category | Expert-service operating platform | Creator storefront | Long-term career mentorship | Peer/expert advice app |
+| First Familiarise wedge | Indian tech mentors | Broad creators | Career mentees and mentors | Peer guidance users |
+| 1:1 paid calls | Yes | Yes | Yes | Source describes expert advice, not payment workflow |
+| Ongoing subscriptions | Yes | Not primary in cited source | Yes, long-term mentorship | Not clear from cited source |
+| Webinars/classes | Yes | Webinars/group sessions and courses in cited source | Career mentorship programs | Not clear from cited source |
+| Document review | Yes | Not emphasized in cited source | Not homepage emphasis | Not clear from cited source |
+| Integrated video/chat | Yes | Cited source mentions Zoom/Calendar/WhatsApp integrations | Not homepage emphasis | App-based |
+| Enterprise/org layer | Yes, future B2B | Not core comparison | Not core comparison | Not core comparison |
+
+Where uncertain, do not claim absence in public copy. Say "not emphasized publicly" or "not the core positioning."
+
+## Public Comparison Copy
+
+Use:
+
+> Familiarise is for Indian tech mentors who need more than a booking link: 1:1s, subscriptions, webinars, classes, document review, integrated video/chat, reviews, and payment workflows in one place.
+
+Avoid:
+
+> Familiarise destroys Topmate/Preplaced/ProPeers.
+
+## Sales Battle Questions
+
+Ask prospects:
+
+- Are people already asking you for advice?
+- What do you currently use to collect payment and schedule?
+- Do clients send resumes, code, portfolios, or context before calls?
+- Would ongoing mentorship or webinars fit your audience?
+- What is the most annoying operational step after someone says "I want to book"?
+
+The right competitor angle becomes obvious from their answers.
+

--- a/docs/sales-marketing/csmo-2026-launch/07-kpi-dashboard-and-operating-cadence.md
+++ b/docs/sales-marketing/csmo-2026-launch/07-kpi-dashboard-and-operating-cadence.md
@@ -1,0 +1,278 @@
+# KPI Dashboard And Operating Cadence
+
+**Purpose:** Make the first 90 days measurable without buying a heavy CRM.
+
+## North Star
+
+Monthly active consultants: consultants who complete at least one paid session in a calendar month.
+
+Why:
+
+- Signups are vanity.
+- GMV is lagging.
+- Active consultants show supply health and marketplace usefulness.
+
+## CRM Fields
+
+Use Google Sheets or Zoho CRM free tier.
+
+Required columns:
+
+- `lead_id`
+- `name`
+- `linkedin_url`
+- `email`
+- `x_url`
+- `city_country`
+- `current_role`
+- `company`
+- `expertise_area`
+- `source`
+- `proof_link`
+- `existing_monetization_signal`
+- `audience_signal`
+- `score_expertise`
+- `score_audience`
+- `score_platform_fit`
+- `score_activity`
+- `total_score`
+- `suggested_first_offer`
+- `personalization_line`
+- `status`
+- `owner`
+- `last_touch_date`
+- `next_touch_date`
+- `reply_status`
+- `demo_date`
+- `signup_date`
+- `activation_date`
+- `first_booking_date`
+- `notes`
+
+Status values:
+
+- `new`
+- `qualified`
+- `message_drafted`
+- `contacted`
+- `connected`
+- `replied`
+- `demo_booked`
+- `demo_completed`
+- `signed_up`
+- `activated`
+- `first_booking`
+- `review_collected`
+- `nurture`
+- `not_fit`
+- `not_interested`
+
+## Lead Scoring
+
+Score each 1-5.
+
+| Dimension | 1 | 3 | 5 |
+| --- | --- | --- | --- |
+| Expertise | Generic engineer | Senior in useful domain | Recognized mentor/speaker/specialist |
+| Audience | No visible audience | Some posts or network | Engaged audience or existing demand |
+| Platform fit | Only one vague use case | 1-2 clear offers | Multiple service formats fit |
+| Activity | Inactive online | Occasional posts | Active in last 30 days |
+
+Priority:
+
+- 16-20: founder outreach.
+- 12-15: intern drafted, founder reviewed.
+- 8-11: nurture or content audience.
+- Below 8: skip.
+
+## Funnel Metrics
+
+Track weekly.
+
+| Funnel stage | Week 4 target | Week 8 target | Day 90 target |
+| --- | ---: | ---: | ---: |
+| Qualified leads in CRM | 300 | 700 | 1,000 |
+| Outreach sent | 100 | 350 | 600 |
+| Qualified replies | 15 | 50 | 90 |
+| Demo calls booked | 10 | 25 | 35 |
+| Demo calls completed | 7 | 18 | 28 |
+| Consultant signups | 5 | 15 | 25 |
+| Activated consultants | 3 | 10 | 15 |
+| First paid bookings | 0-3 | 10 | 25 |
+| Reviews | 0-2 | 6 | 15 |
+
+## Channel KPIs
+
+| Channel | Primary KPI | Minimum threshold |
+| --- | --- | ---: |
+| LinkedIn manual | Qualified reply rate | 12% target, 8% floor |
+| Sales Navigator | Demo booked per InMail | 5%+ |
+| Cold email | Qualified reply rate | 2% floor |
+| X/Twitter | Qualified conversations | 3/month |
+| Instagram | Qualified DMs or webinar signups | 2/month early |
+| Facebook | Qualified comments/DMs | 2/month early |
+| Reddit | Useful conversations or insights | 4/month |
+| Webinars | Booking interest from attendees | 5-10% |
+| SEO | Indexed profile/pages and impressions | Upward trend |
+| Offline | Demo calls per event | 2+ |
+
+## Weekly Dashboard
+
+Create a single weekly report:
+
+```text
+WEEK OF:
+
+SUPPLY FUNNEL
+Qualified leads added:
+Outreach sent:
+Qualified replies:
+Demo booked:
+Demo completed:
+Signups:
+Activated consultants:
+
+DEMAND / BOOKINGS
+Webinar registrations:
+Webinar attendees:
+Booking interests:
+Paid bookings:
+GMV:
+Reviews collected:
+
+CHANNELS
+Best channel:
+Worst channel:
+Highest quality reply:
+Top objection:
+
+OPERATIONS
+Profiles completed:
+Offers created:
+Availability set:
+Payout readiness:
+Support issues:
+
+NEXT WEEK
+Top 10 prospects:
+Experiments to start:
+Experiments to stop:
+Founder asks:
+```
+
+## Daily Standup
+
+10 minutes async or live.
+
+Sales / CS intern answers:
+
+- How many leads added yesterday?
+- How many messages drafted?
+- Which replies need founder action?
+- Which demos/onboardings are scheduled?
+- Any CRM hygiene issues?
+
+Marketing intern answers:
+
+- What shipped yesterday?
+- What proof asset is next?
+- Which consultant profile needs work?
+- What content generated conversation?
+
+Founder answers:
+
+- Which prospects get personal attention today?
+- Which objections need new scripts?
+- Which product issues block activation?
+
+## Weekly Meeting
+
+60 minutes every Friday.
+
+Agenda:
+
+1. Funnel review.
+2. Channel review.
+3. Objection review.
+4. Consultant activation review.
+5. Content/proof review.
+6. Next week's top 20 targets.
+7. Kill/scale decisions.
+
+## Intern Scorecards
+
+### Sales / CS Intern
+
+Weekly targets:
+
+- 100 qualified rows reviewed or enriched.
+- 50 new qualified leads.
+- 50 message drafts.
+- 95% CRM completeness.
+- All warm replies routed to founder within 1 business day.
+- All onboarding checklists updated.
+
+Quality bar:
+
+- Personalization lines must be specific.
+- Suggested offer must match expertise.
+- No duplicate prospects.
+- No spammy language.
+
+### Marketing Intern
+
+Weekly targets:
+
+- 5 social posts.
+- 1 consultant spotlight.
+- 1 SEO draft or profile optimization batch.
+- 1 webinar/proof asset if available.
+- Competitor/content notes updated.
+
+Quality bar:
+
+- Copy must be specific to tech mentors or tech consultees.
+- No unverifiable claims.
+- No generic "unlock your potential" language.
+- Every post has a clear audience and CTA.
+
+## Scale Rules
+
+Scale a channel when:
+
+- It beats minimum KPI for 2 consecutive weeks.
+- It produces qualified conversations, not just views.
+- Founder can close or delegate the follow-up.
+- Cost per activated consultant is below ₹2,000 excluding founder time.
+
+Examples:
+
+- LinkedIn beats 15% qualified reply rate for 100 messages: increase founder/intern volume carefully.
+- Webinars produce 5+ booking interests twice: make webinars weekly.
+- Cold email gets 5% reply with low bounce: add another 100 verified prospects.
+
+## Kill Or Pause Rules
+
+Pause a channel when:
+
+- It misses the minimum threshold for 2 consecutive weeks.
+- It damages trust or triggers moderation/spam issues.
+- It consumes founder time without qualified conversations.
+- It attracts low-fit prospects.
+
+Do not kill SEO before 90 days. SEO is evaluated on indexing, impressions, and content quality early.
+
+## First 90-Day Retrospective
+
+At day 90, answer:
+
+- Which channel recruited the best consultants?
+- Which channel created first bookings?
+- Which ICP converted fastest?
+- Which offer type sold first?
+- What objection appeared most?
+- What product gap blocked activation?
+- What proof asset converted best?
+- Should we deepen tech or add an adjacent vertical?
+- Should interns continue, convert, or be replaced?
+

--- a/docs/sales-marketing/csmo-2026-launch/08-offline-and-partnerships.md
+++ b/docs/sales-marketing/csmo-2026-launch/08-offline-and-partnerships.md
@@ -1,0 +1,232 @@
+# Offline And Partnerships Playbook
+
+**Decision:** Light targeted offline only. Online remains dominant.
+
+Offline exists to create trust, warm intros, and local proof. It should not become event tourism.
+
+## Offline Strategy
+
+Use offline for three jobs:
+
+1. Meet credible tech mentors who are hard to reach cold.
+2. Create warm introductions through community organizers.
+3. Generate webinar and student demand once credible mentors exist.
+
+Monthly budget:
+
+- ₹2K-₹5K in the first 90 days.
+
+Monthly target:
+
+- 1-2 events.
+- 10 qualified conversations.
+- 4 follow-up calls.
+- 1 activated consultant or partner opportunity.
+
+## Event Types
+
+| Event type | Use for | Priority |
+| --- | --- | --- |
+| Tech meetups | Consultant recruiting, founder credibility | P1 |
+| Startup events | Startup tech advisory consultants and founder consultees | P2 |
+| College tech clubs | Demand generation, ambassadors, webinars | P2 |
+| Coworking events | Founder/operator advisory supply | P3 |
+| Conferences | High-value networking if cost is low | P3 |
+
+## Pre-Event Checklist
+
+Before attending:
+
+- Identify attendee/speaker list if available.
+- Pick 5-10 target people.
+- Read one post/project for each target.
+- Prepare one-line reason to talk to each person.
+- Prepare QR code to Familiarise demo or waitlist.
+- Prepare founder intro:
+
+> I am building Familiarise, an India-first platform for tech mentors to sell consultations, subscriptions, webinars, and classes with integrated video, document review, payments, and reviews. We are recruiting a small beta group of credible tech mentors.
+
+Do not bring generic flyers unless the event allows it.
+
+## At-Event Script
+
+Opening:
+
+> I liked your point about `topic`. I am building Familiarise for Indian tech mentors, and your experience in `expertise` sounds close to the people we are recruiting. Do people already ask you for advice or mock interviews?
+
+If yes:
+
+> That is exactly the workflow we are supporting. Instead of calendar plus payment link plus Zoom plus docs, Familiarise puts the service workflow in one place. Would it be okay if I sent you a 5-minute demo?
+
+If no:
+
+> Makes sense. Is there anyone in your circle who actively mentors engineers or does interview prep?
+
+Do not:
+
+- Pitch for more than 60 seconds.
+- Ask them to sign up at the event.
+- Criticize platforms they use.
+
+## Post-Event Follow-Up
+
+Within 24 hours:
+
+> Hi `name`, good meeting you at `event`. I enjoyed our chat about `specific_topic`. As promised, here is the Familiarise demo link: `link`. I think your first offer could be `suggested_offer`. Open to a 15-minute walkthrough this week?
+
+Within 48 hours:
+
+- Add to CRM.
+- Set next follow-up.
+- Connect on LinkedIn.
+- Tag source as event.
+
+Within 7 days:
+
+- Invite to demo, webinar, or beta mentor call.
+
+## College Partnerships
+
+Use only after at least 10 credible tech mentors are activated.
+
+Target:
+
+- Engineering colleges.
+- Coding clubs.
+- Placement cells.
+- Alumni associations.
+- Competitive programming clubs.
+
+Offer:
+
+- Free webinar with credible mentor.
+- Discount/referral credit for first paid session.
+- Campus ambassador after proof.
+
+Do not lead with:
+
+- "We need users."
+- "Please promote our app."
+
+Lead with:
+
+> We can bring a credible industry mentor for a practical session on `topic`: system design, resume review, DSA interview prep, backend roadmap, or career switching.
+
+Campus ambassador model:
+
+- 1 ambassador per college initially.
+- ₹100-₹200 per qualified signup or booking, not per random signup.
+- Unique referral code.
+- Must follow community rules.
+- No spam in WhatsApp groups.
+
+## Community Partnerships
+
+Target communities:
+
+- Indian engineering Discords.
+- Alumni tech groups.
+- Local developer meetups.
+- Product/startup communities.
+- Newsletter writers covering Indian tech careers.
+
+Partnership offers:
+
+- Free expert webinar.
+- Community-exclusive office hours.
+- Referral credits.
+- Co-branded resource guide.
+- Mentor AMA.
+
+Partner qualification:
+
+- Audience has at least 500 relevant members or strong engagement.
+- Organizer permits useful educational sessions.
+- Audience fits tech mentorship demand.
+- No pay-to-spam arrangement.
+
+## Offline Collateral
+
+One-page leaflet:
+
+- Headline: "Run your tech mentoring business on Familiarise."
+- Subhead: "1:1s, subscriptions, webinars, classes, video, documents, payments, reviews."
+- Commission: "10% platform fee."
+- CTA: "Apply for the tech mentor beta."
+- QR code.
+- Founder contact.
+
+Business card:
+
+- Founder name.
+- Familiarise.
+- "India-first expert-service platform."
+- LinkedIn QR.
+- Demo QR.
+
+Event slide if speaking:
+
+- Problem: tech mentors duct-tape tools.
+- Solution: one platform for expert-service workflows.
+- Who we want: credible Indian tech mentors.
+- CTA: beta mentor application.
+
+## Light Offline Calendar
+
+Month 1:
+
+- Attend 1 tech meetup.
+- Meet 5 prospective mentors.
+- No campus push yet.
+
+Month 2:
+
+- Attend 1 tech/startup event.
+- Host 1 online webinar with a recruited mentor.
+- Start 1 college/community conversation.
+
+Month 3:
+
+- Attend 1 meetup.
+- Run 1 campus/community webinar if mentors are credible.
+- Test one ambassador with strict quality tracking.
+
+## Offline KPIs
+
+| Metric | Target |
+| --- | ---: |
+| Qualified conversations per event | 5+ |
+| LinkedIn connections after event | 10+ |
+| Follow-up calls per event | 2+ |
+| Consultant signups per 2 events | 1+ |
+| Webinar registrations from partner | 20+ |
+| Paid booking interest from partner webinar | 3+ |
+
+## Kill Criteria
+
+Pause an offline channel if:
+
+- 2 events produce no qualified follow-up calls.
+- The audience is mostly job seekers before supply is ready.
+- The event cost exceeds ₹5K without clear target access.
+- Organizers want payment before proof.
+- It distracts founder from high-quality online outreach.
+
+## Partnership Red Lines
+
+Do not:
+
+- Pay for generic college promotion.
+- Let ambassadors spam WhatsApp groups.
+- Promise jobs, referrals, or guaranteed interview outcomes.
+- Allow partners to position Familiarise as a placement agency.
+- Use college logos without permission.
+
+Do:
+
+- Position sessions as practical mentorship and expert access.
+- Use tracked links.
+- Collect feedback after every event.
+- Convert the best questions into content.
+- Invite strong speakers to become consultants.
+


### PR DESCRIPTION
## Summary

Adds a new CSMO strategy pack under docs/sales-marketing/csmo-2026-launch/ for the India-first pre-launch/beta GTM motion.

The pack covers executive GTM thesis, product subsystem selling points, 90-day launch plan, channel playbooks, scripts, hiring and Upwork guidance, competitor battlecards, KPI cadence, and offline partnerships.

## Why

The strategy follows the agreed launch assumptions: Indian tech mentors as the first wedge, 10% commission from day one, ₹25K-50K/month budget, intern-first hiring, Upwork only for lead research, LinkedIn as the operating center, and math-first competitor positioning.

## Validation

Docs-only change. Verified file list, line counts, and scanned for placeholder TODO/FIXME markers.