### PR TITLE
feat(enterprise): per-org MaintenanceWindow read helper + payout-batch enforcement (Part of #746)

### DIFF
--- a/__tests__/enterprise/org-maintenance-window.test.ts
+++ b/__tests__/enterprise/org-maintenance-window.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Coverage for the per-org maintenance read helper
+ * (`getActiveOrgMaintenanceWindow`).
+ *
+ * The schema column `MaintenanceWindow.organizationId` shipped in PR #655
+ * as Tier 1 multi-tenant scaffolding; the read helper added here is the
+ * first piece of runtime enforcement. The payout-batch script consults
+ * this helper to skip a single tenant during a planned OFFLINE window
+ * without affecting the rest of the batch.
+ */
+
+import { getActiveOrgMaintenanceWindow } from "@/lib/maintenance";
+import prisma from "@/lib/prisma";
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    maintenanceWindow: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+const findFirst = prisma.maintenanceWindow.findFirst as jest.MockedFunction<
+  typeof prisma.maintenanceWindow.findFirst
+>;
+
+describe("getActiveOrgMaintenanceWindow", () => {
+  beforeEach(() => {
+    findFirst.mockReset();
+  });
+
+  it("returns the active row when an org-specific OFFLINE window exists", async () => {
+    const row = {
+      phase: "OFFLINE" as const,
+      reason: "Annual maintenance",
+      estimatedEnd: new Date("2026-06-01T00:00:00.000Z"),
+    };
+    findFirst.mockResolvedValueOnce(row);
+
+    const result = await getActiveOrgMaintenanceWindow("org-1");
+    expect(result).toEqual(row);
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org-1",
+        phase: { not: "OFF" },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { phase: true, reason: true, estimatedEnd: true },
+    });
+  });
+
+  it("returns null when no org-specific window is active", async () => {
+    findFirst.mockResolvedValueOnce(null);
+    expect(await getActiveOrgMaintenanceWindow("org-2")).toBeNull();
+  });
+
+  it("scopes by organizationId so platform-wide (NULL) windows are excluded", async () => {
+    // The query filter is the contract: `organizationId: "org-3"`
+    // excludes rows where organizationId IS NULL (platform-wide).
+    findFirst.mockResolvedValueOnce(null);
+    await getActiveOrgMaintenanceWindow("org-3");
+    const call = findFirst.mock.calls[0][0]!;
+    expect((call.where as { organizationId: string }).organizationId).toBe(
+      "org-3",
+    );
+  });
+
+  it("treats DEGRADED as active (caller decides whether to block)", async () => {
+    const row = {
+      phase: "DEGRADED" as const,
+      reason: "Partial outage",
+      estimatedEnd: null,
+    };
+    findFirst.mockResolvedValueOnce(row);
+    const result = await getActiveOrgMaintenanceWindow("org-4");
+    expect(result?.phase).toBe("DEGRADED");
+  });
+});

--- a/lib/maintenance.ts
+++ b/lib/maintenance.ts
@@ -156,3 +156,40 @@ export async function setMaintenanceState(
     }
   });
 }
+
+// ---------------------------------------------------------------------------
+// Per-org maintenance (read side only — admin write API ships separately)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the currently-active MaintenanceWindow row scoped to a single org.
+ *
+ * Per the schema comment on `MaintenanceWindow.organizationId`, NULL rows
+ * are platform-wide and non-null rows scope to a single tenant. This helper
+ * only returns the *org-specific* active window — callers should still
+ * consult `getMaintenanceState()` for the platform-wide Redis check.
+ *
+ * Returns `null` if there is no active org-specific window. "Active" means
+ * `phase !== OFF` and the most recent row by `createdAt`.
+ *
+ * Used by per-org financial jobs (payout batch, subscription invoicing)
+ * to skip an individual tenant during a planned downtime window without
+ * affecting other tenants.
+ */
+export async function getActiveOrgMaintenanceWindow(
+  organizationId: string,
+): Promise<{
+  phase: MaintenancePhase;
+  reason: string | null;
+  estimatedEnd: Date | null;
+} | null> {
+  const row = await prisma.maintenanceWindow.findFirst({
+    where: {
+      organizationId,
+      phase: { not: MaintenancePhase.OFF },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { phase: true, reason: true, estimatedEnd: true },
+  });
+  return row ?? null;
+}

--- a/scripts/payouts/create-payout-batch.ts
+++ b/scripts/payouts/create-payout-batch.ts
@@ -17,6 +17,7 @@
 import { EarningStatus, PayoutStatus, PayoutMethod } from "@prisma/client";
 import { randomUUID, createHash } from "crypto";
 import prisma from "@/lib/prisma";
+import { getActiveOrgMaintenanceWindow } from "@/lib/maintenance";
 import {
   createOrgPayoutBatch,
   PayoutLockError,
@@ -310,6 +311,21 @@ export async function createOrgPayoutBatches(opts?: {
 
   for (const row of eligible) {
     const orgId = row.organizationId;
+
+    // Per-org maintenance gate. The platform-wide check ran at job
+    // entry via `abortIfMaintenance`; this one skips a single tenant
+    // during a planned tenant-scoped downtime so the other orgs in the
+    // batch still get paid. Only OFFLINE blocks payouts — DEGRADED
+    // implies read-only product surfaces, not paused payouts.
+    const orgMaint = await getActiveOrgMaintenanceWindow(orgId);
+    if (orgMaint && orgMaint.phase === "OFFLINE") {
+      result.skippedNotEligible++;
+      result.errors.push(
+        `${orgId}: org-specific OFFLINE maintenance active (${orgMaint.reason ?? "no reason"}); skipped`,
+      );
+      continue;
+    }
+
     // Deterministic per-(org, periodStart) key — re-running the cron in
     // the same window is a no-op via the unique constraint.
     const idempotencyKey = createHash("sha256")


### PR DESCRIPTION
## Summary

First runtime enforcement of the Tier-1 multi-tenant column \`MaintenanceWindow.organizationId\` (shipped in PR #655). The schema column has been carrying NULL = platform-wide and non-null = tenant-scoped semantics, but no code consulted it.

- **\`lib/maintenance.ts\`** — new \`getActiveOrgMaintenanceWindow(orgId)\` helper that returns the most-recent non-OFF MaintenanceWindow row scoped to that org (or null). Callers still consult \`getMaintenanceState()\` for the platform-wide Redis check; this is additive.
- **\`scripts/payouts/create-payout-batch.ts\`** — per-org loop now skips an individual tenant during an active OFFLINE window scoped to that org. Other orgs in the same batch still get paid. DEGRADED is intentionally non-blocking for payouts.
- **\`__tests__/enterprise/org-maintenance-window.test.ts\`** — 4 unit tests pin the query shape so a refactor cannot regress the scoping contract.

## What's deferred (NOT in this push)

- Admin write API for per-org windows (dashboard setting)
- Per-org Redis keys for fast edge reads (currently DB-only)
- Novu notifications when an org-specific window starts/ends
- Wiring into \`jobs/billing/generate-subscription-invoices.ts\` and other per-org crons

These should be a coherent follow-up PR — likely surfacing under #746's roadmap. Filing a dedicated tracker issue once this lands.

## Test plan

- [x] \`npm test -- __tests__/enterprise/\` — 251/251 (was 247; +4 new)
- [x] \`tsc --noEmit\` — clean
- [ ] Manual: insert a row \`{ organizationId: 'X', phase: OFFLINE }\` into MaintenanceWindow, run the payout batch, confirm X is skipped while others continue

Part of #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)