### PR TITLE
Pin landed slot/session fixes (PR-1 of 4): regression tests + cleanup delete-race guard

### DIFF
--- a/__tests__/booking/cleanup-tentative-guard.test.ts
+++ b/__tests__/booking/cleanup-tentative-guard.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #829 — the tentative-slot cleanup must never delete a slot that was
+ * confirmed (or paid) between its scan and its delete. The delete's WHERE
+ * re-states isTentative + no-SUCCEEDED-payment, so a concurrent capture
+ * webhook's flip makes the row stop matching (re-evaluated under the row
+ * lock) instead of being destroyed.
+ */
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    slotOfAppointment: {
+      findMany: jest.fn(),
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    $disconnect: jest.fn(),
+  },
+}));
+jest.mock("../../lib/cron/with-cron-lock", () => ({
+  withCronLock: jest.fn((_j: string, _o: unknown, fn: () => unknown) => fn()),
+  CronLockHeldError: class CronLockHeldError extends Error {},
+  CronLockUnavailableError: class CronLockUnavailableError extends Error {},
+  LONG_JOB_TTL_MS: 35 * 60 * 1000,
+}));
+
+import prisma from "../../lib/prisma";
+import { cleanupTentativeSlots } from "@/scripts/appointments/cleanup-tentative-slots";
+
+const mocked = prisma as unknown as {
+  slotOfAppointment: { findMany: jest.Mock; deleteMany: jest.Mock };
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("#829 — cleanup delete re-states the tentative + unpaid guards", () => {
+  it("carries isTentative + no-SUCCEEDED-payment in the deleteMany WHERE", async () => {
+    mocked.slotOfAppointment.findMany.mockResolvedValue([
+      {
+        id: "slot-1",
+        appointmentId: "appt-1",
+        createdAt: new Date("2026-05-01T00:00:00Z"),
+        startsAt: new Date("2026-05-02T10:00:00Z"),
+        endsAt: new Date("2026-05-02T11:00:00Z"),
+        appointment: { payment: [], consultation: null, subscription: null },
+      },
+    ]);
+    mocked.slotOfAppointment.deleteMany.mockResolvedValue({ count: 1 });
+
+    await cleanupTentativeSlots();
+
+    expect(mocked.slotOfAppointment.deleteMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: { in: ["slot-1"] },
+        isTentative: true,
+        appointment: {
+          payment: { none: { paymentStatus: "SUCCEEDED" } },
+        },
+      }),
+    });
+  });
+
+  it("deletes nothing when the scan finds nothing", async () => {
+    mocked.slotOfAppointment.findMany.mockResolvedValue([]);
+    await cleanupTentativeSlots();
+    expect(mocked.slotOfAppointment.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/booking/slot-session-fix-pins.test.ts
+++ b/__tests__/booking/slot-session-fix-pins.test.ts
@@ -1,0 +1,260 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Regression pins for the slot/session fixes that landed via PRs #825/#838
+ * but whose issues stayed open (#788, #827, #828) plus the #829 cleanup
+ * guard. These tests exist so a future refactor that reintroduces any of the
+ * four bugs fails CI instead of resurfacing in production:
+ *
+ *  #788 — mergeConsecutiveSlots fused adjacent availability ROWS, mis-binding
+ *         sliced sub-windows to the first row's id.
+ *  #827 — confirmExistingAppointment flipped slots confirmed without checking
+ *         for an already-confirmed overlapping slot (cross-user double-book).
+ *  #828 — checkout had no request-level idempotency; the replay helper must
+ *         return the original attempt instead of minting a duplicate.
+ *  #829 — cleanup-tentative-slots deleted by id only, destroying slots whose
+ *         capture webhook confirmed them between the scan and the delete.
+ */
+
+import { mergeConsecutiveSlots } from "@/utils/timeSlotsProcessing";
+import { confirmExistingAppointment } from "@/lib/payments/webhooks/handlers";
+import { replayByIdempotencyKey } from "@/lib/payments/operations/checkout-replay";
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: { payment: { findFirst: jest.fn() } },
+}));
+// handlers.ts pulls heavy transitive deps; stub everything the confirm path
+// doesn't exercise.
+jest.mock("../../lib/email", () => ({
+  sendPaymentSuccessEmail: jest.fn(),
+  sendPaymentFailedEmail: jest.fn(),
+}));
+jest.mock("../../lib/payments/payouts", () => ({
+  createEarningsFromPayment: jest.fn(),
+}));
+jest.mock("../../lib/waitlist/slot-handler", () => ({
+  markWaitlistAsBooked: jest.fn(),
+}));
+jest.mock("../../lib/novu", () => ({
+  notifyPaymentSuccess: jest.fn(),
+  notifyPaymentFailed: jest.fn(),
+  notifyAppointmentBooked: jest.fn(),
+}));
+jest.mock("../../lib/referrals/service", () => ({
+  processConsultantBookingReferral: jest.fn(),
+  reverseCreditsForPayment: jest.fn(),
+  qualifyReferralOnFirstBooking: jest.fn(),
+}));
+jest.mock("../../actions/stream/chat/event-channel.action", () => ({
+  addUserToEventChannel: jest.fn(),
+}));
+jest.mock("../../actions/stream/chat/channel.action", () => ({
+  createDirectMessageChannel: jest.fn(),
+}));
+jest.mock("../../lib/stream-logger", () => ({
+  streamLogger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+jest.mock("../../lib/enterprise/system-events", () => ({
+  recordSystemError: jest.fn().mockResolvedValue(undefined),
+}));
+
+import prisma from "../../lib/prisma";
+import { recordSystemError } from "../../lib/enterprise/system-events";
+
+const mockPaymentFindFirst = (
+  prisma as unknown as { payment: { findFirst: jest.Mock } }
+).payment.findFirst;
+const mockSystemError = recordSystemError as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// #788 — same-source merge guard
+// ---------------------------------------------------------------------------
+describe("#788 — mergeConsecutiveSlots never merges across availability rows", () => {
+  const base = {
+    isAllocated: false,
+    localStartTime: "x",
+    localEndTime: "x",
+    slotId: "s",
+  };
+  const rowA = {
+    ...base,
+    slotOfAvailabilityId: "row-A",
+    slotStartTimeInUTC: "2026-06-26T14:00:00.000Z",
+    slotEndTimeInUTC: "2026-06-26T15:00:00.000Z",
+  };
+  const rowB = {
+    ...base,
+    slotOfAvailabilityId: "row-B",
+    slotStartTimeInUTC: "2026-06-26T15:00:00.000Z",
+    slotEndTimeInUTC: "2026-06-26T16:00:00.000Z",
+  };
+
+  it("keeps adjacent slots from DIFFERENT rows separate (the #788 mis-bind)", () => {
+    const merged = mergeConsecutiveSlots([rowA, rowB] as never);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((m) => m.slotOfAvailabilityId)).toEqual([
+      "row-A",
+      "row-B",
+    ]);
+  });
+
+  it("still merges adjacent sub-windows of the SAME row (the trial use case)", () => {
+    const sameRowB = { ...rowB, slotOfAvailabilityId: "row-A" };
+    const merged = mergeConsecutiveSlots([rowA, sameRowB] as never);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].slotEndTimeInUTC).toBe("2026-06-26T16:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #827 — confirm-time double-booking guard
+// ---------------------------------------------------------------------------
+describe("#827 — confirmExistingAppointment first-confirmed-wins", () => {
+  function mockTx(opts: { conflict: boolean }) {
+    const slotUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+    return {
+      slotUpdateMany,
+      tx: {
+        appointment: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: "appt-1",
+            consultation: { id: "c1" },
+            subscription: null,
+            webinar: null,
+            class: null,
+          }),
+        },
+        slotOfAppointment: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: "slot-1",
+              startsAt: new Date("2026-06-26T15:00:00Z"),
+              endsAt: new Date("2026-06-26T16:00:00Z"),
+              user: [{ id: "booker" }, { id: "consultant" }],
+            },
+          ]),
+          findFirst: jest
+            .fn()
+            .mockResolvedValue(
+              opts.conflict
+                ? { id: "slot-other", appointmentId: "appt-2" }
+                : null,
+            ),
+          updateMany: slotUpdateMany,
+        },
+        consultation: {
+          update: jest.fn().mockResolvedValue({}),
+          findUnique: jest
+            .fn()
+            .mockResolvedValue({ id: "c1", requestStatus: "APPROVED_PENDING_PAYMENT" }),
+        },
+      } as never,
+    };
+  }
+
+  it("blocks confirmation (slots stay tentative) when an overlapping confirmed slot exists", async () => {
+    const m = mockTx({ conflict: true });
+    await confirmExistingAppointment(m.tx, "appt-1", "booker");
+    expect(m.slotUpdateMany).not.toHaveBeenCalled();
+    expect(mockSystemError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "PAYMENT",
+        context: expect.objectContaining({
+          conflictingAppointmentId: "appt-2",
+        }),
+      }),
+    );
+  });
+
+  it("confirms normally when no overlap exists", async () => {
+    const m = mockTx({ conflict: false });
+    await confirmExistingAppointment(m.tx, "appt-1", "booker");
+    expect(m.slotUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { isTentative: false } }),
+    );
+    expect(mockSystemError).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #828 — idempotent checkout replay
+// ---------------------------------------------------------------------------
+describe("#828 — replayByIdempotencyKey returns the original attempt", () => {
+  it("replays a PENDING Razorpay attempt with the original order id", async () => {
+    mockPaymentFindFirst.mockResolvedValue({
+      paymentIntent: "order_original",
+      paymentStatus: "PENDING",
+      paymentGateway: "RAZORPAY",
+      amount: BigInt(50000),
+      currency: "INR",
+      appointmentId: "appt-1",
+      isMockPayment: false,
+    });
+    const res = await replayByIdempotencyKey("user-1", "ck_abc12345");
+    const body = await res!.json();
+    expect(body.reused).toBe(true);
+    expect(body.orderId).toBe("order_original");
+    // scoped to the caller — a guessed key can't read another user's payment
+    expect(mockPaymentFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clientIdempotencyKey: "ck_abc12345", userId: "user-1" },
+      }),
+    );
+  });
+
+  it("replays a SUCCEEDED attempt as already-completed", async () => {
+    mockPaymentFindFirst.mockResolvedValue({
+      paymentIntent: "order_x",
+      paymentStatus: "SUCCEEDED",
+      paymentGateway: "RAZORPAY",
+      amount: BigInt(50000),
+      currency: "INR",
+      appointmentId: "appt-1",
+      isMockPayment: false,
+    });
+    const res = await replayByIdempotencyKey("user-1", "ck_abc12345");
+    const body = await res!.json();
+    expect(body.reused).toBe(true);
+    expect(body.skipPayment).toBe(true);
+  });
+
+  it("409s a terminal attempt so the client mints a fresh key", async () => {
+    mockPaymentFindFirst.mockResolvedValue({
+      paymentIntent: "order_x",
+      paymentStatus: "FAILED",
+      paymentGateway: "RAZORPAY",
+      amount: BigInt(50000),
+      currency: "INR",
+      appointmentId: null,
+      isMockPayment: false,
+    });
+    const res = await replayByIdempotencyKey("user-1", "ck_abc12345");
+    expect(res!.status).toBe(409);
+  });
+
+  it("does not resume a Stripe PENDING attempt (hosted URL is not persisted)", async () => {
+    mockPaymentFindFirst.mockResolvedValue({
+      paymentIntent: "cs_test_x",
+      paymentStatus: "PENDING",
+      paymentGateway: "STRIPE",
+      amount: BigInt(50000),
+      currency: "INR",
+      appointmentId: null,
+      isMockPayment: false,
+    });
+    const res = await replayByIdempotencyKey("user-1", "ck_abc12345");
+    expect(res!.status).toBe(409);
+  });
+
+  it("returns null for an unknown key (fresh attempt proceeds)", async () => {
+    mockPaymentFindFirst.mockResolvedValue(null);
+    await expect(
+      replayByIdempotencyKey("user-1", "ck_unknown"),
+    ).resolves.toBeNull();
+  });
+});

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -9,68 +9,9 @@ import { getSession } from "@/lib/auth-server";
 import { checkoutLimiter, applyRateLimit } from "@/lib/rate-limit";
 import { ZodError } from "zod";
 import { Prisma } from "@prisma/client";
