### PR TITLE
fix(enterprise): BILLING_ADMIN invitable/addable — routes use canonical role schemas

### DIFF
--- a/__tests__/enterprise/member-role-schema-drift.test.ts
+++ b/__tests__/enterprise/member-role-schema-drift.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #817 — pins the canonical role Zod enums in org-labels to their contracts.
+ * The invitations and members routes used to carry LOCAL duplicates of these
+ * enums, and both drifted (BILLING_ADMIN went missing), making the
+ * finance-operator role unassignable through invite OR direct add. The routes
+ * now import the canonical schemas, and this suite stops the canon itself
+ * from drifting against the Prisma enum.
+ */
+
+import { MemberRole } from "@prisma/client";
+
+import {
+  MemberRoleSchema,
+  SelfServiceMemberRoleSchema,
+  HostInvitableMemberRoleSchema,
+} from "@/lib/labels/org-labels";
+
+describe("member-role schema drift (#817)", () => {
+  it("MemberRoleSchema mirrors the Prisma enum exactly", () => {
+    const zod = [...MemberRoleSchema.options].sort();
+    const prisma = Object.values(MemberRole).sort();
+    expect(zod).toEqual(prisma);
+  });
+
+  it("self-service set includes BILLING_ADMIN and excludes the marketplace + operator-only roles", () => {
+    expect(SelfServiceMemberRoleSchema.options).toContain("BILLING_ADMIN");
+    expect(SelfServiceMemberRoleSchema.options).not.toContain("EXPERT");
+    expect(SelfServiceMemberRoleSchema.options).not.toContain("SUPPORT");
+  });
+
+  it("host-invitable set is exactly self-service + EXPERT (SUPPORT stays owner-console-only)", () => {
+    const host = [...HostInvitableMemberRoleSchema.options].sort();
+    const expected = [...SelfServiceMemberRoleSchema.options, "EXPERT"].sort();
+    expect(host).toEqual(expected);
+  });
+});

--- a/app/api/organizations/[orgId]/invitations/route.ts
+++ b/app/api/organizations/[orgId]/invitations/route.ts
@@ -14,6 +14,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
+import { HostInvitableMemberRoleSchema } from "@/lib/labels/org-labels";
 import crypto from "node:crypto";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
