### PR TITLE
docs(enterprise): P1 — frontmatter, SDE reading paths, 70-design-decisions stub

### DIFF
--- a/docs/enterprise/00-foundations/01-overview.md
+++ b/docs/enterprise/00-foundations/01-overview.md
@@ -1,3 +1,11 @@
+---
+title: Enterprise layer — overview
+band: 00-foundations
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Enterprise layer — overview
 
 > **Scope:** organization primitives, programs, wallets, contracts, invoices,

--- a/docs/enterprise/00-foundations/02-organization-types.md
+++ b/docs/enterprise/00-foundations/02-organization-types.md
@@ -1,3 +1,11 @@
+---
+title: Organization types — capability-driven
+band: 00-foundations
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Organization types — capability-driven
 
 The `OrganizationKind` enum is gone. An organization's "type" is now

--- a/docs/enterprise/00-foundations/03-funding-and-programs.md
+++ b/docs/enterprise/00-foundations/03-funding-and-programs.md
@@ -1,3 +1,11 @@
+---
+title: Funding sources and programs
+band: 00-foundations
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Funding sources and programs
 
 Sponsor-side orgs (`canSponsor=true`) attach exactly one `BillingAccount`

--- a/docs/enterprise/00-foundations/04-roles-and-permissions.md
+++ b/docs/enterprise/00-foundations/04-roles-and-permissions.md
@@ -1,3 +1,11 @@
+---
+title: Roles and permissions
+band: 00-foundations
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Roles and permissions
 
 Every membership row carries a typed `MemberRole`. The enum is unified —

--- a/docs/enterprise/00-foundations/05-organization-lifecycle.md
+++ b/docs/enterprise/00-foundations/05-organization-lifecycle.md
@@ -1,3 +1,11 @@
+---
+title: Organization lifecycle
+band: 00-foundations
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Organization lifecycle
 
 Three models carry their own lifecycle state machine in the enterprise

--- a/docs/enterprise/00-foundations/06-hierarchy.md
+++ b/docs/enterprise/00-foundations/06-hierarchy.md
@@ -1,3 +1,11 @@
+---
+title: Organization hierarchy
+band: 00-foundations
+audience: sde2
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Organization hierarchy
 
 > Scope: the schema-only group-hierarchy columns on `Organization`

--- a/docs/enterprise/10-money-and-ledger/01-money-model-overview.md
+++ b/docs/enterprise/10-money-and-ledger/01-money-model-overview.md
@@ -1,3 +1,11 @@
+---
+title: Money model overview
+band: 10-money-and-ledger
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Money model overview
 
 **What this covers:** the principles every money doc in this section (`06`–`14`) builds on — integer paise, the double-entry journal, derived balances, and what the **#772 cutover** changed. Read this first; the rest of the band is detail.

--- a/docs/enterprise/10-money-and-ledger/02-chart-of-accounts.md
+++ b/docs/enterprise/10-money-and-ledger/02-chart-of-accounts.md
@@ -1,3 +1,11 @@
+---
+title: Chart of accounts
+band: 10-money-and-ledger
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Chart of accounts
 
 **What this covers:** the ten `LedgerAccountKind` buckets every posting touches, which side each is *normal* on (so you can read a balance correctly), and how an account is scoped + addressed deterministically. This is the vocabulary the [postings doc](03-ledger-and-postings.md) speaks.

--- a/docs/enterprise/10-money-and-ledger/03-ledger-and-postings.md
+++ b/docs/enterprise/10-money-and-ledger/03-ledger-and-postings.md
@@ -1,3 +1,11 @@
+---
+title: Ledger & postings
+band: 10-money-and-ledger
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Ledger & postings
 
 **What this covers:** the double-entry journal in detail — the `postLedgerTxn()` API, the balance invariant, idempotency, immutability, and the **exact legs every money flow posts**, transcribed from code. This is the reference the rest of the money band cites.

--- a/docs/enterprise/10-money-and-ledger/04-wallet-and-topups.md
+++ b/docs/enterprise/10-money-and-ledger/04-wallet-and-topups.md
@@ -1,3 +1,11 @@
+---
+title: Wallet & Top-ups
+band: 10-money-and-ledger
+audience: sde2
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Wallet & Top-ups
 
 **What this covers:** how an organization's prepaid **wallet** works — the `WalletTopUp` lifecycle (initiate → Razorpay checkout → webhook confirm), how money lands in the wallet via the double-entry journal, and how bookings debit it. The wallet is a *prepaid liability we owe the org*; its balance is **derived from the journal**, with `BillingAccount.walletBalance` kept only as a fast cache.

--- a/docs/enterprise/10-money-and-ledger/05-booking-to-earnings.md
+++ b/docs/enterprise/10-money-and-ledger/05-booking-to-earnings.md
@@ -1,3 +1,11 @@
+---
+title: Booking → earnings
+band: 10-money-and-ledger
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Booking → earnings
 
 **What this covers:** how a sponsored booking turns into money — the three-way split (`RateCard`, basis points, snapshots), the `BOOKING` ledger posting it produces, and the `ConsultantEarnings` / `OrganizationEarnings` rows that cache the result for payout. The funding side (which sources paid) is in [payment legs](08-payment-legs.md); the journal mechanics are in [ledger & postings](03-ledger-and-postings.md).

