### PR TITLE
B2C hardening (PR-C, stacked): slot mis-binding, double-booking guard, checkout idempotency, reconciliation env fix

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -23,6 +23,7 @@ async function replayByIdempotencyKey(userId: string, key: string) {
     select: {
       paymentIntent: true,
       paymentStatus: true,
+      paymentGateway: true,
       amount: true,
       currency: true,
       appointmentId: true,
@@ -39,7 +40,14 @@ async function replayByIdempotencyKey(userId: string, key: string) {
       message: "This checkout was already completed.",
     });
   }
-  if (existing.paymentStatus === "PENDING") {
+  // Stripe stores the hosted checkout URL in client_secret (see
+  // StripeCheckout.tsx); we don't persist it, so a Stripe PENDING replay
+  // can't be resumed — fall through to the fresh-key 409 below instead of
+  // returning a null secret the client can't redirect with.
+  if (
+    existing.paymentStatus === "PENDING" &&
+    existing.paymentGateway !== "STRIPE"
+  ) {
     return NextResponse.json({
       success: true,
       reused: true,

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -8,16 +8,74 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import { checkoutLimiter, applyRateLimit } from "@/lib/rate-limit";
 import { ZodError } from "zod";
+import { Prisma } from "@prisma/client";
+import prisma from "@/lib/prisma";
 import { routeGateway } from "@/lib/payments/gateway-router";
 import { resolveCheckoutTaxContext } from "@/lib/payments/tax/checkout-context";
 
+// #828 — replay the original checkout response for a duplicate attempt. The
+// stored Payment carries enough for the client to reopen the gateway with the
+// SAME order instead of minting (and possibly paying) a second one. Scoped to
+// the caller's userId so a guessed key can't read someone else's payment.
+async function replayByIdempotencyKey(userId: string, key: string) {
+  const existing = await prisma.payment.findFirst({
+    where: { clientIdempotencyKey: key, userId },
+    select: {
+      paymentIntent: true,
+      paymentStatus: true,
+      amount: true,
+      currency: true,
+      appointmentId: true,
+      isMockPayment: true,
+    },
+  });
+  if (!existing) return null;
+  if (existing.paymentStatus === "SUCCEEDED") {
+    return NextResponse.json({
+      success: true,
+      reused: true,
+      skipPayment: true,
+      appointmentId: existing.appointmentId ?? undefined,
+      message: "This checkout was already completed.",
+    });
+  }
+  if (existing.paymentStatus === "PENDING") {
+    return NextResponse.json({
+      success: true,
+      reused: true,
+      orderId: existing.paymentIntent,
+      paymentIntent: { id: existing.paymentIntent, client_secret: null },
+      amount: Number(existing.amount),
+      currency: existing.currency,
+      isMockPayment: existing.isMockPayment,
+      message: "Resuming your in-progress checkout.",
+    });
+  }
+  // Terminal (FAILED/CANCELED/...) — this logical attempt is dead; the client
+  // must mint a fresh key for a new attempt (the wallet top-up contract).
+  return NextResponse.json(
+    {
+      error:
+        "A previous attempt for this checkout already failed. Refresh and try again.",
+      errorType: "IDEMPOTENT_REPLAY_TERMINAL",
+      timestamp: new Date().toISOString(),
+    },
+    { status: 409 },
+  );
+}
+
 export async function POST(req: NextRequest) {
+  // #828 — hoisted so the P2002 catch can replay without re-reading the
+  // (already consumed) request body.
+  let replayUserId: string | undefined;
+  let replayKey: string | undefined;
   try {
     // Check authentication
     const session = await getSession();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+    replayUserId = session.user.id;
 
     // Rate limit: 5 checkouts per minute per user
     const rl = await applyRateLimit(checkoutLimiter, session.user.id);
@@ -29,6 +87,15 @@ export async function POST(req: NextRequest) {
     // Only allow mock payments in development — prevent client-side bypass in production
     const isMockPayment =
       body.isMockPayment === true && process.env.NODE_ENV === "development";
+
+    // #828 — fast-path replay: a double-click / network retry / second tab
+    // with the same key gets the original attempt's response, never a second
+    // Payment + tentative slots + gateway order.
+    replayKey = validatedData.clientIdempotencyKey;
+    if (replayKey) {
+      const replay = await replayByIdempotencyKey(session.user.id, replayKey);
+      if (replay) return replay;
+    }
 
     const { buyerCountry } = await resolveCheckoutTaxContext({
       userId: session.user.id,
@@ -68,6 +135,19 @@ export async function POST(req: NextRequest) {
     }
     return NextResponse.json(result);
   } catch (error) {
+    // #828 — two concurrent identical requests can both miss the replay
+    // lookup; the loser's Payment.create dies on the unique key. Replay the
+    // winner's response instead of surfacing a 500.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002" &&
+      String(error.meta?.target ?? "").includes("clientIdempotencyKey") &&
+      replayUserId &&
+      replayKey
+    ) {
+      const replay = await replayByIdempotencyKey(replayUserId, replayKey);
+      if (replay) return replay;
+    }
     // ZodError from checkoutSchema.parse() — extract first human-readable message
     if (error instanceof ZodError) {
       const firstMessage = error.issues[0]?.message ?? "Invalid request";

--- a/app/checkout/components/LemonSqueezyCheckout.tsx
+++ b/app/checkout/components/LemonSqueezyCheckout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { CheckoutInput, checkoutResponseSchema } from "@/schemas/checkout";
@@ -37,7 +37,9 @@ const LemonSqueezyCheckout: React.FC<LemonSqueezyCheckoutProps> = ({
 }) => {
   const [isProcessing, setIsProcessing] = useState(false);
   // #828 — stable per-mount; the server dedupes retries on this key.
-  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
+  // useState's lazy initializer runs once, unlike a useRef(arg) expression
+  // which would mint a key every render.
+  const [idempotencyKey] = useState(mintClientIdempotencyKey);
   const { toast } = useToast();
 
   const loadLemonSqueezyScript = (): Promise<boolean> => {
@@ -73,7 +75,7 @@ const LemonSqueezyCheckout: React.FC<LemonSqueezyCheckoutProps> = ({
         body: JSON.stringify({
           ...input,
           paymentGateway: "LEMON_SQUEEZY",
-          clientIdempotencyKey: idempotencyKeyRef.current,
+          clientIdempotencyKey: idempotencyKey,
         }),
       });
 

--- a/app/checkout/components/LemonSqueezyCheckout.tsx
+++ b/app/checkout/components/LemonSqueezyCheckout.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { CheckoutInput, checkoutResponseSchema } from "@/schemas/checkout";
+import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 interface LemonSqueezyCheckoutProps {
   input: CheckoutInput;
@@ -35,6 +36,8 @@ const LemonSqueezyCheckout: React.FC<LemonSqueezyCheckoutProps> = ({
   onError,
 }) => {
   const [isProcessing, setIsProcessing] = useState(false);
+  // #828 — stable per-mount; the server dedupes retries on this key.
+  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
   const { toast } = useToast();
 
   const loadLemonSqueezyScript = (): Promise<boolean> => {
@@ -70,6 +73,7 @@ const LemonSqueezyCheckout: React.FC<LemonSqueezyCheckoutProps> = ({
         body: JSON.stringify({
           ...input,
           paymentGateway: "LEMON_SQUEEZY",
+          clientIdempotencyKey: idempotencyKeyRef.current,
         }),
       });
 

--- a/app/checkout/components/RazorpayCheckout.tsx
+++ b/app/checkout/components/RazorpayCheckout.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { loadScript } from "../plans/utils";
 import { CheckoutInput } from "@/schemas/checkout";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 interface RazorpayPaymentResponse {
@@ -77,7 +77,9 @@ export default function RazorpayCheckout({
   const { toast } = useToast();
   const [isProcessing, setIsProcessing] = useState(false);
   // #828 — stable per-mount; the server dedupes retries on this key.
-  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
+  // useState's lazy initializer runs once, unlike a useRef(arg) expression
+  // which would mint a key every render.
+  const [idempotencyKey] = useState(mintClientIdempotencyKey);
 
   const handleCheckout = async () => {
     setIsProcessing(true);
@@ -103,7 +105,7 @@ export default function RazorpayCheckout({
         },
         body: JSON.stringify({
           ...checkoutData,
-          clientIdempotencyKey: idempotencyKeyRef.current,
+          clientIdempotencyKey: idempotencyKey,
         }),
       });
 

--- a/app/checkout/components/RazorpayCheckout.tsx
+++ b/app/checkout/components/RazorpayCheckout.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { loadScript } from "../plans/utils";
 import { CheckoutInput } from "@/schemas/checkout";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 interface RazorpayPaymentResponse {
   razorpay_payment_id: string;
@@ -75,6 +76,8 @@ export default function RazorpayCheckout({
 }: RazorpayCheckoutProps) {
   const { toast } = useToast();
   const [isProcessing, setIsProcessing] = useState(false);
+  // #828 — stable per-mount; the server dedupes retries on this key.
+  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
 
   const handleCheckout = async () => {
     setIsProcessing(true);
@@ -98,7 +101,10 @@ export default function RazorpayCheckout({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(checkoutData),
+        body: JSON.stringify({
+          ...checkoutData,
+          clientIdempotencyKey: idempotencyKeyRef.current,
+        }),
       });
 
       if (!response.ok) {

--- a/app/checkout/components/StripeCheckout.tsx
+++ b/app/checkout/components/StripeCheckout.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { CheckoutInput, checkoutResponseSchema } from "@/schemas/checkout";
 import { loadStripe } from "@stripe/stripe-js";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 // Initialize Stripe with publishable key
@@ -39,7 +39,9 @@ export default function StripeCheckout({
   const { toast } = useToast();
   const [isProcessing, setIsProcessing] = useState(false);
   // #828 — stable per-mount; the server dedupes retries on this key.
-  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
+  // useState's lazy initializer runs once, unlike a useRef(arg) expression
+  // which would mint a key every render.
+  const [idempotencyKey] = useState(mintClientIdempotencyKey);
 
   const handleCheckout = async () => {
     setIsProcessing(true);
@@ -80,7 +82,7 @@ export default function StripeCheckout({
         },
         body: JSON.stringify({
           ...checkoutData,
-          clientIdempotencyKey: idempotencyKeyRef.current,
+          clientIdempotencyKey: idempotencyKey,
         }),
       });
 

--- a/app/checkout/components/StripeCheckout.tsx
+++ b/app/checkout/components/StripeCheckout.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { CheckoutInput, checkoutResponseSchema } from "@/schemas/checkout";
 import { loadStripe } from "@stripe/stripe-js";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 // Initialize Stripe with publishable key
 const stripeKey = process.env.NEXT_PUBLIC_STRIPE_KEY;
@@ -37,6 +38,8 @@ export default function StripeCheckout({
 }: StripeCheckoutProps) {
   const { toast } = useToast();
   const [isProcessing, setIsProcessing] = useState(false);
+  // #828 — stable per-mount; the server dedupes retries on this key.
+  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
 
   const handleCheckout = async () => {
     setIsProcessing(true);
@@ -75,7 +78,10 @@ export default function StripeCheckout({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(checkoutData),
+        body: JSON.stringify({
+          ...checkoutData,
+          clientIdempotencyKey: idempotencyKeyRef.current,
+        }),
       });
 
       console.log("Response status:", response.status);

--- a/app/checkout/components/XFlowCheckout.tsx
+++ b/app/checkout/components/XFlowCheckout.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { CheckoutInput, checkoutResponseSchema } from "@/schemas/checkout";
+import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 interface XFlowCheckoutProps {
   input: CheckoutInput;
@@ -38,6 +39,8 @@ const XFlowCheckout: React.FC<XFlowCheckoutProps> = ({
   onError,
 }) => {
   const [isProcessing, setIsProcessing] = useState(false);
+  // #828 — stable per-mount; the server dedupes retries on this key.
+  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
   const { toast } = useToast();
 
   // Load XFlow script dynamically
@@ -84,6 +87,7 @@ const XFlowCheckout: React.FC<XFlowCheckoutProps> = ({
         body: JSON.stringify({
           ...input,
           gateway: "XFLOW",
+          clientIdempotencyKey: idempotencyKeyRef.current,
         }),
       });
 

--- a/app/checkout/components/XFlowCheckout.tsx
+++ b/app/checkout/components/XFlowCheckout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { CheckoutInput, checkoutResponseSchema } from "@/schemas/checkout";
@@ -40,7 +40,9 @@ const XFlowCheckout: React.FC<XFlowCheckoutProps> = ({
 }) => {
   const [isProcessing, setIsProcessing] = useState(false);
   // #828 — stable per-mount; the server dedupes retries on this key.
-  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
+  // useState's lazy initializer runs once, unlike a useRef(arg) expression
+  // which would mint a key every render.
+  const [idempotencyKey] = useState(mintClientIdempotencyKey);
   const { toast } = useToast();
 
   // Load XFlow script dynamically
@@ -87,7 +89,7 @@ const XFlowCheckout: React.FC<XFlowCheckoutProps> = ({
         body: JSON.stringify({
           ...input,
           gateway: "XFLOW",
-          clientIdempotencyKey: idempotencyKeyRef.current,
+          clientIdempotencyKey: idempotencyKey,
         }),
       });
 

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -84,7 +84,8 @@ export default function ConsultationCheckoutPage({
   const [error, setError] = useState<string | null>(null);
   const [_reviews, setReviews] = useState<ConsultantReview[]>([]);
   const [isCheckoutProcessing, setIsCheckoutProcessing] = useState(false);
-  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
+  // #828 — useState's lazy initializer runs once per mount.
+  const [idempotencyKey] = useState(mintClientIdempotencyKey);
   const isProcessingRef = useRef(false);
   const [processingGateway, setProcessingGateway] = useState<string | null>(
     null,
@@ -294,11 +295,11 @@ export default function ConsultationCheckoutPage({
           ...checkoutData,
           isMockPayment,
           // #828 — stable per-mount; the server dedupes retries on this key.
-          clientIdempotencyKey: idempotencyKeyRef.current,
+          clientIdempotencyKey: idempotencyKey,
         }),
       });
     },
-    [],
+    [idempotencyKey],
   );
 
   const handleCheckout = useCallback(

--- a/app/checkout/plans/consultation/[planId]/page.tsx
+++ b/app/checkout/plans/consultation/[planId]/page.tsx
@@ -37,6 +37,7 @@ import StripeCheckout from "../../../components/StripeCheckout";
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
+import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 // price arrives as number: extended client + JSON serialization (#780)
 type ConsultationPlanWithConsultant = Omit<ConsultationPlan, "price"> & {
@@ -83,6 +84,7 @@ export default function ConsultationCheckoutPage({
   const [error, setError] = useState<string | null>(null);
   const [_reviews, setReviews] = useState<ConsultantReview[]>([]);
   const [isCheckoutProcessing, setIsCheckoutProcessing] = useState(false);
+  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
   const isProcessingRef = useRef(false);
   const [processingGateway, setProcessingGateway] = useState<string | null>(
     null,
@@ -288,7 +290,12 @@ export default function ConsultationCheckoutPage({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ ...checkoutData, isMockPayment }),
+        body: JSON.stringify({
+          ...checkoutData,
+          isMockPayment,
+          // #828 — stable per-mount; the server dedupes retries on this key.
+          clientIdempotencyKey: idempotencyKeyRef.current,
+        }),
       });
     },
     [],

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -81,7 +81,8 @@ export default function SubscriptionCheckoutPage({
   const [error, setError] = useState<string | null>(null);
   const [_reviews, setReviews] = useState<ConsultantReview[]>([]);
   const [isCheckoutProcessing, setIsCheckoutProcessing] = useState(false);
-  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
+  // #828 — useState's lazy initializer runs once per mount.
+  const [idempotencyKey] = useState(mintClientIdempotencyKey);
   const isProcessingRef = useRef(false);
   const [processingGateway, setProcessingGateway] = useState<string | null>(
     null,
@@ -193,11 +194,11 @@ export default function SubscriptionCheckoutPage({
           ...checkoutData,
           isMockPayment,
           // #828 — stable per-mount; the server dedupes retries on this key.
-          clientIdempotencyKey: idempotencyKeyRef.current,
+          clientIdempotencyKey: idempotencyKey,
         }),
       });
     },
-    [],
+    [idempotencyKey],
   );
 
   const handleCheckout = useCallback(

--- a/app/checkout/plans/subscription/[planId]/page.tsx
+++ b/app/checkout/plans/subscription/[planId]/page.tsx
@@ -37,6 +37,7 @@ import {
 import { calculatePricing, formatPercentage } from "../../math";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useCheckoutTaxContext } from "../../useCheckoutTaxContext";
+import { mintClientIdempotencyKey } from "@/app/checkout/plans/utils";
 
 // price arrives as number: extended client + JSON serialization (#780)
 type SubscriptionPlanWithConsultant = Omit<SubscriptionPlan, "price"> & {
@@ -80,6 +81,7 @@ export default function SubscriptionCheckoutPage({
   const [error, setError] = useState<string | null>(null);
   const [_reviews, setReviews] = useState<ConsultantReview[]>([]);
   const [isCheckoutProcessing, setIsCheckoutProcessing] = useState(false);
+  const idempotencyKeyRef = useRef(mintClientIdempotencyKey());
   const isProcessingRef = useRef(false);
   const [processingGateway, setProcessingGateway] = useState<string | null>(
     null,
@@ -187,7 +189,12 @@ export default function SubscriptionCheckoutPage({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ ...checkoutData, isMockPayment }),
+        body: JSON.stringify({
+          ...checkoutData,
+          isMockPayment,
+          // #828 — stable per-mount; the server dedupes retries on this key.
+          clientIdempotencyKey: idempotencyKeyRef.current,
+        }),
       });
     },
     [],

--- a/app/checkout/plans/utils.ts
+++ b/app/checkout/plans/utils.ts
@@ -39,17 +39,33 @@ export function createHandleApiError(
   };
 }
 
+
+// #828 — one key per logical checkout attempt (stable across double-clicks
+// and network retries within a mount; a fresh mount = a fresh attempt). The
+// server CASes on Payment.clientIdempotencyKey and replays the original
+// response instead of minting a duplicate order.
+export function mintClientIdempotencyKey(): string {
+  return globalThis.crypto?.randomUUID
+    ? `ck_${globalThis.crypto.randomUUID().replace(/-/g, "")}`
+    : `ck_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
 // Common API request logic for checkout
 export async function makeCheckoutRequest(
   checkoutData: CheckoutInput,
   isMockPayment: boolean = false,
+  clientIdempotencyKey?: string,
 ): Promise<Response> {
   return fetch("/api/checkout", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ ...checkoutData, isMockPayment }),
+    body: JSON.stringify({
+      ...checkoutData,
+      isMockPayment,
+      ...(clientIdempotencyKey && { clientIdempotencyKey }),
+    }),
   });
 }
 

--- a/docs/enterprise/50-operations/07-chaos-test-runbook.md
+++ b/docs/enterprise/50-operations/07-chaos-test-runbook.md
@@ -1,0 +1,83 @@
+---
+title: Chaos test runbook — pre-launch concurrency and failure drills
+band: 50-operations
+audience: sde3
+status: live
+last-reviewed: 2026-06-10
+---
+
+# Chaos test runbook
+
+This runbook is the go/no-go validation gate for the B2C hardening work
+tracked in #837. It is an eight-scenario suite that two developers can run in
+roughly a day against a staging clone with the Razorpay sandbox. It must
+never be run against production or against the shared development database.
+
+Two prerequisites come first, in this order: the checkout idempotency key
+(#828) must be deployed, because scenarios 1 and 3 are meaningless without
+it, and request logging must carry transaction identifiers and the
+`x-razorpay-event-id` header, because a failed scenario without correlated
+logs cannot be diagnosed. The scenarios are ordered by what kills the
+business fastest.
+
+## The scenarios
+
+**1. Same-slot two-user race (Playwright, two browser contexts, ~30 min).**
+Both contexts POST `/api/checkout` for the identical consultant slot, then
+both complete sandbox payments so both `payment.captured` webhooks land. The
+pass condition is exactly one confirmed slot, with the loser's payment
+surfaced for refund (a `CONFIRMATION_BLOCKED_DOUBLE_BOOKING` system event).
+This exercises the #827 confirm-time recheck end to end.
+
+**2. Webinar capacity overrun (k6 or Playwright, N+1 concurrent, ~20 min).**
+With `maxParticipants = N`, fire N+1 simultaneous checkouts and complete
+every payment. The pass condition is exactly N confirmations. This settles
+empirically whether the in-lock capacity recount sees concurrent tentative
+enrollments.
+
+**3. Double-submit (Playwright, one user, two tabs, ~15 min).** Two POSTs to
+`/api/checkout` with the same payload and the same `clientIdempotencyKey`
+before the first response returns. The pass condition is one Payment row, one
+set of tentative slots, and the second request receiving the first's replayed
+response (`reused: true`).
+
+**4. Webhook replay and reorder (Node script with the Razorpay SDK, ~30
+min).** Replay the same `payment.captured` payload twice (same
+`x-razorpay-event-id`); send `refund.created` before `payment.captured` and
+confirm the defer-and-re-drive path completes once the capture lands; replay
+a capture during an `APPROVED_PENDING_PAYMENT` confirmation. The pass
+condition is zero duplicate confirmations and zero duplicate refund cascades
+(`Refund.cascadedAt` holds).
+
+**5. Cleanup-versus-webhook race (~20 min).** Seed tentative slots aged past
+the cleanup threshold whose payments are PENDING, then run the
+tentative-slot cleanup while firing those payments' capture webhooks. The
+pass condition is that no SUCCEEDED payment ends up with deleted slots
+(issue #829 tracks the known gap).
+
+**6. Load ramp to twice expected peak (k6, ~45 min).** Mixed browse,
+checkout, and validate traffic. Watch four gauges: Netlify function duration
+against the 125-concurrent-invocation ceiling, `pg_stat_activity` connection
+count against the pooler limit, Redis lock acquisition retries, and — most
+importantly — the serializable-retry exhaustion rate (PostgreSQL SSI
+predicts 5–20% conflicts under contention; the give-up rate of
+`withSerializableRetry` is the launch metric). The pass condition is an
+error rate under 5%, P95 under two seconds, and zero pool exhaustion.
+
+**7. Connection drop mid-transaction (~15 min).** `pg_terminate_backend()`
+on active connections during checkout. The pass condition is that Prisma's
+P1001/P1017 surface as a retried request with no half-written appointment.
+The multi-session class checkout is the worst case because of the 60-second
+appointment-lock TTL (issue #832).
+
+**8. Payload and limiter abuse (~15 min).** A ten-megabyte body against the
+report and feedback endpoints, and a burst of POSTs against the event
+routes. The pass condition is 413/422 on size and 429 on burst (issue #831
+tracks the known gaps).
+
+## Go/no-go
+
+Scenarios 1 through 4 must pass with zero duplicate charges and zero double
+bookings, and scenario 6 must pass at twice the expected launch peak. The
+others inform the first-month backlog (#829–#834) rather than blocking
+launch, unless a failure reveals money loss.

--- a/docs/enterprise/50-operations/08-capacity-ladder.md
+++ b/docs/enterprise/50-operations/08-capacity-ladder.md
@@ -1,0 +1,68 @@
+---
+title: Capacity ladder — what breaks at 1k/10k/100k concurrent users
+band: 50-operations
+audience: sde3
+status: live
+last-reviewed: 2026-06-10
+---
+
+# Capacity ladder
+
+This document records the June 2026 capacity research so scale decisions
+start from criteria instead of anxiety. It complements ADR 13 (no message
+queues or workflow engines at this stage) with the concrete numbers for when
+that posture changes. The stack under discussion is Next.js on Netlify
+Functions, Supabase Postgres behind the Supavisor pooler (Prisma uses the
+pooled `DATABASE_URL`; `DIRECT_URL` is reserved for migrations), Upstash
+Redis for rate limits and locks, and GitHub Actions for the cron fleet.
+
+## Around 1,000 concurrent users — fine, with one asterisk (~$45/month)
+
+Connection-pool arithmetic says roughly ten pooled connections serve a
+thousand active users for an OLTP workload like ours, well inside the Pro
+tier's pooler limits. The asterisk is documented in our own incident
+history: the waitlist crons hit ETIMEDOUT at effectively zero user load
+(#821, #814) because background jobs collided on the pooler (#709). The
+first thing that breaks at this scale is not user traffic — it is our own
+cron fleet stampeding the pooler. The #476 cron locks remove the collision
+overlap; the residual actions are setting `connect_timeout=30` and
+`pool_timeout=30` on the pooled connection string and re-running the
+waitlist jobs to confirm.
+
+## Around 10,000 concurrent users — Netlify's function concurrency breaks first (~$110/month)
+
+Netlify allows 125 concurrent function invocations per site by default. A
+checkout in this codebase is expensive — a Serializable transaction plus a
+Redis lock with up to ten retries and multi-table writes — so invocations
+are slow, and slow invocations eat the concurrency budget. At a P95 checkout
+latency of one to two seconds, the platform caps at roughly 60 to 120
+checkouts per second, and browse traffic shares the same budget. The ladder
+here is: move heavy read paths to ISR and edge caching (the #734 work
+doubles as capacity work), bump Supabase one compute tier, and negotiate the
+Netlify concurrency limit. Two instruments become load-bearing at this
+rung: the serializable-retry exhaustion rate (PostgreSQL SSI predicts 5–20%
+conflict rates under contention, so `withSerializableRetry` giving up is
+the early-warning signal) and pooler saturation.
+
+## Around 100,000 concurrent users — the stack does not survive as composed, and that is fine
+
+At this scale Netlify compute pricing becomes prohibitive, the pooler is
+undersized by an order of magnitude, and realtime subsystems hit their
+ceilings. The required moves are persistent compute (Railway, Render, or
+EC2), a real job queue (BullMQ needs persistent workers, which is exactly
+why it is wrong for us today and right after leaving serverless), a larger
+Supabase tier with read replicas, and a CDN-fronted read path — roughly
+$800 to $1,200 per month at entry. The migration is two to four weeks of
+work when the traffic justifies it; pre-building it now would cost months.
+The one cheap pre-commitment we make today is keeping all background work
+behind the existing job-entry abstraction so the GitHub-Actions-to-queue
+swap stays mechanical.
+
+## Queue and broker posture
+
+Standardize on Inngest or QStash for new async work if a queue is needed
+before the persistent-compute move — we already run Inngest for waitlist
+crons, and a second paradigm would be pure carrying cost. BullMQ becomes the
+default at the persistent-compute rung. Kafka is not a conversation worth
+having for this product before sustained six-figure events per second with
+multiple independent consumer groups; revisit thresholds live in ADR 13.

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -2228,6 +2228,9 @@ export async function handleCheckout(
                       ? "CREDITS"
                       : "CARD",
               paymentIntent: paymentResponse!.id,
+              // #828 — unique; a concurrent duplicate attempt dies on P2002
+              // and the route replays this payment's original response.
+              clientIdempotencyKey: validatedData.clientIdempotencyKey ?? null,
               paymentGateway: validatedData.paymentGateway,
               // FIX #520: Zero-amount and mock payments succeed immediately (no webhook)
               paymentStatus: skipPayment

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -13,6 +13,7 @@ import {
 } from "@prisma/client";
 import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
 import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import { recordSystemError } from "@/lib/enterprise/system-events";
 import { validateWebhookMetadata } from "@/schemas/webhooks/metadata";
 import { ZodError } from "zod";
@@ -138,8 +139,15 @@ export async function handlePaymentSuccess(
   // error logging. The `sync-payment-earnings` background job serves as
   // a safety net for any failures in Phase 2.
 
-  // Phase 1: Critical transaction — payment confirmation + appointment
-  const txResult = await prisma.$transaction(async (tx) => {
+  // Phase 1: Critical transaction — payment confirmation + appointment.
+  // Serializable (#827 review): two concurrent capture webhooks for
+  // overlapping slots both pass the confirm-time conflict findFirst at READ
+  // COMMITTED (each sees the other's slots still tentative). Under SSI the
+  // rw-antidependency aborts one side with P2034; the retry then sees the
+  // winner confirmed and blocks. The SUCCEEDED early-return keeps the retry
+  // idempotent.
+  const txResult = await withSerializableRetry(() =>
+    prisma.$transaction(async (tx) => {
     const payment = await tx.payment.findUnique({
       where: { paymentIntent: paymentIntentId },
       include: { user: { include: { consulteeProfile: true } } },
@@ -280,7 +288,10 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       amount: payment.amount,
       currency: payment.currency,
     };
-  });
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
 
   // If transaction returned null, the payment was already processed or had a metadata error
   if (!txResult) return;

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -12,6 +12,8 @@ import {
   RequestStatus,
 } from "@prisma/client";
 import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
+import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
+import { recordSystemError } from "@/lib/enterprise/system-events";
 import { validateWebhookMetadata } from "@/schemas/webhooks/metadata";
 import { ZodError } from "zod";
 import { sendPaymentSuccessEmail, sendPaymentFailedEmail } from "@/lib/email";
@@ -1101,6 +1103,68 @@ async function confirmExistingAppointment(
   if (!appointment) {
     console.warn(`Appointment ${appointmentId} not found for confirmation`);
     return;
+  }
+
+  // #827 — first-confirmed-wins recheck for the EXCLUSIVE booking types.
+  // Checkout's hard-overlap check only blocks against isTentative:false
+  // slots and its tentative dedup is same-user-only, so two different users
+  // can both pay for overlapping slots; whichever capture webhook lands
+  // second must NOT flip its slots confirmed over the winner's. The loser
+  // stays tentative (the orphan/refund path picks it up, see #830) and the
+  // conflict is surfaced loudly instead of double-booking the consultant.
+  // Webinars/classes are capacity-based, not exclusive — skipped.
+  if (appointment.consultation || appointment.subscription) {
+    const mySlots = await tx.slotOfAppointment.findMany({
+      where: { appointmentId, isTentative: true },
+      select: {
+        id: true,
+        startsAt: true,
+        endsAt: true,
+        user: { select: { id: true } },
+      },
+    });
+    for (const slot of mySlots) {
+      // The non-booker participants (the consultant) attend both bookings —
+      // a confirmed overlapping slot sharing one of them is a true conflict.
+      const participantIds = slot.user
+        .map((u) => u.id)
+        .filter((id) => id !== userId);
+      if (participantIds.length === 0) continue;
+      const conflict = await tx.slotOfAppointment.findFirst({
+        where: {
+          id: { not: slot.id },
+          startsAt: { lt: slot.endsAt },
+          endsAt: { gt: slot.startsAt },
+          isTentative: false,
+          user: { some: { id: { in: participantIds } } },
+          appointment: { OR: buildOccupiedAppointmentFilter() },
+        },
+        select: { id: true, appointmentId: true },
+      });
+      if (conflict) {
+        console.error(
+          JSON.stringify({
+            event: "confirmation_blocked_double_booking",
+            appointmentId,
+            conflictingAppointmentId: conflict.appointmentId,
+            slotId: slot.id,
+            timestamp: new Date().toISOString(),
+          }),
+        );
+        void recordSystemError({
+          organizationId: null,
+          category: "PAYMENT",
+          summary: `Double-booking blocked at confirmation: appointment ${appointmentId} overlaps an already-confirmed slot — the payment needs a refund`,
+          err: new Error("CONFIRMATION_BLOCKED_DOUBLE_BOOKING"),
+          context: {
+            appointmentId,
+            conflictingAppointmentId: conflict.appointmentId,
+            slotId: slot.id,
+          },
+        }).catch(() => {});
+        return; // slots stay tentative; do not confirm over the winner
+      }
+    }
   }
 
   // FIX Issue #3: For CLASS, confirm ALL user's slots across all sessions

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3421,6 +3421,10 @@ model Payment {
   paymentIntent  String         @unique
   paymentGateway PaymentGateway
   paymentStatus  PaymentStatus
+  /// #828 — client-minted key, one per logical checkout attempt. The unique
+  /// constraint is the race-proof dedupe: a double-click/retry that slips
+  /// past the route's replay lookup dies on P2002 and replays the original.
+  clientIdempotencyKey String? @unique
   // #781 §B — financial rows Restrict their parents; removal = soft-delete.
   // Hard delete remains possible only while no money row references this.
   deletedAt      DateTime?

--- a/schemas/checkout.ts
+++ b/schemas/checkout.ts
@@ -84,6 +84,9 @@ export const checkoutSchema = z
     schedulingPeriodStartsAt: z.string().datetime().optional(),
     schedulingPeriodEndsAt: z.string().datetime().optional(),
     discountCode: z.string().optional(),
+    // #828 — one key per logical checkout attempt; the server replays the
+    // original response for a duplicate instead of minting a second order.
+    clientIdempotencyKey: z.string().min(8).max(128).optional(),
     paymentGateway: paymentGatewaySchema.default("RAZORPAY"), // Server auto-routes; client hint only
     displayCurrency: z.string().length(3).optional(), // Currency shown in the checkout UI
     notes: z.string().optional(),

--- a/scripts/payments/reconcile-payment-status.ts
+++ b/scripts/payments/reconcile-payment-status.ts
@@ -73,7 +73,11 @@ async function getRazorpayPaymentStatus(
   orderId: string,
 ): Promise<{ status: string; paymentId?: string } | null> {
   const keyId = process.env.RAZORPAY_KEY_ID;
-  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+  // #677 PM-1 — prod env defines RAZORPAY_SECRET (the canonical name the
+  // core lib reads); reading only RAZORPAY_KEY_SECRET silently disabled
+  // this reconciliation in production while it looked green.
+  const keySecret =
+    process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET;
 
   if (!keyId || !keySecret) {
     console.warn("Razorpay credentials not configured");
@@ -215,7 +219,8 @@ async function reconcilePaymentStatusUnlocked(): Promise<PaymentReconciliationRe
     orderBy: { createdAt: "asc" },
   });
 
-  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID && process.env.RAZORPAY_KEY_SECRET);
+  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID &&
+    (process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET));
   if (!razorpayConfigured) {
     console.warn("⚠️ Razorpay credentials not configured — Razorpay records will be skipped");
   }

--- a/scripts/payouts/handle-stuck-payouts.ts
+++ b/scripts/payouts/handle-stuck-payouts.ts
@@ -83,7 +83,11 @@ async function getRazorpayPayoutStatus(
   providerPayoutId: string,
 ): Promise<{ status: string; failureReason?: string } | null> {
   const keyId = process.env.RAZORPAY_KEY_ID;
-  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+  // #677 PM-1 — prod env defines RAZORPAY_SECRET (the canonical name the
+  // core lib reads); reading only RAZORPAY_KEY_SECRET silently disabled
+  // this reconciliation in production while it looked green.
+  const keySecret =
+    process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET;
 
   if (!keyId || !keySecret) {
     console.warn("RazorpayX credentials not configured");
@@ -202,7 +206,8 @@ async function handleStuckPayoutsUnlocked(): Promise<StuckPayoutsResult> {
     },
   });
 
-  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID && process.env.RAZORPAY_KEY_SECRET);
+  const razorpayConfigured = !!(process.env.RAZORPAY_KEY_ID &&
+    (process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET));
   if (!razorpayConfigured) {
     console.warn("⚠️ Razorpay credentials not configured — Razorpay records will be skipped");
   }

--- a/scripts/payouts/process-payouts.ts
+++ b/scripts/payouts/process-payouts.ts
@@ -53,7 +53,11 @@ async function createRazorpayPayout(
   payoutId: string,
 ): Promise<{ id: string }> {
   const keyId = process.env.RAZORPAY_KEY_ID;
-  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+  // #677 PM-1 — prod env defines RAZORPAY_SECRET (the canonical name the
+  // core lib reads); reading only RAZORPAY_KEY_SECRET silently disabled
+  // this reconciliation in production while it looked green.
+  const keySecret =
+    process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET;
 
   if (!keyId || !keySecret) {
     throw new Error("RazorpayX credentials not configured");

--- a/scripts/payouts/reconcile-payout-status.ts
+++ b/scripts/payouts/reconcile-payout-status.ts
@@ -83,7 +83,11 @@ async function getRazorpayPayoutStatus(
   providerPayoutId: string,
 ): Promise<{ status: string; failureReason?: string } | null> {
   const keyId = process.env.RAZORPAY_KEY_ID;
-  const keySecret = process.env.RAZORPAY_KEY_SECRET;
+  // #677 PM-1 — prod env defines RAZORPAY_SECRET (the canonical name the
+  // core lib reads); reading only RAZORPAY_KEY_SECRET silently disabled
+  // this reconciliation in production while it looked green.
+  const keySecret =
+    process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET;
 
   if (!keyId || !keySecret) {
     console.warn("RazorpayX credentials not configured");
@@ -215,7 +219,8 @@ async function reconcilePayoutStatusUnlocked(): Promise<PayoutReconciliationResu
   });
 
   const razorpayConfigured = !!(
-    process.env.RAZORPAY_KEY_ID && process.env.RAZORPAY_KEY_SECRET
+    process.env.RAZORPAY_KEY_ID &&
+    (process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET)
   );
   if (!razorpayConfigured) {
     console.warn(

--- a/utils/timeSlotsProcessing.ts
+++ b/utils/timeSlotsProcessing.ts
@@ -516,8 +516,16 @@ export function mergeConsecutiveSlots(
     const isConsecutive = Math.abs(currentMergedEnd - nextSlotStart) <= 60000;
     const bothAvailable =
       !currentMerged.isAllocated && !currentSlot.isAllocated;
+    // #788 — never merge across different availability rows. The merge keeps
+    // row A's slotOfAvailabilityId, so a cross-row merge mis-binds every
+    // sliced sub-window from row B's range to row A's ID and checkout's
+    // window validator correctly rejects the booking. The merge was designed
+    // (c9ad0de3) to fuse sub-windows WITHIN one row for trials; cross-row
+    // fusion was an accident no flow relies on.
+    const sameSource =
+      currentMerged.slotOfAvailabilityId === currentSlot.slotOfAvailabilityId;
 
-    if (isConsecutive && bothAvailable) {
+    if (isConsecutive && bothAvailable && sameSource) {
       // Extend the current merged slot
       currentMerged = {
         ...currentMerged,


### PR DESCRIPTION
## Stacked on #826 (which stacks on #825)

Third PR in the train. The B2C audit (umbrella #837) found the enterprise side got the full hardening pass while the consumer path — the side real users hit first — did not. This PR ports the four launch-blocking fixes down, plus the ops docs that gate launch.

## Fixes

**Slot picker mis-binding (`Closes #788`).** `mergeConsecutiveSlots` fused adjacent weekly availability rows while keeping only the first row's ID, so sliced sub-windows from the second row were mis-bound and checkout's validator (correctly) rejected them — silently failing an estimated 5–15% of bookings against back-to-back availability for ~4 months. Fix is the issue's Option 1: never merge across different source rows (cross-row fusion was an accident no flow relies on).

**Cross-user double-booking (`Closes #827`).** Checkout's overlap check excludes tentative slots and its dedup is same-user-only, so two users could both pay for overlapping consultant slots. Confirmation now rechecks inside the confirming tx for the exclusive types (consultation/subscription): first-confirmed-wins; the loser stays tentative and raises a `CONFIRMATION_BLOCKED_DOUBLE_BOOKING` SystemEvent for refund. #830 (orphan sweep) is the automated follow-up for the loser.

**Checkout idempotency key (`Closes #828`).** `Payment.clientIdempotencyKey @unique` (additive schema change), one key minted per checkout mount across all six client surfaces (the wallet top-up pattern). Replay semantics: SUCCEEDED → completed booking; PENDING → same gateway order for resume; terminal → 409, mint a fresh key. The unique constraint is the race-proof backstop — a concurrent duplicate dies on P2002 and the route replays the winner.

**Reconciliation env split (`Part of #677`, PM-1).** Verified live: `.env` defines `RAZORPAY_SECRET`, the four payout/payment reconciliation scripts read `RAZORPAY_KEY_SECRET` — every reconciliation safety net silently no-oped while looking green. Scripts now read the canonical name with legacy fallback. (PM-2's `Date.now()` payout key was already fixed on this branch — stale audit claim, documented here.)

## Docs (`Part of #837`)

`docs/enterprise/50-operations/07-chaos-test-runbook.md` — the 8-scenario pre-launch suite (same-slot race, capacity overrun, double-submit, webhook replay/reorder, cleanup race, 2× load ramp, connection drop, payload abuse) with pass conditions; scenarios 1–4 + the load ramp are the launch go/no-go.

`docs/enterprise/50-operations/08-capacity-ladder.md` — 1k/10k/100k concurrent: cron-vs-pooler contention breaks first (already observed at zero load, #709/#821), then Netlify's 125-concurrent-function ceiling, then the composition itself; with the no-pre-build verdict and queue posture (Inngest/QStash if needed; BullMQ only after persistent compute; Kafka effectively never).

## Verification

1287/1287 tests across 95 suites, `tsc --noEmit` clean, eslint clean (one pre-existing warning on an untouched line). Live two-tab/race verification is the chaos runbook's scenarios 1–3, blocked on the Supabase staging reconnect; `npx prisma db push` required before running (new `clientIdempotencyKey` column).

Closes #788
Closes #827
Closes #828
Part of #677
Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)