### PR TITLE
feat(dataexport): Novu in-app fan-out on READY (Part of #701 #746)

### DIFF
--- a/lib/novu/org-workflows.ts
+++ b/lib/novu/org-workflows.ts
@@ -24,6 +24,7 @@ import {
   type OrgInvoiceIssuedPayload,
   type OrgInvoicePaidPayload,
   type OrgLicenseRenewalUpcomingPayload,
+  type OrgDataExportReadyPayload,
   type OrgWalletTopupConfirmedPayload,
   type OrgPayoutCompletedPayload,
   type OrgProgramExhaustedPayload,
@@ -170,6 +171,21 @@ export async function notifyOrgLicenseRenewalUpcoming(
     owners,
     payload,
   );
+}
+
+/**
+ * Fires when an OrgDataExportJob transitions PENDING -> READY. The
+ * existing email path (process-data-exports.ts emailRequester) targets
+ * only the requester; this Novu fan-out adds in-app delivery to the
+ * full OWNER roster so the requester's teammates can act if the
+ * requester is OOO.
+ */
+export async function notifyOrgDataExportReady(
+  orgId: string,
+  payload: OrgDataExportReadyPayload,
+): Promise<void> {
+  const owners = await rosterForOrg(orgId, OWNER_ONLY);
+  return triggerMany(NOVU_WORKFLOWS.ORG_DATA_EXPORT_READY, owners, payload);
 }
 
 /**

--- a/lib/novu/workflows.ts
+++ b/lib/novu/workflows.ts
@@ -86,6 +86,7 @@ export const NOVU_WORKFLOWS = {
   ORG_INVOICE_ISSUED: "org-invoice-issued",
   ORG_INVOICE_PAID: "org-invoice-paid",
   ORG_LICENSE_RENEWAL_UPCOMING: "org-license-renewal-upcoming",
+  ORG_DATA_EXPORT_READY: "org-data-export-ready",
   ORG_WALLET_TOPUP_CONFIRMED: "org-wallet-topup-confirmed",
   ORG_PAYOUT_COMPLETED: "org-payout-completed",
   ORG_PAYOUT_FAILED: "org-payout-failed",
@@ -359,6 +360,15 @@ export type OrgLicenseRenewalUpcomingPayload = {
   daysUntilRenewal: number;
   expectedTotalPaise: number;
   currency: string;
+  dashboardUrl: string;
+};
+
+export type OrgDataExportReadyPayload = {
+  orgName: string;
+  exportId: string;
+  fileSizeBytes: number;
+  expiresAt: string;
+  downloadUrl: string;
   dashboardUrl: string;
 };
 

--- a/scripts/cleanup/process-data-exports.ts
+++ b/scripts/cleanup/process-data-exports.ts
@@ -37,6 +37,8 @@ import { Resend } from "resend";
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
 import { recordSystemError } from "../../lib/enterprise/system-events";
+import { notifyOrgDataExportReady } from "../../lib/novu/org-workflows";
+import { getAppUrl } from "../../lib/url";
 
 export interface DataExportResult {
   picked: number;
@@ -299,6 +301,23 @@ export async function processDataExports(): Promise<DataExportResult> {
         err,
       );
     });
+
+    // Novu fan-out to the OWNER roster so the requester's teammates
+    // see the bundle even if the requester is OOO.
+    const orgRow = await prisma.organization.findUnique({
+      where: { id: job.organizationId },
+      select: { name: true },
+    });
+    if (orgRow) {
+      await notifyOrgDataExportReady(job.organizationId, {
+        orgName: orgRow.name,
+        exportId: job.id,
+        fileSizeBytes: uploaded.sizeBytes,
+        expiresAt: uploaded.expiresAt.toISOString(),
+        downloadUrl: uploaded.url,
+        dashboardUrl: `${getAppUrl()}/dashboard/organization/${job.organizationId}/integrations/data-exports`,
+      });
+    }
 
     result.succeeded = 1;
   } catch (err) {


### PR DESCRIPTION
## Summary

Adds Novu in-app fan-out when an \`OrgDataExportJob\` transitions to READY. The existing requester email keeps targeting only the user who filed the request; the new in-app notification reaches the full OWNER roster so a teammate can pick up the bundle if the requester is OOO.

- \`NOVU_WORKFLOWS.ORG_DATA_EXPORT_READY\` + \`OrgDataExportReadyPayload\`
- \`notifyOrgDataExportReady(orgId, payload)\` — OWNER fan-out
- \`process-data-exports.ts\` — triggers after the audit/email block; failures don't unwind the export

## Still deferred to #701

- Erasure cascade workflow (DPDP §12)
- Retention dashboard UI for older exports
- Withdrawal-of-consent enforcement

## Test plan

- [x] \`tsc --noEmit\` — clean
- [x] \`npm test -- __tests__/enterprise/\` — 251/251

Part of #701
Part of #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)