@@ -28,23 +29,13 @@ import {
 import { notifyOrgInviteSent } from "@/lib/novu/org-workflows";
 import { applyRateLimit, orgInviteLimiter } from "@/lib/rate-limit";
 
-// Roles a self-service inviter can assign. EXPERT is included in the
-// canHost-aware widening below; the rest mirror SELF_SERVICE_MEMBER_ROLES
-// in lib/labels/org-labels.ts — kept in two places because this is the
-// server-side enforcement and the UI subset must never drift from the
-// API subset. SUPPORT remains owner-only and is assigned from Settings,
-// not the invitations form.
-const InvitableRoleSchema = z.enum([
-  "OWNER",
-  "MAINTAINER",
-  "MANAGER",
-  "LEARNER",
-  "EXPERT",
-]);
+// #817 — the canonical invitable set lives in org-labels; a local duplicate
+// here drifted (BILLING_ADMIN went missing) so the route now imports it.
+// EXPERT is gated by canHost below; SUPPORT stays owner-only (Settings).
 
 const InviteBodySchema = z.object({
   email: z.string().email(),
-  role: InvitableRoleSchema,
+  role: HostInvitableMemberRoleSchema,
   // Default expiry: 14 days. Overridable up to 30 to avoid long-lived
   // invite tokens sitting in inboxes indefinitely.
   expiresInDays: z.coerce.number().int().min(1).max(30).default(14),

--- a/app/api/organizations/[orgId]/members/route.ts
+++ b/app/api/organizations/[orgId]/members/route.ts
@@ -13,6 +13,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
+import { MemberRoleSchema } from "@/lib/labels/org-labels";
 import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import {
@@ -29,16 +30,8 @@ import {
   bumpUserSessionGeneration,
 } from "@/lib/api/organizations/membership-transitions";
 
-// Canonical MemberRole Zod enum. Mirrors the Prisma enum — if a role
-// is added to the schema, TS fails here until the list is updated.
-const MemberRoleSchema = z.enum([
-  "OWNER",
-  "MAINTAINER",
-  "MANAGER",
-  "EXPERT",
-  "LEARNER",
-  "SUPPORT",
-]);
+// #817 — the canonical full-enum Zod mirror lives in org-labels; the local
+// duplicate here drifted (BILLING_ADMIN went missing), so import it instead.
 
 const MemberStatusSchema = z.enum(["PENDING", "ACTIVE", "SUSPENDED", "REMOVED"]);
 

--- a/docs/enterprise/00-foundations/04-roles-and-permissions.md
+++ b/docs/enterprise/00-foundations/04-roles-and-permissions.md
@@ -481,6 +481,26 @@ workflow — which used to live on `Membership.applicationNote /
 appliedAt / approvedAt / approvedBy` — was removed alongside this
 rule; those columns are gone (see `expert-lifecycle`).
 
+### The three layers, and which cross-setups are allowed
+
+Confusion recurs here because three layers share vocabulary, so this
+section records the model and the decision explicitly. The platform
+profiles (`ConsultantProfile`, `ConsulteeProfile`) are global, per-User
+identities and are **not** mutually exclusive: one person can both
+deliver and consume on the platform, and each profile is unique per
+user. The workspace roles are the `MemberRole` enum on `Membership`,
+and EXPERT/LEARNER are the two enum values that bridge a workspace
+membership to one of those global profiles; the operator roles (OWNER,
+MAINTAINER, BILLING_ADMIN, MANAGER, SUPPORT) carry no profile linkage
+at all. The following table states what is allowed across those layers.
+
+| Setup | Allowed? | Why |
+|---|---|---|
+| One user holds both profiles platform-wide | Yes | Profiles are global and non-exclusive. |
+| EXPERT in org A while LEARNER in org B | Yes | Each org gets its own Membership row with its own role and profile link; multi-org experts and learners are first-class (see the scenarios doc). |
+| EXPERT and LEARNER inside the same org | No — by decision (2026-06-07) | `@@unique([userId, organizationId])` allows one role per org, and the LEARNER↔EXPERT transition is blocked. Allowing a dual-side membership would make `ProgramAssignment` attribution ambiguous and open self-dealing (an expert consuming their own org's sponsored budget). The remediation is remove + re-invite, or a second org for genuinely separate capacities. |
+| Operator role plus sponsored consumption in the same org | No | Same single-role constraint; operators have no consumer profile linkage. An operator who needs sponsored sessions takes a LEARNER membership in a different org or books personally funded sessions. |
+
 ## Per-role landing in `/dashboard/organization/[orgId]`
 
 The bare org route is no longer a one-way bounce-to-personal for consumer

--- a/docs/enterprise/00-foundations/04-roles-and-permissions.md
+++ b/docs/enterprise/00-foundations/04-roles-and-permissions.md
@@ -501,6 +501,22 @@ at all. The following table states what is allowed across those layers.
 | EXPERT and LEARNER inside the same org | No — by decision (2026-06-07) | `@@unique([userId, organizationId])` allows one role per org, and the LEARNER↔EXPERT transition is blocked. Allowing a dual-side membership would make `ProgramAssignment` attribution ambiguous and open self-dealing (an expert consuming their own org's sponsored budget). The remediation is remove + re-invite, or a second org for genuinely separate capacities. |
 | Operator role plus sponsored consumption in the same org | No | Same single-role constraint; operators have no consumer profile linkage. An operator who needs sponsored sessions takes a LEARNER membership in a different org or books personally funded sessions. |
 
+### Who creates the identity: the who-is-acting rule
+
+Identity creation follows one rule, settled in #819: **creating a profile
+requires the user's own action, while an admin acting on someone else's
+behalf requires the identity to already exist.** Concretely, the admin
+direct-add surface (`POST /members`) refuses both roles when the matching
+profile is missing (`NOT_A_CONSULTANT` / `NOT_A_CONSULTEE`), because an
+org admin's click must never mint a platform identity for somebody else.
+Invitation accept is the user's own consenting click, so it lazy-creates
+the lightweight `ConsulteeProfile` for LEARNER (this is one of the
+sanctioned creation points named in `lib/auth.ts`) but still refuses
+EXPERT when no `ConsultantProfile` exists, because a consultant identity
+carries domain, rate, verification, and payout prerequisites that no
+invite click can substitute for. SSO JIT auto-join keeps its own
+lazy-create path as a separately authorized provisioning channel.
+
 ## Per-role landing in `/dashboard/organization/[orgId]`
 
 The bare org route is no longer a one-way bounce-to-personal for consumer

--- a/lib/labels/org-labels.ts
+++ b/lib/labels/org-labels.ts
@@ -291,7 +291,7 @@ export function narrowFundingSource(
 
 /**
  * Narrow an untyped value to a self-service member role, falling back to
- * MEMBER if unrecognized.
+ * LEARNER if unrecognized.
  */
 export function narrowSelfServiceRole(
   v: unknown,


### PR DESCRIPTION
## What

`BILLING_ADMIN` exists in the Prisma enum, the rank ladder, `applyMembershipRoleEffects`, the labels module, and the roles documentation — yet it could not actually be assigned: both the invitations route and the members route defined **local duplicates** of the role Zod enums, and both duplicates had drifted to omit it, rejecting the role at parse time.

## Fix

The routes now import the canonical `HostInvitableMemberRoleSchema` / `MemberRoleSchema` from `lib/labels/org-labels.ts` (which were always correct) instead of redefining them. A new drift-test suite (`member-role-schema-drift.test.ts`) pins the canonical schemas to the Prisma enum and to each other, so a future role addition fails tests instead of silently becoming unassignable. The UI dropdowns already read `getInvitableRoles()` from the same module, so they pick the role up with no further change.

## Also in this PR

- Stale `narrowSelfServiceRole` JSDoc fixed (`MEMBER` → `LEARNER`; no MEMBER role exists).
- `docs/enterprise/00-foundations/04-roles-and-permissions.md` gains "The three layers, and which cross-setups are allowed" — recording explicitly that ConsultantProfile/ConsulteeProfile are global non-exclusive identities, EXPERT/LEARNER are the workspace roles that bridge to them, cross-org expert/learner combinations are first-class, and same-org dual-side membership stays **blocked by decision (2026-06-07)** with remove + re-invite as remediation.

## Verification

32 tests across 5 suites pass (invitation-accept, role-transitions, anti-lockout, billing-admin-gate, new drift suite); eslint clean; `tsc --noEmit` exit 0.

Closes #817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)