### PR TITLE
Enterprise state-machine and concurrency hardening: CAS transitions, optimistic locking, Serializable org PATCH, cron locks, webhook dead-letter

### DIFF
--- a/.github/workflows/advance-program-cycles.yml
+++ b/.github/workflows/advance-program-cycles.yml
@@ -16,6 +16,9 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cascade-refund-earnings.yml
+++ b/.github/workflows/cascade-refund-earnings.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cleanup-abandoned-org-top-ups.yml
+++ b/.github/workflows/cleanup-abandoned-org-top-ups.yml
@@ -16,6 +16,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cleanup-abandoned-payments.yml
+++ b/.github/workflows/cleanup-abandoned-payments.yml
@@ -18,6 +18,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       # Payment gateway credentials for cancelling abandoned payment intents
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/dunning.yml
+++ b/.github/workflows/dunning.yml
@@ -19,6 +19,9 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       NOVU_SECRET_KEY: ${{ secrets.NOVU_SECRET_KEY }}
 
     steps:

--- a/.github/workflows/handle-lost-disputes.yml
+++ b/.github/workflows/handle-lost-disputes.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/handle-stuck-payouts.yml
+++ b/.github/workflows/handle-stuck-payouts.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       # Payment gateway credentials for querying payout status
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/reconcile-disputes.yml
+++ b/.github/workflows/reconcile-disputes.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       # Payment gateway credentials for querying dispute status
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/reconcile-payment-status.yml
+++ b/.github/workflows/reconcile-payment-status.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       # Payment gateway credentials
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/reconcile-payout-status.yml
+++ b/.github/workflows/reconcile-payout-status.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       # Payment gateway credentials
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/reconcile-pending-refunds.yml
+++ b/.github/workflows/reconcile-pending-refunds.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
       # Payment gateway credentials for querying refund status
       STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/release-earnings.yml
+++ b/.github/workflows/release-earnings.yml
@@ -22,6 +22,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-pending-trust-earnings.yml
+++ b/.github/workflows/release-pending-trust-earnings.yml
@@ -26,6 +26,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sweep-abandoned-overage-charges.yml
+++ b/.github/workflows/sweep-abandoned-overage-charges.yml
@@ -16,6 +16,9 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sweep-orphaned-topup-captures.yml
+++ b/.github/workflows/sweep-orphaned-topup-captures.yml
@@ -16,6 +16,9 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sweep-stuck-webhook-events.yml
+++ b/.github/workflows/sweep-stuck-webhook-events.yml
@@ -20,6 +20,9 @@ jobs:
       # when absent, matching the other money crons.
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sync-payment-earnings.yml
+++ b/.github/workflows/sync-payment-earnings.yml
@@ -15,6 +15,9 @@ jobs:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/timeout-member-overages.yml
+++ b/.github/workflows/timeout-member-overages.yml
@@ -19,6 +19,9 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       NOVU_SECRET_KEY: ${{ secrets.NOVU_SECRET_KEY }}
 
     steps:

--- a/__tests__/enterprise/anti-lockout-gaps.test.ts
+++ b/__tests__/enterprise/anti-lockout-gaps.test.ts
@@ -25,7 +25,14 @@
 jest.mock("../../lib/prisma", () => ({
   __esModule: true,
   default: {
-    contract: { findFirst: jest.fn(), update: jest.fn() },
+    contract: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      // Status moves go through the CAS helper: guarded updateMany +
+      // in-tx findUniqueOrThrow re-read.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      findUniqueOrThrow: jest.fn().mockResolvedValue({ id: "c-1" }),
+    },
     program: {
       findFirst: jest.fn(),
       delete: jest.fn(),
@@ -76,7 +83,12 @@ import { PATCH as contractPATCH } from "@/app/api/organizations/[orgId]/contract
 import { DELETE as programDELETE } from "@/app/api/organizations/[orgId]/programs/[programId]/route";
 
 const mockedPrisma = prisma as unknown as {
-  contract: { findFirst: jest.Mock; update: jest.Mock };
+  contract: {
+    findFirst: jest.Mock;
+    update: jest.Mock;
+    updateMany: jest.Mock;
+    findUniqueOrThrow: jest.Mock;
+  };
   program: { findFirst: jest.Mock; delete: jest.Mock; updateMany: jest.Mock };
   programAssignment: { count: jest.Mock; updateMany: jest.Mock };
   bookingUtilization: { findFirst: jest.Mock };
@@ -197,7 +209,15 @@ describe("PATCH /api/organizations/[orgId]/contracts/[contractId] — terminatio
     )) as Response;
 
     expect(res.status).toBe(200);
-    expect(mockedPrisma.contract.update).toHaveBeenCalled();
+    // Status moves are CAS-guarded updateMany now, not a plain update.
+    expect(mockedPrisma.contract.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["ACTIVE"] },
+        }),
+        data: expect.objectContaining({ status: "TERMINATED" }),
+      }),
+    );
   });
 
   it("does not run the assignment guard for non-TERMINATED transitions", async () => {

--- a/__tests__/enterprise/po-balance-enforcement.test.ts
+++ b/__tests__/enterprise/po-balance-enforcement.test.ts
@@ -43,6 +43,10 @@ jest.mock("../../lib/prisma", () => ({
       findUnique: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
+      // Status moves now go through the CAS helper (#476 audit): guarded
+      // updateMany + in-tx findUniqueOrThrow re-read for the response body.
+      updateMany: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
     },
     settlementLedgerEntry: { create: jest.fn() },
     orgAuditLog: { create: jest.fn().mockResolvedValue({}) },
@@ -115,6 +119,8 @@ const mockedPrisma = prisma as unknown as {
     findUnique: jest.Mock;
     findFirst: jest.Mock;
     update: jest.Mock;
+    updateMany: jest.Mock;
+    findUniqueOrThrow: jest.Mock;
   };
   settlementLedgerEntry: { create: jest.Mock };
   orgAuditLog: { create: jest.Mock };
@@ -331,8 +337,12 @@ describe("PATCH /api/organizations/[orgId]/billing-account/invoices/[invoiceId] 
       invoiceNumber: "ACME-2026-00001",
       pdfStoragePath: null,
     });
-    mockedPrisma.organizationInvoice.update.mockResolvedValue({
+    mockedPrisma.organizationInvoice.updateMany.mockResolvedValue({
+      count: 1,
+    });
+    mockedPrisma.organizationInvoice.findUniqueOrThrow.mockResolvedValue({
       id: "inv-1",
+      status: "VOID",
     });
     mockedPrisma.purchaseOrder.update.mockResolvedValue({ id: "po-1" });
 
@@ -366,7 +376,13 @@ describe("PATCH /api/organizations/[orgId]/billing-account/invoices/[invoiceId] 
       invoiceNumber: "ACME-2026-00002",
       pdfStoragePath: null,
     });
-    mockedPrisma.organizationInvoice.update.mockResolvedValue({ id: "inv-2" });
+    mockedPrisma.organizationInvoice.updateMany.mockResolvedValue({
+      count: 1,
+    });
+    mockedPrisma.organizationInvoice.findUniqueOrThrow.mockResolvedValue({
+      id: "inv-2",
+      status: "VOID",
+    });
 
     const req = new NextRequest(
       "http://localhost/api/organizations/org-1/billing-account/invoices/inv-2",

--- a/__tests__/enterprise/serializable-retry.test.ts
+++ b/__tests__/enterprise/serializable-retry.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
+import { Prisma } from "@prisma/client";
+
+function p2034() {
+  return new Prisma.PrismaClientKnownRequestError("serialization failure", {
+    code: "P2034",
+    clientVersion: "test",
+  });
+}
+
+describe("withSerializableRetry", () => {
+  it("returns the result on first success without retrying", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    await expect(withSerializableRetry(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries P2034 and succeeds on a later attempt", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(p2034())
+      .mockRejectedValueOnce(p2034())
+      .mockResolvedValue("ok");
+    await expect(withSerializableRetry(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after maxRetries and rethrows the P2034", async () => {
+    const fn = jest.fn().mockRejectedValue(p2034());
+    await expect(withSerializableRetry(fn, 2)).rejects.toMatchObject({
+      code: "P2034",
+    });
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("does not retry non-P2034 errors", async () => {
+    const fn = jest.fn().mockRejectedValue(new Error("boom"));
+    await expect(withSerializableRetry(fn)).rejects.toThrow("boom");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry business rejections (IllegalTransitionError)", async () => {
+    // A 409 means the state machine said no — retrying would turn a correct
+    // rejection into a corrupting second attempt.
+    const fn = jest
+      .fn()
+      .mockRejectedValue(new IllegalTransitionError("Contract", "ACTIVE"));
+    await expect(withSerializableRetry(fn)).rejects.toBeInstanceOf(
+      IllegalTransitionError,
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/enterprise/sweep-abandoned-overage-charges.test.ts
+++ b/__tests__/enterprise/sweep-abandoned-overage-charges.test.ts
@@ -16,6 +16,17 @@ jest.mock("../../lib/payments/billing/overage-transitions", () => ({
   transitionOverage: jest.fn(),
 }));
 
+
+// #476 — the sweep cores are now wrapped in withCronLock; pass through so
+// these unit tests exercise the sweep logic, not the lock (covered in
+// with-cron-lock.test.ts).
+jest.mock("../../lib/cron/with-cron-lock", () => ({
+  withCronLock: jest.fn((_job: string, _opts: unknown, fn: () => unknown) => fn()),
+  CronLockHeldError: class CronLockHeldError extends Error {},
+  CronLockUnavailableError: class CronLockUnavailableError extends Error {},
+  LONG_JOB_TTL_MS: 35 * 60 * 1000,
+}));
+
 import prisma from "../../lib/prisma";
 import { transitionOverage } from "../../lib/payments/billing/overage-transitions";
 import { sweepAbandonedOverageCharges } from "../../scripts/cleanup/sweep-abandoned-overage-charges";

--- a/__tests__/enterprise/sweep-orphaned-topup-captures.test.ts
+++ b/__tests__/enterprise/sweep-orphaned-topup-captures.test.ts
@@ -16,6 +16,17 @@ jest.mock("../../lib/api/organizations/wallet", () => ({
   confirmTopUp: jest.fn(),
 }));
 
+
+// #476 — the sweep cores are now wrapped in withCronLock; pass through so
+// these unit tests exercise the sweep logic, not the lock (covered in
+// with-cron-lock.test.ts).
+jest.mock("../../lib/cron/with-cron-lock", () => ({
+  withCronLock: jest.fn((_job: string, _opts: unknown, fn: () => unknown) => fn()),
+  CronLockHeldError: class CronLockHeldError extends Error {},
+  CronLockUnavailableError: class CronLockUnavailableError extends Error {},
+  LONG_JOB_TTL_MS: 35 * 60 * 1000,
+}));
+
 import prisma from "../../lib/prisma";
 import { confirmTopUp } from "../../lib/api/organizations/wallet";
 import { sweepOrphanedTopupCaptures } from "../../scripts/cleanup/sweep-orphaned-topup-captures";

--- a/__tests__/enterprise/sweep-stuck-webhook-events.test.ts
+++ b/__tests__/enterprise/sweep-stuck-webhook-events.test.ts
@@ -26,6 +26,17 @@ jest.mock("../../app/api/webhooks/razorpay-dispatch", () => ({
   processRazorpayWebhookEvent: jest.fn(),
 }));
 
+
+// #476 — the sweep cores are now wrapped in withCronLock; pass through so
+// these unit tests exercise the sweep logic, not the lock (covered in
+// with-cron-lock.test.ts).
+jest.mock("../../lib/cron/with-cron-lock", () => ({
+  withCronLock: jest.fn((_job: string, _opts: unknown, fn: () => unknown) => fn()),
+  CronLockHeldError: class CronLockHeldError extends Error {},
+  CronLockUnavailableError: class CronLockUnavailableError extends Error {},
+  LONG_JOB_TTL_MS: 35 * 60 * 1000,
+}));
+
 import prisma from "../../lib/prisma";
 import { processRazorpayWebhookEvent } from "../../app/api/webhooks/razorpay-dispatch";
 import { sweepStuckWebhookEvents } from "../../scripts/cleanup/sweep-stuck-webhook-events";

--- a/__tests__/enterprise/transitions.test.ts
+++ b/__tests__/enterprise/transitions.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The central transition helper bakes each enum's allowed-from set into the
+ * UPDATE WHERE clause, so an illegal transition matches zero rows and throws
+ * instead of corrupting state. These tests assert the maps (every legal edge,
+ * representative terminal re-entries) and the helper contract (throw on count
+ * 0, audit only after a successful CAS) against a mocked delegate — no DB.
+ */
+
+import {
+  ASSIGNMENT_ALLOWED_FROM,
+  CONTRACT_ALLOWED_FROM,
+  INVOICE_ALLOWED_FROM,
+  IllegalTransitionError,
+  MEMBER_ALLOWED_FROM,
+  ORG_ALLOWED_FROM,
+  ORG_PAYOUT_ACCOUNT_ALLOWED_FROM,
+  PAYOUT_ALLOWED_FROM,
+  PO_ALLOWED_FROM,
+  PROGRAM_ALLOWED_FROM,
+  TERMINAL_STATES,
+  WALLET_TOPUP_ALLOWED_FROM,
+  transitionContract,
+  transitionMembership,
+  transitionOrgInvoice,
+  transitionOrgPayout,
+  transitionOrgPayoutAccount,
+  transitionOrganization,
+  transitionProgram,
+  transitionProgramAssignment,
+  transitionPurchaseOrder,
+} from "@/lib/enterprise/transitions";
+
+function mockTx(count: number) {
+  const updateMany = jest.fn().mockResolvedValue({ count });
+  const create = jest.fn().mockResolvedValue({});
+  return {
+    updateMany,
+    create,
+    tx: {
+      organization: { updateMany },
+      contract: { updateMany },
+      program: { updateMany },
+      programAssignment: { updateMany },
+      membership: { updateMany },
+      organizationInvoice: { updateMany },
+      purchaseOrder: { updateMany },
+      organizationPayoutAccount: { updateMany },
+      organizationPayout: { updateMany },
+      orgAuditLog: { create },
+      // Wrappers only touch their Pick'd delegates; the cast keeps the mock flat.
+    } as never,
+  };
+}
+
+// [wrapper, map] table so every legal edge of every enum is exercised.
+const WRAPPERS = [
+  ["Organization", transitionOrganization, ORG_ALLOWED_FROM],
+  ["Contract", transitionContract, CONTRACT_ALLOWED_FROM],
+  ["Program", transitionProgram, PROGRAM_ALLOWED_FROM],
+  ["ProgramAssignment", transitionProgramAssignment, ASSIGNMENT_ALLOWED_FROM],
+  ["Membership", transitionMembership, MEMBER_ALLOWED_FROM],
+  ["OrganizationInvoice", transitionOrgInvoice, INVOICE_ALLOWED_FROM],
+  ["PurchaseOrder", transitionPurchaseOrder, PO_ALLOWED_FROM],
+  ["OrganizationPayoutAccount", transitionOrgPayoutAccount, ORG_PAYOUT_ACCOUNT_ALLOWED_FROM],
+  ["OrganizationPayout", transitionOrgPayout, PAYOUT_ALLOWED_FROM],
+] as const;
+
+describe("transition wrappers — CAS contract", () => {
+  describe.each(WRAPPERS)("%s", (entity, wrapper, map) => {
+    const reachableTargets = Object.entries(map)
+      .filter(([, froms]) => (froms as string[]).length > 0)
+      .map(([to]) => to);
+
+    it.each(reachableTargets)(
+      "to %s compiles the allowed-from set into the WHERE and resolves on count 1",
+      async (to) => {
+        const m = mockTx(1);
+        await expect(
+          (wrapper as never as (tx: never, args: object) => Promise<void>)(m.tx, {
+            where: { id: "row-1" },
+            to,
+          }),
+        ).resolves.toBeUndefined();
+        expect(m.updateMany).toHaveBeenCalledWith({
+          where: {
+            id: "row-1",
+            status: { in: map[to as keyof typeof map] },
+          },
+          data: { status: to },
+        });
+      },
+    );
+
+    it(`throws IllegalTransitionError (httpStatus 409) on count 0`, async () => {
+      const m = mockTx(0);
+      const to = reachableTargets[0];
+      const err = await (
+        wrapper as never as (tx: never, args: object) => Promise<void>
+      )(m.tx, { where: { id: "row-1" }, to }).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(IllegalTransitionError);
+      expect((err as IllegalTransitionError).httpStatus).toBe(409);
+      expect((err as IllegalTransitionError).entity).toBe(entity);
+    });
+
+    it("does not write the audit row when the CAS matched zero rows", async () => {
+      const m = mockTx(0);
+      await (wrapper as never as (tx: never, args: object) => Promise<void>)(
+        m.tx,
+        {
+          where: { id: "row-1" },
+          to: reachableTargets[0],
+          audit: {
+            organizationId: "org-1",
+            actorMembershipId: null,
+            category: "SYSTEM",
+            action: "X",
+            description: "x",
+          },
+        },
+      ).catch(() => undefined);
+      expect(m.create).not.toHaveBeenCalled();
+    });
+
+    it("writes the audit row in-tx after a successful CAS", async () => {
+      const m = mockTx(1);
+      await (wrapper as never as (tx: never, args: object) => Promise<void>)(
+        m.tx,
+        {
+          where: { id: "row-1" },
+          to: reachableTargets[0],
+          audit: {
+            organizationId: "org-1",
+            actorMembershipId: "mem-1",
+            category: "SYSTEM",
+            action: "X",
+            description: "x",
+          },
+        },
+      );
+      expect(m.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("terminal re-entry is structurally impossible", () => {
+  it("a terminal state never appears in any allowed-from set of its enum", () => {
+    const pairs = [
+      [ORG_ALLOWED_FROM, TERMINAL_STATES.OrgStatus],
+      [CONTRACT_ALLOWED_FROM, TERMINAL_STATES.ContractStatus],
+      [PROGRAM_ALLOWED_FROM, TERMINAL_STATES.ProgramStatus],
+      [ASSIGNMENT_ALLOWED_FROM, TERMINAL_STATES.AssignmentStatus],
+      [MEMBER_ALLOWED_FROM, TERMINAL_STATES.MemberStatus],
+      [INVOICE_ALLOWED_FROM, TERMINAL_STATES.OrgInvoiceStatus],
+      [PO_ALLOWED_FROM, TERMINAL_STATES.PoStatus],
+      [PAYOUT_ALLOWED_FROM, TERMINAL_STATES.PayoutStatus],
+      [WALLET_TOPUP_ALLOWED_FROM, TERMINAL_STATES.WalletTopUpStatus],
+    ] as const;
+    for (const [map, terminals] of pairs) {
+      const froms = new Set(Object.values(map).flat());
+      for (const t of Array.from(terminals)) expect(froms.has(t)).toBe(false);
+    }
+  });
+
+  it("expected terminal sets (audit S3 — resurrectable states are the bug class)", () => {
+    expect(Array.from(TERMINAL_STATES.OrgStatus).sort()).toEqual(["DEACTIVATED"]);
+    expect(Array.from(TERMINAL_STATES.ContractStatus).sort()).toEqual([
+      "EXPIRED",
+      "TERMINATED",
+    ]);
+    expect(Array.from(TERMINAL_STATES.ProgramStatus).sort()).toEqual([
+      "CANCELLED",
+      "EXPIRED",
+    ]);
+    expect(Array.from(TERMINAL_STATES.AssignmentStatus).sort()).toEqual([
+      "CANCELLED",
+      "CLOSED",
+      "ROLLED",
+    ]);
+    expect(Array.from(TERMINAL_STATES.MemberStatus).sort()).toEqual(["ERASED"]);
+    expect(Array.from(TERMINAL_STATES.OrgInvoiceStatus).sort()).toEqual([
+      "CANCELLED",
+      "REFUNDED",
+      "VOID",
+    ]);
+    expect(Array.from(TERMINAL_STATES.PoStatus).sort()).toEqual([
+      "CANCELLED",
+      "CLOSED",
+    ]);
+    // Bank-detail changes can re-verify from any payout-account state.
+    expect(Array.from(TERMINAL_STATES.OrgPayoutAccountStatus)).toEqual([]);
+    expect(Array.from(TERMINAL_STATES.PayoutStatus).sort()).toEqual([
+      "CANCELLED",
+      "FAILED",
+      "REVERSED",
+    ]);
+    expect(Array.from(TERMINAL_STATES.WalletTopUpStatus).sort()).toEqual([
+      "CONFIRMED",
+      "FAILED",
+    ]);
+  });
+
+  it.each([
+    ["TERMINATED contract → ACTIVE", CONTRACT_ALLOWED_FROM.ACTIVE, "TERMINATED"],
+    ["CANCELLED program → ACTIVE", PROGRAM_ALLOWED_FROM.ACTIVE, "CANCELLED"],
+    ["CLOSED PO → ACTIVE", PO_ALLOWED_FROM.ACTIVE, "CLOSED"],
+    ["DEACTIVATED org → ACTIVE", ORG_ALLOWED_FROM.ACTIVE, "DEACTIVATED"],
+    ["REFUNDED invoice → PAID", INVOICE_ALLOWED_FROM.PAID, "REFUNDED"],
+    ["REVERSED payout → COMPLETED", PAYOUT_ALLOWED_FROM.COMPLETED, "REVERSED"],
+  ])("%s is not a legal edge", (_label, froms, from) => {
+    expect(froms).not.toContain(from);
+  });
+});

--- a/__tests__/enterprise/webhooks/worker.test.ts
+++ b/__tests__/enterprise/webhooks/worker.test.ts
@@ -10,7 +10,8 @@
  *   - 2xx → SUCCESS with deliveredAt + endpoint.lastSuccessAt.
  *   - Permanent 4xx (400/403/404/...) → FAILED with no retry slot.
  *   - 5xx / 408 / 429 / network error → RETRY with the next backoff
- *     unless we just used attempt #5, in which case → FAILED.
+ *     unless we just used attempt #5, in which case → DEAD_LETTER
+ *     (delivery-starved, operator-replayable; FAILED stays receiver-rejected).
  *   - Endpoint flipped to PAUSED/DISABLED after enqueue → row marked
  *     FAILED with an explicit reason (operator pause wins).
  */
@@ -191,7 +192,7 @@ describe("runDispatchTick — transient error / retry schedule", () => {
     });
   });
 
-  it("after attempt 5 fails, flips to FAILED instead of scheduling attempt 6", async () => {
+  it("after attempt 5 fails, flips to DEAD_LETTER instead of scheduling attempt 6", async () => {
     const row = makeRow({ attempts: 4 });
     const stub = makePrismaStub(row);
     const fetchFn = mockFetch(async () => new Response("", { status: 502 }));
@@ -203,7 +204,7 @@ describe("runDispatchTick — transient error / retry schedule", () => {
       now: () => FROZEN_NOW_MS,
     });
     expect(stub.updates[0].data).toMatchObject({
-      status: "FAILED",
+      status: "DEAD_LETTER",
       attempts: 5,
       lastError: expect.stringContaining("Exhausted retries"),
     });

--- a/__tests__/enterprise/with-cron-lock.test.ts
+++ b/__tests__/enterprise/with-cron-lock.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  withCronLock,
+  CronLockHeldError,
+  CronLockUnavailableError,
+  LONG_JOB_TTL_MS,
+} from "../../lib/cron/with-cron-lock";
+import {
+  acquireLock,
+  releaseLock,
+  isMockRedis,
+  checkRedisHealth,
+} from "../../lib/redis";
+
+jest.mock("../../lib/redis", () => ({
+  acquireLock: jest.fn(),
+  releaseLock: jest.fn().mockResolvedValue(undefined),
+  isMockRedis: jest.fn(),
+  checkRedisHealth: jest.fn(),
+}));
+
+const mockAcquire = acquireLock as jest.Mock;
+const mockRelease = releaseLock as jest.Mock;
+const mockIsMock = isMockRedis as jest.Mock;
+const mockHealth = checkRedisHealth as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsMock.mockReturnValue(false);
+  mockHealth.mockResolvedValue(true);
+  mockAcquire.mockResolvedValue("token-1");
+});
+
+describe("withCronLock", () => {
+  it("acquires with the #476 key shape, runs, and releases", async () => {
+    const fn = jest.fn().mockResolvedValue("done");
+    await expect(
+      withCronLock("dunning", { failMode: "closed" }, fn),
+    ).resolves.toBe("done");
+    expect(mockAcquire).toHaveBeenCalledWith("cron:lock:dunning", 15 * 60 * 1000);
+    expect(mockRelease).toHaveBeenCalledWith("cron:lock:dunning", "token-1");
+  });
+
+  it("honours a custom TTL", async () => {
+    await withCronLock(
+      "create-payout-batch",
+      { failMode: "closed", ttlMs: LONG_JOB_TTL_MS },
+      async () => null,
+    );
+    expect(mockAcquire).toHaveBeenCalledWith(
+      "cron:lock:create-payout-batch",
+      LONG_JOB_TTL_MS,
+    );
+  });
+
+  it("throws CronLockHeldError (409) when the lock is held — job skips", async () => {
+    mockAcquire.mockResolvedValue(null);
+    const fn = jest.fn();
+    const err = await withCronLock("dunning", { failMode: "closed" }, fn).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(CronLockHeldError);
+    expect((err as CronLockHeldError).httpStatus).toBe(409);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("releases even when the job throws", async () => {
+    const boom = new Error("boom");
+    await expect(
+      withCronLock("dunning", { failMode: "closed" }, async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("fail-closed: refuses to run on mock Redis (pages via exit 1)", async () => {
+    mockIsMock.mockReturnValue(true);
+    const fn = jest.fn();
+    await expect(
+      withCronLock("dunning", { failMode: "closed" }, fn),
+    ).rejects.toBeInstanceOf(CronLockUnavailableError);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("fail-closed: refuses to run when Redis is unhealthy (circuit open)", async () => {
+    mockHealth.mockResolvedValue(false);
+    await expect(
+      withCronLock("dunning", { failMode: "closed" }, async () => null),
+    ).rejects.toBeInstanceOf(CronLockUnavailableError);
+    expect(mockAcquire).not.toHaveBeenCalled();
+  });
+
+  it("fail-open: runs unlocked on mock Redis with a warning", async () => {
+    mockIsMock.mockReturnValue(true);
+    const fn = jest.fn().mockResolvedValue(42);
+    await expect(
+      withCronLock("cleanup-auth-tokens", { failMode: "open" }, fn),
+    ).resolves.toBe(42);
+    expect(mockAcquire).not.toHaveBeenCalled();
+  });
+
+  it("fail-open: still skips when the lock is genuinely held", async () => {
+    mockAcquire.mockResolvedValue(null);
+    await expect(
+      withCronLock("cleanup-auth-tokens", { failMode: "open" }, async () => 1),
+    ).rejects.toBeInstanceOf(CronLockHeldError);
+  });
+});

--- a/app/api/admin/organizations/[orgId]/verify/route.ts
+++ b/app/api/admin/organizations/[orgId]/verify/route.ts
@@ -15,6 +15,10 @@ import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { requireAdminAuth } from "@/lib/auth-helpers";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import {
+  IllegalTransitionError,
+  transitionOrganization,
+} from "@/lib/enterprise/transitions";
 
 // #779 §A — `REJECT` added (admin bounces a PENDING org back with a reason;
 // stays PENDING_VERIFICATION). Action is upper-cased + defaults to VERIFY so
@@ -73,6 +77,10 @@ export async function POST(
         });
       }
 
+      // Friendly pre-check only — names the offending action/state in the
+      // error. Enforcement is the CAS WHERE below: a concurrent admin action
+      // landing between this read and the update matches zero rows and 409s
+      // instead of resurrecting a terminal state.
       const allowedFrom: Record<string, string[]> = {
         // #779 §A — REJECT keeps the org PENDING (a sub-state, not a status move).
         PENDING_VERIFICATION: ["VERIFY", "REJECT", "DEACTIVATE"],
@@ -90,33 +98,6 @@ export async function POST(
         );
       }
 
-      // #779 §A — REJECT doesn't transition status; it stamps the sub-state.
-      const nextStatus =
-        body.action === "REJECT"
-          ? "PENDING_VERIFICATION"
-          : body.action === "VERIFY" || body.action === "REACTIVATE"
-            ? "ACTIVE"
-            : body.action === "SUSPEND"
-              ? "SUSPENDED"
-              : "DEACTIVATED";
-
-      const next = await tx.organization.update({
-        where: { id: orgId },
-        data: {
-          status: nextStatus,
-          // #779 §A — VERIFY clears the resubmit-loop sub-state; REJECT sets it.
-          ...(body.action === "VERIFY" && {
-            verificationReason: null,
-            verificationSubmittedAt: null,
-            verificationRejectedAt: null,
-          }),
-          ...(body.action === "REJECT" && {
-            verificationReason: body.reason,
-            verificationRejectedAt: new Date(),
-          }),
-        },
-      });
-
       const actionKey =
         body.action === "VERIFY"
           ? AUDIT_ACTIONS.SYSTEM.VERIFIED
@@ -128,26 +109,73 @@ export async function POST(
                 ? AUDIT_ACTIONS.SYSTEM.REACTIVATED
                 : AUDIT_ACTIONS.SYSTEM.DEACTIVATED;
 
-      await tx.orgAuditLog.create({
-        data: {
-          organizationId: orgId,
-          actorMembershipId: null,
-          category: "SYSTEM",
-          action: actionKey,
-          description:
-            body.action === "REJECT"
-              ? `Admin reject: stays ${current.status}`
-              : `Admin ${body.action.toLowerCase()}: ${current.status} → ${nextStatus}`,
-          details: {
-            adminUserId: auth.session.user.id,
-            from: current.status,
-            to: nextStatus,
-            reason: body.reason ?? null,
+      if (body.action === "REJECT") {
+        // #779 §A — REJECT stamps the resubmit sub-state, not a status move.
+        // Guarded on still-PENDING so a concurrent VERIFY can't be overwritten
+        // back into rejection.
+        const res = await tx.organization.updateMany({
+          where: { id: orgId, status: "PENDING_VERIFICATION" },
+          data: {
+            verificationReason: body.reason,
+            verificationRejectedAt: new Date(),
           },
-        },
-      });
+        });
+        if (res.count === 0) {
+          throw new IllegalTransitionError("Organization", "REJECT");
+        }
+        await tx.orgAuditLog.create({
+          data: {
+            organizationId: orgId,
+            actorMembershipId: null,
+            category: "SYSTEM",
+            action: actionKey,
+            description: `Admin reject: stays ${current.status}`,
+            details: {
+              adminUserId: auth.session.user.id,
+              from: current.status,
+              to: current.status,
+              reason: body.reason ?? null,
+            },
+          },
+        });
+      } else {
+        const nextStatus =
+          body.action === "VERIFY" || body.action === "REACTIVATE"
+            ? ("ACTIVE" as const)
+            : body.action === "SUSPEND"
+              ? ("SUSPENDED" as const)
+              : ("DEACTIVATED" as const);
 
-      return next;
+        await transitionOrganization(tx, {
+          where: { id: orgId },
+          to: nextStatus,
+          // #779 §A — VERIFY clears the resubmit-loop sub-state.
+          data:
+            body.action === "VERIFY"
+              ? {
+                  verificationReason: null,
+                  verificationSubmittedAt: null,
+                  verificationRejectedAt: null,
+                }
+              : undefined,
+          audit: {
+            organizationId: orgId,
+            actorMembershipId: null,
+            category: "SYSTEM",
+            action: actionKey,
+            description: `Admin ${body.action.toLowerCase()}: ${current.status} → ${nextStatus}`,
+            details: {
+              adminUserId: auth.session.user.id,
+              from: current.status,
+              to: nextStatus,
+              reason: body.reason ?? null,
+            },
+          },
+        });
+      }
+
+      // updateMany returns no row — re-read in-tx for the response body.
+      return tx.organization.findUniqueOrThrow({ where: { id: orgId } });
     });
 
     return NextResponse.json({ organization: updated });

--- a/app/api/cleanup/abandoned-org-top-ups/route.ts
+++ b/app/api/cleanup/abandoned-org-top-ups/route.ts
@@ -16,6 +16,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { cleanupAbandonedOrgTopUps } from "@/scripts/cleanup/cleanup-abandoned-org-top-ups";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get("authorization");
@@ -46,6 +47,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("[cleanup/abandoned-org-top-ups] failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/abandoned-payments/route.ts
+++ b/app/api/cleanup/abandoned-payments/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 import {
   cleanupAbandonedPayments,
   cleanupExpiredApprovalPendingPayments,
@@ -31,6 +32,11 @@ export async function POST(req: NextRequest) {
       overallSuccess: paymentResult.success && consultationResult.success,
     });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Cleanup API route failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/alert-dispute-deadlines/route.ts
+++ b/app/api/cleanup/alert-dispute-deadlines/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { alertDisputeDeadlines } from "@/scripts/disputes/alert-dispute-deadlines";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -36,6 +37,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error checking dispute deadlines:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/alert-orphaned-payments/route.ts
+++ b/app/api/cleanup/alert-orphaned-payments/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { alertOrphanedPayments } from "@/scripts/alerts/alert-orphaned-payments";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -37,6 +38,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in orphaned payments alert:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/appointment-reminders/route.ts
+++ b/app/api/cleanup/appointment-reminders/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { sendAppointmentReminders } from "@/scripts/appointments/send-appointment-reminders";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -33,6 +34,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in appointment reminders:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/archive-webhook-events/route.ts
+++ b/app/api/cleanup/archive-webhook-events/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { archiveWebhookEvents } from "@/scripts/cleanup/archive-webhook-events";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -34,6 +35,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in webhook event archive:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/auth-tokens/route.ts
+++ b/app/api/cleanup/auth-tokens/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { cleanupAuthTokens } from "@/scripts/cleanup/cleanup-auth-tokens";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -35,6 +36,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in auth token cleanup:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/auto-complete-appointments/route.ts
+++ b/app/api/cleanup/auto-complete-appointments/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { autoCompleteAppointments } from "@/scripts/appointments/auto-complete-appointments";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -35,6 +36,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in auto-complete appointments:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/auto-complete-trials/route.ts
+++ b/app/api/cleanup/auto-complete-trials/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { TrialSessionStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -26,22 +27,29 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     const now = new Date();
 
-    const result = await prisma.trialSession.updateMany({
-      where: {
-        status: TrialSessionStatus.SCHEDULED,
-        appointment: {
-          slotsOfAppointment: {
-            some: {
-              endsAt: { lt: now },
+    // #476 — entry-level cron lock; fail-open (idempotent updateMany).
+    const result = await withCronLock(
+      "auto-complete-trials",
+      { failMode: "open" },
+      async () => {
+        return prisma.trialSession.updateMany({
+          where: {
+            status: TrialSessionStatus.SCHEDULED,
+            appointment: {
+              slotsOfAppointment: {
+                some: {
+                  endsAt: { lt: now },
+                },
+              },
             },
           },
-        },
+          data: {
+            status: TrialSessionStatus.COMPLETED,
+            completedAt: now,
+          },
+        });
       },
-      data: {
-        status: TrialSessionStatus.COMPLETED,
-        completedAt: now,
-      },
-    });
+    );
 
     console.log(
       JSON.stringify({
@@ -56,6 +64,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       trialsCompleted: result.count,
     });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in auto-complete-trials cleanup:", error);
     return NextResponse.json(
       { success: false, error: "Failed to auto-complete trial sessions" },

--- a/app/api/cleanup/cascade-refund-earnings/route.ts
+++ b/app/api/cleanup/cascade-refund-earnings/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { cascadeRefundToEarnings } from "@/scripts/refunds/cascade-refund-earnings";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -36,6 +37,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result);
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in refund-earning cascade:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/deactivate-expired-discounts/route.ts
+++ b/app/api/cleanup/deactivate-expired-discounts/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { deactivateExpiredDiscounts } from "@/scripts/cleanup/deactivate-expired-discounts";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -34,6 +35,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in discount deactivation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/dispatch-outbound-webhooks/route.ts
+++ b/app/api/cleanup/dispatch-outbound-webhooks/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextResponse, type NextRequest } from "next/server";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 import {
   dispatchOutboundWebhooks,
   disconnectDatabase,
@@ -32,6 +33,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const result = await dispatchOutboundWebhooks();
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("[cleanup/dispatch-outbound-webhooks] failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/expire-stale-requests/route.ts
+++ b/app/api/cleanup/expire-stale-requests/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { expireStaleRequests } from "@/scripts/appointments/expire-stale-requests";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -34,6 +35,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in stale request expiration:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/handle-lost-disputes/route.ts
+++ b/app/api/cleanup/handle-lost-disputes/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { handleLostDisputes } from "@/scripts/disputes/handle-lost-disputes";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -41,6 +42,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in lost dispute handler:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/handle-stuck-payouts/route.ts
+++ b/app/api/cleanup/handle-stuck-payouts/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { handleStuckPayouts } from "@/scripts/payouts/handle-stuck-payouts";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -35,6 +36,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in stuck payouts handler:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/invalid-appointments/route.ts
+++ b/app/api/cleanup/invalid-appointments/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { timingSafeEqual } from "crypto";
 import { runAllCleanupTasks } from "@/scripts/appointments/cleanup-invalid-appointments";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest) {
   try {
@@ -43,6 +44,11 @@ export async function POST(req: NextRequest) {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Invalid appointments cleanup API route failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/mark-expired-recordings/route.ts
+++ b/app/api/cleanup/mark-expired-recordings/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 import { streamLogger } from "@/lib/stream-logger";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -23,13 +24,23 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     streamLogger.info("Starting mark-expired-recordings cron");
 
-    const expiredCount = await RecordingTransferService.markExpiredRecordings();
+    // #476 — same lock key as the GH Actions entry (jobs/stream/...).
+    const expiredCount = await withCronLock(
+      "mark-expired-recordings",
+      { failMode: "open" },
+      () => RecordingTransferService.markExpiredRecordings(),
+    );
 
     return NextResponse.json({
       success: true,
       expiredCount,
     });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     streamLogger.error("Mark expired recordings cron failed", error);
     return NextResponse.json(
       { error: "Cron job failed" },

--- a/app/api/cleanup/old-stream-recordings/route.ts
+++ b/app/api/cleanup/old-stream-recordings/route.ts
@@ -7,6 +7,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { cleanupOldStreamRecordings } from "@/scripts/cleanup/cleanup-old-stream-recordings";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get("authorization");
@@ -23,6 +24,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const result = await cleanupOldStreamRecordings();
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     return NextResponse.json(
       {
         error: "Stream retention sweep failed",

--- a/app/api/cleanup/process-data-exports/route.ts
+++ b/app/api/cleanup/process-data-exports/route.ts
@@ -6,6 +6,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { processDataExports } from "@/scripts/cleanup/process-data-exports";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get("authorization");
@@ -18,6 +19,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const result = await processDataExports();
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     return NextResponse.json(
       {
         error: "Data export tick failed",

--- a/app/api/cleanup/prune-audit-logs/route.ts
+++ b/app/api/cleanup/prune-audit-logs/route.ts
@@ -6,6 +6,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { pruneAuditLogs } from "@/scripts/cleanup/prune-audit-logs";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get("authorization");
@@ -19,6 +20,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const result = await pruneAuditLogs();
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     return NextResponse.json(
       {
         error: "Audit prune failed",

--- a/app/api/cleanup/reconcile-disputes/route.ts
+++ b/app/api/cleanup/reconcile-disputes/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { reconcileDisputes } from "@/scripts/disputes/reconcile-disputes";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -42,6 +43,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result);
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in dispute reconciliation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/reconcile-document-storage/route.ts
+++ b/app/api/cleanup/reconcile-document-storage/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { reconcileDocumentStorage } from "@/scripts/cleanup/reconcile-document-storage";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -38,6 +39,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in document storage reconciliation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/reconcile-payment-status/route.ts
+++ b/app/api/cleanup/reconcile-payment-status/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { reconcilePaymentStatus } from "@/scripts/payments/reconcile-payment-status";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -38,6 +39,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in payment reconciliation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/reconcile-payout-status/route.ts
+++ b/app/api/cleanup/reconcile-payout-status/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { reconcilePayoutStatus } from "@/scripts/payouts/reconcile-payout-status";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -40,6 +41,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in payout reconciliation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/reconcile-refunds/route.ts
+++ b/app/api/cleanup/reconcile-refunds/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { reconcilePendingRefunds } from "@/scripts/refunds/reconcile-pending-refunds";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -35,6 +36,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result);
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in refund reconciliation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/reconcile-sessions/route.ts
+++ b/app/api/cleanup/reconcile-sessions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { reconcileOrphanedSessions } from "@/jobs/meetings/reconcile-orphaned-sessions";
 import { getMaintenanceState } from "@/lib/maintenance";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest) {
   try {
@@ -30,6 +31,11 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(result);
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Reconcile sessions API route failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/reconcile-slot-availability/route.ts
+++ b/app/api/cleanup/reconcile-slot-availability/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { reconcileSlotAvailability } from "@/scripts/appointments/reconcile-slot-availability";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -38,6 +39,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in slot reconciliation:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/release-earnings/route.ts
+++ b/app/api/cleanup/release-earnings/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { releaseEarningsFromHold } from "@/scripts/earnings/release-earnings";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -33,6 +34,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result);
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in earnings release:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/sso-cert-expiry-alert/route.ts
+++ b/app/api/cleanup/sso-cert-expiry-alert/route.ts
@@ -11,6 +11,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { runSsoCertExpiryAlert } from "@/scripts/cleanup/sso-cert-expiry-alert";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get("authorization");
@@ -40,6 +41,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("[cleanup/sso-cert-expiry-alert] failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/stale-invitations/route.ts
+++ b/app/api/cleanup/stale-invitations/route.ts
@@ -11,6 +11,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { cleanupStaleInvitations } from "@/scripts/cleanup/cleanup-stale-invitations";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const authHeader = req.headers.get("authorization");
@@ -39,6 +40,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("[cleanup/stale-invitations] failed:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/stale-pending-consultations/route.ts
+++ b/app/api/cleanup/stale-pending-consultations/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { cleanupStalePendingConsultations } from "@/scripts/appointments/cleanup-stale-pending-consultations";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -33,6 +34,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in stale consultation cleanup:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/sweep-abandoned-overage-charges/route.ts
+++ b/app/api/cleanup/sweep-abandoned-overage-charges/route.ts
@@ -5,6 +5,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { sweepAbandonedOverageCharges } from "@/scripts/cleanup/sweep-abandoned-overage-charges";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -23,6 +24,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     });
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run) skips
+    // with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in abandoned overage-charge sweep:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/sweep-orphaned-topup-captures/route.ts
+++ b/app/api/cleanup/sweep-orphaned-topup-captures/route.ts
@@ -4,6 +4,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { sweepOrphanedTopupCaptures } from "@/scripts/cleanup/sweep-orphaned-topup-captures";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -25,6 +26,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const status = result.stillFailing > 0 ? 207 : 200;
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in captured-top-up sweep:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/sweep-stuck-webhook-events/route.ts
+++ b/app/api/cleanup/sweep-stuck-webhook-events/route.ts
@@ -8,6 +8,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { sweepStuckWebhookEvents } from "@/scripts/cleanup/sweep-stuck-webhook-events";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -32,6 +33,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const status = result.stillFailing > 0 ? 207 : 200;
     return NextResponse.json(result, { status });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in stuck-webhook sweep:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/sync-payment-earnings/route.ts
+++ b/app/api/cleanup/sync-payment-earnings/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { syncPaymentEarnings } from "@/scripts/earnings/sync-payment-earnings";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -36,6 +37,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result);
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in payment-earning sync:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/tentative-slots/route.ts
+++ b/app/api/cleanup/tentative-slots/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { cleanupTentativeSlots } from "@/scripts/appointments/cleanup-tentative-slots";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -33,6 +34,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(result, { status: result.success ? 200 : 500 });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("Error in tentative slot cleanup:", error);
     return NextResponse.json(
       {

--- a/app/api/cleanup/transfer-expiring-recordings/route.ts
+++ b/app/api/cleanup/transfer-expiring-recordings/route.ts
@@ -11,6 +11,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 import { streamLogger } from "@/lib/stream-logger";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -24,17 +25,25 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
     streamLogger.info("Starting transfer-expiring-recordings cron");
 
-    // Phase 1: Auto-transfer SUPABASE_PERMANENT recordings
-    const transferResult =
-      await RecordingTransferService.processExpiringRecordings(
-        5, // 5 days before expiry
-        10, // batch size
-        "SUPABASE_PERMANENT",
-      );
+    // #476 — both phases under one lock, same key as the GH Actions entry.
+    const { transferResult, expiringStreamOnly } = await withCronLock(
+      "transfer-expiring-recordings",
+      { failMode: "open" },
+      async () => {
+        // Phase 1: Auto-transfer SUPABASE_PERMANENT recordings
+        const transferResult =
+          await RecordingTransferService.processExpiringRecordings(
+            5, // 5 days before expiry
+            10, // batch size
+            "SUPABASE_PERMANENT",
+          );
 
-    // Phase 2: Find STREAM_ONLY recordings expiring soon (for notifications)
-    const expiringStreamOnly =
-      await RecordingTransferService.getExpiringStreamOnlyRecordings(3);
+        // Phase 2: Find STREAM_ONLY recordings expiring soon (for notifications)
+        const expiringStreamOnly =
+          await RecordingTransferService.getExpiringStreamOnlyRecordings(3);
+        return { transferResult, expiringStreamOnly };
+      },
+    );
 
     // TODO: Send Novu notifications to consultants with expiring STREAM_ONLY recordings
     // Group by consultant and send one notification per consultant
@@ -52,6 +61,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       errors: transferResult.errors,
     });
   } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     streamLogger.error("Transfer expiring recordings cron failed", error);
     return NextResponse.json(
       { error: "Cron job failed" },

--- a/app/api/organizations/[orgId]/billing-account/invoices/[invoiceId]/route.ts
+++ b/app/api/organizations/[orgId]/billing-account/invoices/[invoiceId]/route.ts
@@ -22,6 +22,7 @@ import { requireOrgAccess } from "@/lib/auth-helpers";
 // which are finance-team mutations; allow BILLING_ADMIN alongside OWNER.
 import { requireOrgBillingAdminOrOwner } from "@/lib/auth/billing-admin-gate";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { transitionOrgInvoice } from "@/lib/enterprise/transitions";
 
 const PatchStatusSchema = z.enum(["ISSUED", "CANCELLED", "VOID"]);
 
@@ -97,8 +98,10 @@ export async function PATCH(
         });
       }
 
-      // Status transitions — reject invalid combinations explicitly
-      // so the audit trail never has a misleading transition recorded.
+      // Route policy — narrower than the global INVOICE_ALLOWED_FROM on
+      // purpose: PAID/OVERDUE/REFUNDED are webhook- and cron-owned moves, not
+      // manual ones. This pre-check is the friendly error; the CAS below is
+      // the race-safe enforcement.
       if (body.status) {
         const allowed: Record<string, string[]> = {
           DRAFT: ["ISSUED", "CANCELLED"],
@@ -128,49 +131,30 @@ export async function PATCH(
         body.status !== undefined &&
         (body.status === "CANCELLED" || body.status === "VOID");
 
-      const next = await tx.organizationInvoice.update({
-        where: { id: invoiceId },
-        data: {
-          ...(body.status !== undefined && {
-            status: body.status,
-            ...(body.status === "ISSUED" && current.status === "DRAFT"
-              ? { issuedAt: new Date() }
-              : {}),
-          }),
-          ...(body.dueDate !== undefined && { dueDate: body.dueDate }),
-          ...(body.pdfUrl !== undefined && { pdfUrl: body.pdfUrl }),
-          ...(invalidatePdfCache && {
-            pdfStoragePath: null,
-            pdfGeneratedAt: null,
-          }),
-        },
-      });
-
-      // PO balance restoration on VOID / CANCELLED. The invoice POST
-      // route atomically decremented `PurchaseOrder.remainingAmountPaise`
-      // at issue time; when the invoice is now being voided or cancelled,
-      // atomically increment the PO balance back so the consumed budget
-      // is released. Unbounded increment is safe — we can never overshoot
-      // `totalAmountPaise` because we only restore amounts we previously
-      // took. The transition is already guarded by the allow-list above.
       const restorePoBalance =
         body.status &&
         body.status !== current.status &&
         (body.status === "VOID" || body.status === "CANCELLED") &&
         current.purchaseOrderId !== null;
 
-      if (restorePoBalance && current.purchaseOrderId) {
-        await tx.purchaseOrder.update({
-          where: { id: current.purchaseOrderId },
+      if (body.status) {
+        // CAS — a concurrent transition (e.g. the dunning cron flipping
+        // ISSUED → OVERDUE, or the payment webhook landing PAID) between the
+        // pre-check read and this write matches zero rows and 409s instead
+        // of voiding a paid invoice.
+        await transitionOrgInvoice(tx, {
+          where: { id: invoiceId, organizationId: orgId },
+          to: body.status,
           data: {
-            remainingAmountPaise: { increment: current.totalPaise },
+            ...(body.status === "ISSUED" ? { issuedAt: new Date() } : {}),
+            ...(body.dueDate !== undefined && { dueDate: body.dueDate }),
+            ...(body.pdfUrl !== undefined && { pdfUrl: body.pdfUrl }),
+            ...(invalidatePdfCache && {
+              pdfStoragePath: null,
+              pdfGeneratedAt: null,
+            }),
           },
-        });
-      }
-
-      if (body.status && body.status !== current.status) {
-        await tx.orgAuditLog.create({
-          data: {
+          audit: {
             organizationId: orgId,
             actorMembershipId: access.member.id,
             category: "INVOICE",
@@ -193,9 +177,39 @@ export async function PATCH(
           },
         });
 
+        // PO balance restoration on VOID / CANCELLED. The invoice POST
+        // route atomically decremented `PurchaseOrder.remainingAmountPaise`
+        // at issue time; when the invoice is now being voided or cancelled,
+        // atomically increment the PO balance back so the consumed budget
+        // is released. Unbounded increment is safe — we can never overshoot
+        // `totalAmountPaise` because we only restore amounts we previously
+        // took, and the CAS above guarantees this runs at most once per
+        // invoice (VOID/CANCELLED are terminal).
+        if (restorePoBalance && current.purchaseOrderId) {
+          await tx.purchaseOrder.update({
+            where: { id: current.purchaseOrderId },
+            data: {
+              remainingAmountPaise: { increment: current.totalPaise },
+            },
+          });
+        }
+      } else {
+        const scalarData = {
+          ...(body.dueDate !== undefined && { dueDate: body.dueDate }),
+          ...(body.pdfUrl !== undefined && { pdfUrl: body.pdfUrl }),
+        };
+        if (Object.keys(scalarData).length > 0) {
+          await tx.organizationInvoice.update({
+            where: { id: invoiceId },
+            data: scalarData,
+          });
+        }
       }
 
-      return next;
+      // updateMany returns no row — re-read in-tx for the response body.
+      return tx.organizationInvoice.findUniqueOrThrow({
+        where: { id: invoiceId },
+      });
     });
 
     return NextResponse.json({ invoice: updated });

--- a/app/api/organizations/[orgId]/billing-account/purchase-orders/[poId]/route.ts
+++ b/app/api/organizations/[orgId]/billing-account/purchase-orders/[poId]/route.ts
@@ -15,6 +15,8 @@ import { requireOrgAccess } from "@/lib/auth-helpers";
 // BILLING_ADMIN alongside OWNER while still excluding MAINTAINER. See
 // `lib/auth/billing-admin-gate.ts`.
 import { requireOrgBillingAdminOrOwner } from "@/lib/auth/billing-admin-gate";
+import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { transitionPurchaseOrder } from "@/lib/enterprise/transitions";
 
 const PoStatusSchema = z.enum(["ACTIVE", "CLOSED", "CANCELLED"]);
 
@@ -92,30 +94,77 @@ export async function PATCH(
           httpStatus: 404,
         });
       }
-      return tx.purchaseOrder.update({
-        where: { id: poId },
-        data: {
-          ...(body.status !== undefined && { status: body.status }),
-          ...(body.poDate !== undefined && { poDate: body.poDate }),
-          ...(body.validUntil !== undefined && { validUntil: body.validUntil }),
-          ...(body.totalAmountPaise !== undefined && {
-            totalAmountPaise: body.totalAmountPaise,
-          }),
-          ...(body.remainingAmountPaise !== undefined && {
-            remainingAmountPaise: body.remainingAmountPaise,
-          }),
-          ...(body.uploadedDocUrl !== undefined && {
-            uploadedDocUrl: body.uploadedDocUrl,
-          }),
-        },
-      });
+      // Money/term fields are only meaningful on an ACTIVE PO — editing them
+      // on a CLOSED/CANCELLED row is the same class of bug as terminal-state
+      // re-entry, so they share the CAS guard. The doc attachment is plain
+      // paperwork and stays editable in any state.
+      const moneyOrTermData = {
+        ...(body.poDate !== undefined && { poDate: body.poDate }),
+        ...(body.validUntil !== undefined && { validUntil: body.validUntil }),
+        ...(body.totalAmountPaise !== undefined && {
+          totalAmountPaise: body.totalAmountPaise,
+        }),
+        ...(body.remainingAmountPaise !== undefined && {
+          remainingAmountPaise: body.remainingAmountPaise,
+        }),
+      };
+      const docData = {
+        ...(body.uploadedDocUrl !== undefined && {
+          uploadedDocUrl: body.uploadedDocUrl,
+        }),
+      };
+
+      if (body.status !== undefined && body.status !== current.status) {
+        await transitionPurchaseOrder(tx, {
+          where: { id: poId, organizationId: orgId },
+          to: body.status,
+          data: { ...moneyOrTermData, ...docData },
+          audit: {
+            organizationId: orgId,
+            actorMembershipId: access.member.id,
+            category: "INVOICE", // PO lifecycle rides the INVOICE category (see OrgAuditCategory)
+            action:
+              body.status === "CLOSED"
+                ? AUDIT_ACTIONS.INVOICE.PURCHASE_ORDER_CLOSED
+                : AUDIT_ACTIONS.INVOICE.PURCHASE_ORDER_CANCELLED,
+            description: `PurchaseOrder ${poId}: ${current.status} → ${body.status}`,
+            details: { poId, from: current.status, to: body.status },
+          },
+        });
+      } else {
+        if (Object.keys(moneyOrTermData).length > 0) {
+          const res = await tx.purchaseOrder.updateMany({
+            where: { id: poId, organizationId: orgId, status: "ACTIVE" },
+            data: moneyOrTermData,
+          });
+          if (res.count === 0) {
+            throw Object.assign(
+              new Error(
+                "PO amounts and dates are immutable once the PO is closed or cancelled",
+              ),
+              { httpStatus: 409, code: "PO_NOT_ACTIVE" },
+            );
+          }
+        }
+        if (Object.keys(docData).length > 0) {
+          await tx.purchaseOrder.update({ where: { id: poId }, data: docData });
+        }
+      }
+
+      // updateMany returns no row — re-read in-tx for the response body.
+      return tx.purchaseOrder.findUniqueOrThrow({ where: { id: poId } });
     });
     return NextResponse.json({ purchaseOrder: updated });
   } catch (err) {
     if (err instanceof Error && "httpStatus" in err) {
       const status =
         typeof err.httpStatus === "number" ? err.httpStatus : 500;
-      return NextResponse.json({ error: err.message }, { status });
+      const code =
+        "code" in err && typeof err.code === "string" ? err.code : undefined;
+      return NextResponse.json(
+        { error: err.message, ...(code && { code }) },
+        { status },
+      );
     }
     throw err;
   }

--- a/app/api/organizations/[orgId]/contracts/[contractId]/route.ts
+++ b/app/api/organizations/[orgId]/contracts/[contractId]/route.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { transitionContract } from "@/lib/enterprise/transitions";
 import { getContractLockState } from "@/lib/enterprise/config-lock";
 
 // Term fields that lock once the contract leaves DRAFT or starts billing
@@ -205,48 +206,31 @@ export async function PATCH(
         }
       }
 
-      const next = await tx.contract.update({
-        where: { id: contractId },
-        data: {
-          ...(body.status !== undefined && { status: body.status }),
-          ...(body.signedAt !== undefined && { signedAt: body.signedAt }),
-          ...(body.effectiveFrom !== undefined && {
-            effectiveFrom: body.effectiveFrom,
-          }),
-          ...(body.effectiveTo !== undefined && {
-            effectiveTo: body.effectiveTo,
-          }),
-          ...(body.paymentTermsDays !== undefined && {
-            paymentTermsDays: body.paymentTermsDays,
-          }),
-          ...(body.autoRenew !== undefined && { autoRenew: body.autoRenew }),
-          ...(body.terms !== undefined && {
-            terms: JSON.parse(JSON.stringify(body.terms)),
-          }),
-          ...(body.purchaseOrderId !== undefined && {
-            purchaseOrderId: body.purchaseOrderId,
-          }),
-        },
-      });
+      const scalarData = {
+        ...(body.signedAt !== undefined && { signedAt: body.signedAt }),
+        ...(body.effectiveFrom !== undefined && {
+          effectiveFrom: body.effectiveFrom,
+        }),
+        ...(body.effectiveTo !== undefined && {
+          effectiveTo: body.effectiveTo,
+        }),
+        ...(body.paymentTermsDays !== undefined && {
+          paymentTermsDays: body.paymentTermsDays,
+        }),
+        ...(body.autoRenew !== undefined && { autoRenew: body.autoRenew }),
+        ...(body.terms !== undefined && {
+          terms: JSON.parse(JSON.stringify(body.terms)),
+        }),
+        ...(body.purchaseOrderId !== undefined && {
+          purchaseOrderId: body.purchaseOrderId,
+        }),
+      };
 
-      // #779 §A — TERMINATED cascade: a terminated contract takes its
-      // programs (ACTIVE → EXPIRED) and their still-ACTIVE assignments
-      // (→ CLOSED) down with it, in this same tx, so nothing is left
-      // drawing against a dead contract.
-      if (body.status === "TERMINATED" && current.status !== "TERMINATED") {
-        await tx.program.updateMany({
-          where: { contractId, status: "ACTIVE" },
-          data: { status: "EXPIRED" },
-        });
-        await tx.programAssignment.updateMany({
-          where: { program: { contractId }, status: "ACTIVE" },
-          data: { status: "CLOSED" },
-        });
-      }
-
-      // Status transitions get dedicated audit actions so the timeline
-      // reads cleanly; a plain "updated" line loses the lifecycle signal.
-      if (body.status && body.status !== current.status) {
+      if (body.status !== undefined && body.status !== current.status) {
+        // CAS — the allowed-from guard rides the WHERE, so a concurrent
+        // transition (or a stale tab re-activating a TERMINATED contract)
+        // matches zero rows and 409s. Status transitions get dedicated audit
+        // actions so the timeline reads cleanly.
         const action =
           body.status === "ACTIVE"
             ? AUDIT_ACTIONS.CONTRACT.CONTRACT_SIGNED
@@ -255,8 +239,11 @@ export async function PATCH(
               : body.status === "EXPIRED"
                 ? AUDIT_ACTIONS.CONTRACT.CONTRACT_EXPIRED
                 : AUDIT_ACTIONS.CONTRACT.CONTRACT_CREATED;
-        await tx.orgAuditLog.create({
-          data: {
+        await transitionContract(tx, {
+          where: { id: contractId, organizationId: orgId },
+          to: body.status,
+          data: scalarData,
+          audit: {
             organizationId: orgId,
             actorMembershipId: access.member.id,
             category: "CONTRACT",
@@ -269,9 +256,30 @@ export async function PATCH(
             },
           },
         });
+
+        // #779 §A — TERMINATED cascade: a terminated contract takes its
+        // programs (ACTIVE → EXPIRED) and their still-ACTIVE assignments
+        // (→ CLOSED) down with it, in this same tx, so nothing is left
+        // drawing against a dead contract.
+        if (body.status === "TERMINATED") {
+          await tx.program.updateMany({
+            where: { contractId, status: "ACTIVE" },
+            data: { status: "EXPIRED" },
+          });
+          await tx.programAssignment.updateMany({
+            where: { program: { contractId }, status: "ACTIVE" },
+            data: { status: "CLOSED" },
+          });
+        }
+      } else if (Object.keys(scalarData).length > 0) {
+        await tx.contract.update({
+          where: { id: contractId },
+          data: scalarData,
+        });
       }
 
-      return next;
+      // updateMany returns no row — re-read in-tx for the response body.
+      return tx.contract.findUniqueOrThrow({ where: { id: contractId } });
     });
 
     return NextResponse.json({ contract: updated });

--- a/app/api/organizations/[orgId]/members/[memberId]/route.ts
+++ b/app/api/organizations/[orgId]/members/[memberId]/route.ts
@@ -19,6 +19,7 @@ import { isAtLeastRole } from "@/lib/auth/role-ranks";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { dispatchWebhookEvent } from "@/lib/enterprise/outbound-webhooks/dispatch";
 import { isBlockedRoleTransition } from "@/lib/enterprise/role-transitions";
+import { transitionMembership } from "@/lib/enterprise/transitions";
 import {
   applyMembershipRoleEffects,
   bumpUserSessionGeneration,
@@ -210,24 +211,52 @@ export async function PATCH(
           ? patch.payoutRecipient
           : undefined;
 
-      const updated = await tx.membership.update({
-        where: { id: memberId },
-        data: {
-          ...(patch.role !== undefined && { role: patch.role }),
-          ...(patch.status !== undefined && { status: patch.status }),
-          ...(patch.departmentLabel !== undefined && {
-            departmentLabel: patch.departmentLabel,
-          }),
-          ...(roleEffects && {
-            consulteeProfileId: roleEffects.consulteeProfileId,
-            consultantProfileId: roleEffects.consultantProfileId,
-            payoutRecipient: roleEffects.payoutRecipient,
-          }),
-          ...(explicitPayoutRecipient !== undefined && {
-            payoutRecipient: explicitPayoutRecipient,
-          }),
-        },
-      });
+      // Status moves are CAS-guarded (a concurrent REMOVE/ERASE landing first
+      // matches zero rows and 409s instead of being resurrected); the
+      // remaining fields ride a plain update in the same tx.
+      if (patch.status !== undefined && patch.status !== current.status) {
+        await transitionMembership(tx, {
+          where: { id: memberId, organizationId: orgId },
+          to: patch.status,
+        });
+
+        // PATCH → REMOVED is the same operation as DELETE — run the same
+        // assignment cascade so the member's slot frees up (see the DELETE
+        // handler's rationale).
+        if (patch.status === "REMOVED") {
+          const now = new Date();
+          await tx.programAssignment.updateMany({
+            where: {
+              membershipId: memberId,
+              periodEnd: { gte: now },
+              status: { in: ["ACTIVE", "PAUSED"] },
+            },
+            data: { periodEnd: now, status: "CANCELLED" },
+          });
+        }
+      }
+
+      const otherData = {
+        ...(patch.role !== undefined && { role: patch.role }),
+        ...(patch.departmentLabel !== undefined && {
+          departmentLabel: patch.departmentLabel,
+        }),
+        ...(roleEffects && {
+          consulteeProfileId: roleEffects.consulteeProfileId,
+          consultantProfileId: roleEffects.consultantProfileId,
+          payoutRecipient: roleEffects.payoutRecipient,
+        }),
+        ...(explicitPayoutRecipient !== undefined && {
+          payoutRecipient: explicitPayoutRecipient,
+        }),
+      };
+      const updated =
+        Object.keys(otherData).length > 0
+          ? await tx.membership.update({
+              where: { id: memberId },
+              data: otherData,
+            })
+          : await tx.membership.findUniqueOrThrow({ where: { id: memberId } });
 
       // Bump the user's session-generation marker so the customSession
       // hook picks up the role / status change on their next request
@@ -438,10 +467,11 @@ export async function DELETE(
       // payouts, earnings, and wallet entries do too. A hard delete
       // would cascade across half the compliance tables. REMOVED is a
       // tombstone — it hides the row from all listing endpoints, blocks
-      // login attempts, but keeps the history queryable.
-      await tx.membership.update({
-        where: { id: memberId },
-        data: { status: "REMOVED" },
+      // login attempts, but keeps the history queryable. The CAS makes a
+      // concurrent double-DELETE 409 instead of re-running the cascade.
+      await transitionMembership(tx, {
+        where: { id: memberId, organizationId: orgId },
+        to: "REMOVED",
       });
 
       // Bump the user's session-generation marker so their next
@@ -483,9 +513,15 @@ export async function DELETE(
       // #779 §A — close the period AND stamp status=CANCELLED (member
       // removed mid-cycle) so the assignment lifecycle is explicit, not
       // inferred from periodEnd alone.
+      // Status guard: only live allocations cascade — a ROLLED/CLOSED row
+      // must never be re-stamped CANCELLED by a (forced) re-removal.
       const now = new Date();
       const terminated = await tx.programAssignment.updateMany({
-        where: { membershipId: memberId, periodEnd: { gte: now } },
+        where: {
+          membershipId: memberId,
+          periodEnd: { gte: now },
+          status: { in: ["ACTIVE", "PAUSED"] },
+        },
         data: { periodEnd: now, status: "CANCELLED" },
       });
 

--- a/app/api/organizations/[orgId]/programs/[programId]/route.ts
+++ b/app/api/organizations/[orgId]/programs/[programId]/route.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { transitionProgram } from "@/lib/enterprise/transitions";
 import { getProgramLockState } from "@/lib/enterprise/config-lock";
 
 const ProgramStatusSchema = z.enum([
@@ -272,21 +273,74 @@ export async function PATCH(
         }
       }
 
-      const next = await tx.program.update({
+      const programData = {
+        ...(body.name !== undefined && { name: body.name }),
+        ...(body.archived !== undefined && {
+          archivedAt: body.archived ? new Date() : null,
+        }),
+        ...(body.coveredPlanTypes !== undefined && {
+          coveredPlanTypes: body.coveredPlanTypes,
+        }),
+        ...(body.allowedCategories !== undefined && {
+          allowedCategories: body.allowedCategories,
+        }),
+      };
+
+      if (body.status !== undefined && body.status !== current.status) {
+        // CAS — allowed-from rides the WHERE (tenancy via the contract
+        // relation), so a concurrent transition or a stale tab reactivating a
+        // CANCELLED/EXPIRED program matches zero rows and 409s.
+        await transitionProgram(tx, {
+          where: { id: programId, contract: { organizationId: orgId } },
+          to: body.status,
+          data: programData,
+        });
+
+        // Cancelling must take the live assignments down in the same tx —
+        // otherwise members keep drawing entitlements from a dead program
+        // (checkout honors ACTIVE assignments). periodEnd: now mirrors the
+        // member-removal cascade so the periodEnd>=now filter dies with the
+        // status, not after it.
+        let assignmentsCancelled = 0;
+        if (body.status === "CANCELLED") {
+          const cascaded = await tx.programAssignment.updateMany({
+            where: { programId, status: { in: ["ACTIVE", "PAUSED"] } },
+            data: { status: "CANCELLED", periodEnd: new Date() },
+          });
+          assignmentsCancelled = cascaded.count;
+        }
+
+        await tx.orgAuditLog.create({
+          data: {
+            organizationId: orgId,
+            actorMembershipId: access.member.id,
+            category: "PROGRAM",
+            action:
+              body.status === "PAUSED"
+                ? AUDIT_ACTIONS.PROGRAM.PROGRAM_PAUSED
+                : body.status === "ACTIVE"
+                  ? AUDIT_ACTIONS.PROGRAM.PROGRAM_RESUMED
+                  : body.status === "CANCELLED"
+                    ? AUDIT_ACTIONS.PROGRAM.PROGRAM_CANCELLED
+                    : AUDIT_ACTIONS.PROGRAM.PROGRAM_EXPIRED,
+            description: `Program ${programId}: ${current.status} → ${body.status}`,
+            details: {
+              programId,
+              from: current.status,
+              to: body.status,
+              ...(body.status === "CANCELLED" && { assignmentsCancelled }),
+            },
+          },
+        });
+      } else if (Object.keys(programData).length > 0) {
+        await tx.program.update({
+          where: { id: programId },
+          data: programData,
+        });
+      }
+
+      const next = await tx.program.findUniqueOrThrow({
         where: { id: programId },
-        data: {
-          ...(body.name !== undefined && { name: body.name }),
-          ...(body.status !== undefined && { status: body.status }),
-          ...(body.archived !== undefined && {
-            archivedAt: body.archived ? new Date() : null,
-          }),
-          ...(body.coveredPlanTypes !== undefined && {
-            coveredPlanTypes: body.coveredPlanTypes,
-          }),
-          ...(body.allowedCategories !== undefined && {
-            allowedCategories: body.allowedCategories,
-          }),
-        },
       });
 
       // Per-type money fields route to the live config table. `type` is
@@ -356,29 +410,6 @@ export async function PATCH(
             action: AUDIT_ACTIONS.PROGRAM.PROGRAM_ARCHIVED,
             description: `Program ${programId} ${body.archived ? "archived" : "unarchived"}`,
             details: { programId, archived: body.archived },
-          },
-        });
-      }
-
-      // Status transitions get the dedicated PROGRAM_PAUSED action so
-      // the audit timeline shows the lifecycle event separately from a
-      // plain rename.
-      if (body.status && body.status !== current.status) {
-        await tx.orgAuditLog.create({
-          data: {
-            organizationId: orgId,
-            actorMembershipId: access.member.id,
-            category: "PROGRAM",
-            action:
-              body.status === "PAUSED"
-                ? AUDIT_ACTIONS.PROGRAM.PROGRAM_PAUSED
-                : AUDIT_ACTIONS.PROGRAM.PROGRAM_CREATED,
-            description: `Program ${programId}: ${current.status} → ${body.status}`,
-            details: {
-              programId,
-              from: current.status,
-              to: body.status,
-            },
           },
         });
       }

--- a/app/api/organizations/[orgId]/route.ts
+++ b/app/api/organizations/[orgId]/route.ts
@@ -13,10 +13,13 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { requireOrgAccess, requireOrgOwner } from "@/lib/auth-helpers";
 import { isAtLeastRole } from "@/lib/auth/role-ranks";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { transitionOrganization } from "@/lib/enterprise/transitions";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import { encryptPAN } from "@/lib/payments/tax/pan-crypto";
 
 const SizeBucketSchema = z.enum([
@@ -66,10 +69,22 @@ const PatchBodySchema = z
     defaultCancellationPolicy: z.string().max(5000).nullable().optional(),
     defaultRefundPolicy: z.string().max(5000).nullable().optional(),
     isPublic: z.boolean().optional(),
+    expectedVersion: z.coerce.number().int().min(1).optional(),
   })
   .refine((v) => Object.keys(v).length > 0, {
     message: "PATCH body must contain at least one field",
-  });
+  })
+  // Capability flips gate the whole billing/payout subsystem — a stale tab must
+  // get a 409, never last-write-wins. Other fields stay back-compatible.
+  .refine(
+    (v) =>
+      (v.canSponsor === undefined && v.canHost === undefined) ||
+      v.expectedVersion !== undefined,
+    {
+      message: "expectedVersion is required when changing capabilities",
+      path: ["expectedVersion"],
+    },
+  );
 
 export async function GET(
   _req: NextRequest,
@@ -184,7 +199,12 @@ export async function PATCH(
   }
 
   try {
-    const updated = await prisma.$transaction(async (tx) => {
+    // Serializable closes the TOCTOU between the wind-down COUNT checks below
+    // and the UPDATE (S2 in the state audit): a concurrent invoice/assignment
+    // insert aborts one side with P2034 (retried, then 503) instead of
+    // slipping into the window and stranding obligations behind a flipped flag.
+    const updated = await withSerializableRetry(() =>
+      prisma.$transaction(async (tx) => {
       const current = await tx.organization.findUnique({
         where: { id: orgId },
         include: { billingAccount: { select: { id: true, walletBalance: true } } },
@@ -193,6 +213,26 @@ export async function PATCH(
         throw Object.assign(new Error("Organization not found"), {
           httpStatus: 404,
         });
+      }
+
+      // Optimistic lock — a stale tab (multi-tab toggle race) 409s instead of
+      // last-write-wins. The CAS also takes the row lock, serializing the rich
+      // nested update below behind it.
+      if (body.expectedVersion !== undefined) {
+        const cas = await tx.organization.updateMany({
+          where: { id: orgId, version: body.expectedVersion },
+          data: { version: { increment: 1 } },
+        });
+        if (cas.count === 0) {
+          throw Object.assign(
+            new Error("Settings were changed in another session — reload and retry"),
+            {
+              httpStatus: 409,
+              code: "VERSION_CONFLICT",
+              currentVersion: current.version,
+            },
+          );
+        }
       }
 
       const nextCanSponsor = body.canSponsor ?? current.canSponsor;
@@ -455,7 +495,10 @@ export async function PATCH(
       });
 
       return next;
-    });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
 
     return NextResponse.json({ organization: updated });
   } catch (err) {
@@ -463,16 +506,36 @@ export async function PATCH(
       const status =
         typeof err.httpStatus === "number" ? err.httpStatus : 500;
       // #779 §A — forward the structured wind-down code + counts so the UI
-      // can render the per-blocker message instead of a bare 409.
+      // can render the per-blocker message instead of a bare 409. The
+      // VERSION_CONFLICT branch additionally carries currentVersion so the
+      // client can refetch-and-retry without an extra GET.
       const code =
         "code" in err && typeof err.code === "string" ? err.code : undefined;
       const counts =
         "counts" in err && err.counts && typeof err.counts === "object"
           ? err.counts
           : undefined;
+      const currentVersion =
+        "currentVersion" in err && typeof err.currentVersion === "number"
+          ? err.currentVersion
+          : undefined;
       return NextResponse.json(
-        { error: err.message, ...(code && { code }), ...(counts && { counts }) },
+        {
+          error: err.message,
+          ...(code && { code }),
+          ...(counts && { counts }),
+          ...(currentVersion !== undefined && { currentVersion }),
+        },
         { status },
+      );
+    }
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2034"
+    ) {
+      return NextResponse.json(
+        { error: "Transaction conflict — please retry", code: "P2034" },
+        { status: 503 },
       );
     }
     throw err;
@@ -575,12 +638,13 @@ export async function DELETE(
 
       // Soft delete: name/slug/GSTIN/PAN stay (issued invoices reference
       // them — statutory retention); personal contact details are scrubbed
-      // per DPDP. DEACTIVATED is already terminal for every billing,
-      // membership, and notification surface via the org-status tuples.
-      await tx.organization.update({
+      // per DPDP. The CAS in transitionOrganization makes DEACTIVATED
+      // unreachable from itself — a concurrent second DELETE 409s instead of
+      // re-stamping deletedAt.
+      await transitionOrganization(tx, {
         where: { id: orgId },
+        to: "DEACTIVATED",
         data: {
-          status: "DEACTIVATED",
           deletedAt: new Date(),
           billingEmail: null,
           billingContactName: null,
@@ -590,9 +654,7 @@ export async function DELETE(
           supportContactEmail: null,
           escalationContactEmail: null,
         },
-      });
-      await tx.orgAuditLog.create({
-        data: {
+        audit: {
           organizationId: orgId,
           actorMembershipId: access.member.id,
           category: "SETTINGS",

--- a/app/api/organizations/[orgId]/webhooks/[endpointId]/deliveries/[deliveryId]/redeliver/route.ts
+++ b/app/api/organizations/[orgId]/webhooks/[endpointId]/deliveries/[deliveryId]/redeliver/route.ts
@@ -68,8 +68,14 @@ export async function POST(
           { httpStatus: 409 },
         );
       }
-      const next = await tx.outboundWebhookDelivery.update({
-        where: { id: deliveryId },
+      // CAS — only settled rows may be replayed. PENDING is already queued,
+      // RETRY already has a slot, and resetting an IN_FLIGHT row mid-delivery
+      // would double-send and orphan the worker's claim.
+      const requeued = await tx.outboundWebhookDelivery.updateMany({
+        where: {
+          id: deliveryId,
+          status: { in: ["SUCCESS", "FAILED", "DEAD_LETTER"] },
+        },
         // Reset attempt counters + clear retry slot so the worker
         // treats this as a fresh PENDING row at the next tick.
         data: {
@@ -81,6 +87,17 @@ export async function POST(
           signature: null,
           deliveredAt: null,
         },
+      });
+      if (requeued.count === 0) {
+        throw Object.assign(
+          new Error(
+            "Delivery is already queued or in flight — only settled (success/failed/dead-letter) deliveries can be replayed.",
+          ),
+          { httpStatus: 409 },
+        );
+      }
+      const next = await tx.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id: deliveryId },
       });
       await tx.orgAuditLog.create({
         data: {

--- a/app/dashboard/organization/[orgId]/settings/page.tsx
+++ b/app/dashboard/organization/[orgId]/settings/page.tsx
@@ -70,6 +70,8 @@ interface SettingsResponse {
   profile: {
     id: string;
     status: OrgStatus;
+    // Optimistic-lock clock — echoed back as expectedVersion on PATCH.
+    version: number;
     canSponsor: boolean;
     canHost: boolean;
     billingEmail: string | null;
@@ -112,6 +114,7 @@ interface PatchPayload {
   gstin?: string | null;
   gstStateCode?: string | null;
   gstRegStatus?: GstRegStatus;
+  expectedVersion?: number;
 }
 
 async function patchSettings(orgId: string, payload: PatchPayload) {
@@ -121,7 +124,14 @@ async function patchSettings(orgId: string, payload: PatchPayload) {
     body: JSON.stringify(payload),
   });
   const body = await res.json();
-  if (!res.ok) throw new Error(body.error || "Failed to update settings");
+  if (!res.ok) {
+    // Carry the structured code so onError can branch (VERSION_CONFLICT →
+    // stale-tab dialog instead of the generic error banner).
+    throw Object.assign(new Error(body.error || "Failed to update settings"), {
+      code: body.code as string | undefined,
+      currentVersion: body.currentVersion as number | undefined,
+    });
+  }
   return body;
 }
 
@@ -160,6 +170,10 @@ export default function OrgSettingsPage({
   const [pendingDisable, setPendingDisable] = useState<
     null | "canSponsor" | "canHost"
   >(null);
+  // Stale-tab write rejected by the server's version CAS (409
+  // VERSION_CONFLICT) — the dialog offers a reload instead of silently
+  // letting last-write-wins eat the other session's changes.
+  const [conflictOpen, setConflictOpen] = useState(false);
 
   useEffect(() => {
     if (!data) return;
@@ -187,6 +201,8 @@ export default function OrgSettingsPage({
         description: description.trim() || null,
         industry: industry.trim() || null,
         website: website.trim() || null,
+        // Optimistic lock — the server CASes on this and 409s a stale tab.
+        ...(data && { expectedVersion: data.profile.version }),
         ...(isAtLeast("OWNER") && {
           slug: slug.trim() || undefined,
           billingEmail: billingEmail.trim() || null,
@@ -202,7 +218,12 @@ export default function OrgSettingsPage({
       setError(null);
       setTimeout(() => setSuccess(false), 2500);
     },
-    onError: (err: Error) => {
+    onError: (err: Error & { code?: string }) => {
+      if (err.code === "VERSION_CONFLICT") {
+        setConflictOpen(true);
+        setSuccess(false);
+        return;
+      }
       setError(err.message);
       setSuccess(false);
     },
@@ -678,6 +699,33 @@ export default function OrgSettingsPage({
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction onClick={confirmCapabilityDisable}>
                 Disable
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        <AlertDialog open={conflictOpen} onOpenChange={setConflictOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Settings changed elsewhere</AlertDialogTitle>
+              <AlertDialogDescription>
+                Another session (a second tab, or a teammate) saved these
+                settings after you loaded this page. Your change was not
+                applied. Reload to see the latest values, then make your edit
+                again.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogAction
+                onClick={() => {
+                  setConflictOpen(false);
+                  // Refetch resets every form field via the data-sync effect.
+                  queryClient.invalidateQueries({
+                    queryKey: ["org-settings", orgId],
+                  });
+                }}
+              >
+                Reload settings
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/docs/enterprise/70-design-decisions/00-README.md
+++ b/docs/enterprise/70-design-decisions/00-README.md
@@ -37,3 +37,4 @@ All twelve ADRs below are written and live (#793); this index is the authoritati
 | 10 | [Session-generation clock](10-session-generation-clock.md) | Role changes bump `User.sessionGeneration` to force a membership refetch instead of revoking sessions. |
 | 11 | [Live-payout submission freeze](11-live-payout-submission-freeze.md) | `ENABLE_LIVE_PAYOUTS` freezes only the gateway submission step; the whole pipeline upstream of it runs for real. |
 | 12 | [PENDING_TRUST earnings parking](12-pending-trust-earnings-parking.md) | Earnings for unverified INVOICE-funded orgs park in `PENDING_TRUST` until the org verifies or pays, closing the ghost-org fraud hole (#687). |
+| 13 | [Postgres-native concurrency](13-postgres-native-concurrency.md) | State transitions are guarded by CAS WHERE clauses, Serializable retries, version columns, and Redis cron locks — no Kafka, RabbitMQ, Temporal, or Inngest at this stage. |

--- a/docs/enterprise/70-design-decisions/13-postgres-native-concurrency.md
+++ b/docs/enterprise/70-design-decisions/13-postgres-native-concurrency.md
@@ -1,0 +1,152 @@
+---
+title: Postgres-native concurrency control over message queues and workflow engines
+band: 70-design-decisions
+audience: sde3
+status: live
+last-reviewed: 2026-06-10
+---
+
+# ADR 13 — Concurrency control is Postgres-native; no Kafka, RabbitMQ, Temporal, or Inngest
+
+## Context
+
+A staff-level audit of the enterprise subsystem (June 2026) examined every
+state surface for races, crashes, and abuse: the `canSponsor`/`canHost`
+capability axes, eleven lifecycle status enums, multi-tab settings editing,
+cron concurrency, and webhook delivery. The recurring bug class it found was
+read–check–blind-write: a route reads a row, validates a transition or an
+invariant against that snapshot, and then writes unconditionally. Under
+Postgres's default READ COMMITTED isolation, two concurrent requests can both
+pass the check against the pre-image and both commit — two browser tabs could
+disable `canSponsor` and `canHost` simultaneously even though the route
+guards against ever having both false, and a concurrent admin action could
+resurrect a terminal state (`TERMINATED` contract back to `ACTIVE`).
+
+The audit also raised the build-versus-adopt question every growing system
+hits: should the platform adopt a message broker (Kafka, RabbitMQ), a durable
+workflow engine (Temporal, Inngest, Trigger.dev), or keep state in Postgres?
+This document records the decision so it does not get re-litigated each time
+an incident or a conference talk makes one of those tools look attractive.
+
+## Decision
+
+We do not adopt any message broker or external workflow engine at this stage.
+Postgres remains the single source of truth for all state, and concurrency
+control is layered onto it with four mechanisms, each matched to a different
+contention profile.
+
+**Layer 1 — status-CAS transitions.** Every lifecycle status move goes
+through `lib/enterprise/transitions.ts`, which bakes the declarative
+allowed-from set into the UPDATE's WHERE clause
+(`updateMany({ where: { id, status: { in: ALLOWED_FROM[to] } } })`). Postgres
+re-evaluates the predicate under the row lock, so two racing transitions
+serialize and exactly one wins; the loser matches zero rows and surfaces a
+409 `IllegalTransitionError`. The WHERE clause is the state machine —
+app-level pre-checks remain only for friendly error text. Terminal states
+appear in no allowed-from set, which makes terminal re-entry structurally
+impossible rather than a matter of reviewer vigilance.
+
+**Layer 2 — Serializable isolation with bounded retry.** Where an invariant
+spans multiple rows (the capability wind-down checks count invoices,
+assignments, experts, and payouts before allowing a flip), a CAS on one row
+cannot help. Those transactions run at `isolationLevel: "Serializable"` and
+are wrapped in `withSerializableRetry` (`lib/db/serializable-retry.ts`),
+which retries only Prisma error P2034 with jittered exponential backoff and
+maps exhaustion to a 503. Business rejections (409s) are never retried.
+These call sites are rare and low-traffic by construction — settings and
+governance changes, not checkout paths.
+
+**Layer 3 — version-column optimistic locking.** Human-edited settings rows
+(`Organization`, `OrganizationPayoutAccount`, `OrganizationSSOSettings`)
+carry a `version Int @default(1)`. The client echoes the version it loaded;
+the PATCH CASes on it (`updateMany({ where: { id, version } })`) and
+increments, so a stale tab receives a 409 `VERSION_CONFLICT` with the current
+version, and the dashboard shows a "settings changed elsewhere" dialog that
+reloads the form. Capability flips require the version token; other fields
+accept it optionally for back-compatibility. Status transitions do not need
+version columns because they CAS on the status column itself.
+
+**Layer 4 — Redis locks for cron mutual exclusion only.** Every cron job
+entry is wrapped in `withCronLock` (`lib/cron/with-cron-lock.ts`, issue
+#476), which takes a `cron:lock:<jobName>` lock via the existing
+`acquireLock`/`releaseLock` helpers. Redis is never load-bearing for data
+correctness — that is what layers 1–3 and the unique constraints are for —
+it only prevents the wasteful and noisy double-runs that schedule overlap,
+`workflow_dispatch` re-runs, and the GitHub-Actions-plus-HTTP double entry
+can produce.
+
+## Redis degradation policy
+
+Upstash Redis is a separate failure domain from Postgres, so the lock layer
+defines explicit behaviour for when it is absent or unreachable. Money jobs
+(payouts, dunning, invoice generation, overage sweeps, earnings releases)
+are **fail-closed**: with no real lock available they refuse to run, exit
+non-zero, and the workflow's notify-on-failure step pages an operator —
+a missed schedule is recoverable, an unlocked double-run of dunning emails is
+not. Cleanup and alert jobs are **fail-open**: they run unlocked with a
+warning, because their side effects are harmless to repeat. A held lock is
+always a clean skip (exit 0 from GitHub Actions, HTTP 409 from the
+CRON_SECRET routes) since the next schedule retries. Four jobs
+(`process-payouts`, `create-payout-batch`, `approval-payments`,
+`stream-sync`) keep their pre-existing internal resource locks from #620 and
+are not double-wrapped.
+
+## Why not the alternatives
+
+**Kafka and RabbitMQ** solve high-throughput event distribution to long-lived
+consumers. Netlify functions cannot host long-lived consumers at all — every
+broker integration would require new always-on infrastructure — and Upstash
+deprecated its serverless Kafka product over exactly this mismatch. At this
+platform's event volume (well under one event per second), a Postgres jobs
+table with `SKIP LOCKED` outperforms the operational cost of a broker by
+orders of magnitude. The realistic trigger to revisit is sustained four-digit
+events per second with multiple independent consumer groups needing replay,
+which is not on any current roadmap.
+
+**Temporal** is genuinely the strongest answer to "what if the server crashes
+mid-workflow," but self-hosting it costs a meaningful fraction of a full-time
+engineer plus a Cassandra/Postgres cluster, and Temporal Cloud adds an
+external dependency and a per-action bill for flows that are currently two to
+four steps long. Our flows fit the simpler pattern Temporal itself recommends
+below its complexity threshold: state rows in Postgres with status columns,
+idempotency keys, and reconcile sweepers that re-drive half-finished work
+(`capturedAt` pre-stamps, orphan sweeps, stuck-payout handling). A crash
+mid-transaction rolls back atomically; a crash between side effects is
+re-driven by the sweepers.
+
+**Inngest / Trigger.dev / QStash** are lighter, but each inserts a hosted
+control plane between our cron triggers and our money flows. Inngest's
+August 2024 outage froze all customer function execution for 46 minutes —
+with DB-backed state and GitHub Actions crons, the equivalent failure mode
+degrades to rows sitting in PENDING until the next scheduled run, which is
+the failure mode we already handle.
+
+The revisit thresholds, recorded so the next discussion starts from criteria
+rather than vibes: adopt a durable workflow engine (evaluate DBOS, pgflow,
+or Inngest first, Temporal Cloud second) when a business flow exceeds
+roughly five sequential steps with waits measured in hours, or when sweeper
+re-drive logic starts duplicating orchestration the engine would own; adopt
+QStash or a queue when event volume sustains roughly 1k events/second or a
+fan-out needs more than one consumer of the same stream. Kafka is
+effectively never justified for this product shape.
+
+## Consequences
+
+Application code must use the helpers rather than ad-hoc writes: status
+moves call the typed `transition*` wrappers, multi-row invariant checks run
+Serializable with retry, settings PATCHes thread `expectedVersion`, and new
+cron jobs wrap their core in `withCronLock` and classify themselves
+fail-open or fail-closed. The unit tests in
+`__tests__/enterprise/transitions.test.ts` assert every legal edge and that
+terminal states appear in no allowed-from set, so widening a lifecycle is a
+reviewed map change, not a scattered route edit.
+
+Because there is no `prisma/migrations` directory (the schema is applied
+with `db push` pre-MVP), database-level CHECK constraints and triggers are
+not currently expressible. The CAS WHERE clauses are therefore the
+enforcement layer. Follow-ups once `prisma migrate` is adopted: add CHECK
+constraints mirroring the terminal-state sets and the
+`canSponsor OR canHost` invariant as defence in depth; extend version
+columns to `BillingAccount` and `WebhookEndpoint` settings; thread
+`expectedVersion` through the SSO and payout-account clients the way the
+settings page does.

--- a/jobs/alerts/alert-orphaned-payments.ts
+++ b/jobs/alerts/alert-orphaned-payments.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/alerts/alert-orphaned-payments";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -71,6 +72,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in orphaned payments alert:", error);
     process.exit(1);
   } finally {

--- a/jobs/appointments/auto-complete-appointments.ts
+++ b/jobs/appointments/auto-complete-appointments.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/appointments/auto-complete-appointments";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -81,6 +82,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in auto-complete appointments:", error);
     process.exit(1);
   } finally {

--- a/jobs/appointments/cleanup-invalid-appointments.ts
+++ b/jobs/appointments/cleanup-invalid-appointments.ts
@@ -14,6 +14,7 @@ import {
 
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions using environment files
@@ -88,6 +89,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     console.error("💥 Cleanup job failed:", errorMessage);

--- a/jobs/appointments/cleanup-stale-pending-consultations.ts
+++ b/jobs/appointments/cleanup-stale-pending-consultations.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/appointments/cleanup-stale-pending-consultations";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -72,6 +73,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in stale consultation cleanup:", error);
     process.exit(1);
   } finally {

--- a/jobs/appointments/cleanup-tentative-slots.ts
+++ b/jobs/appointments/cleanup-tentative-slots.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/appointments/cleanup-tentative-slots";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -72,6 +73,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in tentative slot cleanup:", error);
     process.exit(1);
   } finally {

--- a/jobs/appointments/expire-stale-requests.ts
+++ b/jobs/appointments/expire-stale-requests.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/appointments/expire-stale-requests";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -77,6 +78,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in stale request expiration:", error);
     process.exit(1);
   } finally {

--- a/jobs/appointments/reconcile-slot-availability.ts
+++ b/jobs/appointments/reconcile-slot-availability.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/appointments/reconcile-slot-availability";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -103,6 +104,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in slot reconciliation:", error);
     process.exit(1);
   } finally {

--- a/jobs/appointments/send-appointment-reminders.ts
+++ b/jobs/appointments/send-appointment-reminders.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/appointments/send-appointment-reminders";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -73,6 +74,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in appointment reminders:", error);
     process.exit(1);
   } finally {

--- a/jobs/billing/advance-program-cycles.ts
+++ b/jobs/billing/advance-program-cycles.ts
@@ -37,6 +37,7 @@ import {
   resolveProgramCycle,
 } from "@/lib/enterprise/cycle-engine";
 import { Prisma } from "@prisma/client";
+import { withCronLock, CronLockHeldError, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Bounded scan — one batch per run; the next tick drains the remainder.
 const BATCH_SIZE = 500;
@@ -214,7 +215,11 @@ async function main() {
   console.log(
     `[advance-program-cycles] Starting at ${new Date().toISOString()}`,
   );
-  const stats = await runAdvanceProgramCycles();
+  const stats = await withCronLock(
+    "advance-program-cycles",
+    { failMode: "closed", ttlMs: LONG_JOB_TTL_MS },
+    () => runAdvanceProgramCycles(),
+  );
   console.log(
     `[advance-program-cycles] Done. scanned=${stats.scanned} rolled=${stats.rolled} closed=${stats.closed} skipped=${stats.skipped}`,
   );
@@ -224,6 +229,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[advance-program-cycles] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/billing/dunning.ts
+++ b/jobs/billing/dunning.ts
@@ -30,6 +30,7 @@ import prisma from "@/lib/prisma";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { notifyOrgInvoiceOverdue } from "@/lib/novu/org-workflows";
 import { getAppUrl } from "@/lib/url";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 // #779 — 7-day cadence between escalations, capped at 3 reminders.
 const REMINDER_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -278,7 +279,11 @@ export async function runDunning(): Promise<DunningStats> {
 
 async function main() {
   console.log(`[dunning] Starting at ${new Date().toISOString()}`);
-  const stats = await runDunning();
+  const stats = await withCronLock(
+    "dunning",
+    { failMode: "closed" },
+    () => runDunning(),
+  );
   console.log(
     `[dunning] Done. scannedStage1=${stats.scannedStage1} markedOverdue=${stats.markedOverdue} scannedStage2=${stats.scannedStage2} remindersSent=${stats.remindersSent} suspended=${stats.suspended}`,
   );
@@ -287,6 +292,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[dunning] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/billing/generate-subscription-invoices.ts
+++ b/jobs/billing/generate-subscription-invoices.ts
@@ -35,6 +35,7 @@ import { BILLABLE_ORG_STATUSES } from "@/lib/enterprise/org-status";
 import { notifyOrgLicenseRenewalUpcoming } from "@/lib/novu/org-workflows";
 import { getAppUrl } from "@/lib/url";
 import { Currency, OrgInvoiceStatus, Prisma } from "@prisma/client";
+import { withCronLock, CronLockHeldError, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Reminder fires when nextInvoiceDate is within this many days. Once
 // per cycle (gated by BillingSubscription.renewalReminderSentAt).
@@ -304,12 +305,21 @@ async function main() {
   console.log(
     `[generate-subscription-invoices] Starting at ${new Date().toISOString()}`,
   );
-  await runGenerateSubscriptionInvoices();
+  await withCronLock(
+    "generate-subscription-invoices",
+    { failMode: "closed", ttlMs: LONG_JOB_TTL_MS },
+    () => runGenerateSubscriptionInvoices(),
+  );
 }
 
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[generate-subscription-invoices] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/billing/settle-invoice-accruals.ts
+++ b/jobs/billing/settle-invoice-accruals.ts
@@ -15,6 +15,7 @@ import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { abortIfMaintenance } from "@/lib/maintenance-cron";
 import { rollupOrgInvoiceAccruals } from "@/lib/payments/billing/invoice-rollup";
+import { withCronLock, CronLockHeldError, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 export async function settleInvoiceAccruals(): Promise<{
   orgsProcessed: number;
@@ -86,7 +87,11 @@ async function main() {
   console.log(
     `[settle-invoice-accruals] Starting at ${new Date().toISOString()}`,
   );
-  const r = await settleInvoiceAccruals();
+  const r = await withCronLock(
+    "settle-invoice-accruals",
+    { failMode: "closed", ttlMs: LONG_JOB_TTL_MS },
+    () => settleInvoiceAccruals(),
+  );
   console.log(
     `[settle-invoice-accruals] Done. orgsProcessed=${r.orgsProcessed} invoicesCreated=${r.invoicesCreated}`,
   );
@@ -95,6 +100,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[settle-invoice-accruals] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/billing/timeout-member-overages.ts
+++ b/jobs/billing/timeout-member-overages.ts
@@ -24,6 +24,7 @@ import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { notifyMemberOverageTimedOut } from "@/lib/novu/org-workflows";
 import { getAppUrl } from "@/lib/url";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 // #779 — 14-day window before a never-settled member overage times out.
 const TIMEOUT_DAYS = 14;
@@ -110,7 +111,11 @@ async function main() {
   console.log(
     `[timeout-member-overages] Starting at ${new Date().toISOString()}`,
   );
-  const stats = await runTimeoutMemberOverages();
+  const stats = await withCronLock(
+    "timeout-member-overages",
+    { failMode: "closed" },
+    () => runTimeoutMemberOverages(),
+  );
   console.log(
     `[timeout-member-overages] Done. scanned=${stats.scanned} timedOut=${stats.timedOut}`,
   );
@@ -119,6 +124,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[timeout-member-overages] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/billing/wallet-low-balance.ts
+++ b/jobs/billing/wallet-low-balance.ts
@@ -23,6 +23,7 @@ import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { notifyOrgWalletLow } from "@/lib/novu/org-workflows";
 import { getAppUrl } from "@/lib/url";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 const COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
@@ -96,7 +97,11 @@ export async function runWalletLowBalance(): Promise<WalletLowStats> {
 
 async function main() {
   console.log(`[wallet-low-balance] Starting at ${new Date().toISOString()}`);
-  const stats = await runWalletLowBalance();
+  const stats = await withCronLock(
+    "wallet-low-balance",
+    { failMode: "open" },
+    () => runWalletLowBalance(),
+  );
   console.log(
     `[wallet-low-balance] Done. scanned=${stats.scanned} notified=${stats.notified}`,
   );
@@ -105,6 +110,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[wallet-low-balance] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/cleanup/archive-webhook-events.ts
+++ b/jobs/cleanup/archive-webhook-events.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/cleanup/archive-webhook-events";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -76,6 +77,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in webhook archive:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/cleanup-abandoned-org-top-ups.ts
+++ b/jobs/cleanup/cleanup-abandoned-org-top-ups.ts
@@ -15,6 +15,7 @@ import {
 } from "../../scripts/cleanup/cleanup-abandoned-org-top-ups";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: AbandonedOrgTopUpCleanupResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -63,6 +64,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in abandoned org top-up cleanup:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/cleanup-auth-tokens.ts
+++ b/jobs/cleanup/cleanup-auth-tokens.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/cleanup/cleanup-auth-tokens";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -72,6 +73,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in auth token cleanup:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/cleanup-old-stream-recordings.ts
+++ b/jobs/cleanup/cleanup-old-stream-recordings.ts
@@ -14,6 +14,7 @@ import {
   type StreamRetentionResult,
 } from "../../scripts/cleanup/cleanup-old-stream-recordings";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: StreamRetentionResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -39,6 +40,11 @@ if (require.main === module) {
       outputToGitHubActions(result);
       if (!result.success) process.exit(1);
     } catch (err) {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("Fatal error:", err);
       process.exit(1);
     } finally {

--- a/jobs/cleanup/cleanup-stale-invitations.ts
+++ b/jobs/cleanup/cleanup-stale-invitations.ts
@@ -17,6 +17,7 @@ import {
   type StaleInvitationsCleanupResult,
 } from "../../scripts/cleanup/cleanup-stale-invitations";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: StaleInvitationsCleanupResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -60,6 +61,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in stale invitation cleanup:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/deactivate-expired-discounts.ts
+++ b/jobs/cleanup/deactivate-expired-discounts.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/cleanup/deactivate-expired-discounts";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -79,6 +80,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in discount deactivation:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/dispatch-outbound-webhooks.ts
+++ b/jobs/cleanup/dispatch-outbound-webhooks.ts
@@ -20,6 +20,7 @@ import {
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
 import prisma from "../../lib/prisma";
 import { recordSystemEvent } from "../../lib/enterprise/system-events";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 // The delivery table IS the queue (see worker.ts). If overdue rows pile up
 // past this, the worker isn't keeping pace — page someone (#776 §K).
@@ -74,6 +75,11 @@ if (require.main === module) {
       await checkQueueBacklog();
       if (!result.success) process.exit(1);
     } catch (err) {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("Fatal error:", err);
       process.exit(1);
     } finally {

--- a/jobs/cleanup/process-data-exports.ts
+++ b/jobs/cleanup/process-data-exports.ts
@@ -12,6 +12,7 @@ import {
   type DataExportResult,
 } from "../../scripts/cleanup/process-data-exports";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: DataExportResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -38,6 +39,11 @@ if (require.main === module) {
       outputToGitHubActions(result);
       if (!result.success) process.exit(1);
     } catch (err) {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("Fatal error:", err);
       process.exit(1);
     } finally {

--- a/jobs/cleanup/prune-audit-logs.ts
+++ b/jobs/cleanup/prune-audit-logs.ts
@@ -13,6 +13,7 @@ import {
   type AuditPruneResult,
 } from "../../scripts/cleanup/prune-audit-logs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: AuditPruneResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -40,6 +41,11 @@ if (require.main === module) {
       outputToGitHubActions(result);
       if (!result.success) process.exit(1);
     } catch (err) {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("Fatal error:", err);
       process.exit(1);
     } finally {

--- a/jobs/cleanup/reconcile-document-storage.ts
+++ b/jobs/cleanup/reconcile-document-storage.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/cleanup/reconcile-document-storage";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -80,6 +81,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in document storage reconciliation:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/release-pending-trust-earnings.ts
+++ b/jobs/cleanup/release-pending-trust-earnings.ts
@@ -27,6 +27,7 @@
 import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { EarningStatus } from "@prisma/client";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 export interface ReleasePendingTrustResult {
   scanned: number;
@@ -34,7 +35,17 @@ export interface ReleasePendingTrustResult {
   errors: string[];
 }
 
+// #476 — fail-closed: the CAS updateMany below is the correctness layer; this
+// lock is entry-level mutual exclusion for schedule overlap / manual re-runs.
 export async function runReleasePendingTrustEarnings(): Promise<ReleasePendingTrustResult> {
+  return withCronLock(
+    "release-pending-trust-earnings",
+    { failMode: "closed" },
+    () => runReleasePendingTrustEarningsUnlocked(),
+  );
+}
+
+async function runReleasePendingTrustEarningsUnlocked(): Promise<ReleasePendingTrustResult> {
   const result: ReleasePendingTrustResult = {
     scanned: 0,
     released: 0,
@@ -107,6 +118,11 @@ if (require.main === module) {
       process.exit(0);
     })
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        process.exit(0);
+      }
       console.error("Fatal:", err);
       process.exit(1);
     })

--- a/jobs/cleanup/sso-cert-expiry-alert.ts
+++ b/jobs/cleanup/sso-cert-expiry-alert.ts
@@ -15,6 +15,7 @@ import {
   type SsoCertExpiryAlertResult,
 } from "../../scripts/cleanup/sso-cert-expiry-alert";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: SsoCertExpiryAlertResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -62,6 +63,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in SSO cert expiry alert:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/sweep-abandoned-overage-charges.ts
+++ b/jobs/cleanup/sweep-abandoned-overage-charges.ts
@@ -10,6 +10,7 @@ import {
 } from "../../scripts/cleanup/sweep-abandoned-overage-charges";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: OverageSweepResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -36,6 +37,13 @@ async function main(): Promise<void> {
     console.log(`   Failed (ceiling freed): ${result.failed}`);
     outputToGitHubActions(result);
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct outcome
+    // (exit 0, no page). CronLockUnavailableError on this fail-closed job
+    // falls through to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in abandoned overage-charge sweep:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/sweep-orphaned-topup-captures.ts
+++ b/jobs/cleanup/sweep-orphaned-topup-captures.ts
@@ -10,6 +10,7 @@ import {
 } from "../../scripts/cleanup/sweep-orphaned-topup-captures";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: TopupCaptureSweepResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -50,6 +51,13 @@ async function main(): Promise<void> {
     }
     outputToGitHubActions(result);
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in captured-top-up sweep:", error);
     process.exit(1);
   } finally {

--- a/jobs/cleanup/sweep-stuck-webhook-events.ts
+++ b/jobs/cleanup/sweep-stuck-webhook-events.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/cleanup/sweep-stuck-webhook-events";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 function outputToGitHubActions(result: SweepResult): void {
   if (!process.env.GITHUB_ACTIONS) return;
@@ -57,6 +58,13 @@ async function main(): Promise<void> {
 
     outputToGitHubActions(result);
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in stuck-webhook sweep:", error);
     process.exit(1);
   } finally {

--- a/jobs/compliance/consent-retention-sweeper.ts
+++ b/jobs/compliance/consent-retention-sweeper.ts
@@ -25,6 +25,7 @@
 
 import prisma from "@/lib/prisma";
 import { abortIfMaintenance } from "@/lib/maintenance-cron";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 const DELETE_BATCH_SIZE = 500;
 const MAX_BATCHES_PER_RUN = 40; // caps total work at 20k rows / sweep
@@ -91,7 +92,11 @@ async function main() {
   console.log(
     `[consent-retention-sweeper] Starting at ${new Date().toISOString()}`,
   );
-  const r = await runConsentRetentionSweeper();
+  const r = await withCronLock(
+    "consent-retention-sweeper",
+    { failMode: "open" },
+    () => runConsentRetentionSweeper(),
+  );
   console.log(
     `[consent-retention-sweeper] Done. expired=${r.expired} deleted=${r.deleted} deleteMode=${r.deleteMode}`,
   );
@@ -100,6 +105,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[consent-retention-sweeper] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/compliance/databreach-deadline-alerts.ts
+++ b/jobs/compliance/databreach-deadline-alerts.ts
@@ -37,12 +37,24 @@ import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { Resend } from "resend";
 import { getAppUrl } from "@/lib/url";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 const REPORTING_DEADLINE_HOURS = 72;
 const WARN_HOURS_BEFORE_DEADLINE = 12; // surface breaches when ≤12h remain
 const MAX_ROWS_IN_EMAIL = 50;
 
+// #476 — entry-level cron lock; fail-open (repeat-safe side effects).
 export async function runDataBreachDeadlineAlerts(): Promise<{
+  atRisk: number;
+  overdue: number;
+  emailSent: boolean;
+}> {
+  return withCronLock("databreach-deadline-alerts", { failMode: "open" }, () =>
+    runDataBreachDeadlineAlertsUnlocked(),
+  );
+}
+
+async function runDataBreachDeadlineAlertsUnlocked(): Promise<{
   atRisk: number;
   overdue: number;
   emailSent: boolean;
@@ -164,6 +176,11 @@ if (require.main === module) {
       );
     })
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[DataBreach] cron failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/compliance/irp-uploader.ts
+++ b/jobs/compliance/irp-uploader.ts
@@ -32,6 +32,7 @@ import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { generateIrn } from "@/lib/compliance/irp";
 import { buildIrpPayload } from "@/lib/compliance/irp-payload";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 // #703 — platform-side seller constants. GSTIN mirrors the invoice-PDF
 // route (PLATFORM_GSTIN); the rest are env-overridable for a future
@@ -48,7 +49,18 @@ const SELLER = {
   stateCode: process.env.SUPPLIER_STATE_CODE ?? "KA",
 };
 
+// #476 — entry-level cron lock; fail-open (repeat-safe side effects).
 export async function runIrpUploader(): Promise<{
+  processed: number;
+  failed: number;
+  skipped: number;
+}> {
+  return withCronLock("irp-uploader", { failMode: "open" }, () =>
+    runIrpUploaderUnlocked(),
+  );
+}
+
+async function runIrpUploaderUnlocked(): Promise<{
   processed: number;
   failed: number;
   skipped: number;
@@ -216,6 +228,11 @@ export async function runIrpUploader(): Promise<{
 if (require.main === module) {
   runIrpUploader()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[IRP] uploader failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/compliance/msme-payment-alerts.ts
+++ b/jobs/compliance/msme-payment-alerts.ts
@@ -26,11 +26,23 @@ import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { Resend } from "resend";
 import { getAppUrl } from "@/lib/url";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 const ALERT_WINDOW_DAYS = 5;
 const MAX_ROWS_IN_EMAIL = 20;
 
+// #476 — entry-level cron lock; fail-open (repeat-safe side effects).
 export async function runMsmePaymentAlerts(): Promise<{
+  alerted: number;
+  atRisk: number;
+  emailSent: boolean;
+}> {
+  return withCronLock("msme-payment-alerts", { failMode: "open" }, () =>
+    runMsmePaymentAlertsUnlocked(),
+  );
+}
+
+async function runMsmePaymentAlertsUnlocked(): Promise<{
   alerted: number;
   atRisk: number;
   emailSent: boolean;
@@ -174,6 +186,11 @@ if (require.main === module) {
       );
     })
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[MSME] cron failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/contracts/auto-renew-contracts.ts
+++ b/jobs/contracts/auto-renew-contracts.ts
@@ -31,6 +31,7 @@ import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { Prisma } from "@prisma/client";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 const BATCH_SIZE = 500;
 
@@ -163,7 +164,11 @@ export async function runAutoRenewContracts(): Promise<RenewStats> {
 
 async function main() {
   console.log(`[auto-renew-contracts] Starting at ${new Date().toISOString()}`);
-  const stats = await runAutoRenewContracts();
+  const stats = await withCronLock(
+    "auto-renew-contracts",
+    { failMode: "open" },
+    () => runAutoRenewContracts(),
+  );
   console.log(
     `[auto-renew-contracts] Done. scanned=${stats.scanned} renewed=${stats.renewed} skipped=${stats.skipped}`,
   );
@@ -173,6 +178,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[auto-renew-contracts] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/contracts/expire-contracts.ts
+++ b/jobs/contracts/expire-contracts.ts
@@ -26,6 +26,7 @@
 import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 interface ExpireStats {
   scanned: number;
@@ -111,7 +112,11 @@ export async function runExpireContracts(): Promise<ExpireStats> {
 
 async function main() {
   console.log(`[expire-contracts] Starting at ${new Date().toISOString()}`);
-  const stats = await runExpireContracts();
+  const stats = await withCronLock(
+    "expire-contracts",
+    { failMode: "open" },
+    () => runExpireContracts(),
+  );
   console.log(
     `[expire-contracts] Done. scanned=${stats.scanned} expired=${stats.expired} assignmentsClosed=${stats.assignmentsClosed}`,
   );
@@ -122,6 +127,11 @@ async function main() {
 if (require.main === module) {
   main()
     .catch((err) => {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (err instanceof CronLockHeldError) {
+        console.log(`⏭️  ${err.message}`);
+        return;
+      }
       console.error("[expire-contracts] Failed:", err);
       process.exitCode = 1;
     })

--- a/jobs/disputes/alert-dispute-deadlines.ts
+++ b/jobs/disputes/alert-dispute-deadlines.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/disputes/alert-dispute-deadlines";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -75,6 +76,11 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in dispute deadline alert:", error);
     process.exit(1);
   } finally {

--- a/jobs/disputes/handle-lost-disputes.ts
+++ b/jobs/disputes/handle-lost-disputes.ts
@@ -15,6 +15,7 @@ import {
 } from "../../scripts/disputes/handle-lost-disputes";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -81,6 +82,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in lost dispute handler:", error);
     process.exit(1);
   } finally {

--- a/jobs/disputes/reconcile-disputes.ts
+++ b/jobs/disputes/reconcile-disputes.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/disputes/reconcile-disputes";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -78,6 +79,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in dispute reconciliation:", error);
     process.exit(1);
   } finally {

--- a/jobs/earnings/release-earnings.ts
+++ b/jobs/earnings/release-earnings.ts
@@ -15,6 +15,7 @@ import {
 
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions using environment files
@@ -74,6 +75,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     console.error("💥 Release earnings job failed:", errorMessage);

--- a/jobs/earnings/sync-payment-earnings.ts
+++ b/jobs/earnings/sync-payment-earnings.ts
@@ -15,6 +15,7 @@ import {
 } from "../../scripts/earnings/sync-payment-earnings";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -71,6 +72,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in payment-earning sync:", error);
     process.exit(1);
   } finally {

--- a/jobs/meetings/reconcile-orphaned-sessions.ts
+++ b/jobs/meetings/reconcile-orphaned-sessions.ts
@@ -20,6 +20,7 @@ import {
   isStreamConfigured,
 } from "../../lib/stream-client";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { withCronLock, CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 export interface ReconciliationResult {
   processed: number;
@@ -30,7 +31,14 @@ export interface ReconciliationResult {
   details: string[];
 }
 
+// #476 — entry-level cron lock; fail-open (repeat-safe side effects).
 export async function reconcileOrphanedSessions(): Promise<ReconciliationResult> {
+  return withCronLock("reconcile-orphaned-sessions", { failMode: "open" }, () =>
+    reconcileOrphanedSessionsUnlocked(),
+  );
+}
+
+async function reconcileOrphanedSessionsUnlocked(): Promise<ReconciliationResult> {
   const result: ReconciliationResult = {
     processed: 0,
     reconciled: 0,
@@ -165,6 +173,11 @@ if (require.main === module) {
 
       if (!result.success) process.exit(1);
     } catch (error) {
+      // #476 — lock held = another run is live; skip cleanly (exit 0).
+      if (error instanceof CronLockHeldError) {
+        console.log(`⏭️  ${error.message}`);
+        return;
+      }
       console.error("Fatal error:", error);
       process.exit(1);
     } finally {

--- a/jobs/payments/cleanup-abandoned-payments.ts
+++ b/jobs/payments/cleanup-abandoned-payments.ts
@@ -16,6 +16,7 @@ import {
 
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions using environment files
@@ -95,6 +96,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error";
     console.error("💥 Cleanup job failed:", errorMessage);

--- a/jobs/payments/reconcile-payment-status.ts
+++ b/jobs/payments/reconcile-payment-status.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/payments/reconcile-payment-status";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -86,6 +87,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in payment reconciliation:", error);
     process.exit(1);
   } finally {

--- a/jobs/payouts/handle-stuck-payouts.ts
+++ b/jobs/payouts/handle-stuck-payouts.ts
@@ -18,6 +18,7 @@ import {
   recordSystemEvent,
   recordSystemError,
 } from "../../lib/enterprise/system-events";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -104,6 +105,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in stuck payouts handler:", error);
     await recordSystemError({
       category: "PAYOUT",

--- a/jobs/payouts/reconcile-payout-status.ts
+++ b/jobs/payouts/reconcile-payout-status.ts
@@ -14,6 +14,7 @@ import {
 } from "../../scripts/payouts/reconcile-payout-status";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -103,6 +104,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in payout reconciliation:", error);
     process.exit(1);
   } finally {

--- a/jobs/reconcile/reconcile-ledgers.ts
+++ b/jobs/reconcile/reconcile-ledgers.ts
@@ -23,6 +23,7 @@ import {
   recordSystemEvent,
   recordSystemError,
 } from "../../lib/enterprise/system-events";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 async function main(): Promise<void> {
   await abortIfMaintenance("reconcile-ledgers");
@@ -79,6 +80,11 @@ async function main(): Promise<void> {
       process.exit(2);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in ledger reconciliation:", error);
     // #776 §K — a crashed auditor means we're flying blind on money integrity.
     await recordSystemError({

--- a/jobs/refunds/cascade-refund-earnings.ts
+++ b/jobs/refunds/cascade-refund-earnings.ts
@@ -15,6 +15,7 @@ import {
 } from "../../scripts/refunds/cascade-refund-earnings";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -71,6 +72,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in refund-earning cascade:", error);
     process.exit(1);
   } finally {

--- a/jobs/refunds/reconcile-pending-refunds.ts
+++ b/jobs/refunds/reconcile-pending-refunds.ts
@@ -15,6 +15,7 @@ import {
 } from "../../scripts/refunds/reconcile-pending-refunds";
 import fs from "fs";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
 
 /**
  * Output results to GitHub Actions
@@ -79,6 +80,13 @@ async function main(): Promise<void> {
       process.exit(1);
     }
   } catch (error) {
+    // #476 — lock held = another run is live; skipping is the correct
+    // outcome (exit 0, no page). CronLockUnavailableError falls through
+    // to exit 1 so the workflow's notify step pages.
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("❌ Fatal error in refund reconciliation:", error);
     process.exit(1);
   } finally {

--- a/jobs/stream/mark-expired-recordings.ts
+++ b/jobs/stream/mark-expired-recordings.ts
@@ -8,6 +8,10 @@
 
 import { RecordingTransferService } from "../../lib/stream/recording-transfer-service";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import {
+  withCronLock,
+  CronLockHeldError,
+} from "../../lib/cron/with-cron-lock";
 import fs from "fs";
 
 async function main(): Promise<void> {
@@ -17,8 +21,12 @@ async function main(): Promise<void> {
   console.log(`   Timestamp: ${new Date().toISOString()}`);
 
   try {
-    const expiredCount =
-      await RecordingTransferService.markExpiredRecordings();
+    // #476 — entry-level cron lock; fail-open (repeat-safe side effects).
+    const expiredCount = await withCronLock(
+      "mark-expired-recordings",
+      { failMode: "open" },
+      () => RecordingTransferService.markExpiredRecordings(),
+    );
 
     const duration = (Date.now() - startTime) / 1000;
     console.log(`\n⏱️ Job completed in ${duration.toFixed(2)} seconds`);
@@ -33,6 +41,11 @@ async function main(): Promise<void> {
 
     console.log("🎉 Job completed successfully");
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("💥 Job failed:", error);
     if (process.env.GITHUB_ACTIONS && process.env.GITHUB_OUTPUT) {
       fs.appendFileSync(process.env.GITHUB_OUTPUT, "success=false\n");

--- a/jobs/stream/transfer-expiring-recordings.ts
+++ b/jobs/stream/transfer-expiring-recordings.ts
@@ -9,6 +9,10 @@
 
 import { RecordingTransferService } from "../../lib/stream/recording-transfer-service";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import {
+  withCronLock,
+  CronLockHeldError,
+} from "../../lib/cron/with-cron-lock";
 import fs from "fs";
 
 async function main(): Promise<void> {
@@ -18,16 +22,25 @@ async function main(): Promise<void> {
   console.log(`   Timestamp: ${new Date().toISOString()}`);
 
   try {
-    // Auto-transfer SUPABASE_PERMANENT recordings expiring in 5 days
-    const result = await RecordingTransferService.processExpiringRecordings(
-      5,
-      10,
-      "SUPABASE_PERMANENT",
-    );
+    // #476 — both steps under one entry-level lock; fail-open.
+    const { result, expiringStreamOnly } = await withCronLock(
+      "transfer-expiring-recordings",
+      { failMode: "open" },
+      async () => {
+        // Auto-transfer SUPABASE_PERMANENT recordings expiring in 5 days
+        const result =
+          await RecordingTransferService.processExpiringRecordings(
+            5,
+            10,
+            "SUPABASE_PERMANENT",
+          );
 
-    // Find STREAM_ONLY recordings expiring in 3 days (for warnings)
-    const expiringStreamOnly =
-      await RecordingTransferService.getExpiringStreamOnlyRecordings(3);
+        // Find STREAM_ONLY recordings expiring in 3 days (for warnings)
+        const expiringStreamOnly =
+          await RecordingTransferService.getExpiringStreamOnlyRecordings(3);
+        return { result, expiringStreamOnly };
+      },
+    );
 
     const duration = (Date.now() - startTime) / 1000;
     console.log(`\n⏱️ Job completed in ${duration.toFixed(2)} seconds`);
@@ -53,6 +66,11 @@ async function main(): Promise<void> {
 
     console.log("🎉 Job completed successfully");
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
     console.error("💥 Job failed:", error);
     if (process.env.GITHUB_ACTIONS && process.env.GITHUB_OUTPUT) {
       fs.appendFileSync(process.env.GITHUB_OUTPUT, "success=false\n");

--- a/jobs/waitlist/process-expired-notifications.ts
+++ b/jobs/waitlist/process-expired-notifications.ts
@@ -9,6 +9,7 @@ import { processExpiredNotifications, handleSlotOpening } from "@/lib/waitlist";
 import { sendWaitlistExpiredEmail } from "@/lib/waitlist/notifications";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
 import { getAppUrl } from "../../lib/url";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface ProcessExpiredResult {
   processed: number;
@@ -25,7 +26,14 @@ export interface ProcessExpiredResult {
  * 3. Send expiration notification email
  * 4. Notify next person in queue
  */
+// #476 — entry-level cron lock; fail-open (repeat-safe side effects).
 export async function processExpiredNotificationsJob(): Promise<ProcessExpiredResult> {
+  return withCronLock("process-expired-notifications", { failMode: "open" }, () =>
+    processExpiredNotificationsJobUnlocked(),
+  );
+}
+
+async function processExpiredNotificationsJobUnlocked(): Promise<ProcessExpiredResult> {
   await abortIfMaintenance("process-expired-notifications");
   const startTime = Date.now();
   const errors: Array<{ id: string; error: string }> = [];

--- a/jobs/waitlist/send-expiration-reminders.ts
+++ b/jobs/waitlist/send-expiration-reminders.ts
@@ -9,6 +9,7 @@ import prisma from "@/lib/prisma";
 import { WaitlistStatus } from "@prisma/client";
 import { sendWaitlistExpiringEmail } from "@/lib/waitlist/notifications";
 import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface SendRemindersResult {
   found: number;
@@ -24,7 +25,14 @@ export interface SendRemindersResult {
  * 2. Send reminder email
  * 3. Mark as reminded
  */
+// #476 — entry-level cron lock; fail-open (repeat-safe side effects).
 export async function sendExpirationRemindersJob(): Promise<SendRemindersResult> {
+  return withCronLock("send-expiration-reminders", { failMode: "open" }, () =>
+    sendExpirationRemindersJobUnlocked(),
+  );
+}
+
+async function sendExpirationRemindersJobUnlocked(): Promise<SendRemindersResult> {
   await abortIfMaintenance("send-expiration-reminders");
   const startTime = Date.now();
   const errors: Array<{ id: string; error: string }> = [];

--- a/lib/compliance/erasure/scrub-user.ts
+++ b/lib/compliance/erasure/scrub-user.ts
@@ -140,6 +140,18 @@ export async function scrubUser(
         where: { userId, status: { in: ["PENDING", "ACTIVE", "SUSPENDED"] } },
         data: { status: "ERASED" },
       });
+      // ERASED is terminal — without this, an erased member's live
+      // allocations keep counting against program caps and entitlements,
+      // same as the member-removal cascade (members route). Status-guarded
+      // so ROLLED/CLOSED history is never re-stamped.
+      await tx.programAssignment.updateMany({
+        where: {
+          membershipId: { in: memberships.map((m) => m.id) },
+          periodEnd: { gte: now },
+          status: { in: ["ACTIVE", "PAUSED"] },
+        },
+        data: { periodEnd: now, status: "CANCELLED" },
+      });
     }
 
     // Free-text PII on profiles (best-effort — fields may or may not

--- a/lib/cron/with-cron-lock.ts
+++ b/lib/cron/with-cron-lock.ts
@@ -1,0 +1,81 @@
+import { acquireLock, releaseLock, isMockRedis, checkRedisHealth } from "@/lib/redis";
+
+/**
+ * #476 — distributed mutual exclusion for cron job entries. Schedule overlap,
+ * workflow_dispatch re-runs, and the GH-Actions + CRON_SECRET HTTP double
+ * entry can all run the same job twice; jobs whose side effects are only
+ * partially idempotent (dunning emails, notify fan-outs) must not double-run.
+ *
+ * This wraps the CORE function (scripts/** or lib/**) so every entry point
+ * inherits the lock. It is for mutual exclusion only — data correctness comes
+ * from the CAS transitions and unique constraints, never from this lock
+ * (Redis is a different failure domain than Postgres; see ADR 13).
+ */
+export class CronLockHeldError extends Error {
+  readonly httpStatus = 409 as const;
+  readonly code = "CRON_LOCK_HELD" as const;
+  constructor(readonly jobName: string) {
+    super(`${jobName} is already running — skipped (cron lock held)`);
+    this.name = "CronLockHeldError";
+  }
+}
+
+/** A fail-closed job refused to run because no real Redis lock is possible. */
+export class CronLockUnavailableError extends Error {
+  readonly code = "CRON_LOCK_UNAVAILABLE" as const;
+  constructor(readonly jobName: string) {
+    super(
+      `${jobName} is fail-closed and requires a real Redis lock, but Redis is not configured or unreachable`,
+    );
+    this.name = "CronLockUnavailableError";
+  }
+}
+
+const DEFAULT_TTL_MS = 15 * 60 * 1000; // workflows set timeout-minutes: 10
+/** Payout/reconcile family runs up to 30 min (ADR 05) — lock must outlive it. */
+export const LONG_JOB_TTL_MS = 35 * 60 * 1000;
+
+export interface CronLockOpts {
+  ttlMs?: number;
+  /**
+   * closed — money jobs: without a real lock the job refuses to run and the
+   *   workflow's notify-on-failure step pages (silent unlocked double-runs of
+   *   dunning/payout sweeps are worse than a missed schedule).
+   * open — cleanup/alert jobs: run unlocked with a warning when Redis is
+   *   absent; their side effects are harmless to repeat.
+   */
+  failMode: "open" | "closed";
+}
+
+export async function withCronLock<T>(
+  jobName: string,
+  opts: CronLockOpts,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = `cron:lock:${jobName}`;
+
+  if (isMockRedis()) {
+    if (opts.failMode === "closed") throw new CronLockUnavailableError(jobName);
+    console.warn(
+      `[${jobName}] Redis not configured — running UNLOCKED (fail-open)`,
+    );
+    return fn();
+  }
+
+  // acquireLock returns null for BOTH "held" and "circuit open". Held is a
+  // clean skip; an unreachable Redis on a fail-closed job must page instead —
+  // otherwise money jobs freeze silently for as long as the outage lasts.
+  if (opts.failMode === "closed") {
+    const healthy = await checkRedisHealth();
+    if (!healthy) throw new CronLockUnavailableError(jobName);
+  }
+
+  const token = await acquireLock(key, opts.ttlMs ?? DEFAULT_TTL_MS);
+  if (!token) throw new CronLockHeldError(jobName);
+
+  try {
+    return await fn();
+  } finally {
+    await releaseLock(key, token); // never throws; TTL is the safety net
+  }
+}

--- a/lib/db/serializable-retry.ts
+++ b/lib/db/serializable-retry.ts
@@ -1,0 +1,36 @@
+import { Prisma } from "@prisma/client";
+
+const SERIALIZABLE_MAX_RETRIES = 3;
+
+/**
+ * Retries a function that may fail due to Prisma serialization conflicts
+ * (P2034) with jittered exponential backoff. Only the isolation-level abort is
+ * transient — anything else (IllegalTransitionError, VERSION_CONFLICT 409s,
+ * validation errors) propagates immediately so business rejections are never
+ * retried into accidental success.
+ */
+export async function withSerializableRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries = SERIALIZABLE_MAX_RETRIES,
+): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      const isSerializationFailure =
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2034";
+
+      if (!isSerializationFailure || attempt === maxRetries) {
+        throw error;
+      }
+
+      // 50/100/200ms + jitter so two retrying writers don't re-collide in step.
+      const backoffMs = 50 * 2 ** attempt + Math.random() * 25;
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+
+  // Unreachable, but satisfies TypeScript
+  throw new Error("withSerializableRetry: exhausted retries");
+}

--- a/lib/enterprise/audit-actions.ts
+++ b/lib/enterprise/audit-actions.ts
@@ -48,6 +48,12 @@ export const AUDIT_ACTIONS = {
   PROGRAM: {
     PROGRAM_CREATED: "PROGRAM_CREATED",
     PROGRAM_PAUSED: "PROGRAM_PAUSED",
+    // Lifecycle actions for the remaining ProgramStatus edges — the PATCH
+    // route previously fell back to PROGRAM_CREATED for resume/cancel/expire,
+    // which corrupted the timeline signal.
+    PROGRAM_RESUMED: "PROGRAM_RESUMED",
+    PROGRAM_CANCELLED: "PROGRAM_CANCELLED",
+    PROGRAM_EXPIRED: "PROGRAM_EXPIRED",
     // #779 — cycle engine rolled an assignment to its next period.
     PROGRAM_ASSIGNMENT_ROLLED: "PROGRAM_ASSIGNMENT_ROLLED",
     // #777 §B — archive/unarchive (soft-hide; financial history preserved).
@@ -70,6 +76,9 @@ export const AUDIT_ACTIONS = {
   },
   INVOICE: {
     PURCHASE_ORDER_CREATED: "PURCHASE_ORDER_CREATED",
+    // PO lifecycle — the PATCH route previously wrote no audit row at all.
+    PURCHASE_ORDER_CLOSED: "PURCHASE_ORDER_CLOSED",
+    PURCHASE_ORDER_CANCELLED: "PURCHASE_ORDER_CANCELLED",
     INVOICE_GENERATED: "INVOICE_GENERATED",
     INVOICE_ISSUED: "INVOICE_ISSUED",
     // #779 — dunning cron flipped ISSUED → OVERDUE.

--- a/lib/enterprise/outbound-webhooks/worker.ts
+++ b/lib/enterprise/outbound-webhooks/worker.ts
@@ -286,10 +286,13 @@ export async function runDispatchTick(params: {
     // Retry path — 5xx / 408 / 429 / network error.
     const nextAttemptNumber = attemptNumber + 1;
     if (attemptNumber >= MAX_ATTEMPTS) {
+      // DEAD_LETTER, not FAILED: delivery-starved (receiver may be fine
+      // tomorrow), operator-replayable via /redeliver. FAILED stays the
+      // receiver-rejected terminal (permanent 4xx / endpoint paused).
       await prisma.outboundWebhookDelivery.update({
         where: { id: row.id },
         data: {
-          status: "FAILED",
+          status: "DEAD_LETTER",
           httpStatusCode: httpStatusCode ?? null,
           signature,
           attempts: attemptNumber,

--- a/lib/enterprise/transitions.ts
+++ b/lib/enterprise/transitions.ts
@@ -1,0 +1,351 @@
+import type { Tx } from "@/lib/prisma";
+/**
+ * Central guarded status transitions for every enterprise lifecycle enum —
+ * the generalization of `lib/payments/billing/overage-transitions.ts`, which
+ * stays the reference implementation for OverageChargeStatus (its richer
+ * recovery edges are owned by the settlement call sites; see #812).
+ *
+ * The doctrine (docs/enterprise/70-design-decisions/13-postgres-native-concurrency.md):
+ * the allowed-from set is baked into the UPDATE's WHERE clause, so an illegal
+ * transition — terminal-state re-entry, a concurrent admin action landing
+ * first, a stale tab — matches zero rows instead of corrupting state. The
+ * WHERE clause is the state machine; app-level pre-checks are only friendly
+ * error text. Postgres re-evaluates the predicate under the row lock, so two
+ * racing transitions serialize and exactly one wins.
+ *
+ * Maps are keyed by TARGET state (same orientation as overage-transitions):
+ * `ALLOWED_FROM[to]` lists the only states the row may currently be in.
+ * Deliberately dependency-light (Prisma types only) so routes and jobs can
+ * import it without dragging in heavy graphs.
+ */
+import type {
+  AssignmentStatus,
+  ContractStatus,
+  MemberStatus,
+  OrgAuditCategory,
+  OrgInvoiceStatus,
+  OrgPayoutAccountStatus,
+  OrgStatus,
+  PayoutStatus,
+  PoStatus,
+  Prisma,
+  ProgramStatus,
+  WalletTopUpStatus,
+} from "@prisma/client";
+
+export class IllegalTransitionError extends Error {
+  readonly httpStatus = 409 as const;
+  readonly code = "ILLEGAL_TRANSITION" as const;
+  constructor(
+    readonly entity: string,
+    readonly to: string,
+  ) {
+    super(
+      `${entity} cannot transition to ${to}: row missing, out of scope, or not in an allowed from-state`,
+    );
+    this.name = "IllegalTransitionError";
+  }
+}
+
+/** In-tx OrgAuditLog row, written only after the CAS succeeds. */
+interface AuditSpec {
+  organizationId: string;
+  actorMembershipId: string | null;
+  category: OrgAuditCategory;
+  action: string;
+  description: string;
+  details?: Prisma.InputJsonValue;
+}
+
+interface TransitionArgs<S extends string, D> {
+  /** id plus tenancy scope (e.g. organizationId) — the CAS guard is appended to this. */
+  where: { id: string } & Record<string, unknown>;
+  to: S;
+  /** Extra columns stamped in the same UPDATE. */
+  data?: D;
+  audit?: AuditSpec;
+}
+
+// Shared post-CAS tail: throw on zero rows, then (and only then) audit.
+// Cascades are NOT a hook — callers sequence them after the call in the same
+// tx, which also lets cascade counts land in the audit details.
+async function finalize(
+  tx: Pick<Tx, "orgAuditLog">,
+  entity: string,
+  to: string,
+  count: number,
+  audit?: AuditSpec,
+): Promise<void> {
+  if (count === 0) throw new IllegalTransitionError(entity, to);
+  if (audit) await tx.orgAuditLog.create({ data: audit });
+}
+
+/** States with no outgoing edge — reconcile jobs may assert these never change. */
+function terminalsOf<S extends string>(allowed: Record<S, S[]>): ReadonlySet<S> {
+  const froms = new Set(Object.values<S[]>(allowed).flat());
+  return new Set((Object.keys(allowed) as S[]).filter((s) => !froms.has(s)));
+}
+
+//////////////////////////////////////////////////// Organization ////////////////////////////////////////////////////
+
+// REJECT is a sub-state stamp (verificationReason/-RejectedAt), not a status
+// move — the org stays PENDING_VERIFICATION through the resubmit loop (#779 §A).
+export const ORG_ALLOWED_FROM: Record<OrgStatus, OrgStatus[]> = {
+  PENDING_VERIFICATION: [], // entry state only
+  ACTIVE: ["PENDING_VERIFICATION", "SUSPENDED"],
+  SUSPENDED: ["ACTIVE"],
+  DEACTIVATED: ["PENDING_VERIFICATION", "ACTIVE", "SUSPENDED"],
+};
+
+export async function transitionOrganization(
+  tx: Pick<Tx, "organization" | "orgAuditLog">,
+  args: TransitionArgs<
+    OrgStatus,
+    Omit<Prisma.OrganizationUncheckedUpdateManyInput, "status" | "version">
+  >,
+): Promise<void> {
+  const res = await tx.organization.updateMany({
+    where: { ...args.where, status: { in: ORG_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "Organization", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// Contract ////////////////////////////////////////////////////
+
+// AMENDMENT/RENEWAL create successor rows (supersession chain) — terminal
+// contracts are never mutated, so EXPIRED/TERMINATED have no outgoing edges.
+export const CONTRACT_ALLOWED_FROM: Record<ContractStatus, ContractStatus[]> = {
+  DRAFT: [],
+  ACTIVE: ["DRAFT"],
+  EXPIRED: ["ACTIVE"],
+  TERMINATED: ["ACTIVE"],
+};
+
+export async function transitionContract(
+  tx: Pick<Tx, "contract" | "orgAuditLog">,
+  args: TransitionArgs<
+    ContractStatus,
+    Omit<Prisma.ContractUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.contract.updateMany({
+    where: { ...args.where, status: { in: CONTRACT_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "Contract", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// Program ////////////////////////////////////////////////////
+
+// Programs are created ACTIVE (no DRAFT). Cancelling must cascade
+// assignments → CANCELLED in the same tx — sequence it after this call.
+export const PROGRAM_ALLOWED_FROM: Record<ProgramStatus, ProgramStatus[]> = {
+  ACTIVE: ["PAUSED"],
+  PAUSED: ["ACTIVE"],
+  EXPIRED: ["ACTIVE", "PAUSED"],
+  CANCELLED: ["ACTIVE", "PAUSED"],
+};
+
+export async function transitionProgram(
+  tx: Pick<Tx, "program" | "orgAuditLog">,
+  args: TransitionArgs<
+    ProgramStatus,
+    Omit<Prisma.ProgramUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.program.updateMany({
+    where: { ...args.where, status: { in: PROGRAM_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "Program", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// ProgramAssignment ////////////////////////////////////////////////////
+
+// ROLLED only from ACTIVE — the cycle engine skips PAUSED assignments.
+export const ASSIGNMENT_ALLOWED_FROM: Record<AssignmentStatus, AssignmentStatus[]> = {
+  ACTIVE: ["PAUSED"],
+  ROLLED: ["ACTIVE"],
+  PAUSED: ["ACTIVE"],
+  CLOSED: ["ACTIVE", "PAUSED"],
+  CANCELLED: ["ACTIVE", "PAUSED"],
+};
+
+export async function transitionProgramAssignment(
+  tx: Pick<Tx, "programAssignment" | "orgAuditLog">,
+  args: TransitionArgs<
+    AssignmentStatus,
+    Omit<Prisma.ProgramAssignmentUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.programAssignment.updateMany({
+    where: { ...args.where, status: { in: ASSIGNMENT_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "ProgramAssignment", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// Membership ////////////////////////////////////////////////////
+
+// ERASED is the DPDP §12 tombstone — reachable from everything, including
+// REMOVED, and the only state REMOVED may still move to.
+export const MEMBER_ALLOWED_FROM: Record<MemberStatus, MemberStatus[]> = {
+  PENDING: [],
+  ACTIVE: ["PENDING", "SUSPENDED"],
+  // PENDING → SUSPENDED: an invited-but-not-joined member can be suspended
+  // (dashboard PATCH) or SCIM-deprovisioned before first login.
+  SUSPENDED: ["PENDING", "ACTIVE"],
+  REMOVED: ["PENDING", "ACTIVE", "SUSPENDED"],
+  ERASED: ["PENDING", "ACTIVE", "SUSPENDED", "REMOVED"],
+};
+
+export async function transitionMembership(
+  tx: Pick<Tx, "membership" | "orgAuditLog">,
+  args: TransitionArgs<
+    MemberStatus,
+    Omit<Prisma.MembershipUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.membership.updateMany({
+    where: { ...args.where, status: { in: MEMBER_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "Membership", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// OrganizationInvoice ////////////////////////////////////////////////////
+
+// VOID is pre-payment cancellation of an issued invoice; REFUNDED is
+// post-payment (see the OrgInvoiceStatus enum docstring). CANCELLED only
+// kills DRAFTs that were never issued.
+export const INVOICE_ALLOWED_FROM: Record<OrgInvoiceStatus, OrgInvoiceStatus[]> = {
+  DRAFT: [],
+  ISSUED: ["DRAFT"],
+  PAID: ["ISSUED", "OVERDUE"],
+  OVERDUE: ["ISSUED"],
+  VOID: ["ISSUED", "OVERDUE"],
+  CANCELLED: ["DRAFT"],
+  REFUNDED: ["PAID"],
+};
+
+export async function transitionOrgInvoice(
+  tx: Pick<Tx, "organizationInvoice" | "orgAuditLog">,
+  args: TransitionArgs<
+    OrgInvoiceStatus,
+    Omit<Prisma.OrganizationInvoiceUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.organizationInvoice.updateMany({
+    where: { ...args.where, status: { in: INVOICE_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "OrganizationInvoice", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// PurchaseOrder ////////////////////////////////////////////////////
+
+export const PO_ALLOWED_FROM: Record<PoStatus, PoStatus[]> = {
+  ACTIVE: [],
+  CLOSED: ["ACTIVE"],
+  CANCELLED: ["ACTIVE"],
+};
+
+export async function transitionPurchaseOrder(
+  tx: Pick<Tx, "purchaseOrder" | "orgAuditLog">,
+  args: TransitionArgs<
+    PoStatus,
+    Omit<Prisma.PurchaseOrderUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.purchaseOrder.updateMany({
+    where: { ...args.where, status: { in: PO_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "PurchaseOrder", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// OrganizationPayoutAccount ////////////////////////////////////////////////////
+
+// Bank-detail changes reset to PENDING_VERIFICATION from any state (the
+// payout-account PUT re-verifies new credentials), so nothing is terminal.
+export const ORG_PAYOUT_ACCOUNT_ALLOWED_FROM: Record<
+  OrgPayoutAccountStatus,
+  OrgPayoutAccountStatus[]
+> = {
+  PENDING_VERIFICATION: ["VERIFIED", "FAILED_VERIFICATION", "SUSPENDED"],
+  VERIFIED: ["PENDING_VERIFICATION", "SUSPENDED"],
+  FAILED_VERIFICATION: ["PENDING_VERIFICATION"],
+  SUSPENDED: ["VERIFIED"],
+};
+
+export async function transitionOrgPayoutAccount(
+  tx: Pick<Tx, "organizationPayoutAccount" | "orgAuditLog">,
+  args: TransitionArgs<
+    OrgPayoutAccountStatus,
+    Omit<Prisma.OrganizationPayoutAccountUncheckedUpdateManyInput, "status" | "version">
+  >,
+): Promise<void> {
+  const res = await tx.organizationPayoutAccount.updateMany({
+    where: {
+      ...args.where,
+      status: { in: ORG_PAYOUT_ACCOUNT_ALLOWED_FROM[args.to] },
+    },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "OrganizationPayoutAccount", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// OrganizationPayout ////////////////////////////////////////////////////
+
+// REVERSED only from COMPLETED — bank returned funds after settlement (#812);
+// the ledger reversal + earning re-open are sequenced by the payout service.
+export const PAYOUT_ALLOWED_FROM: Record<PayoutStatus, PayoutStatus[]> = {
+  PENDING: [],
+  APPROVED: ["PENDING"],
+  PROCESSING: ["APPROVED"],
+  COMPLETED: ["PROCESSING"],
+  FAILED: ["PROCESSING"],
+  CANCELLED: ["PENDING"],
+  REVERSED: ["COMPLETED"],
+};
+
+export async function transitionOrgPayout(
+  tx: Pick<Tx, "organizationPayout" | "orgAuditLog">,
+  args: TransitionArgs<
+    PayoutStatus,
+    Omit<Prisma.OrganizationPayoutUncheckedUpdateManyInput, "status">
+  >,
+): Promise<void> {
+  const res = await tx.organizationPayout.updateMany({
+    where: { ...args.where, status: { in: PAYOUT_ALLOWED_FROM[args.to] } },
+    data: { status: args.to, ...args.data },
+  });
+  await finalize(tx, "OrganizationPayout", args.to, res.count, args.audit);
+}
+
+//////////////////////////////////////////////////// Declared-only maps ////////////////////////////////////////////////////
+
+// WalletTopUp's live CAS sites stay in lib/api/organizations/wallet.ts until
+// the #812 §P0 top-up work lands (PR-B) — declared here so the map is the
+// single documented source of legality.
+export const WALLET_TOPUP_ALLOWED_FROM: Record<WalletTopUpStatus, WalletTopUpStatus[]> = {
+  PENDING: [],
+  CONFIRMED: ["PENDING"],
+  FAILED: ["PENDING"],
+};
+
+//////////////////////////////////////////////////// Terminal sets ////////////////////////////////////////////////////
+
+export const TERMINAL_STATES = {
+  OrgStatus: terminalsOf(ORG_ALLOWED_FROM),
+  ContractStatus: terminalsOf(CONTRACT_ALLOWED_FROM),
+  ProgramStatus: terminalsOf(PROGRAM_ALLOWED_FROM),
+  AssignmentStatus: terminalsOf(ASSIGNMENT_ALLOWED_FROM),
+  MemberStatus: terminalsOf(MEMBER_ALLOWED_FROM),
+  OrgInvoiceStatus: terminalsOf(INVOICE_ALLOWED_FROM),
+  PoStatus: terminalsOf(PO_ALLOWED_FROM),
+  OrgPayoutAccountStatus: terminalsOf(ORG_PAYOUT_ACCOUNT_ALLOWED_FROM),
+  PayoutStatus: terminalsOf(PAYOUT_ALLOWED_FROM),
+  WalletTopUpStatus: terminalsOf(WALLET_TOPUP_ALLOWED_FROM),
+} as const;

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -1,4 +1,5 @@
 import prisma, { type Tx } from "@/lib/prisma";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import { Prisma as PrismaNamespace } from "@prisma/client";
 import type { ReferralCode, Referral, ReferralCredit } from "@prisma/client";
 import { sumPaise } from "@/lib/payments/utils/money";
@@ -35,36 +36,6 @@ export { QUALIFICATION_WINDOW_DAYS, CREDIT_EXPIRY_MONTHS };
 // Constants
 const DEFAULT_REFERRER_REWARD = 50000; // ₹500 in paise
 const DEFAULT_REFEREE_REWARD = 20000; // ₹200 in paise
-const SERIALIZABLE_MAX_RETRIES = 3;
-
-/**
- * Retries a function that may fail due to Prisma serialization conflicts (P2034).
- * Applies exponential backoff between retries.
- */
-async function withSerializableRetry<T>(
-  fn: () => Promise<T>,
-  maxRetries = SERIALIZABLE_MAX_RETRIES,
-): Promise<T> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      const isSerializationFailure =
-        error instanceof PrismaNamespace.PrismaClientKnownRequestError &&
-        error.code === "P2034";
-
-      if (!isSerializationFailure || attempt === maxRetries) {
-        throw error;
-      }
-
-      const backoffMs = 50 * 2 ** attempt; // 50ms, 100ms, 200ms
-      await new Promise((resolve) => setTimeout(resolve, backoffMs));
-    }
-  }
-
-  // Unreachable, but satisfies TypeScript
-  throw new Error("withSerializableRetry: exhausted retries");
-}
 
 /**
  * Creates or returns an existing referral code for a user.

--- a/lib/scim/operations.ts
+++ b/lib/scim/operations.ts
@@ -140,6 +140,19 @@ export async function createOrReprovisionScimUser(
     });
 
     if (existingMembership) {
+      // Terminal tombstones are admin/compliance-owned — an IdP reprovision
+      // heartbeat must not resurrect a REMOVED/ERASED membership. Surfacing
+      // the conflict (instead of silently flipping back to ACTIVE) makes the
+      // IdP-side error visible to the org's IT admin.
+      if (
+        existingMembership.status === "REMOVED" ||
+        existingMembership.status === "ERASED"
+      ) {
+        return {
+          kind: "CONFLICT",
+          detail: `membership is ${existingMembership.status.toLowerCase()} — re-invite via the dashboard instead of re-provisioning`,
+        };
+      }
       const nextStatus = active ? "ACTIVE" : "SUSPENDED";
       // #789 review — only invalidate the session when the role or status
       // actually moves, so an idempotent reprovision (the common IdP heartbeat)
@@ -264,9 +277,15 @@ export async function deprovisionScimUser(
   if (!membership) return { kind: "NOT_FOUND" };
 
   return prisma.$transaction(async (tx) => {
-    const updated = await tx.membership.update({
-      where: { id: membership.id },
+    // Guarded + idempotent: a deprovision retry on an already-SUSPENDED row is
+    // a no-op, and a REMOVED/ERASED tombstone is never resurrected — the IdP
+    // reads those as inactive either way.
+    await tx.membership.updateMany({
+      where: { id: membership.id, status: { in: ["PENDING", "ACTIVE"] } },
       data: { status: "SUSPENDED" },
+    });
+    const updated = await tx.membership.findUniqueOrThrow({
+      where: { id: membership.id },
     });
     // #789 — invalidate the deprovisioned user's cached session memberships so
     // the suspension takes effect immediately instead of lingering for the

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -457,6 +457,10 @@ model Organization {
   slug String @unique
 
   status    OrgStatus @default(PENDING_VERIFICATION)
+  /// Optimistic-lock clock for owner-editable settings. The PATCH CASes on the
+  /// client's expectedVersion and increments, so a stale tab gets a 409 instead
+  /// of silently overwriting (multi-tab last-write-wins).
+  version   Int       @default(1)
   // #781 §B — financial rows Restrict their parents; removal = soft-delete.
   // Hard delete remains possible only while no money row references this.
   deletedAt DateTime?
@@ -1420,6 +1424,8 @@ model OrganizationPayoutAccount {
 
   status     OrgPayoutAccountStatus @default(PENDING_VERIFICATION)
   verifiedAt DateTime?
+  /// Optimistic-lock clock — same CAS contract as Organization.version.
+  version    Int                    @default(1)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -1804,6 +1810,9 @@ model OrganizationSSOSettings {
   /// again (auth layer skips the enforceSSO gate while breakGlassUntil > now).
   /// Who/why lives in the OrgAuditLog row the route emits — no duplicate columns.
   breakGlassUntil DateTime?
+
+  /// Optimistic-lock clock — same CAS contract as Organization.version.
+  version Int @default(1)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -4739,6 +4748,10 @@ enum DeliveryStatus {
   SUCCESS
   RETRY
   FAILED
+  /// All retry attempts exhausted — terminal, operator-replayable via the
+  /// redeliver route. FAILED stays for receiver-rejected (permanent 4xx /
+  /// endpoint paused) deliveries.
+  DEAD_LETTER
 }
 
 /// Per-org SCIM 2.0 bearer tokens. Stored as SHA-256 hashes; the raw token

--- a/scripts/alerts/alert-orphaned-payments.ts
+++ b/scripts/alerts/alert-orphaned-payments.ts
@@ -19,6 +19,7 @@
 
 import prisma from "../../lib/prisma";
 import { PaymentStatus } from "@prisma/client";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Only check payments within the last 7 days
 const ALERT_WINDOW_DAYS = 7;
@@ -44,7 +45,15 @@ export interface OrphanedPaymentsAlertResult {
 /**
  * Find succeeded payments without appointments and alert
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function alertOrphanedPayments(): Promise<OrphanedPaymentsAlertResult> {
+  return withCronLock("alert-orphaned-payments", { failMode: "open" }, () =>
+    alertOrphanedPaymentsUnlocked(),
+  );
+}
+
+async function alertOrphanedPaymentsUnlocked(): Promise<OrphanedPaymentsAlertResult> {
   const errors: string[] = [];
   let criticalCount = 0;
   let totalAmount = 0;

--- a/scripts/appointments/auto-complete-appointments.ts
+++ b/scripts/appointments/auto-complete-appointments.ts
@@ -27,6 +27,7 @@ import {
 } from "@prisma/client";
 import { notifyAppointmentCompleted } from "../../lib/novu/service";
 import { getAppUrl } from "../../lib/url";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Only complete appointments that ended at least 1 hour ago
 // This gives buffer time for any post-session activities
@@ -609,7 +610,15 @@ async function completeIndividualSlots(): Promise<{
 /**
  * Main function to auto-complete all eligible appointments
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function autoCompleteAppointments(): Promise<AutoCompleteResult> {
+  return withCronLock("auto-complete-appointments", { failMode: "open" }, () =>
+    autoCompleteAppointmentsUnlocked(),
+  );
+}
+
+async function autoCompleteAppointmentsUnlocked(): Promise<AutoCompleteResult> {
   const allErrors: string[] = [];
 
   console.log("🔄 Starting auto-complete appointments scan...");

--- a/scripts/appointments/cleanup-invalid-appointments.ts
+++ b/scripts/appointments/cleanup-invalid-appointments.ts
@@ -21,6 +21,7 @@
 
 import { RequestStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 /**
  * Result structure for cleanup operations
@@ -505,7 +506,15 @@ export async function cleanupInvalidDurationSubscriptions(): Promise<{
  *
  * @returns Combined results from all cleanup operations
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function runAllCleanupTasks(): Promise<CleanupResult> {
+  return withCronLock("cleanup-invalid-appointments", { failMode: "open" }, () =>
+    runAllCleanupTasksUnlocked(),
+  );
+}
+
+async function runAllCleanupTasksUnlocked(): Promise<CleanupResult> {
   const startTime = Date.now();
   console.log(
     `\n🚀 Starting invalid appointment cleanup at ${new Date().toISOString()}\n`,

--- a/scripts/appointments/cleanup-stale-pending-consultations.ts
+++ b/scripts/appointments/cleanup-stale-pending-consultations.ts
@@ -20,6 +20,7 @@
 
 import prisma from "../../lib/prisma";
 import { RequestStatus } from "@prisma/client";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Cancel consultations with APPROVED/APPROVED_PENDING_PAYMENT but no payment after 7 days
 const STALE_THRESHOLD_DAYS = 7;
@@ -35,7 +36,15 @@ export interface StalePendingConsultationsResult {
 /**
  * Cleanup stale pending consultations
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function cleanupStalePendingConsultations(): Promise<StalePendingConsultationsResult> {
+  return withCronLock("cleanup-stale-pending-consultations", { failMode: "open" }, () =>
+    cleanupStalePendingConsultationsUnlocked(),
+  );
+}
+
+async function cleanupStalePendingConsultationsUnlocked(): Promise<StalePendingConsultationsResult> {
   const errors: string[] = [];
   let consultationsCancelled = 0;
   let slotsReleased = 0;

--- a/scripts/appointments/cleanup-tentative-slots.ts
+++ b/scripts/appointments/cleanup-tentative-slots.ts
@@ -19,6 +19,7 @@
 
 import prisma from "../../lib/prisma";
 import { PaymentStatus } from "@prisma/client";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Release tentative slots older than 7 days with no successful payment
 const TENTATIVE_EXPIRATION_DAYS = 7;
@@ -34,7 +35,15 @@ export interface TentativeSlotCleanupResult {
 /**
  * Find and release stale tentative slots
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function cleanupTentativeSlots(): Promise<TentativeSlotCleanupResult> {
+  return withCronLock("cleanup-tentative-slots", { failMode: "open" }, () =>
+    cleanupTentativeSlotsUnlocked(),
+  );
+}
+
+async function cleanupTentativeSlotsUnlocked(): Promise<TentativeSlotCleanupResult> {
   const errors: string[] = [];
   let slotsReleased = 0;
   const appointmentsAffected = new Set<string>();

--- a/scripts/appointments/expire-stale-requests.ts
+++ b/scripts/appointments/expire-stale-requests.ts
@@ -17,6 +17,7 @@
 
 import prisma from "../../lib/prisma";
 import { RequestStatus } from "@prisma/client";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Expire requests in PENDING state for more than 30 days
 const PENDING_EXPIRATION_DAYS = 30;
@@ -233,7 +234,15 @@ async function expirePaymentPendingRequests(): Promise<{
 /**
  * Main function to expire all stale requests
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function expireStaleRequests(): Promise<ExpireStaleRequestsResult> {
+  return withCronLock("expire-stale-requests", { failMode: "open" }, () =>
+    expireStaleRequestsUnlocked(),
+  );
+}
+
+async function expireStaleRequestsUnlocked(): Promise<ExpireStaleRequestsResult> {
   const allErrors: string[] = [];
 
   console.log("🕐 Starting stale request expiration...");

--- a/scripts/appointments/reconcile-slot-availability.ts
+++ b/scripts/appointments/reconcile-slot-availability.ts
@@ -20,6 +20,7 @@
 
 import prisma from "../../lib/prisma";
 import { PaymentStatus } from "@prisma/client";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 export interface SlotReconciliationResult {
   success: boolean;
@@ -337,7 +338,15 @@ async function detectDoubleBookings(): Promise<{
 /**
  * Main function to reconcile slot availability
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function reconcileSlotAvailability(): Promise<SlotReconciliationResult> {
+  return withCronLock("reconcile-slot-availability", { failMode: "open", ttlMs: LONG_JOB_TTL_MS }, () =>
+    reconcileSlotAvailabilityUnlocked(),
+  );
+}
+
+async function reconcileSlotAvailabilityUnlocked(): Promise<SlotReconciliationResult> {
   const allErrors: string[] = [];
 
   console.log("🔄 Starting slot availability reconciliation...");

--- a/scripts/appointments/send-appointment-reminders.ts
+++ b/scripts/appointments/send-appointment-reminders.ts
@@ -17,6 +17,7 @@ import prisma from "../../lib/prisma";
 import redis from "../../lib/redis";
 import { notifyAppointmentReminder } from "../../lib/novu/service";
 import { getAppUrl } from "../../lib/url";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Reminder windows (in milliseconds)
 const REMINDER_24H = {
@@ -232,7 +233,15 @@ async function sendRemindersForWindow(window: {
 /**
  * Main function to send all appointment reminders
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function sendAppointmentReminders(): Promise<ReminderResult> {
+  return withCronLock("send-appointment-reminders", { failMode: "open" }, () =>
+    sendAppointmentRemindersUnlocked(),
+  );
+}
+
+async function sendAppointmentRemindersUnlocked(): Promise<ReminderResult> {
   console.log("🔔 Starting appointment reminders scan...");
 
   const [result24h, result1h] = await Promise.all([

--- a/scripts/cleanup/archive-webhook-events.ts
+++ b/scripts/cleanup/archive-webhook-events.ts
@@ -17,6 +17,7 @@
  */
 
 import prisma from "../../lib/prisma";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Delete processed events older than this
 const PROCESSED_RETENTION_DAYS = 30;
@@ -36,7 +37,15 @@ export interface WebhookArchiveResult {
 /**
  * Archive (delete) old webhook events
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function archiveWebhookEvents(): Promise<WebhookArchiveResult> {
+  return withCronLock("archive-webhook-events", { failMode: "open" }, () =>
+    archiveWebhookEventsUnlocked(),
+  );
+}
+
+async function archiveWebhookEventsUnlocked(): Promise<WebhookArchiveResult> {
   const errors: string[] = [];
   let processedEventsDeleted = 0;
   let failedEventsDeleted = 0;

--- a/scripts/cleanup/cleanup-abandoned-org-top-ups.ts
+++ b/scripts/cleanup/cleanup-abandoned-org-top-ups.ts
@@ -26,6 +26,7 @@
  */
 
 import prisma from "../../lib/prisma";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 const DEFAULT_GRACE_HOURS = 6; // gateway retry budget + user completion window
 
@@ -46,7 +47,17 @@ export interface AbandonedOrgTopUpCleanupOptions {
 /**
  * Reap pending wallet top-up placeholders older than the grace window.
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function cleanupAbandonedOrgTopUps(
+  options: AbandonedOrgTopUpCleanupOptions = {},
+): Promise<AbandonedOrgTopUpCleanupResult> {
+  return withCronLock("cleanup-abandoned-org-top-ups", { failMode: "closed" }, () =>
+    cleanupAbandonedOrgTopUpsUnlocked(options),
+  );
+}
+
+async function cleanupAbandonedOrgTopUpsUnlocked(
   options: AbandonedOrgTopUpCleanupOptions = {},
 ): Promise<AbandonedOrgTopUpCleanupResult> {
   const graceHours = options.graceHours ?? DEFAULT_GRACE_HOURS;

--- a/scripts/cleanup/cleanup-auth-tokens.ts
+++ b/scripts/cleanup/cleanup-auth-tokens.ts
@@ -18,6 +18,7 @@
  */
 
 import prisma from "../../lib/prisma";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface AuthTokenCleanupResult {
   success: boolean;
@@ -32,7 +33,15 @@ export interface AuthTokenCleanupResult {
 /**
  * Clean up all expired auth tokens
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function cleanupAuthTokens(): Promise<AuthTokenCleanupResult> {
+  return withCronLock("cleanup-auth-tokens", { failMode: "open" }, () =>
+    cleanupAuthTokensUnlocked(),
+  );
+}
+
+async function cleanupAuthTokensUnlocked(): Promise<AuthTokenCleanupResult> {
   const errors: string[] = [];
   let verificationTokensDeleted = 0;
   let sessionsDeleted = 0;

--- a/scripts/cleanup/cleanup-old-stream-recordings.ts
+++ b/scripts/cleanup/cleanup-old-stream-recordings.ts
@@ -20,6 +20,7 @@
 
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface StreamRetentionResult {
   scanned: number;
@@ -29,7 +30,15 @@ export interface StreamRetentionResult {
   errors: string[];
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function cleanupOldStreamRecordings(): Promise<StreamRetentionResult> {
+  return withCronLock("cleanup-old-stream-recordings", { failMode: "open" }, () =>
+    cleanupOldStreamRecordingsUnlocked(),
+  );
+}
+
+async function cleanupOldStreamRecordingsUnlocked(): Promise<StreamRetentionResult> {
   const result: StreamRetentionResult = {
     scanned: 0,
     expired: 0,

--- a/scripts/cleanup/cleanup-stale-invitations.ts
+++ b/scripts/cleanup/cleanup-stale-invitations.ts
@@ -31,6 +31,7 @@
 
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface StaleInvitationsCleanupResult {
   success: boolean;
@@ -39,7 +40,15 @@ export interface StaleInvitationsCleanupResult {
   timestamp: string;
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function cleanupStaleInvitations(): Promise<StaleInvitationsCleanupResult> {
+  return withCronLock("cleanup-stale-invitations", { failMode: "open" }, () =>
+    cleanupStaleInvitationsUnlocked(),
+  );
+}
+
+async function cleanupStaleInvitationsUnlocked(): Promise<StaleInvitationsCleanupResult> {
   const now = new Date();
   const errors: string[] = [];
   let expired = 0;

--- a/scripts/cleanup/deactivate-expired-discounts.ts
+++ b/scripts/cleanup/deactivate-expired-discounts.ts
@@ -19,6 +19,7 @@
  */
 
 import prisma from "../../lib/prisma";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface ExpiredDiscountsResult {
   success: boolean;
@@ -168,7 +169,15 @@ async function deactivateMaxUsesReached(): Promise<{
 /**
  * Main function to deactivate expired discount codes
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function deactivateExpiredDiscounts(): Promise<ExpiredDiscountsResult> {
+  return withCronLock("deactivate-expired-discounts", { failMode: "open" }, () =>
+    deactivateExpiredDiscountsUnlocked(),
+  );
+}
+
+async function deactivateExpiredDiscountsUnlocked(): Promise<ExpiredDiscountsResult> {
   const allErrors: string[] = [];
   const allCodes: string[] = [];
 

--- a/scripts/cleanup/dispatch-outbound-webhooks.ts
+++ b/scripts/cleanup/dispatch-outbound-webhooks.ts
@@ -18,6 +18,7 @@
 
 import prisma from "../../lib/prisma";
 import { runDispatchTick } from "../../lib/enterprise/outbound-webhooks/worker";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface DispatchOutboundWebhooksResult {
   scanned: number;
@@ -28,7 +29,15 @@ export interface DispatchOutboundWebhooksResult {
   errors: string[];
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function dispatchOutboundWebhooks(): Promise<DispatchOutboundWebhooksResult> {
+  return withCronLock("dispatch-outbound-webhooks", { failMode: "open" }, () =>
+    dispatchOutboundWebhooksUnlocked(),
+  );
+}
+
+async function dispatchOutboundWebhooksUnlocked(): Promise<DispatchOutboundWebhooksResult> {
   const tick = await runDispatchTick({ prisma });
   return {
     scanned: tick.scanned,

--- a/scripts/cleanup/process-data-exports.ts
+++ b/scripts/cleanup/process-data-exports.ts
@@ -39,6 +39,7 @@ import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
 import { recordSystemError } from "../../lib/enterprise/system-events";
 import { notifyOrgDataExportReady } from "../../lib/novu/org-workflows";
 import { getAppUrl } from "../../lib/url";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 export interface DataExportResult {
   picked: number;
@@ -229,7 +230,15 @@ async function emailRequester(params: {
   });
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function processDataExports(): Promise<DataExportResult> {
+  return withCronLock("process-data-exports", { failMode: "open", ttlMs: LONG_JOB_TTL_MS }, () =>
+    processDataExportsUnlocked(),
+  );
+}
+
+async function processDataExportsUnlocked(): Promise<DataExportResult> {
   const result: DataExportResult = {
     picked: 0,
     succeeded: 0,

--- a/scripts/cleanup/prune-audit-logs.ts
+++ b/scripts/cleanup/prune-audit-logs.ts
@@ -28,6 +28,7 @@
 import prisma from "../../lib/prisma";
 import type { OrgAuditCategory } from "@prisma/client";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 const KEEP_7Y_CATEGORIES: OrgAuditCategory[] = [
   "INVOICE",
@@ -57,7 +58,15 @@ export interface AuditPruneResult {
   errors: string[];
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function pruneAuditLogs(): Promise<AuditPruneResult> {
+  return withCronLock("prune-audit-logs", { failMode: "open" }, () =>
+    pruneAuditLogsUnlocked(),
+  );
+}
+
+async function pruneAuditLogsUnlocked(): Promise<AuditPruneResult> {
   const now = Date.now();
   const ms7y = 7 * 365 * 24 * 60 * 60 * 1000;
   const ms2y = 2 * 365 * 24 * 60 * 60 * 1000;

--- a/scripts/cleanup/reconcile-document-storage.ts
+++ b/scripts/cleanup/reconcile-document-storage.ts
@@ -22,6 +22,7 @@
 
 import prisma from "../../lib/prisma";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Grace period before deleting orphaned files (days)
 const ORPHAN_GRACE_PERIOD_DAYS = 7;
@@ -248,7 +249,15 @@ async function deleteOrphanedFiles(
 /**
  * Main function to reconcile document storage
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function reconcileDocumentStorage(): Promise<DocumentReconciliationResult> {
+  return withCronLock("reconcile-document-storage", { failMode: "open", ttlMs: LONG_JOB_TTL_MS }, () =>
+    reconcileDocumentStorageUnlocked(),
+  );
+}
+
+async function reconcileDocumentStorageUnlocked(): Promise<DocumentReconciliationResult> {
   const errors: string[] = [];
   let orphanedFilesFound = 0;
   let orphanedFilesDeleted = 0;

--- a/scripts/cleanup/sso-cert-expiry-alert.ts
+++ b/scripts/cleanup/sso-cert-expiry-alert.ts
@@ -38,6 +38,7 @@ import { X509Certificate } from "node:crypto";
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
 import { notifyOrgSsoCertExpiring } from "../../lib/novu/org-workflows";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 type Severity = "WARN" | "CRITICAL" | "EXPIRED";
 
@@ -74,7 +75,15 @@ function parseNotAfter(samlConfigJson: string): Date | null {
   }
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function runSsoCertExpiryAlert(): Promise<SsoCertExpiryAlertResult> {
+  return withCronLock("sso-cert-expiry-alert", { failMode: "open" }, () =>
+    runSsoCertExpiryAlertUnlocked(),
+  );
+}
+
+async function runSsoCertExpiryAlertUnlocked(): Promise<SsoCertExpiryAlertResult> {
   const now = new Date();
   const errors: string[] = [];
   let alerted = 0;

--- a/scripts/cleanup/sweep-abandoned-overage-charges.ts
+++ b/scripts/cleanup/sweep-abandoned-overage-charges.ts
@@ -11,6 +11,7 @@
  */
 import prisma from "@/lib/prisma";
 import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface OverageSweepResult {
   success: boolean;
@@ -18,7 +19,20 @@ export interface OverageSweepResult {
   failed: number;
 }
 
+// #476 — locked at the core so the GH Actions entry (jobs/**) and the
+// CRON_SECRET HTTP entry (app/api/cleanup/**) share one mutual exclusion.
+// fail-closed: FAILing a side-charge twice would double-free the ceiling.
 export async function sweepAbandonedOverageCharges(
+  opts: { ageDays?: number; limit?: number } = {},
+): Promise<OverageSweepResult> {
+  return withCronLock(
+    "sweep-abandoned-overage-charges",
+    { failMode: "closed" },
+    () => sweepAbandonedOverageChargesUnlocked(opts),
+  );
+}
+
+async function sweepAbandonedOverageChargesUnlocked(
   opts: { ageDays?: number; limit?: number } = {},
 ): Promise<OverageSweepResult> {
   const ageDays = opts.ageDays ?? 7;

--- a/scripts/cleanup/sweep-orphaned-topup-captures.ts
+++ b/scripts/cleanup/sweep-orphaned-topup-captures.ts
@@ -12,6 +12,7 @@
  */
 import prisma from "@/lib/prisma";
 import { confirmTopUp } from "@/lib/api/organizations/wallet";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface TopupCaptureSweepResult {
   success: boolean;
@@ -29,7 +30,17 @@ export interface TopupCaptureSweepOptions {
   limit?: number;
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function sweepOrphanedTopupCaptures(
+  opts: TopupCaptureSweepOptions = {},
+): Promise<TopupCaptureSweepResult> {
+  return withCronLock("sweep-orphaned-topup-captures", { failMode: "closed" }, () =>
+    sweepOrphanedTopupCapturesUnlocked(opts),
+  );
+}
+
+async function sweepOrphanedTopupCapturesUnlocked(
   opts: TopupCaptureSweepOptions = {},
 ): Promise<TopupCaptureSweepResult> {
   const graceMinutes = opts.graceMinutes ?? 5;

--- a/scripts/cleanup/sweep-stuck-webhook-events.ts
+++ b/scripts/cleanup/sweep-stuck-webhook-events.ts
@@ -19,6 +19,7 @@
 import prisma from "@/lib/prisma";
 import { processRazorpayWebhookEvent } from "@/app/api/webhooks/razorpay-dispatch";
 import type { RazorpayWebhookEnvelope } from "@/schemas/webhooks/razorpay";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface SweepResult {
   success: boolean;
@@ -55,7 +56,17 @@ export interface SweepOptions {
   limit?: number;
 }
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function sweepStuckWebhookEvents(
+  opts: SweepOptions = {},
+): Promise<SweepResult> {
+  return withCronLock("sweep-stuck-webhook-events", { failMode: "closed" }, () =>
+    sweepStuckWebhookEventsUnlocked(opts),
+  );
+}
+
+async function sweepStuckWebhookEventsUnlocked(
   opts: SweepOptions = {},
 ): Promise<SweepResult> {
   const staleMinutes = opts.staleMinutes ?? 6;

--- a/scripts/disputes/alert-dispute-deadlines.ts
+++ b/scripts/disputes/alert-dispute-deadlines.ts
@@ -19,6 +19,7 @@
 
 import prisma from "../../lib/prisma";
 import { DisputeStatus } from "@prisma/client";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 // Alert for disputes due within this many hours
 const ALERT_THRESHOLD_HOURS = 48;
@@ -48,7 +49,15 @@ interface DisputeAlert {
 /**
  * Find disputes with approaching deadlines and generate alerts
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: repeat-safe side effects, lock is belt-and-braces.
 export async function alertDisputeDeadlines(): Promise<DisputeDeadlineAlertResult> {
+  return withCronLock("alert-dispute-deadlines", { failMode: "open" }, () =>
+    alertDisputeDeadlinesUnlocked(),
+  );
+}
+
+async function alertDisputeDeadlinesUnlocked(): Promise<DisputeDeadlineAlertResult> {
   const now = new Date();
   const alertThreshold = new Date(
     Date.now() + ALERT_THRESHOLD_HOURS * 60 * 60 * 1000,

--- a/scripts/disputes/handle-lost-disputes.ts
+++ b/scripts/disputes/handle-lost-disputes.ts
@@ -22,6 +22,7 @@
 import prisma from "../../lib/prisma";
 import { DisputeStatus, EarningStatus } from "@prisma/client";
 import { refundEarnings } from "../../lib/payments/payouts/earnings-service";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface LostDisputeHandlerResult {
   success: boolean;
@@ -37,7 +38,15 @@ export interface LostDisputeHandlerResult {
 /**
  * Find lost disputes with non-REFUNDED earnings and update them
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function handleLostDisputes(): Promise<LostDisputeHandlerResult> {
+  return withCronLock("handle-lost-disputes", { failMode: "closed" }, () =>
+    handleLostDisputesUnlocked(),
+  );
+}
+
+async function handleLostDisputesUnlocked(): Promise<LostDisputeHandlerResult> {
   const errors: string[] = [];
   let updatedCount = 0;
   let skippedCount = 0;

--- a/scripts/disputes/reconcile-disputes.ts
+++ b/scripts/disputes/reconcile-disputes.ts
@@ -16,6 +16,7 @@
 import prisma from "../../lib/prisma";
 import { DisputeStatus, PaymentGateway, Prisma } from "@prisma/client";
 import { getDispute } from "../../lib/payments";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Prioritize disputes with approaching deadlines (7 days)
 const APPROACHING_DEADLINE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -65,7 +66,15 @@ function mapGatewayDisputeStatus(status: string): DisputeStatus {
 /**
  * Find and reconcile disputes that may have stale status
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function reconcileDisputes(): Promise<DisputeReconciliationResult> {
+  return withCronLock("reconcile-disputes", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    reconcileDisputesUnlocked(),
+  );
+}
+
+async function reconcileDisputesUnlocked(): Promise<DisputeReconciliationResult> {
   const approachingDeadline = new Date(Date.now() + APPROACHING_DEADLINE_MS);
   const staleThreshold = new Date(Date.now() - STALE_THRESHOLD_MS);
   const urgentThreshold = new Date(Date.now() + 48 * 60 * 60 * 1000);

--- a/scripts/earnings/release-earnings.ts
+++ b/scripts/earnings/release-earnings.ts
@@ -17,6 +17,7 @@
 import { EarningStatus, Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { sumPaise } from "@/lib/payments/utils/money";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 /**
  * Result structure for release operations
@@ -39,7 +40,15 @@ export interface ReleaseResult {
  *
  * @returns ReleaseResult with counts and error details
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function releaseEarningsFromHold(): Promise<ReleaseResult> {
+  return withCronLock("release-earnings", { failMode: "closed" }, () =>
+    releaseEarningsFromHoldUnlocked(),
+  );
+}
+
+async function releaseEarningsFromHoldUnlocked(): Promise<ReleaseResult> {
   console.log("💰 Starting earnings release from hold...");
 
   const result: ReleaseResult = {

--- a/scripts/earnings/sync-payment-earnings.ts
+++ b/scripts/earnings/sync-payment-earnings.ts
@@ -23,6 +23,7 @@ import prisma from "../../lib/prisma";
 import { PaymentStatus, AppointmentsType } from "@prisma/client";
 import { AppointmentType } from "../../lib/payments/payouts/constants";
 import { createEarningsFromPayment } from "../../lib/payments/payouts/earnings-service";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Only sync payments within the last 30 days
 const SYNC_WINDOW_DAYS = 30;
@@ -62,7 +63,15 @@ function mapAppointmentType(type: AppointmentsType): AppointmentType {
  * Find succeeded payments without earnings and create them
  * Uses batch processing to handle large datasets efficiently
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function syncPaymentEarnings(): Promise<PaymentEarningSyncResult> {
+  return withCronLock("sync-payment-earnings", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    syncPaymentEarningsUnlocked(),
+  );
+}
+
+async function syncPaymentEarningsUnlocked(): Promise<PaymentEarningSyncResult> {
   const errors: string[] = [];
   let totalProcessed = 0;
   let createdCount = 0;

--- a/scripts/payments/cleanup-abandoned-payments.ts
+++ b/scripts/payments/cleanup-abandoned-payments.ts
@@ -21,6 +21,7 @@ import Stripe from "stripe";
 import { cancelRazorpayOrder } from "../../lib/payments/core/razorpay";
 import { reverseCreditsForPayment } from "@/lib/referrals/service";
 import prisma from "@/lib/prisma";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 /**
  * Result structure for cleanup operations
@@ -110,7 +111,15 @@ export async function cancelPaymentIntent(
  *
  * @returns CleanupResult with counts and error details
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function cleanupAbandonedPayments(): Promise<CleanupResult> {
+  return withCronLock("cleanup-abandoned-payments", { failMode: "closed" }, () =>
+    cleanupAbandonedPaymentsUnlocked(),
+  );
+}
+
+async function cleanupAbandonedPaymentsUnlocked(): Promise<CleanupResult> {
   console.log("🧹 Starting abandoned payment cleanup...");
 
   const result: CleanupResult = {
@@ -375,7 +384,15 @@ export async function cleanupAbandonedPayments(): Promise<CleanupResult> {
  *
  * @returns CleanupResult with counts and error details
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function cleanupExpiredApprovalPendingPayments(): Promise<CleanupResult> {
+  return withCronLock("cleanup-abandoned-payments", { failMode: "closed" }, () =>
+    cleanupExpiredApprovalPendingPaymentsUnlocked(),
+  );
+}
+
+async function cleanupExpiredApprovalPendingPaymentsUnlocked(): Promise<CleanupResult> {
   console.log(
     "🧹 Starting cleanup of expired APPROVED_PENDING_PAYMENT consultations...",
   );

--- a/scripts/payments/reconcile-payment-status.ts
+++ b/scripts/payments/reconcile-payment-status.ts
@@ -19,6 +19,7 @@
 
 import prisma from "../../lib/prisma";
 import { PaymentStatus, PaymentGateway } from "@prisma/client";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Only reconcile payments older than 5 minutes (give webhooks time)
 const MIN_AGE_MINUTES = 5;
@@ -175,7 +176,15 @@ function mapGatewayStatus(
 /**
  * Find and reconcile stale PENDING payments
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function reconcilePaymentStatus(): Promise<PaymentReconciliationResult> {
+  return withCronLock("reconcile-payment-status", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    reconcilePaymentStatusUnlocked(),
+  );
+}
+
+async function reconcilePaymentStatusUnlocked(): Promise<PaymentReconciliationResult> {
   const errors: string[] = [];
   let reconciledCount = 0;
   let succeededCount = 0;

--- a/scripts/payouts/handle-stuck-payouts.ts
+++ b/scripts/payouts/handle-stuck-payouts.ts
@@ -20,6 +20,7 @@
 
 import prisma from "../../lib/prisma";
 import { PayoutStatus, PaymentGateway } from "@prisma/client";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Consider payouts stuck if in PROCESSING for more than 24 hours
 const STUCK_THRESHOLD_HOURS = 24;
@@ -167,7 +168,15 @@ function mapGatewayStatus(
 /**
  * Find and handle stuck payouts
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function handleStuckPayouts(): Promise<StuckPayoutsResult> {
+  return withCronLock("handle-stuck-payouts", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    handleStuckPayoutsUnlocked(),
+  );
+}
+
+async function handleStuckPayoutsUnlocked(): Promise<StuckPayoutsResult> {
   const errors: string[] = [];
   let reconciledCount = 0;
   let retriedCount = 0;

--- a/scripts/payouts/reconcile-payout-status.ts
+++ b/scripts/payouts/reconcile-payout-status.ts
@@ -19,6 +19,7 @@
 
 import prisma from "../../lib/prisma";
 import { PayoutStatus, PaymentGateway } from "@prisma/client";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Only reconcile payouts older than 48 hours (give webhooks time)
 const MIN_AGE_HOURS = 48;
@@ -173,7 +174,15 @@ function mapGatewayStatus(
 /**
  * Reconcile stale PENDING/PROCESSING payouts with gateway status
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function reconcilePayoutStatus(): Promise<PayoutReconciliationResult> {
+  return withCronLock("reconcile-payout-status", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    reconcilePayoutStatusUnlocked(),
+  );
+}
+
+async function reconcilePayoutStatusUnlocked(): Promise<PayoutReconciliationResult> {
   const errors: string[] = [];
   const discrepancies: string[] = [];
   let reconciledCount = 0;

--- a/scripts/reconcile/reconcile-ledgers.ts
+++ b/scripts/reconcile/reconcile-ledgers.ts
@@ -76,6 +76,7 @@ import type { Prisma } from "@prisma/client";
 import { checkPaymentLegsSumToAmount } from "@/lib/payments/payment-legs";
 import { ledgerBalancePaise } from "@/lib/payments/ledger/post";
 import { sumPaise } from "@/lib/payments/utils/money";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 export type ReconcileScope = {
   /** Human-readable scope tag, e.g. "full" or "org:<orgId>". */
@@ -179,7 +180,19 @@ export type ReconcileReport = {
   findings: Finding[];
 };
 
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: read-only auditor, lock is belt-and-braces.
 export async function runReconcileLedgers(
+  opts: ReconcileScope,
+): Promise<ReconcileReport> {
+  return withCronLock(
+    "reconcile-ledgers",
+    { failMode: "open", ttlMs: LONG_JOB_TTL_MS },
+    () => runReconcileLedgersUnlocked(opts),
+  );
+}
+
+async function runReconcileLedgersUnlocked(
   opts: ReconcileScope,
 ): Promise<ReconcileReport> {
   const startedAt = Date.now();

--- a/scripts/refunds/cascade-refund-earnings.ts
+++ b/scripts/refunds/cascade-refund-earnings.ts
@@ -24,6 +24,7 @@ import { Prisma, RefundStatus } from "@prisma/client";
 
 import prisma from "../../lib/prisma";
 import { applyRefundCascade } from "../../lib/payments/operations/refund";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface RefundEarningCascadeResult {
   success: boolean;
@@ -46,7 +47,15 @@ export interface RefundEarningCascadeResult {
  * signal, and `applyRefundCascade` claims it atomically so this cron, the webhook
  * and the app path can never double-process the same refund.
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function cascadeRefundToEarnings(): Promise<RefundEarningCascadeResult> {
+  return withCronLock("cascade-refund-earnings", { failMode: "closed" }, () =>
+    cascadeRefundToEarningsUnlocked(),
+  );
+}
+
+async function cascadeRefundToEarningsUnlocked(): Promise<RefundEarningCascadeResult> {
   const errors: string[] = [];
   let updatedCount = 0;
   let errorCount = 0;

--- a/scripts/refunds/reconcile-pending-refunds.ts
+++ b/scripts/refunds/reconcile-pending-refunds.ts
@@ -16,6 +16,7 @@ import { PaymentGateway, Prisma, RefundStatus } from "@prisma/client";
 import { listRefunds } from "../../lib/payments";
 import { notifyRefundFailed } from "../../lib/novu/service";
 import { getAppUrl } from "../../lib/url";
+import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
 
 // Threshold: Only reconcile refunds older than 1 hour
 const RECONCILIATION_THRESHOLD_MS = 60 * 60 * 1000;
@@ -55,7 +56,15 @@ function mapGatewayRefundStatus(status: string): RefundStatus {
 /**
  * Find and reconcile PENDING refunds with placeholder IDs
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function reconcilePendingRefunds(): Promise<RefundReconciliationResult> {
+  return withCronLock("reconcile-pending-refunds", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    reconcilePendingRefundsUnlocked(),
+  );
+}
+
+async function reconcilePendingRefundsUnlocked(): Promise<RefundReconciliationResult> {
   const thresholdDate = new Date(Date.now() - RECONCILIATION_THRESHOLD_MS);
   const errors: string[] = [];
   let reconciledCount = 0;
@@ -195,7 +204,15 @@ export interface FailedRefundNotifyResult {
  * else the default copy), notifies the payer, and claim-stamps
  * `failedNotifiedAt` so the same failure isn't paged twice.
  */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-closed: money state must not double-run unlocked.
 export async function notifyFailedRefunds(): Promise<FailedRefundNotifyResult> {
+  return withCronLock("reconcile-pending-refunds", { failMode: "closed", ttlMs: LONG_JOB_TTL_MS }, () =>
+    notifyFailedRefundsUnlocked(),
+  );
+}
+
+async function notifyFailedRefundsUnlocked(): Promise<FailedRefundNotifyResult> {
   const now = new Date();
   const failed = await prisma.refund.findMany({
     where: {

--- a/scripts/waitlist/process-expired-notifications.ts
+++ b/scripts/waitlist/process-expired-notifications.ts
@@ -12,6 +12,7 @@ import { WaitlistStatus } from "@prisma/client";
 import { processExpiredNotifications, handleSlotOpening } from "@/lib/waitlist";
 import { sendWaitlistExpiredEmail } from "@/lib/waitlist/notifications";
 import { getAppUrl } from "../../lib/url";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 async function main() {
   console.log("🕐 Starting expired notification processor...");
@@ -95,6 +96,11 @@ async function main() {
 
     process.exit(0);
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      process.exit(0);
+    }
     console.error("❌ Error processing expired notifications:", error);
     process.exit(1);
   }

--- a/scripts/waitlist/send-expiration-reminders.ts
+++ b/scripts/waitlist/send-expiration-reminders.ts
@@ -10,6 +10,7 @@
 import prisma from "@/lib/prisma";
 import { WaitlistStatus } from "@prisma/client";
 import { sendWaitlistExpiringEmail } from "@/lib/waitlist/notifications";
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
 async function main() {
   console.log("🔔 Starting expiration reminder sender...");
@@ -107,6 +108,11 @@ async function main() {
 
     process.exit(0);
   } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      process.exit(0);
+    }
     console.error("❌ Error sending expiration reminders:", error);
     process.exit(1);
   }


### PR DESCRIPTION
## Problem

A staff-level audit of the enterprise subsystem found one recurring bug class — **read–check–blind-write at READ COMMITTED** — across the org capability axes and six lifecycle routes, plus unlocked crons and no dead-letter terminal for webhook deliveries:

- **S1 — multi-tab capability toggle is last-write-wins.** Two OWNER tabs PATCHing `app/api/organizations/[orgId]/route.ts` could simultaneously disable `canSponsor` and `canHost`, each passing the "at least one must stay true" guard against the pre-image. No version/ETag existed anywhere.
- **S2 — TOCTOU between wind-down COUNT checks and the capability UPDATE** (same route, no isolation level): a concurrent invoice/assignment insert could land in the window, stranding live obligations behind a flipped flag.
- **S3 — terminal-state resurrection** on six routes that validated transitions app-side but wrote status unconditionally: contracts (`TERMINATED→ACTIVE` possible), programs, purchase orders (no state machine at all), members, invoices, and the admin verify route.
- **S4 — program CANCELLED left assignments ACTIVE** (deterministic, not a race): members kept drawing entitlements from a dead program because checkout honors ACTIVE assignments.
- **S7 — ~45 cron jobs ran without distributed locks** (#476): schedule overlap and `workflow_dispatch` re-runs could double-run partially-idempotent jobs (dunning emails are the motivating case).
- **S8 — retry-exhausted webhook deliveries landed in plain FAILED**, indistinguishable from receiver-rejected, with an unguarded redeliver that could reset an IN_FLIGHT row mid-delivery.

## Approach — the four-layer doctrine (ADR 13)

1. **Status-CAS transitions** — `lib/enterprise/transitions.ts` bakes each enum's allowed-from set into the `updateMany` WHERE; the loser of a race matches zero rows and 409s. Terminal states appear in no allowed-from set, making resurrection structurally impossible. Pre-checks remain as friendly error text only.
2. **Serializable + bounded retry** (`lib/db/serializable-retry.ts`) where invariants span rows (the wind-down counts). Retries only P2034; business 409s never re-attempt.
3. **Version-column optimistic locking** on settings-bearing rows (`Organization`, `OrganizationPayoutAccount`, `OrganizationSSOSettings`); the dashboard threads `expectedVersion` and shows a "Settings changed elsewhere" dialog on conflict.
4. **Redis locks for cron mutual exclusion only** (`lib/cron/with-cron-lock.ts`): money jobs fail-closed (refuse to run unlocked → notify step pages), cleanup jobs fail-open. Redis is never load-bearing for data correctness.

## Schema

`version Int @default(1)` ×3 + `DEAD_LETTER` enum value. Additive only, schema-freeze compatible. **`prisma db push` not yet run** — the dev Supabase is disconnected; run it before live verification.

## Deliberately untouched

- WalletTopUp/OverageCharge live CAS sites (`lib/api/organizations/wallet.ts`, `overage-transitions.ts`) — PR-B (#812 §P0) owns those files; the maps are declared in the helper for documentation.
- `process-payouts` / `create-payout-batch` / `approval-payments` / `stream-sync` keep their #620 internal locks (not double-wrapped).
- GST gross-up + overage basePaise money-math bugs — PR-B, stacked on this.

## Verification

- 1275/1275 jest tests across 94 suites (85 new transition/retry tests, 8 cron-lock tests; 6 pre-existing suites updated where they asserted the old buggy behavior, e.g. exhaustion→FAILED).
- `tsc --noEmit` clean; eslint 0 errors.
- Live dev-server race scripts (two-tab 409, parallel cron 409) are written into the plan but blocked on the Supabase reconnect; code-only verification per current constraint.

Closes #476
Part of #812
Part of #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)