### PR TITLE
feat(enterprise): #714 PERSONAL spend dashboard surfaces (/home card + date filter)

### DIFF
--- a/app/api/organizations/[orgId]/analytics/route.ts
+++ b/app/api/organizations/[orgId]/analytics/route.ts
@@ -10,6 +10,7 @@
  *   programs      { total, active, activeAssignments }
  *   wallet        { balancePaise, recentTopUps, recentDebits } (WALLET only)
  *   invoices      { outstanding, pastDue, paidLast30d }        (INVOICE only)
+ *   reimbursements{ last30dCount, last30dPaise }               (PERSONAL only — #714)
  *   earnings      { pending, ready, paid, refunded }           (canHost only)
  *
  * All aggregates are `count` / `_sum` queries — no per-row enumeration —
@@ -64,6 +65,7 @@ export async function GET(
     pastDueInvoiceCount,
     earningsAggregate,
     licenseSubscription,
+    reimbursementAgg,
   ] = await Promise.all([
     prisma.membership.groupBy({
       by: ["status"],
@@ -144,6 +146,20 @@ export async function GET(
           select: { id: true, model: true, cycle: true, flatFeePaise: true },
         })
       : Promise.resolve(null),
+    // PERSONAL-funded orgs: org-tagged SUCCEEDED payments in the last
+    // 30d (members paid out of pocket). Drives the /home reimbursement
+    // summary card — full report lives at /reimbursements. (#714)
+    org.billingAccount?.fundingSource === "PERSONAL"
+      ? prisma.payment.aggregate({
+          where: {
+            organizationId: orgId,
+            paymentStatus: "SUCCEEDED",
+            createdAt: { gte: thirtyDaysAgo },
+          },
+          _sum: { amount: true },
+          _count: { _all: true },
+        })
+      : Promise.resolve(null),
   ]);
 
   const memberTotal = memberAggregate.reduce(
@@ -207,6 +223,12 @@ export async function GET(
           model: licenseSubscription.model,
           cycle: licenseSubscription.cycle,
           flatFeePaise: licenseSubscription.flatFeePaise,
+        }
+      : null,
+    reimbursements: reimbursementAgg
+      ? {
+          last30dCount: reimbursementAgg._count._all,
+          last30dPaise: reimbursementAgg._sum.amount ?? 0,
         }
       : null,
     earnings: org.canHost

--- a/app/dashboard/organization/[orgId]/home/HomePageClient.tsx
+++ b/app/dashboard/organization/[orgId]/home/HomePageClient.tsx
@@ -76,6 +76,10 @@ interface OrgAnalytics {
     cycle: "MONTHLY" | "QUARTERLY" | "ANNUAL";
     flatFeePaise: number | null;
   } | null;
+  reimbursements: {
+    last30dCount: number;
+    last30dPaise: number;
+  } | null;
   earnings: Array<{
     status: string;
     count: number;
@@ -500,6 +504,29 @@ export function HomePageClient({ orgId }: { orgId: string }) {
                   />
                 )}
               </>
+            )}
+
+            {/* Reimbursements — PERSONAL-funded orgs only (#714) */}
+            {data.reimbursements && isAtLeast("MANAGER") && (
+              <Link
+                href={`/dashboard/organization/${orgId}/reimbursements`}
+                className="contents"
+              >
+                <StatCard
+                  title="To reimburse (30d)"
+                  value={formatCurrencyAmount(
+                    data.reimbursements.last30dPaise,
+                    currency,
+                  )}
+                  subtitle={`${data.reimbursements.last30dCount} payment${
+                    data.reimbursements.last30dCount === 1 ? "" : "s"
+                  } — view report`}
+                  icon={Wallet}
+                  variant={
+                    data.reimbursements.last30dCount > 0 ? "info" : "default"
+                  }
+                />
+              </Link>
             )}
 
             {/* Host-side earnings summary */}

--- a/app/dashboard/organization/[orgId]/reimbursements/page.tsx
+++ b/app/dashboard/organization/[orgId]/reimbursements/page.tsx
@@ -6,13 +6,15 @@
  * payment list. CSV export downloads via /export endpoint.
  */
 
-import { use } from "react";
+import { use, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { format } from "date-fns";
 import { Download } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   DashboardHeader,
   DashboardContent,
@@ -80,13 +82,35 @@ export default function OrgReimbursementsPage({
   const { orgId } = use(params);
   const searchParams = useSearchParams();
   const page = Number(searchParams?.get("page") ?? "1") || 1;
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+
+  // ISO-encode the date inputs so the server's z.string().datetime()
+  // parser accepts them. Empty inputs are dropped — the API treats
+  // missing from/to as "no bound".
+  const fromIso = fromDate ? new Date(fromDate).toISOString() : undefined;
+  const toIso = toDate
+    ? new Date(`${toDate}T23:59:59.999`).toISOString()
+    : undefined;
+
+  const apiUrl = new URLSearchParams({ page: String(page) });
+  if (fromIso) apiUrl.set("from", fromIso);
+  if (toIso) apiUrl.set("to", toIso);
+
+  const exportUrl = (() => {
+    const q = new URLSearchParams();
+    if (fromIso) q.set("from", fromIso);
+    if (toIso) q.set("to", toIso);
+    const qs = q.toString();
+    return `/api/organizations/${orgId}/reimbursements/export${qs ? `?${qs}` : ""}`;
+  })();
 
   const { data, isLoading, isError, error } =
     useQuery<ReimbursementsResponse>({
-      queryKey: ["org-reimbursements", orgId, page],
+      queryKey: ["org-reimbursements", orgId, page, fromIso, toIso],
       queryFn: async () => {
         const res = await fetch(
-          `/api/organizations/${orgId}/reimbursements?page=${page}`,
+          `/api/organizations/${orgId}/reimbursements?${apiUrl.toString()}`,
         );
         if (res.status === 404) {
           throw new Error(
@@ -107,10 +131,7 @@ export default function OrgReimbursementsPage({
         subtitle="Members paid out of pocket on org bookings — pay them back via your payroll using this report."
         actions={
           <Button asChild variant="outline" size="sm">
-            <a
-              href={`/api/organizations/${orgId}/reimbursements/export`}
-              download
-            >
+            <a href={exportUrl} download>
               <Download className="mr-2 h-4 w-4" />
               Download CSV
             </a>
@@ -118,6 +139,29 @@ export default function OrgReimbursementsPage({
         }
       />
       <DashboardContent>
+        <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-md">
+          <div className="space-y-1.5">
+            <Label htmlFor="from-date">From</Label>
+            <Input
+              id="from-date"
+              type="date"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+              max={toDate || undefined}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="to-date">To</Label>
+            <Input
+              id="to-date"
+              type="date"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+              min={fromDate || undefined}
+            />
+          </div>
+        </div>
+
         {data && (
           <div className="mb-4 flex flex-wrap gap-3">
             <div className="rounded-lg border bg-card p-4">


### PR DESCRIPTION
## Summary

Two small surfaces for PERSONAL-funded orgs (Wipro-scale reimbursement model) to make spend reporting practical:

- **/home: "To reimburse (30d)" StatCard** — only renders when \`fundingSource=PERSONAL\` (MANAGER+). Shows last-30d total + count, links through to the report. Backed by a new \`payment.aggregate\` in \`/api/organizations/[orgId]/analytics\`.
- **/reimbursements: date-range filter** — From/To date inputs above the summary cards. Flows into the existing \`?from\`/\`?to\` API params (already supported) so finance can pull a specific payroll cycle. CSV export link picks up the same window.

The reimbursement *page* and API already existed (C4 commit batch). This PR completes the surfaces #714 specifically called out as still missing.

## Test plan

- [x] \`npm test -- __tests__/enterprise/\` — 247/247 pass, no regressions
- [x] \`tsc --noEmit\` — clean
- [ ] Manual smoke (LearnPro Test, PERSONAL): /home shows the "To reimburse (30d)" card → click → /reimbursements with current data → set From=2026-04-01 → page filters → CSV export downloads filtered window

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)