### PR TITLE
feat(stream): denorm MeetingSession.organizationId for org-scoped call audit (Part of #674 #746)

### DIFF
--- a/actions/stream/meetings/meeting.action.ts
+++ b/actions/stream/meetings/meeting.action.ts
@@ -97,6 +97,15 @@ export async function createDbMeetingSession(
     streamCallId: validatedStreamCallId,
   });
 
+  let organizationId: string | null = null;
+  if (slot.appointmentId) {
+    const appointment = await prisma.appointment.findUnique({
+      where: { id: slot.appointmentId },
+      select: { organizationId: true },
+    });
+    organizationId = appointment?.organizationId ?? null;
+  }
+
   try {
     const meetingSession = await prisma.meetingSession.create({
       data: {
@@ -105,6 +114,9 @@ export async function createDbMeetingSession(
         slotOfAppointment: {
           connect: { id: slot.id },
         },
+        ...(organizationId
+          ? { organization: { connect: { id: organizationId } } }
+          : {}),
       },
     });
 

--- a/app/api/organizations/[orgId]/stream/calls/route.ts
+++ b/app/api/organizations/[orgId]/stream/calls/route.ts
@@ -3,11 +3,9 @@
  *
  * Org-scoped Stream call + recording metadata export. MANAGER+ gate
  * because the call log is a compliance surface (who met with whom,
- * when, for how long). The route reads from our local `MeetingSession`
- * table — not Stream's API — because we already denormalize the
- * organizationId via `Appointment.organizationId` and a Stream
- * `queryCalls` call would re-do that join over the network on every
- * page load.
+ * when, for how long). Reads from local MeetingSession (indexed by
+ * organizationId, #674) rather than Stream's API — every page load
+ * would otherwise re-do the join over the network.
  *
  * Recordings are joined eagerly so a dashboard listing 50 calls
  * doesn't fan out 50 separate `listRecordings` HTTP calls. The local
@@ -43,14 +41,7 @@ export async function GET(
   // hits + bytes on the wire.
   const withRecordings = url.searchParams.get("withRecordings") === "1";
 
-  // The join walks MeetingSession → SlotOfAppointment → Appointment to
-  // reach the org. Appointment.organizationId is the denormalized
-  // tenant key (#674), so the WHERE clause stays on a single index.
-  const where = {
-    slotOfAppointment: {
-      appointment: { organizationId: orgId },
-    },
-  };
+  const where = { organizationId: orgId };
 
   const [totalResults, sessions] = await prisma.$transaction([
     prisma.meetingSession.count({ where }),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -597,9 +597,12 @@ model Organization {
 
   // #674 personal-vs-org scope split — appointments / waitlist entries /
   // recordings booked or produced by org members. Mirrors TrialsByOrg.
-  appointmentsByOrg Appointment[] @relation("AppointmentByOrg")
-  waitlistByOrg     Waitlist[]    @relation("WaitlistByOrg")
-  recordingsByOrg   Recording[]   @relation("RecordingByOrg")
+  appointmentsByOrg   Appointment[]    @relation("AppointmentByOrg")
+  waitlistByOrg       Waitlist[]       @relation("WaitlistByOrg")
+  recordingsByOrg     Recording[]      @relation("RecordingByOrg")
+  // Denormalized for org-scoped Stream call audit (#674). See
+  // `MeetingSession.organizationId` for the write-side rationale.
+  streamSessionsByOrg MeetingSession[] @relation("StreamSessionByOrg")
 
   // Payment attribution
   payments Payment[] @relation("PaymentOrgTag")
@@ -3095,10 +3098,22 @@ model MeetingSession {
   slotOfAppointment   SlotOfAppointment @relation(fields: [slotOfAppointmentId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   slotOfAppointmentId String            @unique
 
+  /// Denormalized from `slotOfAppointment.appointment.organizationId` —
+  /// the canonical tenant key (#674). Lets org-scoped Stream call audit
+  /// queries (e.g. `/api/organizations/[orgId]/stream/calls`) index
+  /// directly on (organizationId, createdAt) instead of joining
+  /// MeetingSession → SlotOfAppointment → Appointment. Nullable because
+  /// platform calls (personal bookings) have no org context. Written at
+  /// MeetingSession.create time alongside slotOfAppointmentId; never
+  /// updated after.
+  organizationId String?
+  organization   Organization? @relation("StreamSessionByOrg", fields: [organizationId], references: [id], onDelete: SetNull)
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@index([isRecording])
+  @@index([organizationId, createdAt])
 }
 
 // Recording storage types


### PR DESCRIPTION
## Summary

Denormalizes \`MeetingSession.organizationId\` so org-scoped Stream call audit queries index directly on \`(organizationId, createdAt)\` instead of joining \`MeetingSession → SlotOfAppointment → Appointment\`.

- Schema: \`organizationId String?\` + \`Organization @relation("StreamSessionByOrg")\` + compound index
- Write site: \`actions/stream/meetings/meeting.action.ts\` pulls \`appointment.organizationId\` once and connects on create
- Query site: \`app/api/organizations/[orgId]/stream/calls/route.ts\` switches from the 2-hop where-clause to \`where: { organizationId: orgId }\`

Migration \`20260528_meeting_session_organization_id_denorm\` already applied to Supabase.

## Test plan

- [x] \`tsc --noEmit\` — clean
- [x] \`npm test -- __tests__/enterprise/\` — 251/251
- [ ] Manual: GET \`/api/organizations/[orgId]/stream/calls\` for an org with sessions, confirm results return without join cost

Part of #674
Part of #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)