-import prisma from "@/lib/prisma";
+import { replayByIdempotencyKey } from "@/lib/payments/operations/checkout-replay";
 import { routeGateway } from "@/lib/payments/gateway-router";
 import { resolveCheckoutTaxContext } from "@/lib/payments/tax/checkout-context";
-
-// #828 — replay the original checkout response for a duplicate attempt. The
-// stored Payment carries enough for the client to reopen the gateway with the
-// SAME order instead of minting (and possibly paying) a second one. Scoped to
-// the caller's userId so a guessed key can't read someone else's payment.
-async function replayByIdempotencyKey(userId: string, key: string) {
-  const existing = await prisma.payment.findFirst({
-    where: { clientIdempotencyKey: key, userId },
-    select: {
-      paymentIntent: true,
-      paymentStatus: true,
-      paymentGateway: true,
-      amount: true,
-      currency: true,
-      appointmentId: true,
-      isMockPayment: true,
-    },
-  });
-  if (!existing) return null;
-  if (existing.paymentStatus === "SUCCEEDED") {
-    return NextResponse.json({
-      success: true,
-      reused: true,
-      skipPayment: true,
-      appointmentId: existing.appointmentId ?? undefined,
-      message: "This checkout was already completed.",
-    });
-  }
-  // Stripe stores the hosted checkout URL in client_secret (see
-  // StripeCheckout.tsx); we don't persist it, so a Stripe PENDING replay
-  // can't be resumed — fall through to the fresh-key 409 below instead of
-  // returning a null secret the client can't redirect with.
-  if (
-    existing.paymentStatus === "PENDING" &&
-    existing.paymentGateway !== "STRIPE"
-  ) {
-    return NextResponse.json({
-      success: true,
-      reused: true,
-      orderId: existing.paymentIntent,
-      paymentIntent: { id: existing.paymentIntent, client_secret: null },
-      amount: Number(existing.amount),
-      currency: existing.currency,
-      isMockPayment: existing.isMockPayment,
-      message: "Resuming your in-progress checkout.",
-    });
-  }
-  // Terminal (FAILED/CANCELED/...) — this logical attempt is dead; the client
-  // must mint a fresh key for a new attempt (the wallet top-up contract).
-  return NextResponse.json(
-    {
-      error:
-        "A previous attempt for this checkout already failed. Refresh and try again.",
-      errorType: "IDEMPOTENT_REPLAY_TERMINAL",
-      timestamp: new Date().toISOString(),
-    },
-    { status: 409 },
-  );
-}
 
 export async function POST(req: NextRequest) {
   // #828 — hoisted so the P2002 catch can replay without re-reading the

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": [
+    "jobs/**/*.ts",
+    "scripts/**/*.ts",
+    "emails/**/*.tsx",
+    "prisma/seed.ts",
+    "prisma/seedFiles/*.ts"
+  ],
+  "ignore": [".claude/**", "docs/**"],
+  "ignoreBinaries": ["tsx", "psql", "supabase"],
+  "ignoreDependencies": []
+}

