### PR TITLE
Money correctness (PR-B, stacked): overage basePaise restore/recarve + GST gross-up test coverage

### DIFF
--- a/__tests__/enterprise/overage-base-carve.test.ts
+++ b/__tests__/enterprise/overage-base-carve.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #812 §P0 — basePaise carve bookkeeping. FAILing a CHARGE_MEMBER side-charge
+ * must return the carved basePaise to the org's parent accrual (restore);
+ * the recovery edges (retry / late capture) must take it back out (recarve).
+ * An already-invoiced parent must never have its leg silently diverged from
+ * the issued document — those return "invoiced" for the caller to surface.
+ */
+
+import {
+  restoreOverageBaseCarve,
+  recarveOverageBase,
+} from "@/lib/payments/billing/overage-base-carve";
+import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+
+interface MockOpts {
+  event?: object | null;
+  parent?: object | null;
+  legUpdateManyCount?: number;
+}
+
+function mockTx(opts: MockOpts = {}) {
+  const event =
+    opts.event === undefined
+      ? {
+          id: "ov1",
+          basePaise: 300,
+          overageBehavior: "CHARGE_MEMBER",
+          payment: { id: "side1", parentPaymentId: "parent1" },
+        }
+      : opts.event;
+  const parent =
+    opts.parent === undefined
+      ? { id: "parent1", billableToOrgInvoiceId: null }
+      : opts.parent;
+  const legUpdate = jest.fn().mockResolvedValue({});
+  const legUpdateMany = jest
+    .fn()
+    .mockResolvedValue({ count: opts.legUpdateManyCount ?? 1 });
+  const paymentUpdate = jest.fn().mockResolvedValue({});
+  return {
+    legUpdate,
+    legUpdateMany,
+    paymentUpdate,
+    tx: {
+      overageEvent: {
+        findFirst: jest.fn().mockResolvedValue(event),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      payment: {
+        findUnique: jest.fn().mockResolvedValue(parent),
+        update: paymentUpdate,
+      },
+      paymentLeg: { update: legUpdate, updateMany: legUpdateMany },
+    } as never,
+  };
+}
+
+describe("restoreOverageBaseCarve", () => {
+  it("increments the parent INVOICE_ACCRUAL leg and amount by basePaise", async () => {
+    const m = mockTx();
+    await expect(
+      restoreOverageBaseCarve(m.tx, { overageEventId: "ov1" }),
+    ).resolves.toBe("restored");
+    expect(m.legUpdate).toHaveBeenCalledWith({
+      where: {
+        paymentId_source: { paymentId: "parent1", source: "INVOICE_ACCRUAL" },
+      },
+      data: { amountPaise: { increment: 300 } },
+    });
+    expect(m.paymentUpdate).toHaveBeenCalledWith({
+      where: { id: "parent1" },
+      data: { amount: { increment: 300 } },
+    });
+  });
+
+  it("returns invoiced (no leg writes) when the parent is already on an invoice", async () => {
+    const m = mockTx({
+      parent: { id: "parent1", billableToOrgInvoiceId: "inv1" },
+    });
+    await expect(
+      restoreOverageBaseCarve(m.tx, { overageEventId: "ov1" }),
+    ).resolves.toBe("invoiced");
+    expect(m.legUpdate).not.toHaveBeenCalled();
+    expect(m.paymentUpdate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["zero basePaise", { id: "ov1", basePaise: 0, overageBehavior: "CHARGE_MEMBER", payment: { id: "s", parentPaymentId: "p" } }],
+    ["CHARGE_ORG event", { id: "ov1", basePaise: 300, overageBehavior: "CHARGE_ORG", payment: { id: "s", parentPaymentId: "p" } }],
+    ["no parent linkage", { id: "ov1", basePaise: 300, overageBehavior: "CHARGE_MEMBER", payment: { id: "s", parentPaymentId: null } }],
+    ["missing event", null],
+  ])("is a no-op for %s", async (_label, event) => {
+    const m = mockTx({ event });
+    await expect(
+      restoreOverageBaseCarve(m.tx, { overageEventId: "ov1" }),
+    ).resolves.toBe("none");
+    expect(m.legUpdate).not.toHaveBeenCalled();
+  });
+
+  it("resolves the event via the side payment id too", async () => {
+    const m = mockTx();
+    await restoreOverageBaseCarve(m.tx, { sidePaymentId: "side1" });
+    expect(
+      (m.tx as never as { overageEvent: { findFirst: jest.Mock } }).overageEvent
+        .findFirst,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { paymentId: "side1" } }),
+    );
+  });
+});
+
+describe("recarveOverageBase", () => {
+  it("decrements the leg (guarded) and parent amount", async () => {
+    const m = mockTx();
+    await expect(
+      recarveOverageBase(m.tx, { overageEventId: "ov1" }),
+    ).resolves.toBe("recarved");
+    expect(m.legUpdateMany).toHaveBeenCalledWith({
+      where: {
+        paymentId: "parent1",
+        source: "INVOICE_ACCRUAL",
+        amountPaise: { gte: 300 },
+      },
+      data: { amountPaise: { decrement: 300 } },
+    });
+    expect(m.paymentUpdate).toHaveBeenCalledWith({
+      where: { id: "parent1" },
+      data: { amount: { decrement: 300 } },
+    });
+  });
+
+  it("returns invoiced when the parent is already on an invoice", async () => {
+    const m = mockTx({
+      parent: { id: "parent1", billableToOrgInvoiceId: "inv1" },
+    });
+    await expect(
+      recarveOverageBase(m.tx, { overageEventId: "ov1" }),
+    ).resolves.toBe("invoiced");
+    expect(m.legUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns invoiced (and leaves amount untouched) when the guarded decrement matches no leg", async () => {
+    const m = mockTx({ legUpdateManyCount: 0 });
+    await expect(
+      recarveOverageBase(m.tx, { overageEventId: "ov1" }),
+    ).resolves.toBe("invoiced");
+    expect(m.paymentUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("transitionOverage fromIn narrowing (#812)", () => {
+  function txWithSpy() {
+    const updateMany = jest.fn().mockResolvedValue({ count: 1 });
+    return { updateMany, tx: { overageEvent: { updateMany } } as never };
+  }
+
+  it("narrows the guard to the requested subset", async () => {
+    const m = txWithSpy();
+    await transitionOverage(m.tx, { paymentId: "s1" }, "CHARGED", undefined, {
+      fromIn: ["FAILED"],
+    });
+    expect(m.updateMany).toHaveBeenCalledWith({
+      where: { paymentId: "s1", chargeStatus: { in: ["FAILED"] } },
+      data: { chargeStatus: "CHARGED" },
+    });
+  });
+
+  it("never widens beyond ALLOWED_FROM — illegal entries are intersected away", async () => {
+    const m = txWithSpy();
+    // REVERSED is not a legal source for CHARGED; only FAILED survives.
+    await transitionOverage(m.tx, { paymentId: "s1" }, "CHARGED", undefined, {
+      fromIn: ["FAILED", "REVERSED" as never],
+    });
+    expect(m.updateMany).toHaveBeenCalledWith({
+      where: { paymentId: "s1", chargeStatus: { in: ["FAILED"] } },
+      data: { chargeStatus: "CHARGED" },
+    });
+  });
+});

--- a/__tests__/enterprise/overage-base-carve.test.ts
+++ b/__tests__/enterprise/overage-base-carve.test.ts
@@ -20,6 +20,7 @@ interface MockOpts {
   event?: object | null;
   parent?: object | null;
   legUpdateManyCount?: number;
+  parentUpdateManyCount?: number;
 }
 
 function mockTx(opts: MockOpts = {}) {
@@ -41,10 +42,14 @@ function mockTx(opts: MockOpts = {}) {
     .fn()
     .mockResolvedValue({ count: opts.legUpdateManyCount ?? 1 });
   const paymentUpdate = jest.fn().mockResolvedValue({});
+  const paymentUpdateMany = jest
+    .fn()
+    .mockResolvedValue({ count: opts.parentUpdateManyCount ?? 1 });
   return {
     legUpdate,
     legUpdateMany,
     paymentUpdate,
+    paymentUpdateMany,
     tx: {
       overageEvent: {
         findFirst: jest.fn().mockResolvedValue(event),
@@ -53,6 +58,7 @@ function mockTx(opts: MockOpts = {}) {
       payment: {
         findUnique: jest.fn().mockResolvedValue(parent),
         update: paymentUpdate,
+        updateMany: paymentUpdateMany,
       },
       paymentLeg: { update: legUpdate, updateMany: legUpdateMany },
     } as never,
@@ -60,32 +66,33 @@ function mockTx(opts: MockOpts = {}) {
 }
 
 describe("restoreOverageBaseCarve", () => {
-  it("increments the parent INVOICE_ACCRUAL leg and amount by basePaise", async () => {
+  it("increments the parent (guarded on uninvoiced) and the leg by basePaise", async () => {
     const m = mockTx();
     await expect(
       restoreOverageBaseCarve(m.tx, { overageEventId: "ov1" }),
     ).resolves.toBe("restored");
+    // TOCTOU guard: the invoiced check rides the parent UPDATE's WHERE.
+    expect(m.paymentUpdateMany).toHaveBeenCalledWith({
+      where: { id: "parent1", billableToOrgInvoiceId: null },
+      data: { amount: { increment: 300 } },
+    });
     expect(m.legUpdate).toHaveBeenCalledWith({
       where: {
         paymentId_source: { paymentId: "parent1", source: "INVOICE_ACCRUAL" },
       },
       data: { amountPaise: { increment: 300 } },
     });
-    expect(m.paymentUpdate).toHaveBeenCalledWith({
-      where: { id: "parent1" },
-      data: { amount: { increment: 300 } },
-    });
   });
 
-  it("returns invoiced (no leg writes) when the parent is already on an invoice", async () => {
+  it("returns invoiced (no leg writes) when the guarded parent update matches no row", async () => {
     const m = mockTx({
       parent: { id: "parent1", billableToOrgInvoiceId: "inv1" },
+      parentUpdateManyCount: 0,
     });
     await expect(
       restoreOverageBaseCarve(m.tx, { overageEventId: "ov1" }),
     ).resolves.toBe("invoiced");
     expect(m.legUpdate).not.toHaveBeenCalled();
-    expect(m.paymentUpdate).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -114,11 +121,15 @@ describe("restoreOverageBaseCarve", () => {
 });
 
 describe("recarveOverageBase", () => {
-  it("decrements the leg (guarded) and parent amount", async () => {
+  it("decrements the parent (guarded on uninvoiced) then the leg (guarded)", async () => {
     const m = mockTx();
     await expect(
       recarveOverageBase(m.tx, { overageEventId: "ov1" }),
     ).resolves.toBe("recarved");
+    expect(m.paymentUpdateMany).toHaveBeenCalledWith({
+      where: { id: "parent1", billableToOrgInvoiceId: null },
+      data: { amount: { decrement: 300 } },
+    });
     expect(m.legUpdateMany).toHaveBeenCalledWith({
       where: {
         paymentId: "parent1",
@@ -127,15 +138,12 @@ describe("recarveOverageBase", () => {
       },
       data: { amountPaise: { decrement: 300 } },
     });
-    expect(m.paymentUpdate).toHaveBeenCalledWith({
-      where: { id: "parent1" },
-      data: { amount: { decrement: 300 } },
-    });
   });
 
-  it("returns invoiced when the parent is already on an invoice", async () => {
+  it("returns invoiced when the guarded parent update matches no row", async () => {
     const m = mockTx({
       parent: { id: "parent1", billableToOrgInvoiceId: "inv1" },
+      parentUpdateManyCount: 0,
     });
     await expect(
       recarveOverageBase(m.tx, { overageEventId: "ov1" }),
@@ -143,12 +151,11 @@ describe("recarveOverageBase", () => {
     expect(m.legUpdateMany).not.toHaveBeenCalled();
   });
 
-  it("returns invoiced (and leaves amount untouched) when the guarded decrement matches no leg", async () => {
+  it("throws (rolling the tx back) when the leg lacks the restored base on an uninvoiced parent", async () => {
     const m = mockTx({ legUpdateManyCount: 0 });
     await expect(
       recarveOverageBase(m.tx, { overageEventId: "ov1" }),
-    ).resolves.toBe("invoiced");
-    expect(m.paymentUpdate).not.toHaveBeenCalled();
+    ).rejects.toThrow(/missing the restored basePaise/);
   });
 });
 

--- a/__tests__/enterprise/overage-member-webhook.test.ts
+++ b/__tests__/enterprise/overage-member-webhook.test.ts
@@ -32,6 +32,10 @@ jest.mock("../../lib/payments/ledger/post", () => ({
 jest.mock("../../lib/payments/billing/overage-transitions", () => ({
   transitionOverage: jest.fn(),
 }));
+jest.mock("../../lib/payments/billing/overage-base-carve", () => ({
+  restoreOverageBaseCarve: jest.fn().mockResolvedValue("restored"),
+  recarveOverageBase: jest.fn().mockResolvedValue("recarved"),
+}));
 jest.mock("../../lib/enterprise/system-events", () => ({
   recordSystemError: jest.fn().mockResolvedValue(undefined),
 }));
@@ -85,11 +89,13 @@ describe("handleOverageMemberSuccess", () => {
         update: {},
       }),
     );
+    // #812 — two-step CAS: the still-carved edge is tried first.
     expect(mockTransition).toHaveBeenCalledWith(
       tx,
       { paymentId: "side1" },
       "CHARGED",
       { settledAt: expect.any(Date) },
+      { fromIn: ["PENDING", "ACCRUED"] },
     );
     // the journal the CHARGE_MEMBER reconcile invariant joins on
     expect(mockPost).toHaveBeenCalledWith(tx, {

--- a/__tests__/enterprise/refund-credit-note.test.ts
+++ b/__tests__/enterprise/refund-credit-note.test.ts
@@ -39,6 +39,10 @@ function mockTx(opts: {
           // #776 — credit notes only mint against an issued invoice.
           status: "ISSUED",
           issuedAt: new Date("2026-05-01T00:00:00.000Z"),
+          // #812 — subtotalPaise drives the gross-up (tax over SUBTOTAL, not
+          // total); omitting it silently zeroed taxFraction and the test
+          // affirmed the old under-credit bug.
+          subtotalPaise: 1000,
           totalPaise: 1180,
           igstPaise: 0,
           cgstPaise: 90,
@@ -81,7 +85,14 @@ describe("mintRefundCreditNote", () => {
     const data = tx._creditNoteCreate.mock.calls[0][0].data;
     expect(data.refundId).toBe("ref1");
     expect(data.invoiceId).toBe("inv1");
-    expect(data.totalPaise).toBe(1000);
+    // #812 — a full refund of a ₹1180 invoice (₹1000 + 18% GST) must mint a
+    // ₹1180 credit note: the reversed accrual legs are tax-EXCLUSIVE, so GST
+    // is grossed up on top (CGST Sec 34 reverses output tax proportionally).
+    expect(data.subtotalPaise).toBe(1000);
+    expect(data.cgstPaise).toBe(90);
+    expect(data.sgstPaise).toBe(90);
+    expect(data.igstPaise).toBe(0);
+    expect(data.totalPaise).toBe(1180);
     // #789 — the prefix is capped so the number satisfies CGST Rule 53's
     // 16-character limit; "ACME-CN-2026-0001" (17 chars) was itself a breach.
     expect(data.creditNoteNumber).toBe("ACM-CN-2026-0001");

--- a/__tests__/enterprise/sweep-abandoned-overage-charges.test.ts
+++ b/__tests__/enterprise/sweep-abandoned-overage-charges.test.ts
@@ -8,12 +8,24 @@
  * (cycleOverageSoFarPaise excludes only REVERSED/BLOCKED/FAILED). This job FAILs
  * the abandoned ones so they stop blocking legit bookings.
  */
-jest.mock("../../lib/prisma", () => ({
-  __esModule: true,
-  default: { overageEvent: { findMany: jest.fn() } },
-}));
+jest.mock("../../lib/prisma", () => {
+  const client = {
+    overageEvent: { findMany: jest.fn() },
+    // #812 — the sweep claims per-event in a tx (FAIL + basePaise restore).
+    $transaction: jest.fn(
+      (fn: (tx: unknown) => Promise<unknown>): Promise<unknown> => fn(client),
+    ),
+  };
+  return { __esModule: true, default: client };
+});
 jest.mock("../../lib/payments/billing/overage-transitions", () => ({
   transitionOverage: jest.fn(),
+}));
+jest.mock("../../lib/payments/billing/overage-base-carve", () => ({
+  restoreOverageBaseCarve: jest.fn().mockResolvedValue("restored"),
+}));
+jest.mock("../../lib/enterprise/system-events", () => ({
+  recordSystemError: jest.fn().mockResolvedValue(undefined),
 }));
 
 
@@ -68,14 +80,18 @@ describe("sweepAbandonedOverageCharges (#785)", () => {
         },
       ]),
     );
-    // PENDING→FAILED by id (transitionOverage appends the legal-from guard),
+    // #812 — per-event tx now: PENDING→FAILED claim (transitionOverage
+    // appends the legal-from guard) + basePaise restore land together,
     // stamping an auditable write-off reason (#779 §A).
-    expect(mockTransition).toHaveBeenCalledWith(
-      expect.anything(),
-      { id: { in: ["ov_1", "ov_2"] } },
-      "FAILED",
-      { chargeFailureReason: expect.stringContaining("swept at 7d") },
-    );
+    expect(mockTransition).toHaveBeenCalledTimes(2);
+    for (const id of ["ov_1", "ov_2"]) {
+      expect(mockTransition).toHaveBeenCalledWith(
+        expect.anything(),
+        { id },
+        "FAILED",
+        { chargeFailureReason: expect.stringContaining("swept at 7d") },
+      );
+    }
   });
 
   it("empty scan → no transition", async () => {

--- a/app/api/overage/[overageEventId]/order/route.ts
+++ b/app/api/overage/[overageEventId]/order/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createRazorpayOrder } from "@/lib/payments/core/razorpay";
 import { PaymentStatus } from "@prisma/client";
 import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+import { recarveOverageBase } from "@/lib/payments/billing/overage-base-carve";
 
 /**
  * #775 — resume-checkout for a CHARGE_MEMBER overage side-charge.
@@ -60,6 +61,39 @@ export async function POST(
     return NextResponse.json({ error: "Nothing to pay" }, { status: 400 });
   }
 
+  // Retry edge BEFORE minting the order: a FAILED charge had its basePaise
+  // restored to the org's parent accrual (#812 §P0), so resuming must carve it
+  // back out atomically with the FAILED→PENDING flip — otherwise the member's
+  // payment double-collects with the org's invoice. If the parent was already
+  // rolled onto an invoice while FAILED, the retry is refused (the org has
+  // been billed for the base; collecting it from the member too is wrong).
+  // No-op when already PENDING (still carved). If the mint below fails after
+  // this commits, the event sits PENDING/recarved until the abandoned-sweep
+  // re-FAILs it and restores — self-healing.
+  const retryBlocked = await prisma.$transaction(async (tx) => {
+    const moved = await transitionOverage(tx, { id: event.id }, "PENDING");
+    if (moved === 0) return false;
+    const recarve = await recarveOverageBase(tx, { overageEventId: event.id });
+    if (recarve === "invoiced") {
+      throw Object.assign(new Error("OVERAGE_RETRY_AFTER_INVOICE"), {
+        httpStatus: 409,
+      });
+    }
+    return false;
+  }).catch((err) => {
+    if (err instanceof Error && "httpStatus" in err) return true;
+    throw err;
+  });
+  if (retryBlocked) {
+    return NextResponse.json(
+      {
+        error:
+          "This charge can no longer be paid — your organization has already been billed for it. Contact support if you believe this is wrong.",
+      },
+      { status: 409 },
+    );
+  }
+
   const order = await createRazorpayOrder({
     amount: event.marginalPaise,
     currency: event.payment.currency,
@@ -82,9 +116,6 @@ export async function POST(
     where: { id: event.payment.id },
     data: { paymentIntent: order.id, paymentStatus: PaymentStatus.PENDING },
   });
-  // Guarded FAILED → PENDING only (no-op if already PENDING); CHARGED/REVERSED
-  // were already rejected above.
-  await transitionOverage(prisma, { id: event.id }, "PENDING");
 
   return NextResponse.json({
     orderId: order.id,

--- a/jobs/billing/timeout-member-overages.ts
+++ b/jobs/billing/timeout-member-overages.ts
@@ -23,6 +23,8 @@
 import "dotenv/config";
 import prisma from "@/lib/prisma";
 import { notifyMemberOverageTimedOut } from "@/lib/novu/org-workflows";
+import { restoreOverageBaseCarve } from "@/lib/payments/billing/overage-base-carve";
+import { recordSystemError } from "@/lib/enterprise/system-events";
 import { getAppUrl } from "@/lib/url";
 import { withCronLock, CronLockHeldError } from "@/lib/cron/with-cron-lock";
 
@@ -84,13 +86,25 @@ export async function runTimeoutMemberOverages(): Promise<TimeoutStats> {
             chargeFailureReason: TIMEOUT_REASON,
           },
         });
-        return claim.count > 0;
+        if (claim.count === 0) return null;
+        // #812 §P0 — the member never pays basePaise on a timed-out charge;
+        // return it to the org's parent accrual in the same tx.
+        return restoreOverageBaseCarve(tx, { overageEventId: ev.id });
       },
       { isolationLevel: "Serializable" },
     );
 
-    if (!claimed) continue;
+    if (claimed === null) continue;
     stats.timedOut += 1;
+    if (claimed === "invoiced") {
+      void recordSystemError({
+        organizationId: null,
+        category: "OVERAGE",
+        summary: `Timed-out overage ${ev.id}: basePaise not restorable — parent already invoiced; manual billing adjustment needed`,
+        err: new Error("OVERAGE_BASE_RESTORE_AFTER_INVOICE"),
+        context: { overageEventId: ev.id },
+      }).catch(() => {});
+    }
 
     // Fire-and-forget — committed state, no DB writes in the notify path.
     void notifyMemberOverageTimedOut(ev.programAssignment.membership.userId, {

--- a/lib/payments/billing/overage-base-carve.ts
+++ b/lib/payments/billing/overage-base-carve.ts
@@ -70,17 +70,22 @@ export async function restoreOverageBaseCarve(
 ): Promise<CarveOutcome> {
   const ctx = await loadCarveContext(tx, ref);
   if (!ctx) return "none";
-  if (ctx.parent.billableToOrgInvoiceId !== null) return "invoiced";
+
+  // Guarded parent-first write: the invoiced check rides the UPDATE's WHERE
+  // (re-evaluated under the row lock), so a rollup stamping
+  // billableToOrgInvoiceId between our read and this write yields count 0
+  // instead of silently diverging the leg from the issued document.
+  const parentBumped = await tx.payment.updateMany({
+    where: { id: ctx.parent.id, billableToOrgInvoiceId: null },
+    data: { amount: { increment: ctx.event.basePaise } },
+  });
+  if (parentBumped.count === 0) return "invoiced";
 
   await tx.paymentLeg.update({
     where: {
       paymentId_source: { paymentId: ctx.parent.id, source: "INVOICE_ACCRUAL" },
     },
     data: { amountPaise: { increment: ctx.event.basePaise } },
-  });
-  await tx.payment.update({
-    where: { id: ctx.parent.id },
-    data: { amount: { increment: ctx.event.basePaise } },
   });
   return "restored";
 }
@@ -98,9 +103,18 @@ export async function recarveOverageBase(
 ): Promise<CarveOutcome> {
   const ctx = await loadCarveContext(tx, ref);
   if (!ctx) return "none";
-  if (ctx.parent.billableToOrgInvoiceId !== null) return "invoiced";
+
+  // Guarded parent-first write — same TOCTOU shape as the restore above.
+  const parentCut = await tx.payment.updateMany({
+    where: { id: ctx.parent.id, billableToOrgInvoiceId: null },
+    data: { amount: { decrement: ctx.event.basePaise } },
+  });
+  if (parentCut.count === 0) return "invoiced";
 
   // Guarded decrement — mirrors the original carve's fail-closed stance.
+  // Count 0 here means the leg lacks the restored base while the parent is
+  // still uninvoiced: an invariant breach, not a billing race. Throw so the
+  // caller's tx rolls the parent decrement back instead of half-applying.
   const carved = await tx.paymentLeg.updateMany({
     where: {
       paymentId: ctx.parent.id,
@@ -109,10 +123,10 @@ export async function recarveOverageBase(
     },
     data: { amountPaise: { decrement: ctx.event.basePaise } },
   });
-  if (carved.count === 0) return "invoiced";
-  await tx.payment.update({
-    where: { id: ctx.parent.id },
-    data: { amount: { decrement: ctx.event.basePaise } },
-  });
+  if (carved.count === 0) {
+    throw new Error(
+      `recarveOverageBase: INVOICE_ACCRUAL leg on payment ${ctx.parent.id} is missing the restored basePaise=${ctx.event.basePaise} — rolling back`,
+    );
+  }
   return "recarved";
 }

--- a/lib/payments/billing/overage-base-carve.ts
+++ b/lib/payments/billing/overage-base-carve.ts
@@ -1,0 +1,118 @@
+import type { Tx } from "@/lib/prisma";
+/**
+ * #812 §P0 / #775 / #782 — basePaise carve bookkeeping for CHARGE_MEMBER
+ * overage side-charges.
+ *
+ * At booking time, overage-settlement carves the over-cap pass-through
+ * (basePaise) OUT of the parent payment's INVOICE_ACCRUAL leg — the org pays
+ * only the covered portion; the member's side-charge collects base +
+ * surcharge. Until #812 the three abandon paths (gateway failure, abandoned
+ * sweep, 14-day timeout) FAILed the side-charge without putting basePaise
+ * back, silently under-billing the org for a session its member consumed.
+ *
+ * restore = FAILED: give the parent accrual its basePaise back so the next
+ * invoice rollup bills the org correctly. recarve = the recovery edges
+ * (FAILED→PENDING retry, FAILED→CHARGED late capture): take it out again so
+ * the member's payment doesn't double-collect with the org's invoice.
+ *
+ * Both are gated by the caller's CAS transition (run ONLY when the claim
+ * matched a row), which makes them exactly-once per edge. If the parent was
+ * already rolled onto an invoice (billableToOrgInvoiceId set), touching the
+ * leg would silently diverge from the issued document — those cases return
+ * "invoiced" and the caller surfaces a SystemEvent / 409 instead.
+ *
+ * Dependency-light (Prisma types only) so the sweep jobs can import it.
+ */
+
+export type CarveOutcome = "restored" | "recarved" | "none" | "invoiced";
+
+type CarveRef = { overageEventId: string } | { sidePaymentId: string };
+
+async function loadCarveContext(
+  tx: Pick<Tx, "overageEvent" | "payment">,
+  ref: CarveRef,
+) {
+  const event = await tx.overageEvent.findFirst({
+    where:
+      "overageEventId" in ref
+        ? { id: ref.overageEventId }
+        : { paymentId: ref.sidePaymentId },
+    select: {
+      id: true,
+      basePaise: true,
+      overageBehavior: true,
+      payment: { select: { id: true, parentPaymentId: true } },
+    },
+  });
+  if (
+    !event ||
+    event.overageBehavior !== "CHARGE_MEMBER" ||
+    event.basePaise <= 0 ||
+    !event.payment?.parentPaymentId
+  ) {
+    return null;
+  }
+  const parent = await tx.payment.findUnique({
+    where: { id: event.payment.parentPaymentId },
+    select: { id: true, billableToOrgInvoiceId: true },
+  });
+  if (!parent) return null;
+  return { event, parent };
+}
+
+/**
+ * FAILED edge: return the carved basePaise to the parent's INVOICE_ACCRUAL
+ * leg + amount. Call ONLY after a successful PENDING→FAILED CAS, in the same tx.
+ */
+export async function restoreOverageBaseCarve(
+  tx: Pick<Tx, "overageEvent" | "payment" | "paymentLeg">,
+  ref: CarveRef,
+): Promise<CarveOutcome> {
+  const ctx = await loadCarveContext(tx, ref);
+  if (!ctx) return "none";
+  if (ctx.parent.billableToOrgInvoiceId !== null) return "invoiced";
+
+  await tx.paymentLeg.update({
+    where: {
+      paymentId_source: { paymentId: ctx.parent.id, source: "INVOICE_ACCRUAL" },
+    },
+    data: { amountPaise: { increment: ctx.event.basePaise } },
+  });
+  await tx.payment.update({
+    where: { id: ctx.parent.id },
+    data: { amount: { increment: ctx.event.basePaise } },
+  });
+  return "restored";
+}
+
+/**
+ * Recovery edges (FAILED→PENDING retry, FAILED→CHARGED late capture): carve
+ * basePaise back out. Call ONLY after a successful CAS from FAILED, in the
+ * same tx. "invoiced" = the parent rolled onto an invoice while FAILED
+ * (restored base was billed) — the caller must refuse the retry / flag the
+ * capture, because the member paying now would double-collect basePaise.
+ */
+export async function recarveOverageBase(
+  tx: Pick<Tx, "overageEvent" | "payment" | "paymentLeg">,
+  ref: CarveRef,
+): Promise<CarveOutcome> {
+  const ctx = await loadCarveContext(tx, ref);
+  if (!ctx) return "none";
+  if (ctx.parent.billableToOrgInvoiceId !== null) return "invoiced";
+
+  // Guarded decrement — mirrors the original carve's fail-closed stance.
+  const carved = await tx.paymentLeg.updateMany({
+    where: {
+      paymentId: ctx.parent.id,
+      source: "INVOICE_ACCRUAL",
+      amountPaise: { gte: ctx.event.basePaise },
+    },
+    data: { amountPaise: { decrement: ctx.event.basePaise } },
+  });
+  if (carved.count === 0) return "invoiced";
+  await tx.payment.update({
+    where: { id: ctx.parent.id },
+    data: { amount: { decrement: ctx.event.basePaise } },
+  });
+  return "recarved";
+}

--- a/lib/payments/billing/overage-transitions.ts
+++ b/lib/payments/billing/overage-transitions.ts
@@ -50,9 +50,21 @@ export async function transitionOverage(
     /** #779 §A telemetry — why a FAILED write-off happened (sweep/timeout). */
     chargeFailureReason?: string | null;
   },
+  opts?: {
+    /**
+     * #812 — narrow the guard to a subset of the legal from-states
+     * (intersected with ALLOWED_FROM, never widened). Lets a caller learn
+     * WHICH edge fired: FAILED→CHARGED must re-carve basePaise, while
+     * PENDING→CHARGED must not — and a read-then-check would race.
+     */
+    fromIn?: OverageChargeStatus[];
+  },
 ): Promise<number> {
+  const allowedFrom = opts?.fromIn
+    ? opts.fromIn.filter((s) => ALLOWED_FROM[to].includes(s))
+    : ALLOWED_FROM[to];
   const res = await tx.overageEvent.updateMany({
-    where: { ...where, chargeStatus: { in: ALLOWED_FROM[to] } },
+    where: { ...where, chargeStatus: { in: allowedFrom } },
     data: { chargeStatus: to, ...data },
   });
   return res.count;

--- a/lib/payments/webhooks/overage-handlers.ts
+++ b/lib/payments/webhooks/overage-handlers.ts
@@ -23,6 +23,10 @@ import prisma from "@/lib/prisma";
 import { PaymentStatus } from "@prisma/client";
 import { postLedgerTxn, type Posting } from "@/lib/payments/ledger/post";
 import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+import {
+  recarveOverageBase,
+  restoreOverageBaseCarve,
+} from "@/lib/payments/billing/overage-base-carve";
 import { recordSystemError } from "@/lib/enterprise/system-events";
 
 /**
@@ -71,14 +75,43 @@ export async function handleOverageMemberSuccess(
 
     // Transition FIRST so the journal below mirrors the state machine: the
     // org-relief credit posts only for an event that actually became CHARGED.
-    const moved = await transitionOverage(
+    // Two-step CAS (#812): which edge fired matters — FAILED→CHARGED is a
+    // late capture whose basePaise was restored to the org accrual when the
+    // sweep FAILed it, so it must be carved back out; PENDING/ACCRUED→CHARGED
+    // is still carved. A read-then-check would race the sweeps.
+    const settledAt = new Date();
+    let moved = await transitionOverage(
       tx,
       { paymentId: side.id },
       "CHARGED",
-      {
-        settledAt: new Date(),
-      },
+      { settledAt },
+      { fromIn: ["PENDING", "ACCRUED"] },
     );
+    if (moved === 0) {
+      moved = await transitionOverage(
+        tx,
+        { paymentId: side.id },
+        "CHARGED",
+        { settledAt },
+        { fromIn: ["FAILED"] },
+      );
+      if (moved > 0) {
+        const recarve = await recarveOverageBase(tx, { sidePaymentId: side.id });
+        if (recarve === "invoiced") {
+          // The org was already invoiced for the restored base while the
+          // charge sat FAILED; the member's capture now over-relieves the org
+          // by basePaise. Money already moved — flag for a manual adjustment
+          // rather than refusing the capture.
+          void recordSystemError({
+            organizationId: side.organizationId,
+            category: "OVERAGE",
+            summary: `Late capture of overage side-payment ${side.id} after the parent was invoiced — basePaise double-collected; manual billing adjustment needed`,
+            err: new Error("OVERAGE_RECARVE_AFTER_INVOICE"),
+            context: { sidePaymentId: side.id, paymentIntentId },
+          }).catch(() => {});
+        }
+      }
+    }
 
     if (moved === 0) {
       // Capture raced a reversal: the booking refunded (event → REVERSED)
@@ -138,6 +171,24 @@ export async function handleOverageMemberFailure(
       where: { id: side.id },
       data: { paymentStatus: PaymentStatus.FAILED },
     });
-    await transitionOverage(tx, { paymentId: side.id }, "FAILED");
+    const moved = await transitionOverage(tx, { paymentId: side.id }, "FAILED");
+    if (moved > 0) {
+      // #812 §P0 — the member isn't paying basePaise; return it to the org's
+      // parent accrual in the same tx. "invoiced" (parent already rolled onto
+      // an invoice) is surfaced by the sweeps when they re-FAIL; here the
+      // charge stays retryable so a recarve on recovery rebalances it.
+      const restore = await restoreOverageBaseCarve(tx, {
+        sidePaymentId: side.id,
+      });
+      if (restore === "invoiced") {
+        void recordSystemError({
+          organizationId: null,
+          category: "OVERAGE",
+          summary: `Failed overage side-payment ${side.id}: basePaise not restorable — parent already invoiced; manual billing adjustment needed`,
+          err: new Error("OVERAGE_BASE_RESTORE_AFTER_INVOICE"),
+          context: { sidePaymentId: side.id, paymentIntentId },
+        }).catch(() => {});
+      }
+    }
   });
 }

--- a/scripts/cleanup/sweep-abandoned-overage-charges.ts
+++ b/scripts/cleanup/sweep-abandoned-overage-charges.ts
@@ -11,6 +11,8 @@
  */
 import prisma from "@/lib/prisma";
 import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+import { restoreOverageBaseCarve } from "@/lib/payments/billing/overage-base-carve";
+import { recordSystemError } from "@/lib/enterprise/system-events";
 import { withCronLock } from "@/lib/cron/with-cron-lock";
 
 export interface OverageSweepResult {
@@ -75,21 +77,45 @@ async function sweepAbandonedOverageChargesUnlocked(
     return { success: true, scanned: 0, failed: 0 };
   }
 
-  // PENDING→FAILED is the only legal target; transitionOverage appends the guard,
-  // so a side-charge that paid (→CHARGED) between the read and here is skipped.
-  // chargeFailureReason makes the silent write-off auditable (#779 §A) — the
-  // 14d timeout cron distinguishes its own FAILs via chargeTimedOutAt.
-  const failed = await transitionOverage(
-    prisma,
-    { id: { in: abandoned.map((a) => a.id) } },
-    "FAILED",
-    {
-      chargeFailureReason: `Abandoned before payment started (swept at ${ageDays}d)`,
-    },
-  );
+  // Per-event tx: the PENDING→FAILED claim (CAS — a side-charge that paid
+  // (→CHARGED) between the read and here matches zero rows) and the basePaise
+  // restore (#812 §P0) must land together. chargeFailureReason makes the
+  // silent write-off auditable (#779 §A) — the 14d timeout cron distinguishes
+  // its own FAILs via chargeTimedOutAt.
+  let failed = 0;
+  let invoicedSkips = 0;
+  for (const a of abandoned) {
+    const outcome = await prisma.$transaction(async (tx) => {
+      const moved = await transitionOverage(tx, { id: a.id }, "FAILED", {
+        chargeFailureReason: `Abandoned before payment started (swept at ${ageDays}d)`,
+      });
+      if (moved === 0) return null;
+      // FAILing the side-charge means the member never pays basePaise — give
+      // it back to the org's parent accrual so the next rollup bills it.
+      return restoreOverageBaseCarve(tx, { overageEventId: a.id });
+    });
+    if (outcome === null) continue;
+    failed += 1;
+    if (outcome === "invoiced") {
+      // Parent already rolled onto an issued invoice with the carved (smaller)
+      // base — the org was under-billed for this session. Needs a manual
+      // billing adjustment; surface it instead of silently diverging the leg.
+      invoicedSkips += 1;
+      void recordSystemError({
+        organizationId: null,
+        category: "OVERAGE",
+        summary: `Abandoned overage ${a.id}: basePaise not restorable — parent already invoiced; manual billing adjustment needed`,
+        err: new Error("OVERAGE_BASE_RESTORE_AFTER_INVOICE"),
+        context: { overageEventId: a.id },
+      }).catch(() => {});
+    }
+  }
 
   console.log(
-    `🧹 Failed ${failed} abandoned CHARGE_MEMBER overage charge(s) — circuit-breaker ceiling freed`,
+    `🧹 Failed ${failed} abandoned CHARGE_MEMBER overage charge(s) — circuit-breaker ceiling freed` +
+      (invoicedSkips > 0
+        ? ` (${invoicedSkips} need manual billing adjustment — parent already invoiced)`
+        : ""),
   );
   return { success: true, scanned: abandoned.length, failed };
 }


### PR DESCRIPTION
## Stacked on #825

Second of the two stacked PRs from the state-machine audit. The audit named four money scenarios (S5/S6/S9/S10 from #812 §P0/P1); **re-verification against the current branch found two already fixed**, so this PR ships the two that remained:

## S9 — CHARGE_MEMBER basePaise leak (the substantive fix)

At booking time, `overage-settlement.ts` carves `basePaise` out of the parent payment's `INVOICE_ACCRUAL` leg — the org pays only the covered portion because the member's side-charge is supposed to collect base + surcharge. All three abandon paths (gateway failure webhook, abandoned sweep at 7d, timeout at 14d) FAILed the side-charge **without restoring the carve**: the org was under-billed, the member paid nothing, and the revenue leak was silent and deterministic at normal abandonment rates.

The fix is symmetric and CAS-gated (`lib/payments/billing/overage-base-carve.ts`):

- **FAILED edges restore** — inside the same tx as the PENDING→FAILED claim, which makes the restore exactly-once regardless of which sweep wins the race.
- **Recovery edges recarve** — `FAILED→PENDING` (resume-checkout) recarves atomically before the gateway order is minted, refusing with a 409 if the org was already invoiced for the restored base; `FAILED→CHARGED` (late capture) uses a new two-step CAS (`fromIn` narrowing on `transitionOverage`, intersected with `ALLOWED_FROM`, never widened) so the handler knows *which* edge fired without a racy read-then-check.
- **Already-invoiced parents are never silently diverged** from the issued document — those cases surface an `OVERAGE` SystemEvent for a manual billing adjustment instead of corrupting the leg.

## S10 — GST gross-up: test was silently skipping the fix

The production gross-up (#812 §P0: credit-note tax computed over the invoice *subtotal*, since the reversed accrual legs are tax-exclusive) was already live in `mintRefundCreditNote` — but the test mock omitted `subtotalPaise`, so `taxFraction` computed 0 and the assertion pinned the old under-credit value (₹1000 for a ₹1180 refund). The fixture now exercises the real path and asserts ₹1180 with the 90/90 CGST/SGST split.

## Verified already fixed (no code change, documented here)

- **S6 (refund-before-capture dropped):** the Razorpay handler returns the `DeferSignal` sentinel (`app/api/webhooks/utils.ts:850`) so the sweeper re-drives until the payment lands.
- **S5 (top-up half-commit):** `confirmTopUp` already composes the CAS claim + wallet credit + `topup:<orderId>` ledger post in one tx, with the #785 `capturedAt` pre-stamp and amount-mismatch guard. The reconcile alert is wired too: findings → SystemEvent + exit 2 → the workflow's notify-ops step.

Deliberately untouched: multi-collaborator refund splits (entangled with #773's deferred journal posting) and clawback automation (#715).

## Verification

524/524 enterprise tests (12 new carve tests incl. the never-widen property; webhook/sweep suites updated to the per-event tx + two-step CAS shapes), `tsc --noEmit` clean, eslint clean.

Part of #812
Refs #775, #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)