### PR TITLE
Issue #755 #756

### DIFF
--- a/app/api/organizations/[orgId]/analytics/route.ts
+++ b/app/api/organizations/[orgId]/analytics/route.ts
@@ -63,6 +63,7 @@ export async function GET(
     paidInvoiceAgg,
     pastDueInvoiceCount,
     earningsAggregate,
+    licenseSubscription,
   ] = await Promise.all([
     prisma.membership.groupBy({
       by: ["status"],
@@ -133,6 +134,16 @@ export async function GET(
           _count: { _all: true },
         })
       : Promise.resolve([]),
+    // BillingSubscription is set up by the LICENSE contract create flow
+    // (see app/api/organizations/[orgId]/contracts/route.ts). For LICENSE
+    // orgs we surface it so the home Get-Started checklist can mark
+    // "Configure billing settings" done once a fee has been captured.
+    org.billingAccount?.fundingSource === "LICENSE" && baId
+      ? prisma.billingSubscription.findUnique({
+          where: { billingAccountId: baId.id },
+          select: { id: true, model: true, cycle: true, flatFeePaise: true },
+        })
+      : Promise.resolve(null),
   ]);
 
   const memberTotal = memberAggregate.reduce(
@@ -191,6 +202,13 @@ export async function GET(
             paidLast30dPaise: paidInvoiceAgg?._sum.totalPaise ?? 0,
           }
         : null,
+    subscription: licenseSubscription
+      ? {
+          model: licenseSubscription.model,
+          cycle: licenseSubscription.cycle,
+          flatFeePaise: licenseSubscription.flatFeePaise,
+        }
+      : null,
     earnings: org.canHost
       ? earningsAggregate.map((e) => ({
           status: e.status,

--- a/app/api/organizations/[orgId]/billing/route.ts
+++ b/app/api/organizations/[orgId]/billing/route.ts
@@ -44,7 +44,7 @@ export async function GET(
   startOfMonth.setUTCDate(1);
   startOfMonth.setUTCHours(0, 0, 0, 0);
 
-  const [monthAgg, outstandingAgg, pendingAgg] = await Promise.all([
+  const [monthAgg, outstandingAgg, pendingAgg, licenseContract] = await Promise.all([
     prisma.payment.aggregate({
       where: {
         organizationId: orgId,
@@ -74,6 +74,40 @@ export async function GET(
           _count: { _all: true },
         })
       : Promise.resolve(null),
+    // Surface the active LICENSE contract + its BillingSubscription for
+    // the Annual License panel on /billing. T5 (#756 GS-1) wires the
+    // contract create flow to atomically insert a BillingSubscription;
+    // this is the read side that displays it. We explicitly filter to
+    // contracts that HAVE a subscription — an org with multiple ACTIVE
+    // LICENSE contracts (e.g. older fee-less ones alongside a newer one
+    // that captured the fee) should show the one with the actual
+    // commercial value, not whichever has the most recent effectiveFrom.
+    billingAccount?.fundingSource === "LICENSE"
+      ? prisma.contract.findFirst({
+          where: {
+            organizationId: orgId,
+            status: "ACTIVE",
+            subscription: { isNot: null },
+          },
+          orderBy: { effectiveFrom: "desc" },
+          select: {
+            id: true,
+            effectiveFrom: true,
+            effectiveTo: true,
+            autoRenew: true,
+            subscription: {
+              select: {
+                model: true,
+                cycle: true,
+                flatFeePaise: true,
+                currentCycleStart: true,
+                currentCycleEnd: true,
+                nextInvoiceDate: true,
+              },
+            },
+          },
+        })
+      : Promise.resolve(null),
   ]);
 
   const org = await prisma.organization.findUnique({
@@ -98,5 +132,26 @@ export async function GET(
         }
       : null,
     paymentTermsDays: org?.paymentTermsDays ?? 60,
+    licenseContract: licenseContract
+      ? {
+          id: licenseContract.id,
+          effectiveFrom: licenseContract.effectiveFrom.toISOString(),
+          effectiveTo: licenseContract.effectiveTo?.toISOString() ?? null,
+          autoRenew: licenseContract.autoRenew,
+          subscription: licenseContract.subscription
+            ? {
+                model: licenseContract.subscription.model,
+                cycle: licenseContract.subscription.cycle,
+                flatFeePaise: licenseContract.subscription.flatFeePaise,
+                currentCycleStart:
+                  licenseContract.subscription.currentCycleStart.toISOString(),
+                currentCycleEnd:
+                  licenseContract.subscription.currentCycleEnd.toISOString(),
+                nextInvoiceDate:
+                  licenseContract.subscription.nextInvoiceDate.toISOString(),
+              }
+            : null,
+        }
+      : null,
   });
 }

--- a/app/api/organizations/[orgId]/contracts/route.ts
+++ b/app/api/organizations/[orgId]/contracts/route.ts
@@ -22,6 +22,8 @@ const ContractStatusSchema = z.enum([
   "TERMINATED",
 ]);
 
+const LicenseCycleSchema = z.enum(["MONTHLY", "QUARTERLY", "ANNUAL"]);
+
 const CreateBodySchema = z
   .object({
     billingAccountId: z.string().min(1),
@@ -37,6 +39,13 @@ const CreateBodySchema = z
     autoRenew: z.coerce.boolean().default(false),
     terms: z.unknown().optional(),
     status: ContractStatusSchema.default("DRAFT"),
+    // LICENSE-funded contracts can include a flat-fee BillingSubscription
+    // at create time. Both fields are optional and only meaningful when
+    // the BillingAccount has fundingSource=LICENSE. When provided, the
+    // server creates Contract + BillingSubscription atomically in one tx
+    // so the LICENSE commercial value (annual fee + cycle) is recorded.
+    licenseFeePaise: z.coerce.number().int().min(1).optional(),
+    licenseCycle: LicenseCycleSchema.optional(),
   })
   .refine(
     (v) => v.effectiveTo === null || v.effectiveTo === undefined
@@ -80,6 +89,14 @@ export async function GET(
       programs: {
         select: { id: true, name: true, type: true, status: true },
       },
+      subscription: {
+        select: {
+          id: true,
+          model: true,
+          cycle: true,
+          flatFeePaise: true,
+        },
+      },
       _count: { select: { programs: true } },
     },
     orderBy: { createdAt: "desc" },
@@ -118,13 +135,45 @@ export async function POST(
   // hitting a FK error later.
   const billingAccount = await prisma.billingAccount.findUnique({
     where: { id: body.billingAccountId },
-    select: { ownerOrgId: true, currency: true },
+    select: {
+      ownerOrgId: true,
+      currency: true,
+      fundingSource: true,
+      subscription: { select: { id: true } },
+    },
   });
   if (!billingAccount || billingAccount.ownerOrgId !== orgId) {
     return NextResponse.json(
       { error: "BillingAccount does not belong to this organization" },
       { status: 400 },
     );
+  }
+
+  // LICENSE subscription gate: license fields are only meaningful when
+  // funding=LICENSE, and we don't currently support overwriting an
+  // existing subscription via contract create (renewals are a separate
+  // flow). Fail loud rather than silently dropping the operator's input.
+  const wantsLicenseSubscription =
+    body.licenseFeePaise !== undefined && body.licenseCycle !== undefined;
+  if (wantsLicenseSubscription) {
+    if (billingAccount.fundingSource !== "LICENSE") {
+      return NextResponse.json(
+        {
+          error:
+            "License fee fields are only allowed when the BillingAccount funding source is LICENSE",
+        },
+        { status: 400 },
+      );
+    }
+    if (billingAccount.subscription) {
+      return NextResponse.json(
+        {
+          error:
+            "A BillingSubscription already exists for this BillingAccount. Subscription updates aren't supported via contract creation yet — terminate the existing subscription first.",
+        },
+        { status: 409 },
+      );
+    }
   }
 
   if (body.purchaseOrderId) {
@@ -154,6 +203,27 @@ export async function POST(
         terms: body.terms === undefined ? null : JSON.parse(JSON.stringify(body.terms)),
       },
     });
+
+    if (wantsLicenseSubscription) {
+      const cycleEnd = computeCycleEnd(body.effectiveFrom, body.licenseCycle!);
+      await tx.billingSubscription.create({
+        data: {
+          contractId: created.id,
+          billingAccountId: body.billingAccountId,
+          model: "FLAT_FEE",
+          cycle: body.licenseCycle!,
+          ratePerSeatPaise: null,
+          flatFeePaise: body.licenseFeePaise!,
+          activeSeatCount: 0,
+          currentCycleStart: body.effectiveFrom,
+          currentCycleEnd: cycleEnd,
+          nextInvoiceDate: cycleEnd,
+          startsAt: body.effectiveFrom,
+          endsAt: body.effectiveTo ?? null,
+        },
+      });
+    }
+
     await tx.orgAuditLog.create({
       data: {
         organizationId: orgId,
@@ -165,6 +235,12 @@ export async function POST(
           contractId: created.id,
           billingAccountId: body.billingAccountId,
           paymentTermsDays: body.paymentTermsDays,
+          ...(wantsLicenseSubscription
+            ? {
+                licenseFeePaise: body.licenseFeePaise,
+                licenseCycle: body.licenseCycle,
+              }
+            : {}),
         },
       },
     });
@@ -172,4 +248,22 @@ export async function POST(
   });
 
   return NextResponse.json({ contract }, { status: 201 });
+}
+
+/**
+ * Compute the end of a billing cycle given a start date and cycle type.
+ * Used to seed BillingSubscription.currentCycleEnd + nextInvoiceDate at
+ * contract create time. Mirrors the cycle math elsewhere in the codebase
+ * (jobs/billing/generate-subscription-invoices.ts uses the same +1mo /
+ * +3mo / +1yr offsets).
+ */
+function computeCycleEnd(
+  start: Date,
+  cycle: "MONTHLY" | "QUARTERLY" | "ANNUAL",
+): Date {
+  const end = new Date(start);
+  if (cycle === "MONTHLY") end.setMonth(end.getMonth() + 1);
+  else if (cycle === "QUARTERLY") end.setMonth(end.getMonth() + 3);
+  else end.setFullYear(end.getFullYear() + 1);
+  return end;
 }

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/payments/constants";
 import type { AppliedDiscount } from "@/types/checkout";
 import { OrgPayerSelector } from "@/app/checkout/components/OrgPayerSelector";
+import { useSession } from "@/lib/auth-client";
 import {
   ConsultantProfile,
   ConsultantReview,
@@ -89,6 +90,16 @@ export default function ConsultationCheckoutPage({
   const [discountError, setDiscountError] = useState<string | null>(null);
   const [useReferralCredits, setUseReferralCredits] = useState(false);
   const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(null);
+  const { data: session } = useSession();
+  const selectedOrgFundingSource = useMemo(() => {
+    if (!selectedOrganizationId) return null;
+    const memberships = session?.user?.organizationMemberships ?? [];
+    return (
+      memberships.find((m) => m.organizationId === selectedOrganizationId)
+        ?.fundingSource ?? null
+    );
+  }, [selectedOrganizationId, session?.user?.organizationMemberships]);
+  const isLicenseCovered = selectedOrgFundingSource === "LICENSE";
   const [availableCredits, setAvailableCredits] = useState(0);
   const [isLoadingCredits, setIsLoadingCredits] = useState(true);
 
@@ -802,8 +813,15 @@ export default function ConsultationCheckoutPage({
               <Separator className="bg-zinc-200" />
               <div className="flex items-center justify-between font-semibold">
                 <div>Total</div>
-                <div>{formatPrice(pricing.total)}</div>
+                <div>
+                  {isLicenseCovered ? formatPrice(0) : formatPrice(pricing.total)}
+                </div>
               </div>
+              {isLicenseCovered && (
+                <p className="text-xs text-emerald-600">
+                  Session value {formatPrice(pricing.total)} — covered by enterprise license
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/app/dashboard/organization/[orgId]/billing/BillingPageClient.tsx
+++ b/app/dashboard/organization/[orgId]/billing/BillingPageClient.tsx
@@ -74,6 +74,24 @@ const billingSummarySchema = z.object({
     .object({ amount: z.number(), paymentCount: z.number() })
     .nullable(),
   paymentTermsDays: z.number(),
+  licenseContract: z
+    .object({
+      id: z.string(),
+      effectiveFrom: z.string(),
+      effectiveTo: z.string().nullable(),
+      autoRenew: z.boolean(),
+      subscription: z
+        .object({
+          model: z.enum(["PER_SEAT", "FLAT_FEE"]),
+          cycle: z.enum(["MONTHLY", "QUARTERLY", "ANNUAL"]),
+          flatFeePaise: z.number().nullable(),
+          currentCycleStart: z.string(),
+          currentCycleEnd: z.string(),
+          nextInvoiceDate: z.string(),
+        })
+        .nullable(),
+    })
+    .nullable(),
 });
 type BillingSummary = z.infer<typeof billingSummarySchema>;
 
@@ -435,6 +453,80 @@ export function BillingPageClient({ orgId }: { orgId: string }) {
           </TabsList>
 
           <TabsContent value="invoices" className="space-y-6">
+            {/* Annual License panel — surfaces the LICENSE commercial
+                value (fee, cycle, renewal, auto-renew) that the
+                contract create flow (T5 / #756 GS-1) captures into
+                BillingSubscription. Renders only when funding=LICENSE
+                AND a subscription has been recorded; LICENSE orgs
+                without a subscription see no panel (the contract was
+                created with the fee field skipped). */}
+            {summary.data?.fundingSource === "LICENSE" &&
+              summary.data.licenseContract?.subscription && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Annual License</CardTitle>
+                    <CardDescription>
+                      Pre-paid flat-fee contract. Bookings under this
+                      org consume no per-session charge — they&apos;re
+                      covered by this license.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+                      <div>
+                        <dt className="text-zinc-500">Fee</dt>
+                        <dd className="font-medium">
+                          {formatCurrencyAmount(
+                            summary.data.licenseContract.subscription.flatFeePaise ?? 0,
+                            "INR",
+                          )}{" "}
+                          / {summary.data.licenseContract.subscription.cycle.toLowerCase()}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-zinc-500">Current cycle</dt>
+                        <dd className="font-medium">
+                          {new Date(
+                            summary.data.licenseContract.subscription.currentCycleStart,
+                          ).toLocaleDateString("en-IN", {
+                            day: "2-digit",
+                            month: "short",
+                            year: "numeric",
+                          })}{" "}
+                          →{" "}
+                          {new Date(
+                            summary.data.licenseContract.subscription.currentCycleEnd,
+                          ).toLocaleDateString("en-IN", {
+                            day: "2-digit",
+                            month: "short",
+                            year: "numeric",
+                          })}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-zinc-500">Next renewal</dt>
+                        <dd className="font-medium">
+                          {new Date(
+                            summary.data.licenseContract.subscription.nextInvoiceDate,
+                          ).toLocaleDateString("en-IN", {
+                            day: "2-digit",
+                            month: "short",
+                            year: "numeric",
+                          })}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-zinc-500">Auto-renew</dt>
+                        <dd className="font-medium">
+                          {summary.data.licenseContract.autoRenew
+                            ? "Enabled"
+                            : "Disabled"}
+                        </dd>
+                      </div>
+                    </dl>
+                  </CardContent>
+                </Card>
+              )}
             {summary.isLoading ? (
               <p className="text-sm text-zinc-500">Loading…</p>
             ) : (
@@ -475,9 +567,12 @@ export function BillingPageClient({ orgId }: { orgId: string }) {
                   />
                 )}
                 {/* Payment terms only apply to INVOICE-funded orgs.
-                    WALLET orgs pre-fund their balance and have no credit
-                    terms; showing NET-60 there is misleading. */}
-                {summary.data?.fundingSource !== "WALLET" && (
+                    WALLET orgs pre-fund their balance, LICENSE orgs pay
+                    a flat fee — neither has NET-X invoice billing, so
+                    showing NET-60 there is misleading. Mirrors the
+                    contracts/page.tsx + form fix for T4/T5. */}
+                {summary.data?.fundingSource !== "WALLET" &&
+                  summary.data?.fundingSource !== "LICENSE" && (
                   <StatCard
                     title="Payment terms"
                     value={`NET-${summary.data?.paymentTermsDays ?? 60}`}
@@ -566,7 +661,11 @@ export function BillingPageClient({ orgId }: { orgId: string }) {
                         colSpan={5}
                         className="text-center text-sm text-zinc-500 py-6"
                       >
-                        No invoices yet.
+                        {summary.data?.fundingSource === "LICENSE"
+                          ? summary.data.licenseContract?.subscription
+                            ? "LICENSE-funded orgs don't generate per-booking invoices. See the Annual License panel above."
+                            : "LICENSE-funded orgs don't generate per-booking invoices. The annual license fee covers all usage."
+                          : "No invoices yet."}
                       </TableCell>
                     </TableRow>
                   )}

--- a/app/dashboard/organization/[orgId]/contracts/page.tsx
+++ b/app/dashboard/organization/[orgId]/contracts/page.tsx
@@ -173,11 +173,13 @@ const STATUS_BADGE: Record<ContractStatus, string> = {
 function CreateContractDialog({
   orgId,
   billingAccountId,
+  fundingSource,
   open,
   onOpenChange,
 }: {
   orgId: string;
   billingAccountId: string;
+  fundingSource: string | undefined;
   open: boolean;
   onOpenChange: (v: boolean) => void;
 }) {
@@ -270,20 +272,22 @@ function CreateContractDialog({
             </div>
           </div>
 
-          <div className="space-y-1.5">
-            <Label htmlFor="payment-terms">Payment terms (days) *</Label>
-            <Input
-              id="payment-terms"
-              type="number"
-              min={1}
-              max={120}
-              value={paymentTermsDays}
-              onChange={(e) => setPaymentTermsDays(e.target.value)}
-            />
-            <p className="text-xs text-zinc-500">
-              NET-{paymentTermsDays || "?"} — how many days after invoice date the org must pay.
-            </p>
-          </div>
+          {fundingSource !== "LICENSE" && (
+            <div className="space-y-1.5">
+              <Label htmlFor="payment-terms">Payment terms (days) *</Label>
+              <Input
+                id="payment-terms"
+                type="number"
+                min={1}
+                max={120}
+                value={paymentTermsDays}
+                onChange={(e) => setPaymentTermsDays(e.target.value)}
+              />
+              <p className="text-xs text-zinc-500">
+                NET-{paymentTermsDays || "?"} — how many days after invoice date the org must pay.
+              </p>
+            </div>
+          )}
 
           <div className="space-y-2">
             <Label>Initial status</Label>
@@ -490,7 +494,9 @@ export default function OrgContractsPage({
                         {c.effectiveTo ? fmtDate(c.effectiveTo) : "open-ended"}
                       </TableCell>
                       <TableCell className="text-sm text-zinc-600">
-                        NET-{c.paymentTermsDays}
+                        {c.billingAccount?.fundingSource === "LICENSE"
+                          ? "—"
+                          : `NET-${c.paymentTermsDays}`}
                         {c.autoRenew && (
                           <span className="ml-1 text-xs text-zinc-400">(auto-renew)</span>
                         )}
@@ -565,6 +571,7 @@ export default function OrgContractsPage({
         <CreateContractDialog
           orgId={orgId}
           billingAccountId={billingAccountId}
+          fundingSource={billingAccount.data?.billingAccount.fundingSource}
           open={createOpen}
           onOpenChange={setCreateOpen}
         />

--- a/app/dashboard/organization/[orgId]/contracts/page.tsx
+++ b/app/dashboard/organization/[orgId]/contracts/page.tsx
@@ -72,6 +72,12 @@ interface ContractItem {
     status: string;
   } | null;
   programs: Array<{ id: string; name: string; type: string; status: string }>;
+  subscription: {
+    id: string;
+    model: "PER_SEAT" | "FLAT_FEE";
+    cycle: "MONTHLY" | "QUARTERLY" | "ANNUAL";
+    flatFeePaise: number | null;
+  } | null;
   _count: { programs: number };
 }
 
@@ -106,6 +112,8 @@ async function createContract(
     paymentTermsDays: number;
     autoRenew: boolean;
     status: "DRAFT" | "ACTIVE";
+    licenseFeePaise?: number;
+    licenseCycle?: "MONTHLY" | "QUARTERLY" | "ANNUAL";
   },
 ) {
   const res = await fetch(`/api/organizations/${orgId}/contracts`, {
@@ -190,6 +198,10 @@ function CreateContractDialog({
   const [paymentTermsDays, setPaymentTermsDays] = useState("60");
   const [autoRenew, setAutoRenew] = useState(false);
   const [status, setStatus] = useState<"DRAFT" | "ACTIVE">("ACTIVE");
+  const [licenseFeeINR, setLicenseFeeINR] = useState("");
+  const [licenseCycle, setLicenseCycle] = useState<
+    "MONTHLY" | "QUARTERLY" | "ANNUAL"
+  >("ANNUAL");
   const [error, setError] = useState<string | null>(null);
 
   const reset = () => {
@@ -198,6 +210,8 @@ function CreateContractDialog({
     setPaymentTermsDays("60");
     setAutoRenew(false);
     setStatus("ACTIVE");
+    setLicenseFeeINR("");
+    setLicenseCycle("ANNUAL");
     setError(null);
   };
 
@@ -225,6 +239,18 @@ function CreateContractDialog({
       setError("End date must be after the start date.");
       return;
     }
+    // For LICENSE-funded orgs, optionally include the flat fee + cycle
+    // so the server can create a BillingSubscription atomically with
+    // the Contract. Trim/parse the rupee input — empty means "skip".
+    let licenseFeePaise: number | undefined;
+    if (fundingSource === "LICENSE" && licenseFeeINR.trim() !== "") {
+      const inr = parseFloat(licenseFeeINR);
+      if (!Number.isFinite(inr) || inr <= 0) {
+        setError("License fee must be a positive number (₹).");
+        return;
+      }
+      licenseFeePaise = Math.round(inr * 100);
+    }
     createMutation.mutate({
       billingAccountId,
       effectiveFrom: new Date(effectiveFrom).toISOString(),
@@ -232,6 +258,9 @@ function CreateContractDialog({
       paymentTermsDays: terms,
       autoRenew,
       status,
+      ...(licenseFeePaise !== undefined
+        ? { licenseFeePaise, licenseCycle }
+        : {}),
     });
   };
 
@@ -243,7 +272,7 @@ function CreateContractDialog({
         onOpenChange(v);
       }}
     >
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
         <DialogHeader>
           <DialogTitle>New Contract</DialogTitle>
         </DialogHeader>
@@ -286,6 +315,45 @@ function CreateContractDialog({
               <p className="text-xs text-zinc-500">
                 NET-{paymentTermsDays || "?"} — how many days after invoice date the org must pay.
               </p>
+            </div>
+          )}
+
+          {fundingSource === "LICENSE" && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="license-fee">License fee (₹/year)</Label>
+                <Input
+                  id="license-fee"
+                  type="number"
+                  min={1}
+                  step="1"
+                  placeholder="e.g. 7500000"
+                  value={licenseFeeINR}
+                  onChange={(e) => setLicenseFeeINR(e.target.value)}
+                />
+                <p className="text-xs text-zinc-500">
+                  Optional. Recording the fee enables annual renewal billing
+                  and dashboard display. Skipping is reversible only by
+                  terminating this contract and creating a new one.
+                </p>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="license-cycle">Billing cycle</Label>
+                <select
+                  id="license-cycle"
+                  className="flex h-10 w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm"
+                  value={licenseCycle}
+                  onChange={(e) =>
+                    setLicenseCycle(
+                      e.target.value as "MONTHLY" | "QUARTERLY" | "ANNUAL",
+                    )
+                  }
+                >
+                  <option value="ANNUAL">Annual</option>
+                  <option value="QUARTERLY">Quarterly</option>
+                  <option value="MONTHLY">Monthly</option>
+                </select>
+              </div>
             </div>
           )}
 
@@ -464,6 +532,7 @@ export default function OrgContractsPage({
                 )}
               </div>
             ) : (
+              <div className="overflow-x-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -495,7 +564,9 @@ export default function OrgContractsPage({
                       </TableCell>
                       <TableCell className="text-sm text-zinc-600">
                         {c.billingAccount?.fundingSource === "LICENSE"
-                          ? "—"
+                          ? c.subscription?.flatFeePaise != null
+                            ? `₹${(c.subscription.flatFeePaise / 100).toLocaleString("en-IN")} / ${c.subscription.cycle.toLowerCase()}`
+                            : "—"
                           : `NET-${c.paymentTermsDays}`}
                         {c.autoRenew && (
                           <span className="ml-1 text-xs text-zinc-400">(auto-renew)</span>
@@ -558,6 +629,7 @@ export default function OrgContractsPage({
                   ))}
                 </TableBody>
               </Table>
+              </div>
             )}
             {actionError && (
               <p className="mt-3 text-sm text-red-600">{actionError}</p>

--- a/app/dashboard/organization/[orgId]/contracts/page.tsx
+++ b/app/dashboard/organization/[orgId]/contracts/page.tsx
@@ -109,7 +109,7 @@ async function createContract(
     billingAccountId: string;
     effectiveFrom: string;
     effectiveTo?: string | null;
-    paymentTermsDays: number;
+    paymentTermsDays?: number;
     autoRenew: boolean;
     status: "DRAFT" | "ACTIVE";
     licenseFeePaise?: number;
@@ -230,20 +230,27 @@ function CreateContractDialog({
 
   const handleSubmit = () => {
     setError(null);
-    const terms = parseInt(paymentTermsDays, 10);
-    if (!Number.isFinite(terms) || terms < 1 || terms > 120) {
-      setError("Payment terms must be between 1 and 120 days.");
-      return;
+    const isLicense = fundingSource === "LICENSE";
+    // LICENSE-funded orgs don't see the payment-terms field (annual fee
+    // is paid upfront, not on net-X terms). Skip validation and omit
+    // the field from the payload so the server's default(60) applies —
+    // otherwise stale text typed before switching to LICENSE would fire
+    // a hidden-field error.
+    let terms: number | undefined;
+    if (!isLicense) {
+      const parsed = parseInt(paymentTermsDays, 10);
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > 120) {
+        setError("Payment terms must be between 1 and 120 days.");
+        return;
+      }
+      terms = parsed;
     }
     if (effectiveTo && new Date(effectiveTo) <= new Date(effectiveFrom)) {
       setError("End date must be after the start date.");
       return;
     }
-    // For LICENSE-funded orgs, optionally include the flat fee + cycle
-    // so the server can create a BillingSubscription atomically with
-    // the Contract. Trim/parse the rupee input — empty means "skip".
     let licenseFeePaise: number | undefined;
-    if (fundingSource === "LICENSE" && licenseFeeINR.trim() !== "") {
+    if (isLicense && licenseFeeINR.trim() !== "") {
       const inr = parseFloat(licenseFeeINR);
       if (!Number.isFinite(inr) || inr <= 0) {
         setError("License fee must be a positive number (₹).");
@@ -255,7 +262,7 @@ function CreateContractDialog({
       billingAccountId,
       effectiveFrom: new Date(effectiveFrom).toISOString(),
       effectiveTo: effectiveTo ? new Date(effectiveTo).toISOString() : null,
-      paymentTermsDays: terms,
+      ...(terms !== undefined ? { paymentTermsDays: terms } : {}),
       autoRenew,
       status,
       ...(licenseFeePaise !== undefined

--- a/app/dashboard/organization/[orgId]/home/HomePageClient.tsx
+++ b/app/dashboard/organization/[orgId]/home/HomePageClient.tsx
@@ -71,6 +71,11 @@ interface OrgAnalytics {
     paidLast30dCount: number;
     paidLast30dPaise: number;
   } | null;
+  subscription: {
+    model: "PER_SEAT" | "FLAT_FEE";
+    cycle: "MONTHLY" | "QUARTERLY" | "ANNUAL";
+    flatFeePaise: number | null;
+  } | null;
   earnings: Array<{
     status: string;
     count: number;
@@ -296,7 +301,8 @@ export function HomePageClient({ orgId }: { orgId: string }) {
             label: "Configure billing settings",
             done:
               (data?.wallet !== null && data?.wallet !== undefined) ||
-              (data?.invoices !== null && data?.invoices !== undefined),
+              (data?.invoices !== null && data?.invoices !== undefined) ||
+              (data?.subscription !== null && data?.subscription !== undefined),
             href: `/dashboard/organization/${orgId}/billing`,
           },
         ]

--- a/app/dashboard/organization/[orgId]/my-program/page.tsx
+++ b/app/dashboard/organization/[orgId]/my-program/page.tsx
@@ -171,8 +171,10 @@ export default async function MyProgramPage({
 
                 {seat && (
                   <p className="mt-3 text-xs text-muted-foreground">
-                    {OVERAGE_BEHAVIOR_LABEL[seat.overageBehavior] ??
-                      seat.overageBehavior}
+                    {cap === null
+                      ? "Unlimited — no cap"
+                      : (OVERAGE_BEHAVIOR_LABEL[seat.overageBehavior] ??
+                        seat.overageBehavior)}
                   </p>
                 )}
 


### PR DESCRIPTION
## Summary

Polish pass on the LICENSE-funded org flow:

- **#755** — `/my-program`: render "Unlimited — no cap" instead of overage label when `cap === null`; checkout shows `₹0` with "Session value … covered by enterprise license" subtitle for LICENSE bookings.
- **#756** — Contract create form: capture LICENSE flat fee + cycle, hide NET-X for LICENSE; `/billing` gets an Annual License panel + LICENSE-aware empty state; `/home` Get Started marks "Configure billing settings" done when `BillingSubscription` is present.
- **Follow-up (this push):** bypass payment-terms validation for the hidden LICENSE field (was firing against stale text typed before fundingSource flip). Per Gemini code-assist review feedback.

## Test plan

- [x] `npm test -- billing-admin-gate.test.ts license-credit-pool-bogus.test.ts` — 12/12 pass
- [x] `tsc --noEmit` — clean
- [ ] Manual smoke: create LICENSE contract end-to-end → /home checklist completes → /billing shows panel → /my-program shows Unlimited → checkout shows ₹0

Closes #755
Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)