### PR TITLE
feat(billing): LICENSE renewal-upcoming Novu reminder (Part of #746)

### DIFF
--- a/jobs/billing/generate-subscription-invoices.ts
+++ b/jobs/billing/generate-subscription-invoices.ts
@@ -31,13 +31,21 @@ import prisma from "@/lib/prisma";
 import { deriveGstBreakdown } from "@/lib/compliance/gst";
 import { generateOrgInvoiceNumber } from "@/lib/payments/billing/invoice-numbering";
 import { BILLABLE_ORG_STATUSES } from "@/lib/enterprise/org-status";
+import { notifyOrgLicenseRenewalUpcoming } from "@/lib/novu/org-workflows";
+import { getAppUrl } from "@/lib/url";
 import { Currency, OrgInvoiceStatus, Prisma } from "@prisma/client";
+
+// Reminder fires when nextInvoiceDate is within this many days. Once
+// per cycle (gated by BillingSubscription.renewalReminderSentAt).
+const RENEWAL_REMINDER_WINDOW_DAYS = 7;
 
 export async function runGenerateSubscriptionInvoices(): Promise<{
   generated: number;
   skipped: number;
+  remindersSent: number;
 }> {
   const now = new Date();
+  const remindersSent = await sendRenewalReminders(now);
 
   const dueSubs = await prisma.billingSubscription.findMany({
     where: {
@@ -116,6 +124,9 @@ export async function runGenerateSubscriptionInvoices(): Promise<{
               currentCycleStart: nextStart,
               currentCycleEnd: nextEnd,
               nextInvoiceDate: nextEnd,
+              // New cycle, new reminder window — clear the gate so
+              // the upcoming-renewal Novu fires once before nextEnd.
+              renewalReminderSentAt: null,
             },
           });
           if (claimed.count === 0) {
@@ -222,7 +233,75 @@ export async function runGenerateSubscriptionInvoices(): Promise<{
   }
 
   console.log(
-    `[cron] generate-subscription-invoices: ${generated} invoices created, ${skipped} skipped`,
+    `[cron] generate-subscription-invoices: ${generated} invoices, ${skipped} skipped, ${remindersSent} renewal reminders`,
   );
-  return { generated, skipped };
+  return { generated, skipped, remindersSent };
+}
+
+async function sendRenewalReminders(now: Date): Promise<number> {
+  const horizon = new Date(now);
+  horizon.setDate(horizon.getDate() + RENEWAL_REMINDER_WINDOW_DAYS);
+
+  const due = await prisma.billingSubscription.findMany({
+    where: {
+      renewalReminderSentAt: null,
+      nextInvoiceDate: { gt: now, lte: horizon },
+      contract: {
+        organization: { status: { in: BILLABLE_ORG_STATUSES } },
+      },
+    },
+    include: {
+      contract: {
+        include: {
+          organization: { select: { id: true, name: true } },
+        },
+      },
+    },
+  });
+
+  let sent = 0;
+  for (const sub of due) {
+    const expectedTotalPaise =
+      sub.model === "FLAT_FEE"
+        ? (sub.flatFeePaise ?? 0)
+        : (sub.ratePerSeatPaise ?? 0) * sub.activeSeatCount;
+
+    const daysUntilRenewal = Math.max(
+      0,
+      Math.ceil(
+        (sub.nextInvoiceDate.getTime() - now.getTime()) /
+          (24 * 60 * 60 * 1000),
+      ),
+    );
+
+    // Claim first so a crashed Novu trigger doesn't double-fire on the
+    // next cron tick. Conditional update gates on the still-null
+    // value, mirroring the invoice claim pattern below.
+    const claimed = await prisma.billingSubscription.updateMany({
+      where: { id: sub.id, renewalReminderSentAt: null },
+      data: { renewalReminderSentAt: now },
+    });
+    if (claimed.count === 0) continue;
+
+    try {
+      await notifyOrgLicenseRenewalUpcoming(sub.contract.organization.id, {
+        orgName: sub.contract.organization.name,
+        cycle: sub.cycle,
+        renewalDate: sub.nextInvoiceDate.toISOString(),
+        daysUntilRenewal,
+        expectedTotalPaise,
+        currency: "INR",
+        dashboardUrl: `${getAppUrl()}/dashboard/organization/${sub.contract.organization.id}/billing`,
+      });
+      sent++;
+    } catch (err) {
+      // Novu non-throwing already, but belt-and-braces — the claim
+      // already committed so re-running won't double-send.
+      console.error(
+        `[cron] renewal-upcoming notify failed for sub ${sub.id}:`,
+        err,
+      );
+    }
+  }
+  return sent;
 }

--- a/lib/novu/org-workflows.ts
+++ b/lib/novu/org-workflows.ts
@@ -23,6 +23,7 @@ import {
   type OrgInviteAcceptedPayload,
   type OrgInvoiceIssuedPayload,
   type OrgInvoicePaidPayload,
+  type OrgLicenseRenewalUpcomingPayload,
   type OrgWalletTopupConfirmedPayload,
   type OrgPayoutCompletedPayload,
   type OrgProgramExhaustedPayload,
@@ -151,6 +152,24 @@ export async function notifyOrgInvoicePaid(
 ): Promise<void> {
   const owners = await rosterForOrg(orgId, OWNER_ONLY);
   return triggerMany(NOVU_WORKFLOWS.ORG_INVOICE_PAID, owners, payload);
+}
+
+/**
+ * Fires N days before a LICENSE BillingSubscription's nextInvoiceDate.
+ * Owners can wire the cycle renewal into their procurement calendar
+ * before the invoice lands. Drives off renewalReminderSentAt on
+ * BillingSubscription so the same window only sends once per cycle.
+ */
+export async function notifyOrgLicenseRenewalUpcoming(
+  orgId: string,
+  payload: OrgLicenseRenewalUpcomingPayload,
+): Promise<void> {
+  const owners = await rosterForOrg(orgId, OWNER_ONLY);
+  return triggerMany(
+    NOVU_WORKFLOWS.ORG_LICENSE_RENEWAL_UPCOMING,
+    owners,
+    payload,
+  );
 }
 
 /**

--- a/lib/novu/workflows.ts
+++ b/lib/novu/workflows.ts
@@ -85,6 +85,7 @@ export const NOVU_WORKFLOWS = {
   ORG_INVITE_ACCEPTED: "org-invite-accepted",
   ORG_INVOICE_ISSUED: "org-invoice-issued",
   ORG_INVOICE_PAID: "org-invoice-paid",
+  ORG_LICENSE_RENEWAL_UPCOMING: "org-license-renewal-upcoming",
   ORG_WALLET_TOPUP_CONFIRMED: "org-wallet-topup-confirmed",
   ORG_PAYOUT_COMPLETED: "org-payout-completed",
   ORG_PAYOUT_FAILED: "org-payout-failed",
@@ -348,6 +349,16 @@ export type OrgInvoicePaidPayload = {
   totalPaise: number;
   currency: string;
   paidAt: string;
+  dashboardUrl: string;
+};
+
+export type OrgLicenseRenewalUpcomingPayload = {
+  orgName: string;
+  cycle: "MONTHLY" | "QUARTERLY" | "ANNUAL";
+  renewalDate: string;
+  daysUntilRenewal: number;
+  expectedTotalPaise: number;
+  currency: string;
   dashboardUrl: string;
 };
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -955,6 +955,9 @@ model BillingSubscription {
   startsAt          DateTime
   endsAt            DateTime?
 
+  /// Stamped when renewal-upcoming reminder fires; cleared on cycle advance (#746).
+  renewalReminderSentAt DateTime?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary

Fires the upcoming-renewal notification for LICENSE-funded orgs once per cycle, 7 days before \`nextInvoiceDate\`. Plugs into the existing daily \`generate-subscription-invoices\` cron — no new schedule needed.

- \`BillingSubscription.renewalReminderSentAt\` — once-per-cycle gate. Set when the reminder fires; cleared when the cron advances \`nextInvoiceDate\` on invoice generation so the next cycle gets its own reminder.
- \`NOVU_WORKFLOWS.ORG_LICENSE_RENEWAL_UPCOMING\` + \`OrgLicenseRenewalUpcomingPayload\` type
- \`notifyOrgLicenseRenewalUpcoming(orgId, payload)\` — OWNER fan-out (mirrors \`notifyOrgInvoiceIssued\`)
- \`sendRenewalReminders()\` step at the top of the cron. The claim \`updateMany\` gates on \`renewalReminderSentAt: null\` so a crashed Novu trigger can't double-fire on the next cron tick.

Migration \`20260528_billing_subscription_renewal_reminder\` already applied to Supabase.

## Out of scope

- Workflow template in the Novu dashboard (ops will wire the body/email template — the trigger ID is reserved).
- GH Actions cron schedule for \`generate-subscription-invoices\` (still local-only; ops to wire).

## Test plan

- [x] \`tsc --noEmit\` — clean
- [x] \`npm test -- __tests__/enterprise/\` — 251/251

Part of #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)