--- a/docs/enterprise/10-money-and-ledger/06-payout-pipeline.md
+++ b/docs/enterprise/10-money-and-ledger/06-payout-pipeline.md
@@ -1,3 +1,11 @@
+---
+title: Payout pipeline (host-side)
+band: 10-money-and-ledger
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Payout pipeline (host-side)
 
 **What this covers:** how host-org earnings roll up into an `OrganizationPayout`, the `ORG_PAYOUT` ledger posting that settles the payable, and the India statutory fields (TDS / MSME / FEMA) the payout carries. The consultant-side payout (`PAYOUT`) is the mirror; the split that creates earnings is in [booking → earnings](05-booking-to-earnings.md).

--- a/docs/enterprise/10-money-and-ledger/07-invoicing.md
+++ b/docs/enterprise/10-money-and-ledger/07-invoicing.md
@@ -1,3 +1,11 @@
+---
+title: Invoicing
+band: 10-money-and-ledger
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Invoicing
 
 **What this covers:** the India-compliant `OrganizationInvoice` — its lifecycle, GST breakdown, IRN/e-invoice fields, CGST Rule 46 numbering, the PO 3-way match, the **dunning** escalation, how a cycle's **overage** rolls into a line item, and how invoice payment clears the `ORG_RECEIVABLE` accrued at booking time — plus the **refund credit-note** machinery (CGST Sec 34 / Rule 53). Funding mechanics are in [payment legs](08-payment-legs.md); the postings are in [ledger & postings](03-ledger-and-postings.md).

--- a/docs/enterprise/10-money-and-ledger/08-payment-legs.md
+++ b/docs/enterprise/10-money-and-ledger/08-payment-legs.md
@@ -1,3 +1,11 @@
+---
+title: Payment legs & stackable funding
+band: 10-money-and-ledger
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Payment legs & stackable funding
 
 **What this covers:** how one booking can be funded by several sources at once (`PaymentLeg`), and how each leg source maps to a **debit in the `BOOKING` ledger posting**. This is the funding side of [booking → earnings](05-booking-to-earnings.md).

--- a/docs/enterprise/10-money-and-ledger/09-ledger-integrity.md
+++ b/docs/enterprise/10-money-and-ledger/09-ledger-integrity.md
@@ -1,3 +1,11 @@
+---
+title: Ledger integrity & reconciliation
+band: 10-money-and-ledger
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Ledger integrity & reconciliation
 
 **What this covers:** the read-only auditor that proves the money model holds — the invariants it checks, the one informational coverage metric, how it runs (nightly cron + on-demand admin route), and what a finding means. This is the safety net that lets us trust derived balances and reconciled caches.

--- a/docs/enterprise/20-iam-and-security/01-sso-and-authentication.md
+++ b/docs/enterprise/20-iam-and-security/01-sso-and-authentication.md
@@ -1,3 +1,11 @@
+---
+title: SSO and authentication
+band: 20-iam-and-security
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # SSO and authentication
 
 SSO for the enterprise layer is a two-table split:

--- a/docs/enterprise/20-iam-and-security/02-jit-and-session-refresh.md
+++ b/docs/enterprise/20-iam-and-security/02-jit-and-session-refresh.md
@@ -1,3 +1,11 @@
+---
+title: JIT auto-join & session refresh
+band: 20-iam-and-security
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # JIT auto-join & session refresh
 
 > **Scope.** How org memberships materialize when a user signs in via

