### PR TITLE
feat(enterprise): stamp orgId + fundingSource in Razorpay notes for booking flow (Part of #687)

### DIFF
--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -94,11 +94,21 @@ type SubscriptionCheckoutResult = {
 
 /**
  * Build payment metadata for both payment intents and webhook handlers
- * Ensures consistency between payment creation and mock payment flows
+ * Ensures consistency between payment creation and mock payment flows.
+ *
+ * When the booking is org-sponsored, `organizationId` and `fundingSource`
+ * are stamped into the gateway's `notes` (C.1, #687). This lets the
+ * webhook attribute the payment to the org without an extra DB lookup
+ * and gives invoice-fraud reconcilers a server-side proof that the
+ * booker's claimed org matches the gateway's record.
  */
 function buildPaymentMetadata(
   data: CheckoutInput,
   userId: string,
+  orgContext?: {
+    organizationId: string | null;
+    fundingSource: "PERSONAL" | "WALLET" | "INVOICE" | "LICENSE" | null;
+  },
 ): { appointmentId: string; appointmentType: string; [key: string]: string } {
   return {
     appointmentId: "pending",
@@ -115,6 +125,12 @@ function buildPaymentMetadata(
     notes: data.notes || "",
     ...(data.eventId && { eventId: data.eventId }),
     ...(data.fromWaitlist && { fromWaitlist: data.fromWaitlist }),
+    ...(orgContext?.organizationId && {
+      organizationId: orgContext.organizationId,
+    }),
+    ...(orgContext?.fundingSource && {
+      fundingSource: orgContext.fundingSource,
+    }),
   };
 }
 
@@ -2000,7 +2016,10 @@ export async function handleCheckout(
         paymentResponse = await PaymentIntentManager.createWithCleanup({
           amount,
           currency,
-          metadata: buildPaymentMetadata(validatedData, userId),
+          metadata: buildPaymentMetadata(validatedData, userId, {
+            organizationId,
+            fundingSource,
+          }),
           paymentGateway: validatedData.paymentGateway,
           isMockPayment,
         });


### PR DESCRIPTION
## Summary

Plumbs the org context into the Razorpay order's \`notes\` payload for booking checkouts. Wallet top-ups and invoice-pay already did this; the booking flow was the gap.

\`buildPaymentMetadata()\` in \`lib/payments/operations/checkout.ts\` gains an optional \`orgContext\` arg ({ organizationId, fundingSource }). Both fields are sourced from the existing \`fundingSource\` derivation around line 1805 (already computed before the gateway call, no new DB queries) and spread into notes only when non-null. Non-org flows are unchanged.

## Why

- **Audit traceability** — gateway record now carries the org claim alongside the booking; finance / reconciliation can verify org attribution against \`Payment.organizationId\` without a DB lookup.
- **Invoice-fraud mitigation (#687)** — the notes become server-side proof that the org context wasn't tampered with between checkout submission and capture. PR-3's webhook reconciler can verify these when it lands.

## Test plan

- [x] \`tsc --noEmit\` — clean
- [ ] Manual smoke: book a session as an org member (Razorpay test mode), inspect the order in Razorpay dashboard, confirm \`notes.organizationId\` and \`notes.fundingSource\` present

The webhook handler is not changed in this push — booking-flow dispatch still keys off \`appointmentId\`/\`userId\`. The notes are stamped now so PR-3's reconciler can verify them.

Part of #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)