--- a/lib/payments/operations/checkout-replay.ts
+++ b/lib/payments/operations/checkout-replay.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+// #828 — replay the original checkout response for a duplicate attempt. The
+// stored Payment carries enough for the client to reopen the gateway with the
+// SAME order instead of minting (and possibly paying) a second one. Scoped to
+// the caller's userId so a guessed key can't read someone else's payment.
+// Exported for the #828 regression tests; the checkout route is the prod caller.
+export async function replayByIdempotencyKey(userId: string, key: string) {
+  const existing = await prisma.payment.findFirst({
+    where: { clientIdempotencyKey: key, userId },
+    select: {
+      paymentIntent: true,
+      paymentStatus: true,
+      paymentGateway: true,
+      amount: true,
+      currency: true,
+      appointmentId: true,
+      isMockPayment: true,
+    },
+  });
+  if (!existing) return null;
+  if (existing.paymentStatus === "SUCCEEDED") {
+    return NextResponse.json({
+      success: true,
+      reused: true,
+      skipPayment: true,
+      appointmentId: existing.appointmentId ?? undefined,
+      message: "This checkout was already completed.",
+    });
+  }
+  // Stripe stores the hosted checkout URL in client_secret (see
+  // StripeCheckout.tsx); we don't persist it, so a Stripe PENDING replay
+  // can't be resumed — fall through to the fresh-key 409 below instead of
+  // returning a null secret the client can't redirect with.
+  if (
+    existing.paymentStatus === "PENDING" &&
+    existing.paymentGateway !== "STRIPE"
+  ) {
+    return NextResponse.json({
+      success: true,
+      reused: true,
+      orderId: existing.paymentIntent,
+      paymentIntent: { id: existing.paymentIntent, client_secret: null },
+      amount: Number(existing.amount),
+      currency: existing.currency,
+      isMockPayment: existing.isMockPayment,
+      message: "Resuming your in-progress checkout.",
+    });
+  }
+  // Terminal (FAILED/CANCELED/...) — this logical attempt is dead; the client
+  // must mint a fresh key for a new attempt (the wallet top-up contract).
+  return NextResponse.json(
+    {
+      error:
+        "A previous attempt for this checkout already failed. Refresh and try again.",
+      errorType: "IDEMPOTENT_REPLAY_TERMINAL",
+      timestamp: new Date().toISOString(),
+    },
+    { status: 409 },
+  );
+}

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -1095,7 +1095,8 @@ async function confirmApprovalStatus(
  * @param appointmentId - The appointment ID to confirm
  * @param userId - The paying user's ID (required for WEBINAR/CLASS to prevent confirming other users' slots)
  */