--- a/docs/enterprise/20-iam-and-security/03-scim-provisioning.md
+++ b/docs/enterprise/20-iam-and-security/03-scim-provisioning.md
@@ -1,3 +1,11 @@
+---
+title: SCIM 2.0 provisioning
+band: 20-iam-and-security
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # SCIM 2.0 provisioning
 
 Familiarise speaks SCIM 2.0 at `/scim/v2/**` so IdPs (Okta, Azure AD,

--- a/docs/enterprise/20-iam-and-security/04-rate-limiting.md
+++ b/docs/enterprise/20-iam-and-security/04-rate-limiting.md
@@ -1,3 +1,11 @@
+---
+title: Rate limiting
+band: 20-iam-and-security
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Rate limiting
 
 > **Scope.** Auth + enterprise rate-limit coverage matrix, who enforces

--- a/docs/enterprise/20-iam-and-security/05-security-headers.md
+++ b/docs/enterprise/20-iam-and-security/05-security-headers.md
@@ -1,3 +1,11 @@
+---
+title: Security headers
+band: 20-iam-and-security
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Security headers
 
 **New here?** HTTP response headers are instructions the server hands

--- a/docs/enterprise/30-programs-and-lifecycle/01-concurrency-and-idempotency.md
+++ b/docs/enterprise/30-programs-and-lifecycle/01-concurrency-and-idempotency.md
@@ -1,3 +1,11 @@
+---
+title: Concurrency & idempotency
+band: 30-programs-and-lifecycle
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Concurrency & idempotency
 
 **What this covers:** the atomic patterns that keep enterprise mutations correct under concurrency, and the idempotency keys that let every side-effect survive a duplicate call. (Merges the former concurrency-and-locking + idempotency-keys docs.)

--- a/docs/enterprise/30-programs-and-lifecycle/02-programs.md
+++ b/docs/enterprise/30-programs-and-lifecycle/02-programs.md
@@ -1,3 +1,11 @@
+---
+title: Programs, assignments, and booking utilization
+band: 30-programs-and-lifecycle
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Programs, assignments, and booking utilization
 
 `Program` is the commercial primitive inside the enterprise layer.

--- a/docs/enterprise/30-programs-and-lifecycle/03-expert-lifecycle.md
+++ b/docs/enterprise/30-programs-and-lifecycle/03-expert-lifecycle.md
@@ -1,3 +1,11 @@
+---
+title: Expert lifecycle
+band: 30-programs-and-lifecycle
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Expert lifecycle
 
 EXPERT is the `MemberRole` value for anyone who delivers services on

--- a/docs/enterprise/30-programs-and-lifecycle/04-dashboard-pages.md
+++ b/docs/enterprise/30-programs-and-lifecycle/04-dashboard-pages.md
@@ -1,3 +1,11 @@
+---
+title: Dashboard pages
+band: 30-programs-and-lifecycle
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Dashboard pages
 
 Every organization-scoped dashboard page lives under

--- a/docs/enterprise/30-programs-and-lifecycle/05-public-pages-and-discovery.md
+++ b/docs/enterprise/30-programs-and-lifecycle/05-public-pages-and-discovery.md
@@ -1,3 +1,11 @@
+---
+title: Public pages and discovery
+band: 30-programs-and-lifecycle
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Public pages and discovery
 
 > **What this covers:** how an org and its plans surface on the public

--- a/docs/enterprise/30-programs-and-lifecycle/06-feature-flags-and-rollout.md
+++ b/docs/enterprise/30-programs-and-lifecycle/06-feature-flags-and-rollout.md
@@ -1,3 +1,11 @@
+---
+title: Feature flags and rollout
+band: 30-programs-and-lifecycle
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Feature flags and rollout
 
 > **What this covers:** the five module-level feature flags in

--- a/docs/enterprise/30-programs-and-lifecycle/07-contract-lifecycle.md
+++ b/docs/enterprise/30-programs-and-lifecycle/07-contract-lifecycle.md
@@ -1,3 +1,11 @@
+---
+title: Contract lifecycle
+band: 30-programs-and-lifecycle
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Contract lifecycle
 
 > **What this covers:** the `Contract` state machine (DRAFT → ACTIVE →

--- a/docs/enterprise/30-programs-and-lifecycle/08-cycle-engine-and-rollover.md
+++ b/docs/enterprise/30-programs-and-lifecycle/08-cycle-engine-and-rollover.md
@@ -1,3 +1,11 @@
+---
+title: Cycle engine and rollover
+band: 30-programs-and-lifecycle
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Cycle engine and rollover
 
 > **What this covers:** the `ProgramAssignment` lifecycle

--- a/docs/enterprise/40-compliance-and-data/01-compliance-dpdp-gst-tds-msme.md
+++ b/docs/enterprise/40-compliance-and-data/01-compliance-dpdp-gst-tds-msme.md
@@ -1,3 +1,11 @@
+---
+title: Compliance: GST · TDS · MSME · DPDP (enterprise touchpoints)
+band: 40-compliance-and-data
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Compliance: GST · TDS · MSME · DPDP (enterprise touchpoints)
 
 **What this covers:** where the enterprise subsystem *touches* India statutory compliance, and the journal/schema hooks behind each. This is the **enterprise-side map**; the authoritative rules, rates, thresholds, and roadmap live in [`../compliance/`](../../compliance/00-overview.md) — this doc links out rather than restating tax law.

--- a/docs/enterprise/40-compliance-and-data/02-deletion-policy.md
+++ b/docs/enterprise/40-compliance-and-data/02-deletion-policy.md
@@ -1,3 +1,11 @@
+---
+title: Deletion policy
+band: 40-compliance-and-data
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Deletion policy
 
 This document defines when the codebase should **soft-delete** (flip a status flag) versus **hard-delete** (`prisma.x.delete()` / `deleteMany`). The current codebase already follows most of these rules; this doc captures the policy so new routes stay consistent.

--- a/docs/enterprise/40-compliance-and-data/03-data-export.md
+++ b/docs/enterprise/40-compliance-and-data/03-data-export.md
@@ -1,3 +1,11 @@
+---
+title: Org-wide data export (DPDP §11)
+band: 40-compliance-and-data
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Org-wide data export (DPDP §11)
 
 Familiarise honours DPDP §11 right-to-access at the organization level

--- a/docs/enterprise/40-compliance-and-data/04-outbound-webhooks.md
+++ b/docs/enterprise/40-compliance-and-data/04-outbound-webhooks.md
@@ -1,3 +1,11 @@
+---
+title: Outbound webhooks
+band: 40-compliance-and-data
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Outbound webhooks
 
 PR #655 introduces per-organization outbound webhook endpoints so that

--- a/docs/enterprise/40-compliance-and-data/05-workspace-preferences.md
+++ b/docs/enterprise/40-compliance-and-data/05-workspace-preferences.md
@@ -1,3 +1,11 @@
+---
+title: Operator workspace preferences
+band: 40-compliance-and-data
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Operator workspace preferences
 
 Plain version: one human can run several orgs (a consultancy with

--- a/docs/enterprise/40-compliance-and-data/06-cross-cutting-integrations.md
+++ b/docs/enterprise/40-compliance-and-data/06-cross-cutting-integrations.md
@@ -1,3 +1,11 @@
+---
+title: Cross-cutting integrations — enterprise surface map
+band: 40-compliance-and-data
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Cross-cutting integrations — enterprise surface map
 
 The enterprise subsystem is not a self-contained module. It plumbs

--- a/docs/enterprise/50-operations/01-api-reference.md
+++ b/docs/enterprise/50-operations/01-api-reference.md
@@ -1,3 +1,11 @@
+---
+title: API reference
+band: 50-operations
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # API reference
 
 > **How to read this table.** Each row is one `path × verb`.

--- a/docs/enterprise/50-operations/02-route-migration-table.md
+++ b/docs/enterprise/50-operations/02-route-migration-table.md
@@ -1,3 +1,11 @@
+---
+title: Route migration table
+band: 50-operations
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Route migration table
 
 > **How to read this table.** Two columns: **Old** = the pre-Arch-4

--- a/docs/enterprise/50-operations/03-runbooks.md
+++ b/docs/enterprise/50-operations/03-runbooks.md
@@ -1,3 +1,11 @@
+---
+title: Operational runbooks
+band: 50-operations
+audience: sde4
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # Operational runbooks
 
 This document captures the step-by-step procedures for responding to the

--- a/docs/enterprise/50-operations/04-monitoring.md
+++ b/docs/enterprise/50-operations/04-monitoring.md
@@ -1,3 +1,11 @@
+---
+title: Monitoring & alerting
+band: 50-operations
+audience: sde3
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Monitoring & alerting
 
 This document is the source of truth for every alert, metric, and

--- a/docs/enterprise/50-operations/05-system-events.md
+++ b/docs/enterprise/50-operations/05-system-events.md
@@ -1,3 +1,11 @@
+---
+title: SystemEvent — engineering-facing operational events
+band: 50-operations
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
 # SystemEvent — engineering-facing operational events
 
 > **Two taxonomies, on purpose.** `SystemEvent` (this doc) is the

--- a/docs/enterprise/50-operations/06-live-payout-go-live-runbook.md
+++ b/docs/enterprise/50-operations/06-live-payout-go-live-runbook.md
@@ -1,3 +1,11 @@
+---
+title: Live-payout go-live runbook
+band: 50-operations
+audience: sde4
+status: designed-not-active
+last-reviewed: 2026-06-05
+---
+
 # Live-payout go-live runbook
 
 > **Status:** `ENABLE_LIVE_PAYOUTS` is **OFF**. Payouts create rows and post

--- a/docs/enterprise/60-scenarios-and-verdicts/01-scenarios-and-examples.md
+++ b/docs/enterprise/60-scenarios-and-verdicts/01-scenarios-and-examples.md
@@ -1,3 +1,11 @@
+---
+title: Scenarios & worked examples — every permutation
+band: 60-scenarios-and-verdicts
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Scenarios & worked examples — every permutation
 
 **What this covers:** the full cross-product of the enterprise axes — **capability** (`canSponsor` × `canHost`), **funding source**, **program type**, **overage behaviour**, **payout recipient** — what each combination means, which are valid, and then **detailed end-to-end playthroughs** (a startup, Wipro, LearnPro, a consulting firm, IIT Madras, a solo consultant, and a product company on the credit-pool money-meter — §5.10a) showing every leg, posting, and settlement — followed by the **v2 lifecycle & money-safety scenarios** (§5.11–§5.16: cycle rollover, surcharge + circuit-breaker overage, dunning, wallet floor, contract supersession, SSO break-glass). This is the doc to read once you understand the parts ([organization-types](../00-foundations/02-organization-types.md)–[ledger-integrity](../10-money-and-ledger/09-ledger-integrity.md), plus [contract-lifecycle](../30-programs-and-lifecycle/07-contract-lifecycle.md)/[cycle-engine-and-rollover](../30-programs-and-lifecycle/08-cycle-engine-and-rollover.md)) and want to see them compose.

--- a/docs/enterprise/60-scenarios-and-verdicts/02-harness-verdict.md
+++ b/docs/enterprise/60-scenarios-and-verdicts/02-harness-verdict.md
@@ -1,3 +1,11 @@
+---
+title: Harness verdict
+band: 60-scenarios-and-verdicts
+audience: sde2
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Harness verdict
 
 The evaluation harness exercises four representative org scenarios plus a

--- a/docs/enterprise/60-scenarios-and-verdicts/03-design-partner-customer-set.md
+++ b/docs/enterprise/60-scenarios-and-verdicts/03-design-partner-customer-set.md
@@ -1,3 +1,11 @@
+---
+title: Design-partner customer set
+band: 60-scenarios-and-verdicts
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Design-partner customer set
 
 This document is the **single source of truth** for sales conversations during the design-partner phase (first 3-6 months post-MVP enterprise launch). It translates current enterprise readiness — post the v2 mega-audit (#777/#778/#779) — into a concrete **yes / wait-list / hard-no** rubric for inbound prospects. _Last refreshed 2026-06-05._

--- a/docs/enterprise/70-design-decisions/00-README.md
+++ b/docs/enterprise/70-design-decisions/00-README.md
@@ -1,0 +1,39 @@
+---
+title: Design decisions (ADRs) — band index
+band: 70-design-decisions
+audience: sde3
+status: partial
+last-reviewed: 2026-06-05
+---
+
+# Design decisions (ADRs) — band index
+
+This band collects the architecture decision records for the enterprise layer. Where the other bands document *what* the system does and *how* it does it, each ADR here records *why* one design was chosen over its alternatives, at the moment the choice was made. Read these before proposing a structural change: most "why don't we just…" questions are answered by an ADR, and a change that reverses one should say so explicitly in its PR description.
+
+## Format
+
+Every ADR follows the same four-part shape, written in full sentences:
+
+1. **Context** — the forces in play when the decision was made, including the constraint or incident that prompted it.
+2. **Decision** — the choice, stated in one or two sentences, with the code or schema that embodies it.
+3. **Alternatives considered** — what was rejected and the concrete reason each alternative lost.
+4. **Consequences** — what we gained, what we pay for it, and the conditions under which the decision should be revisited.
+
+## Index
+
+The twelve ADRs below are being written under #793; this index is the authoritative list of planned records. Each row links once the ADR lands.
+
+| # | ADR | Decision in one line |
+|---|---|---|
+| 01 | Double-entry journal over three logs | One balanced `LedgerTransaction`/`LedgerEntry` journal replaced `FundingLedgerEntry`, `WalletEntry`, and `SettlementLedgerEntry` (#772). |
+| 02 | Integer paise and basis points | All money is integer paise and all splits are integer basis points, so no float ever touches a balance. |
+| 03 | Deterministic ledger-account IDs | Ledger accounts use deterministic composite IDs (`kind\|org\|consultant\|currency`) instead of UUIDs (#783). |
+| 04 | Batch payouts over streaming | Earnings settle in periodic idempotent batches rather than per-earning transfers. |
+| 05 | GitHub Actions crons | Scheduled jobs run as GitHub Actions hitting `CRON_SECRET`-gated endpoints rather than Netlify scheduled functions. |
+| 06 | Typed Membership over BetterAuth Member | Every permission gate reads the typed `Membership` row, never BetterAuth's own member table. |
+| 07 | Upstash rate limiting | BetterAuth's built-in limiter stays off; Upstash sliding windows gate the sensitive routes. |
+| 08 | Gapless invoice counters | Invoice and credit-note numbers come from per-org, per-fiscal-year atomic counters to satisfy CGST Rules 46/53. |
+| 09 | Webhook secret-rotation grace | Outbound webhook secret rotation dual-signs for 24 hours so receivers can cut over without a hard break. |
+| 10 | Session-generation clock | Role changes bump `User.sessionGeneration` to force a membership refetch instead of revoking sessions. |
+| 11 | Live-payout submission freeze | `ENABLE_LIVE_PAYOUTS` freezes only the gateway submission step; the whole pipeline upstream of it runs for real. |
+| 12 | PENDING_TRUST earnings parking | Earnings for unverified INVOICE-funded orgs park in `PENDING_TRUST` until the org verifies or pays, closing the ghost-org fraud hole (#687). |

--- a/docs/enterprise/90-audits/01-readiness-audit.md
+++ b/docs/enterprise/90-audits/01-readiness-audit.md
@@ -1,3 +1,11 @@
+---
+title: Enterprise Subsystem — Production Readiness Checklist
+band: 90-audits
+audience: sde4
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Enterprise Subsystem — Production Readiness Checklist
 
 **Branch:** `feature/enterprise` | **Updated:** 2026-05-02 (Round 2) | **Auditor:** Claude Code (Sonnet 4.6)

--- a/docs/enterprise/90-audits/02-subsystem-checklist.md
+++ b/docs/enterprise/90-audits/02-subsystem-checklist.md
@@ -1,3 +1,11 @@
+---
+title: Enterprise subsystem — deep phased verification checklist
+band: 90-audits
+audience: sde4
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Enterprise subsystem — deep phased verification checklist
 
 A file-tree-grounded map of **every sub-subsystem** of the enterprise layer, grouped into phases you can verify in order. Each item is annotated with the real code path and a status hint from the audit series.

--- a/docs/enterprise/90-audits/03-verification-guide.md
+++ b/docs/enterprise/90-audits/03-verification-guide.md
@@ -1,3 +1,11 @@
+---
+title: Enterprise verification guide — seeded logins + step-by-step flows
+band: 90-audits
+audience: sde4
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Enterprise verification guide — seeded logins + step-by-step flows
 
 The database was reset and reseeded (`small` mode). This guide gives you **every mock login** and a **click-through flow** to verify the enterprise subsystem across all org archetypes. Pair it with [`subsystem-checklist`](02-subsystem-checklist.md) (what each phase covers + known gaps).

--- a/docs/enterprise/90-audits/04-simplification-proposal.md
+++ b/docs/enterprise/90-audits/04-simplification-proposal.md
@@ -4,6 +4,10 @@ subtitle: "PR #655 closeout — what we can prune without touching the schema"
 author: "Familiarise Engineering"
 date: "May 2026"
 superseded_by: "docs/enterprise/00-foundations/01-overview.md (absorbed by the #768–#779 audit series)"
+band: 90-audits
+audience: sde4
+status: live
+last-reviewed: 2026-06-05
 toc: true
 toc-depth: 2
 ---

--- a/docs/enterprise/90-audits/05-production-grade-checklist-2026-05-02.md
+++ b/docs/enterprise/90-audits/05-production-grade-checklist-2026-05-02.md
@@ -1,3 +1,11 @@
+---
+title: Enterprise Production-Grade Checklist
+band: 90-audits
+audience: sde4
+status: live
+last-reviewed: 2026-05-02
+---
+
 # Enterprise Production-Grade Checklist
 
 > **Superseded (2026-06-05):** This is a point-in-time Round-2 audit. For the

--- a/docs/enterprise/README.md
+++ b/docs/enterprise/README.md
@@ -1,12 +1,22 @@
+---
+title: Familiarise Enterprise — documentation
+band: index
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Familiarise Enterprise — documentation
 
-The **enterprise layer** is a capability-driven B2B surface on top of the marketplace: organizations sponsor and/or host, fund sessions through wallets / invoices / licenses, run programs with seat or credit caps, and settle money through a double-entry ledger. This folder is the engineer's map of it — the **banded folders** are written to be read **in order, as one continuous story**, each band building on the last: `00-foundations/` → `10-money-and-ledger/` → `20-iam-and-security/` → `30-programs-and-lifecycle/` → `40-compliance-and-data/` → `50-operations/` → `60-scenarios-and-verdicts/`, with `90-audits/` as the audit-artifacts annex and [`explainers/complete-guide`](explainers/complete-guide.md) as the parallel connective narrative.
+The **enterprise layer** is a capability-driven B2B surface on top of the marketplace: organizations sponsor and/or host, fund sessions through wallets, invoices, or licenses, run programs with seat or credit caps, and settle money through a double-entry ledger. This folder is the engineer's map of that layer. The **banded folders** are written to be read **in order, as one continuous story**, with each band building on the last: `00-foundations/` → `10-money-and-ledger/` → `20-iam-and-security/` → `30-programs-and-lifecycle/` → `40-compliance-and-data/` → `50-operations/` → `60-scenarios-and-verdicts/`. Two bands sit outside the story line: `70-design-decisions/` collects the architecture decision records that explain *why* the system is shaped the way it is, and `90-audits/` is the annex of audit artifacts. [`explainers/complete-guide`](explainers/complete-guide.md) is the parallel connective narrative that walks every concept end to end.
 
-> **New here?** Read [overview](00-foundations/01-overview.md) for the system shape, then [explainers/complete-guide](explainers/complete-guide.md) for the end-to-end narrative. For money specifically, start at [money-model-overview](10-money-and-ledger/01-money-model-overview.md) and walk the `10-money-and-ledger/` band.
+> **New here?** Read the [overview](00-foundations/01-overview.md) for the system shape, then the [complete guide](explainers/complete-guide.md) for the end-to-end narrative. For money specifically, start at [money-model-overview](10-money-and-ledger/01-money-model-overview.md) and walk the `10-money-and-ledger/` band in order. If you want a curated path matched to your experience level, use the [reading paths](#reading-paths-by-level) below.
 
 ---
 
 ## How to read this
+
+The flowchart below routes you from "new developer" to the band that owns your area. Every path assumes you have read the foundations band first.
 
 ```mermaid
 flowchart LR
@@ -18,11 +28,64 @@ flowchart LR
   PATH -->|compliance / data| COMP["40-compliance-and-data/<br/>compliance · deletion · data-export<br/>webhooks · workspace-prefs · integrations"]
   PATH -->|on-call / ops| OPS["50-operations/<br/>api-reference · route-migration · runbooks<br/>monitoring · system-events · payout-go-live"]
   PATH -->|sales / partners| SALES["60-scenarios-and-verdicts/<br/>scenarios · harness-verdict · design-partners"]
+  PATH -->|architecture / why| ADR["70-design-decisions/<br/>ADRs: ledger · money · payouts · auth · webhooks"]
 ```
 
 ---
 
+## Reading paths by level
+
+The bands are one source of truth — these paths are navigation, not copies. Each path includes everything from the previous one, so an SDE3 is expected to have covered the SDE2 list. Every doc carries an `audience:` tag in its frontmatter stating the lowest level for whom it is primary reading; nothing stops an SDE1 from reading an `sde4` doc, but the paths below are the order that builds context without forward references.
+
+### SDE1 — ship a feature without breaking money
+
+This path gives you the system shape, the role model, and just enough of the money model to know what you must not touch casually.
+
+1. [overview](00-foundations/01-overview.md) — read the "anatomy of one booking" sequence diagram twice; it is the spine every other doc hangs detail off.
+2. [organization-types](00-foundations/02-organization-types.md) — the two booleans (`canSponsor`/`canHost`) that define every org.
+3. [roles-and-permissions](00-foundations/04-roles-and-permissions.md) — the `MemberRole` ladder that gates every API route and dashboard page.
+4. [money-model-overview](10-money-and-ledger/01-money-model-overview.md) — the three money rules (integer paise, balanced transactions, derived balances). You do not need the rest of the band yet.
+5. [dashboard-pages](30-programs-and-lifecycle/04-dashboard-pages.md) — what each org dashboard page shows, per role.
+6. [api-reference](50-operations/01-api-reference.md) — keep this open as a reference while you work; do not read it cover to cover.
+
+### SDE2 — own a subsystem
+
+This path makes you productive inside any one band and safe at its boundaries with the others.
+
+1. Everything in the SDE1 path.
+2. All of [`10-money-and-ledger/`](#money--ledger--10-money-and-ledger) in order — the money story only makes sense read front to back.
+3. All of [`20-iam-and-security/`](#iam--sso--security--20-iam-and-security) — SSO, JIT, SCIM, rate limiting, headers.
+4. All of [`30-programs-and-lifecycle/`](#programs--dashboard--discovery--lifecycle--30-programs-and-lifecycle) — programs are where the commercial terms live.
+5. [compliance map](40-compliance-and-data/01-compliance-dpdp-gst-tds-msme.md), [deletion-policy](40-compliance-and-data/02-deletion-policy.md), [data-export](40-compliance-and-data/03-data-export.md), and [outbound-webhooks](40-compliance-and-data/04-outbound-webhooks.md).
+6. Re-read [concurrency-and-idempotency](30-programs-and-lifecycle/01-concurrency-and-idempotency.md) after the money band — the idempotency keys will mean more the second time.
+
+### SDE3 — design changes and review them
+
+This path adds the *why* behind the design and the integrity machinery you must preserve when changing it.
+
+1. Everything in the SDE2 path.
+2. All of [`70-design-decisions/`](70-design-decisions/00-README.md) — the ADRs; read these before proposing structural changes.
+3. [cross-cutting-integrations](40-compliance-and-data/06-cross-cutting-integrations.md) — the wired/partial/skipped map of all eight subsystems.
+4. [ledger-integrity](10-money-and-ledger/09-ledger-integrity.md) — the nightly reconciler and the invariants your change must not break.
+5. [monitoring](50-operations/04-monitoring.md) and [system-events](50-operations/05-system-events.md) — how a change announces itself in production.
+6. [subsystem-checklist](90-audits/02-subsystem-checklist.md) and [verification-guide](90-audits/03-verification-guide.md) — how shipped work gets verified here.
+
+### SDE4 — architecture and regulatory sign-off
+
+This path covers the whole surface, the audit history, and the regulatory rails the money flows must satisfy.
+
+1. Everything in the SDE3 path.
+2. [complete-guide](explainers/complete-guide.md) — the full narrative, front to back.
+3. [compliance map](40-compliance-and-data/01-compliance-dpdp-gst-tds-msme.md) together with the authoritative rule set in [`docs/compliance/`](../compliance/00-overview.md).
+4. [live-payout-go-live-runbook](50-operations/06-live-payout-go-live-runbook.md) — the one flag flip with real-money consequences.
+5. All of [`60-scenarios-and-verdicts/`](#scenarios--verdict--partners--60-scenarios-and-verdicts) — the worked scenarios and the honest ✅/🟡/🔴 verdict grid.
+6. [readiness-audit](90-audits/01-readiness-audit.md) and [simplification-proposal](90-audits/04-simplification-proposal.md) — where the system stands and what could be cut.
+
+---
+
 ## Section map
+
+The table below lists every band in reading order, with the documents each one contains.
 
 | Band folder | Section | Docs |
 | --- | --- | --- |
@@ -33,6 +96,7 @@ flowchart LR
 | `40-compliance-and-data/` | **Compliance / integrations / data** | compliance map, deletion, data export, outbound webhooks, workspace prefs, cross-cutting integrations |
 | `50-operations/` | **Operations** | API reference, route migration, runbooks, monitoring, system events, live-payout go-live |
 | `60-scenarios-and-verdicts/` | **Scenarios / verdict / partners** | worked scenarios, harness verdict, design-partner set |
+| `70-design-decisions/` | **Design decisions (ADRs)** | why the ledger, money representation, payouts, auth, and webhook designs are what they are |
 | `90-audits/` | **Audit artifacts (annex)** | readiness audit, subsystem checklist, verification guide, simplification proposal, superseded 2026-05-02 production-grade checklist |
 
 ---
@@ -40,6 +104,9 @@ flowchart LR
 ## Full index
 
 ### Foundations — `00-foundations/`
+
+These six docs define the primitives every other band assumes: what an organization is, who its members are, and how its lifecycle runs.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [overview](00-foundations/01-overview.md) | system shape, master ER, capability model |
@@ -50,6 +117,9 @@ flowchart LR
 | 06 | [hierarchy](00-foundations/06-hierarchy.md) | `parentOrganizationId`/`rootOrganizationId` (UI deferred) |
 
 ### Money & ledger — `10-money-and-ledger/`
+
+This band tells the money story front to back: how value enters (wallet, invoice, card), how it splits into earnings, and how it leaves (payouts), all through one double-entry journal.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [money-model-overview](10-money-and-ledger/01-money-model-overview.md) | integer paise, double-entry, derived balances, what #772 changed |
@@ -63,6 +133,9 @@ flowchart LR
 | 09 | [ledger-integrity](10-money-and-ledger/09-ledger-integrity.md) | the reconciler: 7 checks + report |
 
 ### IAM / SSO / security — `20-iam-and-security/`
+
+These five docs cover how people get into orgs (SSO, JIT, SCIM) and the protective layers around those entry points.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [sso-and-authentication](20-iam-and-security/01-sso-and-authentication.md) | `OrganizationSSOSettings`, `SsoProvider`, domain claims |
@@ -72,6 +145,9 @@ flowchart LR
 | 05 | [security-headers](20-iam-and-security/05-security-headers.md) | CSP + header posture |
 
 ### Programs / dashboard / discovery / lifecycle — `30-programs-and-lifecycle/`
+
+This band holds the commercial logic (programs, contracts, cycles) and the app surfaces that expose it.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [concurrency-and-idempotency](30-programs-and-lifecycle/01-concurrency-and-idempotency.md) | atomic patterns + every idempotency key |
@@ -84,6 +160,9 @@ flowchart LR
 | 08 | [cycle-engine-and-rollover](30-programs-and-lifecycle/08-cycle-engine-and-rollover.md) | `ProgramAssignment` lifecycle, nightly cycle-advance, successor mint |
 
 ### Compliance / integrations / data — `40-compliance-and-data/`
+
+These docs map the regulatory rails (DPDP, GST, TDS, MSME) onto the models and crons that implement them, plus the org-facing data plumbing.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [compliance-dpdp-gst-tds-msme](40-compliance-and-data/01-compliance-dpdp-gst-tds-msme.md) | enterprise touchpoints → `../compliance/*` |
@@ -94,6 +173,9 @@ flowchart LR
 | 06 | [cross-cutting-integrations](40-compliance-and-data/06-cross-cutting-integrations.md) | per-subsystem wired/skipped map |
 
 ### Operations — `50-operations/`
+
+This band is the on-call surface: every route, cron, alert, and the one go-live runbook.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [api-reference](50-operations/01-api-reference.md) | exhaustive route table (roles + audit actions) |
@@ -104,13 +186,23 @@ flowchart LR
 | 06 | [live-payout-go-live-runbook](50-operations/06-live-payout-go-live-runbook.md) | flip `ENABLE_LIVE_PAYOUTS` safely (sandbox proof + rollback) |
 
 ### Scenarios / verdict / partners — `60-scenarios-and-verdicts/`
+
+These docs validate the system against worked end-to-end examples and state honestly which scenarios are live, partial, or missing.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [scenarios-and-examples](60-scenarios-and-verdicts/01-scenarios-and-examples.md) | worked end-to-end scenarios |
 | 02 | [harness-verdict](60-scenarios-and-verdicts/02-harness-verdict.md) | scenario-by-scenario verdict |
 | 03 | [design-partner-customer-set](60-scenarios-and-verdicts/03-design-partner-customer-set.md) | seed cohort / design partners |
 
+### Design decisions — `70-design-decisions/`
+
+This band collects the architecture decision records: each one states a decision the system embodies, the alternatives that were rejected, and the consequences we live with. Start at the [band index](70-design-decisions/00-README.md), which lists every ADR and the format they follow.
+
 ### Audit artifacts (annex) — `90-audits/`
+
+These are point-in-time audit artifacts; their `last-reviewed` dates intentionally reflect when each audit was performed, not the latest doc sweep.
+
 | # | Doc | Focus |
 |---|---|---|
 | 01 | [readiness-audit](90-audits/01-readiness-audit.md) | enterprise readiness audit |
@@ -120,9 +212,28 @@ flowchart LR
 | 05 | [production-grade-checklist-2026-05-02](90-audits/05-production-grade-checklist-2026-05-02.md) | superseded 2026-05-02 production-grade checklist |
 
 ### The complete guide
+
 | File | Purpose |
 |---|---|
 | [explainers/complete-guide](explainers/complete-guide.md) | the single end-to-end narrative walkthrough across every enterprise concept — read it alongside the banded folders above |
+
+---
+
+## Doc conventions: frontmatter
+
+Every document in this tree opens with a YAML frontmatter block. The fields mean the following:
+
+```yaml
+---
+title: Payout pipeline            # mirrors the H1
+band: 10-money-and-ledger         # the band folder slug; "index" for this README and the explainers
+audience: sde2                    # sde1 | sde2 | sde3 | sde4 — the lowest level for whom this doc is primary reading
+status: live                      # live | partial | designed-not-active
+last-reviewed: 2026-06-05         # the date a human last verified this doc's claims against code
+---
+```
+
+`status: partial` means the doc covers at least one designed-but-not-active surface (these are also flagged 🟡 inline). `status: designed-not-active` means the entire doc describes a surface that is built in schema or docs but not running in production. When you change behavior a doc describes, update the doc and bump its `last-reviewed` date in the same PR.
 
 ---
 
@@ -157,3 +268,4 @@ Docs **defer to code** when prose drifts. The load-bearing sources:
 - **Idempotency keys** are structured: money keys like `booking:<paymentId>`, `topup:<providerOrderId>`, `orgpayout:<payoutId>`; cron claims gate on a stamped timestamp — `rolledAt` (cycle mint), `autoRenewedAt` (contract renew), `autoTopUpLastFiredAt` (auto-top-up) ([concurrency-and-idempotency](30-programs-and-lifecycle/01-concurrency-and-idempotency.md)).
 - **Ledger rows are immutable** — corrections are counter-transactions, never edits or deletes.
 - **Balances are derived** by summing the journal; the few cached numbers are reconciled nightly.
+- **Prose is full sentences** — paragraphs or full-sentence bullets; tables get a sentence lead-in. Terse fragments are reserved for table cells and Mermaid labels.

--- a/docs/enterprise/explainers/complete-guide.md
+++ b/docs/enterprise/explainers/complete-guide.md
@@ -1,3 +1,11 @@
+---
+title: Familiarise Enterprise — The Complete Guide
+band: index
+audience: sde1
+status: live
+last-reviewed: 2026-06-05
+---
+
 # Familiarise Enterprise — The Complete Guide
 
 > **Last refreshed post-#772 (double-entry ledger cutover):** the money model is now a double-entry journal (`LedgerAccount` / `LedgerTransaction` / `LedgerEntry`). The legacy `WalletEntry` / `FundingLedgerEntry` / `SettlementLedgerEntry` rows and the "three-ledger" framing were removed; see Part IV.


### PR DESCRIPTION
## What this does

First sub-PR of the enterprise docs rewrite (#789). It is deliberately mechanical so it can be reviewed quickly and unblock the content phases.

- **YAML frontmatter on all 51 docs** — `title` / `band` / `audience` (sde1–4, the lowest level for whom the doc is primary reading) / `status` (`live` | `partial` | `designed-not-active`) / `last-reviewed`. Docs covering a 🟡 designed-not-active surface are tagged `partial`; the live-payout go-live runbook is tagged `designed-not-active`; `90-audits/` files keep their historical audit dates (e.g., the superseded checklist stays `2026-05-02`). The simplification proposal already had pandoc frontmatter — our keys were merged into the existing block.
- **Four SDE1→SDE4 reading paths in the README** — curated navigation over the banded tree, one source of truth per topic (no per-level copies). Each path includes the previous level's list.
- **`70-design-decisions/` band registered + stubbed** — the band index documents the ADR format and lists the 12 planned records; the ADRs themselves land under #793.
- **Frontmatter convention documented** in the README, plus full-sentence lead-ins added to the index tables.

No content claims were changed in this PR; prose rewrites land per band in later sub-PRs.

Closes #790
Part of #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)