-async function confirmExistingAppointment(
+// Exported for the #827 regression tests; only handlePaymentSuccess calls it in prod.
+export async function confirmExistingAppointment(
   tx: Tx,
   appointmentId: string,
   userId?: string,

--- a/scripts/appointments/cleanup-tentative-slots.ts
+++ b/scripts/appointments/cleanup-tentative-slots.ts
@@ -163,6 +163,14 @@ async function cleanupTentativeSlotsUnlocked(): Promise<TentativeSlotCleanupResu
       const result = await prisma.slotOfAppointment.deleteMany({
         where: {
           id: { in: staleTentativeSlots.map((s) => s.id) },
+          // #829 — re-state the tentative + unpaid conditions so a slot whose
+          // capture webhook confirmed it between the findMany above and this
+          // delete no longer matches (re-evaluated under the row lock). An
+          // id-only delete here destroyed paid bookings.
+          isTentative: true,
+          appointment: {
+            payment: { none: { paymentStatus: PaymentStatus.SUCCEEDED } },
+          },
         },
       });
 


### PR DESCRIPTION
## Why

The slots/sessions audit (2026-06-10) nearly re-reported three already-fixed bugs as critical because their issues stayed open after the fixes merged in #825/#838. This PR pins each fix with a regression test so reintroduction fails CI, closes the issues via linkage, and ships the one S-sized code fix the audit verified as still live.

## What

- **#788 pin** — `mergeConsecutiveSlots` keeps adjacent slices from different availability rows separate (and still fuses same-row sub-windows, the trial use case).
- **#827 pin** — `confirmExistingAppointment` blocks confirmation when an overlapping confirmed slot exists (loser stays tentative + `CONFIRMATION_BLOCKED_DOUBLE_BOOKING` SystemEvent) and confirms cleanly otherwise. Exported for test reach; prod call path unchanged.
- **#828 pin** — replay semantics: PENDING Razorpay resumes with the original order, SUCCEEDED short-circuits, terminal attempts 409 for a fresh key, Stripe PENDING never resumes (hosted URL not persisted), lookups are user-scoped. The helper moved to `lib/payments/operations/checkout-replay.ts` because Next route modules may only export HTTP methods.
- **#829 fix + pin** — the tentative-slot cleanup deleted by id only; a slot whose capture webhook confirmed it between the scan and the delete was destroyed (paid booking, no slot). The `deleteMany` WHERE now re-states `isTentative: true` + no-SUCCEEDED-payment, re-evaluated under the row lock — the same CAS doctrine as everything else post-#825.

**#830 verified NOT closable:** `reconcile-payment-status` CAS-guards status flips but only logs "may need manual appointment creation" on SUCCEEDED — it does not re-drive confirmation of tentative slots. Stays open for the cancel/reschedule correctness PR (PR-4 of this sequence).

## Verification

1298/1298 tests (11 new pins), `tsc --noEmit` clean, eslint clean.

Closes #788
Closes #827
Closes #828
Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)