### PR TITLE
Cancel/reschedule correctness (PR-4 of 4): policy-snapshot refunds, CAS guards, orphan re-drive

### DIFF
--- a/.github/workflows/reconcile-orphaned-confirmations.yml
+++ b/.github/workflows/reconcile-orphaned-confirmations.yml
@@ -1,0 +1,50 @@
+name: Reconcile Orphaned Confirmations
+
+on:
+  schedule:
+    # Run every 30 minutes
+    - cron: "*/30 * * * *"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  reconcile-orphaned-confirmations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      # Database connection (required for Prisma)
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 — fail-closed cron lock: without these the job refuses to run.
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+
+      # Payment gateway credentials
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      RAZORPAY_KEY_ID: ${{ secrets.RAZORPAY_KEY_ID }}
+      RAZORPAY_KEY_SECRET: ${{ secrets.RAZORPAY_KEY_SECRET }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Run payment status reconciliation
+        run: npx tsx jobs/payments/reconcile-orphaned-confirmations.ts
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          SLACK_OPS_WEBHOOK_URL: ${{ secrets.SLACK_OPS_WEBHOOK_URL }}
+        run: bash scripts/ci/notify-ops-failure.sh "reconcile-orphaned-confirmations"

--- a/__tests__/booking-algorithm/authorization.test.ts
+++ b/__tests__/booking-algorithm/authorization.test.ts
@@ -259,10 +259,26 @@ function makeMockTx(appointmentData: any = null) {
       findMany: jest.fn().mockResolvedValue([]),
       delete: jest.fn(),
     },
-    consultation: { update: jest.fn() },
-    subscription: { update: jest.fn() },
-    webinar: { update: jest.fn() },
-    class: { update: jest.fn() },
+    consultation: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    subscription: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    webinar: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    class: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
     slotOfAppointment: { updateMany: jest.fn(), deleteMany: jest.fn() },
   };
 }

--- a/__tests__/booking-algorithm/rescheduleCancel.test.ts
+++ b/__tests__/booking-algorithm/rescheduleCancel.test.ts
@@ -207,10 +207,26 @@ function makeMockTx() {
       delete: jest.fn(),
       deleteMany: jest.fn(),
     },
-    consultation: { update: jest.fn() },
-    subscription: { update: jest.fn() },
-    webinar: { update: jest.fn() },
-    class: { update: jest.fn() },
+    consultation: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    subscription: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    webinar: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    class: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
     slotOfAppointment: { updateMany: jest.fn(), deleteMany: jest.fn() },
   };
 }
@@ -480,12 +496,17 @@ describe("Reschedule Route Handler - POST", () => {
       // Verify slots marked tentative by appointmentId (non-subscription path)
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
         where: { appointmentId: "apt-1" },
-        data: { isTentative: true },
+        data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
 
       // Verify consultation status reverted
-      expect(mockTx.consultation.update).toHaveBeenCalledWith({
-        where: { id: "cons-1" },
+      expect(mockTx.consultation.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: "cons-1",
+          requestStatus: {
+            in: ["PENDING", "APPROVED", "APPROVED_PENDING_PAYMENT", "SCHEDULED"],
+          },
+        },
         data: { requestStatus: "PENDING" },
       });
     });
@@ -526,12 +547,17 @@ describe("Reschedule Route Handler - POST", () => {
       // Should mark all appointment slots tentative
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
         where: { appointmentId: { in: ["apt-1", "apt-2"] } },
-        data: { isTentative: true },
+        data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
 
       // Should update subscription status
-      expect(mockTx.subscription.update).toHaveBeenCalledWith({
-        where: { id: "sub-1" },
+      expect(mockTx.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: "sub-1",
+          requestStatus: {
+            in: ["PENDING", "APPROVED", "APPROVED_PENDING_PAYMENT", "SCHEDULED"],
+          },
+        },
         data: { requestStatus: "PENDING" },
       });
     });
@@ -559,7 +585,7 @@ describe("Reschedule Route Handler - POST", () => {
       // are rescheduled atomically — a partial-tentative session would be inconsistent.
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
         where: { appointmentId: { in: ["apt-1"] } },
-        data: { isTentative: true },
+        data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
     });
 
@@ -637,11 +663,11 @@ describe("Reschedule Route Handler - POST", () => {
 
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
         where: { appointmentId: "apt-1" },
-        data: { isTentative: true },
+        data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
 
-      expect(mockTx.webinar.update).toHaveBeenCalledWith({
-        where: { id: "web-1" },
+      expect(mockTx.webinar.updateMany).toHaveBeenCalledWith({
+        where: { id: "web-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
         data: { status: "SCHEDULED" },
       });
     });
@@ -661,8 +687,8 @@ describe("Reschedule Route Handler - POST", () => {
       expect(res.status).toBe(200);
       expect(body.success).toBe(true);
 
-      expect(mockTx.class.update).toHaveBeenCalledWith({
-        where: { id: "cls-1" },
+      expect(mockTx.class.updateMany).toHaveBeenCalledWith({
+        where: { id: "cls-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
         data: { status: "SCHEDULED" },
       });
     });
@@ -828,8 +854,13 @@ describe("Cancel Route Handler - POST", () => {
       expect(body.cancellationReason).toBe("SCHEDULE_CONFLICT");
 
       // Verify consultation updated with cancellation data
-      expect(mockTx.consultation.update).toHaveBeenCalledWith({
-        where: { id: "cons-1" },
+      expect(mockTx.consultation.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: "cons-1",
+          requestStatus: {
+            in: ["PENDING", "APPROVED", "APPROVED_PENDING_PAYMENT", "SCHEDULED"],
+          },
+        },
         data: expect.objectContaining({
           requestStatus: "CANCELLED",
           cancellationReason: "SCHEDULE_CONFLICT",
@@ -838,9 +869,11 @@ describe("Cancel Route Handler - POST", () => {
         }),
       });
 
-      // Verify slots soft-cancelled (not hard-deleted — preserves payment audit trail)
+      // Verify slots soft-cancelled (not hard-deleted — preserves payment
+      // audit trail); only live SCHEDULED slots flip, history is never
+      // re-stamped.
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
-        where: { appointmentId: "apt-1" },
+        where: { appointmentId: "apt-1", completionStatus: "SCHEDULED" },
         data: { completionStatus: "CANCELLED" },
       });
 
@@ -874,8 +907,13 @@ describe("Cancel Route Handler - POST", () => {
       const res = await cancelHandler(req, makeParams("apt-1"));
 
       expect(res.status).toBe(200);
-      expect(mockTx.subscription.update).toHaveBeenCalledWith({
-        where: { id: "sub-1" },
+      expect(mockTx.subscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: "sub-1",
+          requestStatus: {
+            in: ["PENDING", "APPROVED", "APPROVED_PENDING_PAYMENT", "SCHEDULED"],
+          },
+        },
         data: expect.objectContaining({
           requestStatus: "CANCELLED",
           cancellationReason: "FINANCIAL_REASONS",
@@ -899,8 +937,8 @@ describe("Cancel Route Handler - POST", () => {
 
       expect(res.status).toBe(200);
 
-      expect(mockTx.webinar.update).toHaveBeenCalledWith({
-        where: { id: "web-1" },
+      expect(mockTx.webinar.updateMany).toHaveBeenCalledWith({
+        where: { id: "web-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
         data: { status: "CANCELLED" },
       });
 
@@ -923,8 +961,8 @@ describe("Cancel Route Handler - POST", () => {
 
       expect(res.status).toBe(200);
 
-      expect(mockTx.class.update).toHaveBeenCalledWith({
-        where: { id: "cls-1" },
+      expect(mockTx.class.updateMany).toHaveBeenCalledWith({
+        where: { id: "cls-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
         data: { status: "CANCELLED" },
       });
 
@@ -948,8 +986,13 @@ describe("Cancel Route Handler - POST", () => {
     expect(res.status).toBe(200);
 
     // Cancellation data should have null reason and notes
-    expect(mockTx.consultation.update).toHaveBeenCalledWith({
-      where: { id: "cons-1" },
+    expect(mockTx.consultation.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "cons-1",
+        requestStatus: {
+          in: ["PENDING", "APPROVED", "APPROVED_PENDING_PAYMENT", "SCHEDULED"],
+        },
+      },
       data: expect.objectContaining({
         requestStatus: "CANCELLED",
         cancellationReason: null,

--- a/__tests__/booking-algorithm/rescheduleResponses.test.ts
+++ b/__tests__/booking-algorithm/rescheduleResponses.test.ts
@@ -146,10 +146,26 @@ function makeMockTx(appointmentData: any) {
       findMany: jest.fn().mockResolvedValue([]),
       delete: jest.fn(),
     },
-    consultation: { update: jest.fn() },
-    subscription: { update: jest.fn() },
-    webinar: { update: jest.fn() },
-    class: { update: jest.fn() },
+    consultation: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    subscription: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    webinar: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    class: {
+      update: jest.fn(),
+      // B2 — the cancel/reschedule CAS guards use updateMany.
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
     slotOfAppointment: { updateMany: jest.fn(), deleteMany: jest.fn() },
   };
 }

--- a/__tests__/booking/cancellation-policy.test.ts
+++ b/__tests__/booking/cancellation-policy.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * B1 — the snapshot-at-booking refund policy. The tiers frozen onto the
+ * Appointment at checkout decide the refund; consultant-initiated always
+ * refunds in full; pre-feature bookings (null snapshot) get the platform
+ * defaults.
+ */
+
+import {
+  computeRefundPct,
+  parsePolicySnapshot,
+  resolveCancellationPolicySnapshot,
+  PLATFORM_DEFAULT_TIERS,
+} from "@/lib/payments/operations/cancellation-policy";
+
+describe("computeRefundPct — platform default tiers", () => {
+  it.each([
+    [48, 100], // two days out → full refund
+    [24, 100], // exactly at the 24h boundary → full refund
+    [23.9, 50], // inside a day → half
+    [2, 50], // exactly at the 2h boundary → half
+    [1.5, 0], // inside two hours → nothing
+    [0, 0], // at start time → nothing
+  ])("%s hours before start → %s%%", (hours, pct) => {
+    expect(computeRefundPct(null, hours, false)).toBe(pct);
+  });
+
+  it("refunds nothing after the booking started", () => {
+    expect(computeRefundPct(null, -3, false)).toBe(0);
+  });
+
+  it("consultant-initiated always refunds 100%, even past start", () => {
+    expect(computeRefundPct(null, 1, true)).toBe(100);
+    expect(computeRefundPct(null, -3, true)).toBe(100);
+  });
+});
+
+describe("snapshot freezing", () => {
+  it("a frozen snapshot wins over whatever the defaults become later", () => {
+    const generous = {
+      ...resolveCancellationPolicySnapshot(),
+      tiers: [{ hoursBefore: 0, refundPct: 100 }],
+    };
+    // 1 hour before start: platform default says 0, the buyer's frozen
+    // terms say 100 — the snapshot governs.
+    expect(computeRefundPct(generous, 1, false)).toBe(100);
+  });
+
+  it("round-trips through the Json column", () => {
+    const snap = resolveCancellationPolicySnapshot({
+      orgPolicyText: "Org prose policy",
+    });
+    const parsed = parsePolicySnapshot(JSON.parse(JSON.stringify(snap)));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.tiers).toEqual(PLATFORM_DEFAULT_TIERS);
+    expect(parsed!.orgPolicyText).toBe("Org prose policy");
+  });
+
+  it("rejects malformed snapshots (falls back to defaults at the call site)", () => {
+    expect(parsePolicySnapshot(null)).toBeNull();
+    expect(parsePolicySnapshot("v1")).toBeNull();
+    expect(parsePolicySnapshot({ version: 2, tiers: [] })).toBeNull();
+    expect(parsePolicySnapshot({ version: 1 })).toBeNull();
+  });
+});

--- a/__tests__/booking/slot-session-fix-pins.test.ts
+++ b/__tests__/booking/slot-session-fix-pins.test.ts
@@ -149,6 +149,7 @@ describe("#827 — confirmExistingAppointment first-confirmed-wins", () => {
         },
         consultation: {
           update: jest.fn().mockResolvedValue({}),
+          updateMany: jest.fn().mockResolvedValue({ count: 1 }),
           findUnique: jest
             .fn()
             .mockResolvedValue({ id: "c1", requestStatus: "APPROVED_PENDING_PAYMENT" }),

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -10,6 +10,11 @@ import {
 
 import { getSession } from "@/lib/auth-server";
 import { isPrivileged } from "@/lib/auth-helpers";
+import { refundPayment } from "@/lib/payments/operations/refund";
+import {
+  computeRefundPct,
+  parsePolicySnapshot,
+} from "@/lib/payments/operations/cancellation-policy";
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ appointmentId: string }> },
@@ -84,6 +89,10 @@ export async function POST(
           },
         },
         slotsOfAppointment: { take: 1, select: { startsAt: true } },
+        // B1 — refund terms frozen at booking + the payment to refund.
+        payment: {
+          select: { id: true, amount: true, paymentStatus: true },
+        },
       },
     });
 
@@ -174,30 +183,71 @@ export async function POST(
       cancelledBy: session.user.id,
     };
 
+    // Cancellable from-states: never COMPLETED (history), never CANCELLED
+    // (idempotency — a double-cancel must not re-run refunds), never
+    // REJECTED/EXPIRED (nothing to cancel). The guard rides the WHERE and is
+    // re-evaluated under the row lock (B2/B16 — the #825 CAS doctrine), so a
+    // cancel racing the capture webhook resolves to exactly one winner.
+    const CANCELLABLE_FROM = [
+      "PENDING",
+      "APPROVED",
+      "APPROVED_PENDING_PAYMENT",
+      "SCHEDULED",
+    ] as const;
+
     // Transaction for critical database operations only (with increased timeout)
     const result = await prisma.$transaction(
       async (tx) => {
-        // Update appointment status based on type
+        // Update appointment status based on type — CAS-guarded.
+        let moved = 0;
         if (appointment.consultation) {
-          await tx.consultation.update({
-            where: { id: appointment.consultation.id },
-            data: cancellationData,
-          });
+          moved = (
+            await tx.consultation.updateMany({
+              where: {
+                id: appointment.consultation.id,
+                requestStatus: { in: [...CANCELLABLE_FROM] },
+              },
+              data: cancellationData,
+            })
+          ).count;
         } else if (appointment.subscription) {
-          await tx.subscription.update({
-            where: { id: appointment.subscription.id },
-            data: cancellationData,
-          });
+          moved = (
+            await tx.subscription.updateMany({
+              where: {
+                id: appointment.subscription.id,
+                requestStatus: { in: [...CANCELLABLE_FROM] },
+              },
+              data: cancellationData,
+            })
+          ).count;
         } else if (appointment.webinar) {
-          await tx.webinar.update({
-            where: { id: appointment.webinar.id },
-            data: { status: "CANCELLED" },
-          });
+          moved = (
+            await tx.webinar.updateMany({
+              where: {
+                id: appointment.webinar.id,
+                status: { notIn: ["CANCELLED", "COMPLETED"] },
+              },
+              data: { status: "CANCELLED" },
+            })
+          ).count;
         } else if (appointment.class) {
-          await tx.class.update({
-            where: { id: appointment.class.id },
-            data: { status: "CANCELLED" },
-          });
+          moved = (
+            await tx.class.updateMany({
+              where: {
+                id: appointment.class.id,
+                status: { notIn: ["CANCELLED", "COMPLETED"] },
+              },
+              data: { status: "CANCELLED" },
+            })
+          ).count;
+        }
+        if (moved === 0) {
+          throw Object.assign(
+            new Error(
+              "This appointment can no longer be cancelled (already cancelled, completed, or expired).",
+            ),
+            { httpStatus: 409, code: "NOT_CANCELLABLE" },
+          );
         }
 
         // Soft-cancel: mark slots as CANCELLED instead of deleting.
@@ -207,18 +257,22 @@ export async function POST(
           await tx.slotOfAppointment.updateMany({
             where: {
               appointment: { subscriptionId: appointment.subscription.id },
+              completionStatus: "SCHEDULED",
             },
             data: { completionStatus: "CANCELLED" },
           });
         } else if (appointment.class) {
           await tx.slotOfAppointment.updateMany({
-            where: { appointment: { classId: appointment.class.id } },
+            where: {
+              appointment: { classId: appointment.class.id },
+              completionStatus: "SCHEDULED",
+            },
             data: { completionStatus: "CANCELLED" },
           });
         } else {
           // Consultation/webinar/trial — single appointment
           await tx.slotOfAppointment.updateMany({
-            where: { appointmentId },
+            where: { appointmentId, completionStatus: "SCHEDULED" },
             data: { completionStatus: "CANCELLED" },
           });
         }
@@ -236,6 +290,61 @@ export async function POST(
         timeout: 30000, // 30 second transaction timeout (was 5s default)
       },
     );
+
+    // B1 — policy-driven refund, AFTER the cancel tx commits (refundPayment
+    // runs its own Serializable tx; the CAS above guarantees this block runs
+    // at most once per appointment — a second cancel 409s before reaching it).
+    // Scope: consultation/subscription. Webinar/class buyer refunds belong to
+    // the participant-removal flow, not whole-event cancellation.
+    let refund: { amountRefundedPaise: number; refundPct: number } | null =
+      null;
+    const isExclusiveType =
+      !!appointment.consultation || !!appointment.subscription;
+    const paidPayment = appointment.payment?.find(
+      (p) => p.paymentStatus === "SUCCEEDED" && p.amount > 0,
+    );
+    if (isExclusiveType && paidPayment) {
+      const startsAt = appointment.slotsOfAppointment?.[0]?.startsAt;
+      const hoursUntilStart = startsAt
+        ? (startsAt.getTime() - Date.now()) / 3_600_000
+        : -1;
+      const isConsultantInitiated =
+        session.user.consultantProfileId !== null &&
+        session.user.consultantProfileId !== undefined &&
+        session.user.id !== undefined &&
+        consultantUserId === session.user.id;
+      const refundPct = computeRefundPct(
+        parsePolicySnapshot(appointment.cancellationPolicySnapshot),
+        hoursUntilStart,
+        isConsultantInitiated,
+      );
+      const refundAmount = Math.floor(
+        (Number(paidPayment.amount) * refundPct) / 100,
+      );
+      if (refundAmount > 0) {
+        try {
+          const r = await refundPayment({
+            paymentId: paidPayment.id,
+            amountPaise: refundAmount,
+            reason: `cancellation (${refundPct}% per booking-time policy, ${
+              isConsultantInitiated ? "consultant" : "consultee"
+            }-initiated)`,
+            initiatedByUserId: session.user.id,
+          });
+          refund = { amountRefundedPaise: r.amountRefundedPaise, refundPct };
+        } catch (refundErr) {
+          // The cancellation itself stands; a failed refund must be visible,
+          // not silently swallowed — surface for ops + tell the caller.
+          console.error(
+            `[cancel] refund failed for payment ${paidPayment.id}:`,
+            refundErr,
+          );
+          refund = { amountRefundedPaise: 0, refundPct };
+        }
+      } else {
+        refund = { amountRefundedPaise: 0, refundPct };
+      }
+    }
 
     // Notification metadata (for fire-and-forget notifications after transaction)
     const notificationMeta = {
@@ -313,8 +422,22 @@ export async function POST(
     // Waitlist notifications should only fire when a participant leaves an
     // otherwise-active event (handled in participant removal flow).
 
-    return NextResponse.json(result);
+    return NextResponse.json({ ...result, refund });
   } catch (error) {
+    if (error instanceof Error && "httpStatus" in error) {
+      const status =
+        typeof (error as { httpStatus?: number }).httpStatus === "number"
+          ? (error as { httpStatus: number }).httpStatus
+          : 500;
+      const code =
+        "code" in error && typeof (error as { code?: string }).code === "string"
+          ? (error as { code: string }).code
+          : undefined;
+      return NextResponse.json(
+        { error: error.message, ...(code && { code }) },
+        { status },
+      );
+    }
     if (error instanceof Error && error.message === "Appointment not found") {
       return NextResponse.json(
         { error: "Appointment not found" },

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -9,6 +9,7 @@ import {
   AppointmentNotFoundError,
 } from "@/utils/errors/RescheduleErrors";
 import { notifyAppointmentRescheduled } from "@/lib/novu/service";
+import { logActivity } from "@/lib/activity/log-activity";
 import { getAppUrl } from "@/lib/url";
 
 const MINIMUM_HOURS_BEFORE_RESCHEDULE = 24;
@@ -249,7 +250,7 @@ export async function POST(
             where: {
               appointmentId: { in: affectedAppointmentIds },
             },
-            data: { isTentative: true },
+            data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         } else if (derivedType === "SUBSCRIPTION" && appointment.subscription) {
           // Entire subscription reschedule - mark ALL slots in ALL appointments
@@ -262,7 +263,7 @@ export async function POST(
 
           await tx.slotOfAppointment.updateMany({
             where: { appointmentId: { in: allAppointmentIds } },
-            data: { isTentative: true },
+            data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         } else if (derivedType === "CLASS" && appointment.class) {
           // Entire class reschedule - mark ALL slots in ALL appointments
@@ -275,37 +276,74 @@ export async function POST(
 
           await tx.slotOfAppointment.updateMany({
             where: { appointmentId: { in: allAppointmentIds } },
-            data: { isTentative: true },
+            data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         } else {
           // Non-multi-appointment: mark all slots in the single appointment
           await tx.slotOfAppointment.updateMany({
             where: { appointmentId },
-            data: { isTentative: true },
+            data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         }
 
-        // Update status based on appointment type
+        // Update status based on appointment type — CAS-guarded (B2): a
+        // reschedule racing a cancel/completion must not resurrect the
+        // booking; count 0 means the from-state was terminal → 409.
+        const RESCHEDULABLE_FROM = [
+          "PENDING",
+          "APPROVED",
+          "APPROVED_PENDING_PAYMENT",
+          "SCHEDULED",
+        ] as const;
+        let movedStatus = 1; // group events validated below
         if (appointment.consultation) {
-          await tx.consultation.update({
-            where: { id: appointment.consultation.id },
-            data: { requestStatus: "PENDING" },
-          });
+          movedStatus = (
+            await tx.consultation.updateMany({
+              where: {
+                id: appointment.consultation.id,
+                requestStatus: { in: [...RESCHEDULABLE_FROM] },
+              },
+              data: { requestStatus: "PENDING" },
+            })
+          ).count;
         } else if (appointment.subscription) {
-          await tx.subscription.update({
-            where: { id: appointment.subscription.id },
-            data: { requestStatus: "PENDING" },
-          });
+          movedStatus = (
+            await tx.subscription.updateMany({
+              where: {
+                id: appointment.subscription.id,
+                requestStatus: { in: [...RESCHEDULABLE_FROM] },
+              },
+              data: { requestStatus: "PENDING" },
+            })
+          ).count;
         } else if (appointment.webinar) {
-          await tx.webinar.update({
-            where: { id: appointment.webinar.id },
-            data: { status: "SCHEDULED" },
-          });
+          movedStatus = (
+            await tx.webinar.updateMany({
+              where: {
+                id: appointment.webinar.id,
+                status: { notIn: ["CANCELLED", "COMPLETED"] },
+              },
+              data: { status: "SCHEDULED" },
+            })
+          ).count;
         } else if (appointment.class) {
-          await tx.class.update({
-            where: { id: appointment.class.id },
-            data: { status: "SCHEDULED" },
-          });
+          movedStatus = (
+            await tx.class.updateMany({
+              where: {
+                id: appointment.class.id,
+                status: { notIn: ["CANCELLED", "COMPLETED"] },
+              },
+              data: { status: "SCHEDULED" },
+            })
+          ).count;
+        }
+        if (movedStatus === 0) {
+          throw Object.assign(
+            new Error(
+              "This appointment can no longer be rescheduled (already cancelled or completed).",
+            ),
+            { httpStatus: 409, code: "NOT_RESCHEDULABLE" },
+          );
         }
 
         // Determine reschedule type for response
@@ -334,6 +372,21 @@ export async function POST(
             rescheduleType === "entire_booking"
               ? "All sessions marked for rescheduling. Please select new times."
               : `${slotsToReschedule.length} session(s) marked for rescheduling. Please select new time(s).`,
+          // B14 — context for the post-tx activity log (appointment is only
+          // in scope inside this callback).
+          logContext: {
+            cpId:
+              appointment.consultation?.consultationPlan?.consultantProfileId ??
+              appointment.subscription?.subscriptionPlan?.consultantProfileId ??
+              appointment.webinar?.webinarPlan?.consultantProfileId ??
+              appointment.class?.classPlan?.consultantProfileId ??
+              null,
+            appointmentType: appointment.appointmentType,
+            consultationId: appointment.consultation?.id,
+            subscriptionId: appointment.subscription?.id,
+            webinarId: appointment.webinar?.id,
+            classId: appointment.class?.id,
+          },
         };
       },
       {
@@ -341,7 +394,24 @@ export async function POST(
       },
     );
 
+    // B14 — reschedule now leaves an activity-log entry (cancel always did).
+    if (result.logContext.cpId) {
+      await logActivity({
+        activityType: "APPOINTMENT_RESCHEDULED",
+        description: `Appointment reschedule requested (${result.logContext.appointmentType.toLowerCase()})`,
+        actorId: session.user.id,
+        actorName: session.user.name || "User",
+        actorImage: session.user.image,
+        consultantProfileId: result.logContext.cpId,
+        consultationId: result.logContext.consultationId,
+        subscriptionId: result.logContext.subscriptionId,
+        webinarId: result.logContext.webinarId,
+        classId: result.logContext.classId,
+      });
+    }
+
     // Fire-and-forget: notify both parties about reschedule
+
     // FIX #624: Include webinar/class so group event participants are also notified.
     try {
       const appointment = await prisma.appointment.findUnique({
@@ -442,8 +512,11 @@ export async function POST(
           }
         }
 
-        // Deduplicate
-        const uniqueUserIds = Array.from(new Set(userIds));
+        // Deduplicate; exclude the initiator — you don't need a notification
+        // about your own reschedule (B15).
+        const uniqueUserIds = Array.from(new Set(userIds)).filter(
+          (id) => id !== session.user.id,
+        );
 
         const appointmentType = consultation
           ? "consultation"
@@ -472,6 +545,21 @@ export async function POST(
 
     return NextResponse.json(result);
   } catch (error) {
+    // B2 — the CAS guard's structured 409 (NOT_RESCHEDULABLE).
+    if (error instanceof Error && "httpStatus" in error) {
+      const status =
+        typeof (error as { httpStatus?: number }).httpStatus === "number"
+          ? (error as { httpStatus: number }).httpStatus
+          : 500;
+      const code =
+        "code" in error && typeof (error as { code?: string }).code === "string"
+          ? (error as { code: string }).code
+          : undefined;
+      return NextResponse.json(
+        { error: error.message, ...(code && { code }) },
+        { status },
+      );
+    }
     // Type-safe error handling using custom error classes
     if (error instanceof RescheduleAuthorizationError) {
       return NextResponse.json({ error: error.message }, { status: 403 });

--- a/jobs/payments/reconcile-orphaned-confirmations.ts
+++ b/jobs/payments/reconcile-orphaned-confirmations.ts
@@ -1,0 +1,35 @@
+/**
+ * #830 — orphaned-confirmation re-drive (GitHub Actions wrapper). Finds
+ * SUCCEEDED payments whose slots are still tentative and re-runs the
+ * confirmation under the webhook's own Serializable discipline. Runs every
+ * 30 minutes.
+ */
+import {
+  reconcileOrphanedConfirmations,
+  disconnectDatabase,
+} from "../../scripts/payments/reconcile-orphaned-confirmations";
+import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+
+async function main(): Promise<void> {
+  await abortIfMaintenance("reconcile-orphaned-confirmations");
+  console.log("🩹 Starting orphaned-confirmation reconcile...");
+  try {
+    const result = await reconcileOrphanedConfirmations();
+    console.log(
+      `Done. scanned=${result.scanned} confirmed=${result.confirmed} stillBlocked=${result.stillBlocked}`,
+    );
+  } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
+    console.error("❌ Fatal error in orphaned-confirmation reconcile:", error);
+    process.exit(1);
+  } finally {
+    await disconnectDatabase();
+  }
+}
+
+main();

--- a/lib/payments/operations/cancellation-policy.ts
+++ b/lib/payments/operations/cancellation-policy.ts
@@ -1,0 +1,83 @@
+/**
+ * Cancellation/refund policy — snapshot-at-booking (2026-06-10 decision).
+ *
+ * Tiered time-based refund windows are resolved at CHECKOUT and frozen onto
+ * `Appointment.cancellationPolicySnapshot`, so an org or platform editing its
+ * policy later never retroactively changes a buyer's terms. The cancel flow
+ * reads the snapshot; a null snapshot (pre-feature booking) falls back to the
+ * platform defaults below — same maths, just not frozen.
+ *
+ * Org `defaultCancellationPolicy` is free TEXT today, so v1 snapshots always
+ * carry the platform tiers and record the org prose for the support trail;
+ * structured per-org tiers are a post-launch schema item.
+ */
+
+export interface CancellationPolicyTier {
+  /** Tier applies when the booking starts at least this many hours away. */
+  hoursBefore: number;
+  /** Whole-number percentage of the paid amount refunded. */
+  refundPct: number;
+}
+
+export interface CancellationPolicySnapshot {
+  version: 1;
+  source: "PLATFORM_DEFAULT" | "ORG_DEFAULT";
+  tiers: CancellationPolicyTier[];
+  /** Consultant-initiated cancellations always refund this percentage. */
+  consultantInitiatedPct: number;
+  /** Org policy prose at booking time, for the support trail. */
+  orgPolicyText?: string | null;
+}
+
+// Industry-standard defaults (Calendly/Cal.com-style): full refund a day out,
+// half inside the day, nothing inside two hours. Consultant-initiated is
+// always 100% — the buyer did nothing wrong.
+export const PLATFORM_DEFAULT_TIERS: CancellationPolicyTier[] = [
+  { hoursBefore: 24, refundPct: 100 },
+  { hoursBefore: 2, refundPct: 50 },
+  { hoursBefore: 0, refundPct: 0 },
+];
+
+export function resolveCancellationPolicySnapshot(params?: {
+  orgPolicyText?: string | null;
+}): CancellationPolicySnapshot {
+  return {
+    version: 1,
+    source: "PLATFORM_DEFAULT",
+    tiers: PLATFORM_DEFAULT_TIERS,
+    consultantInitiatedPct: 100,
+    orgPolicyText: params?.orgPolicyText ?? null,
+  };
+}
+
+/**
+ * Percentage of the paid amount to refund for a cancellation `hoursUntilStart`
+ * hours before the booking starts. Negative hours (already started/past)
+ * refund nothing unless consultant-initiated.
+ */
+export function computeRefundPct(
+  snapshot: CancellationPolicySnapshot | null | undefined,
+  hoursUntilStart: number,
+  isConsultantInitiated: boolean,
+): number {
+  const policy = snapshot ?? resolveCancellationPolicySnapshot();
+  if (isConsultantInitiated) return policy.consultantInitiatedPct;
+  if (hoursUntilStart < 0) return 0;
+  // Tiers sorted descending by hoursBefore; first tier whose threshold the
+  // cancellation clears wins.
+  const sorted = [...policy.tiers].sort((a, b) => b.hoursBefore - a.hoursBefore);
+  for (const tier of sorted) {
+    if (hoursUntilStart >= tier.hoursBefore) return tier.refundPct;
+  }
+  return 0;
+}
+
+/** Parse the Json column back into the typed snapshot (defensive). */
+export function parsePolicySnapshot(
+  raw: unknown,
+): CancellationPolicySnapshot | null {
+  if (!raw || typeof raw !== "object") return null;
+  const s = raw as Partial<CancellationPolicySnapshot>;
+  if (s.version !== 1 || !Array.isArray(s.tiers)) return null;
+  return s as CancellationPolicySnapshot;
+}

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -65,6 +65,7 @@ import {
   notifyOrgProgramCapNear,
 } from "@/lib/novu/org-workflows";
 import { sumPaise } from "@/lib/payments/utils/money";
+import { resolveCancellationPolicySnapshot } from "@/lib/payments/operations/cancellation-policy";
 
 // Re-export for backward compatibility
 export const unifiedCheckoutSchema = checkoutSchema;
@@ -571,10 +572,17 @@ export async function validateSlotAvailability(
   if (data.slotOfAvailabilityWeeklyId) {
     const avail = await tx.slotOfAvailabilityWeekly.findUnique({
       where: { id: data.slotOfAvailabilityWeeklyId },
-      include: { consultantProfile: { select: { userId: true } } },
+      include: {
+        consultantProfile: { select: { userId: true, deletedAt: true } },
+      },
     });
     if (!avail) {
       throw new Error("Availability slot not found");
+    }
+    // B13 — the plan-level soft-delete check can race a deletion landing
+    // between plan fetch and slot validation; recheck at the slot level.
+    if (avail.consultantProfile.deletedAt) {
+      throw new Error("This expert is no longer accepting bookings");
     }
     // Verify the availability slot belongs to the correct consultant
     if (
@@ -1368,6 +1376,10 @@ export async function handleConsultationCheckout(
       appointmentType: AppointmentsType.CONSULTATION,
       consultationId: consultation.id,
       organizationId,
+      // B1 — freeze the refund terms at booking; the cancel flow reads this.
+      cancellationPolicySnapshot: JSON.parse(
+        JSON.stringify(resolveCancellationPolicySnapshot()),
+      ),
       slotsOfAppointment: {
         create: slotChunks.map((chunk) => ({
           startsAt: chunk.startsAt,
@@ -1705,6 +1717,20 @@ export async function handleClassCheckout(
   // Check if user is already enrolled - OPT-2: Use extracted utility
   if (isUserEnrolled(classInstance.appointments, userId)) {
     throw new Error("You are already enrolled in this class");
+  }
+
+  // B11 — a partially-scheduled class (consultant hasn't allocated every
+  // session yet) must not accept paid enrollments: the loop below links the
+  // buyer only to EXISTING sessions, silently shorting them the rest.
+  const expectedSessions = classInstance.classPlan?.totalSessions;
+  if (
+    typeof expectedSessions === "number" &&
+    expectedSessions > 0 &&
+    classInstance.appointments.length < expectedSessions
+  ) {
+    throw new Error(
+      `This class is not fully scheduled yet (${classInstance.appointments.length} of ${expectedSessions} sessions). Enrollment opens once all sessions are scheduled.`,
+    );
   }
 
   // Link user to ALL existing slots of ALL class appointments (sessions).

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -1040,21 +1040,33 @@ async function confirmApprovalStatus(
       throw new Error(`Consultation ${entityId} not found`);
     }
 
-    // If status is APPROVED_PENDING_PAYMENT, confirm the appointment
-    if (consultation.requestStatus === RequestStatus.APPROVED_PENDING_PAYMENT) {
-      await tx.consultation.update({
-        where: { id: entityId },
-        data: { requestStatus: RequestStatus.APPROVED },
-      });
-      console.log(
-        `✅ Consultation ${entityId} payment completed - moving from APPROVED_PENDING_PAYMENT to APPROVED`,
-      );
-    } else if (consultation.requestStatus !== RequestStatus.APPROVED) {
-      // Only update if not already approved
-      await tx.consultation.update({
-        where: { id: entityId },
-        data: { requestStatus: RequestStatus.APPROVED },
-      });
+    // B2 (#825 CAS doctrine) — APPROVED is only reachable from the two
+    // pre-payment states. The old else-branch moved ANY status → APPROVED,
+    // so a capture landing after a cancel resurrected the booking. Now the
+    // guard rides the WHERE; a late capture against a terminal booking is
+    // money collected for nothing — surface it for refund instead.
+    const movedConsult = await tx.consultation.updateMany({
+      where: {
+        id: entityId,
+        requestStatus: {
+          in: [RequestStatus.PENDING, RequestStatus.APPROVED_PENDING_PAYMENT],
+        },
+      },
+      data: { requestStatus: RequestStatus.APPROVED },
+    });
+    if (
+      movedConsult.count === 0 &&
+      consultation.requestStatus !== RequestStatus.APPROVED &&
+      consultation.requestStatus !== RequestStatus.SCHEDULED &&
+      consultation.requestStatus !== RequestStatus.COMPLETED
+    ) {
+      void recordSystemError({
+        organizationId: null,
+        category: "PAYMENT",
+        summary: `Payment captured for consultation ${entityId} in terminal state ${consultation.requestStatus} — refund needed`,
+        err: new Error("CAPTURE_AFTER_TERMINAL_STATE"),
+        context: { entityType: "consultation", entityId },
+      }).catch(() => {});
     }
   } else {
     const subscription = await tx.subscription.findUnique({
@@ -1070,8 +1082,12 @@ async function confirmApprovalStatus(
     // Subscription stays PENDING until consultant allocates slots via Requests tab
     // SlotAllocationService.allocate() will set status to APPROVED when slots are allocated
     if (subscription.requestStatus === RequestStatus.APPROVED_PENDING_PAYMENT) {
-      await tx.subscription.update({
-        where: { id: entityId },
+      // CAS — the pre-read can race a cancel; the guard decides (B2).
+      await tx.subscription.updateMany({
+        where: {
+          id: entityId,
+          requestStatus: RequestStatus.APPROVED_PENDING_PAYMENT,
+        },
         data: { requestStatus: RequestStatus.APPROVED },
       });
       console.log(

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2815,6 +2815,8 @@ model ActivityLog {
 
 enum ActivityType {
   CONSULTATION_BOOKED
+  /// B14 — reschedule previously wrote no activity at all (cancel did).
+  APPOINTMENT_RESCHEDULED
   CONSULTATION_COMPLETED
   CONSULTATION_CANCELLED
   SUBSCRIPTION_REQUESTED

--- a/scripts/payments/reconcile-orphaned-confirmations.ts
+++ b/scripts/payments/reconcile-orphaned-confirmations.ts
@@ -1,0 +1,115 @@
+/**
+ * #830 — orphaned-confirmation re-drive.
+ *
+ * A crash (or a blocked #827 conflict) between payment capture and slot
+ * confirmation leaves a SUCCEEDED payment whose slots are still
+ * isTentative=true: the buyer paid, holds no confirmed booking, and the
+ * tentative rows block rebooking of those times. Nothing re-drove these —
+ * reconcile-payment-status only logged "may need manual appointment
+ * creation".
+ *
+ * This sweep finds that orphan class and re-runs confirmExistingAppointment
+ * under the same Serializable + retry discipline as the webhook path. The
+ * #827 first-confirmed-wins recheck inside it stays in force: a genuine
+ * double-booking loser is NOT force-confirmed — it stays tentative with its
+ * CONFIRMATION_BLOCKED_DOUBLE_BOOKING system event, and this sweep reports
+ * it for the refund path instead of fighting the guard.
+ */
+import prisma from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { confirmExistingAppointment } from "@/lib/payments/webhooks/handlers";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
+
+export interface OrphanedConfirmationResult {
+  success: boolean;
+  scanned: number;
+  confirmed: number;
+  stillBlocked: number;
+}
+
+// #476 — fail-closed: re-driving a confirmation twice is guarded by the
+// idempotent slot flip, but the entry must not run unlocked regardless.
+export async function reconcileOrphanedConfirmations(
+  opts: { graceMinutes?: number; limit?: number } = {},
+): Promise<OrphanedConfirmationResult> {
+  return withCronLock("reconcile-orphaned-confirmations", { failMode: "closed" }, () =>
+    reconcileOrphanedConfirmationsUnlocked(opts),
+  );
+}
+
+async function reconcileOrphanedConfirmationsUnlocked(
+  opts: { graceMinutes?: number; limit?: number } = {},
+): Promise<OrphanedConfirmationResult> {
+  const graceMinutes = opts.graceMinutes ?? 15;
+  const limit = opts.limit ?? 200;
+  const cutoff = new Date(Date.now() - graceMinutes * 60_000);
+
+  const orphans = await prisma.payment.findMany({
+    where: {
+      paymentStatus: "SUCCEEDED",
+      updatedAt: { lt: cutoff },
+      appointmentId: { not: null },
+      appointment: {
+        slotsOfAppointment: { some: { isTentative: true } },
+      },
+    },
+    select: { id: true, appointmentId: true, userId: true },
+    take: limit,
+  });
+
+  let confirmed = 0;
+  let stillBlocked = 0;
+  for (const orphan of orphans) {
+    try {
+      await withSerializableRetry(() =>
+        prisma.$transaction(
+          async (tx) => {
+            await confirmExistingAppointment(
+              tx,
+              orphan.appointmentId!,
+              orphan.userId,
+            );
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        ),
+      );
+      const remaining = await prisma.slotOfAppointment.count({
+        where: { appointmentId: orphan.appointmentId!, isTentative: true },
+      });
+      if (remaining === 0) {
+        confirmed += 1;
+        console.log(
+          `✅ Re-drove confirmation for appointment ${orphan.appointmentId} (payment ${orphan.id})`,
+        );
+      } else {
+        // The #827 guard blocked it — a real conflict; the system event it
+        // recorded routes the refund. Count, don't fight.
+        stillBlocked += 1;
+        console.log(
+          `⛔ Appointment ${orphan.appointmentId} still blocked by the double-booking guard — refund path owns it`,
+        );
+      }
+    } catch (err) {
+      stillBlocked += 1;
+      console.error(
+        `❌ Re-drive failed for appointment ${orphan.appointmentId}:`,
+        err,
+      );
+    }
+  }
+
+  console.log(
+    `🩹 Orphaned confirmations: scanned=${orphans.length} confirmed=${confirmed} stillBlocked=${stillBlocked}`,
+  );
+  return {
+    success: true,
+    scanned: orphans.length,
+    confirmed,
+    stillBlocked,
+  };
+}
+
+export async function disconnectDatabase(): Promise<void> {
+  await prisma.$disconnect();
+}

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -42,6 +42,7 @@ import {
   recordBookingUtilization,
   ProgramAssignmentLimitError,
 } from "@/lib/api/organizations/program-helpers";
+import { resolveCancellationPolicySnapshot } from "@/lib/payments/operations/cancellation-policy";
 
 type AppointmentWithSlots = Appointment & {
   slotsOfAppointment: SlotOfAppointment[];
@@ -1412,6 +1413,10 @@ export class SlotAllocationService {
               connect: { id: eventId },
             },
             ...(organizationId ? { organizationId } : {}),
+            // B1 — freeze the refund terms at booking (see cancellation-policy.ts).
+            cancellationPolicySnapshot: JSON.parse(
+              JSON.stringify(resolveCancellationPolicySnapshot()),
+            ),
             slotsOfAppointment: {
               create: slotsToCreate,
             },
@@ -1624,7 +1629,13 @@ export class SlotAllocationService {
       // Find appointments with tentative slots for this event
       const appointments = await tx.appointment.findMany({
         where: whereClause,
-        include: { slotsOfAppointment: true },
+        include: {
+          slotsOfAppointment: true,
+          // B8 — Payment has onDelete: Cascade on Appointment; deleting an
+          // appointment with payment rows destroys the payment/refund audit
+          // trail. Count them so the delete below can refuse.
+          _count: { select: { payment: true } },
+        },
       });
 
       for (const appointment of appointments) {
@@ -1644,8 +1655,10 @@ export class SlotAllocationService {
             },
           });
 
-          // If no confirmed slots exist, delete the now-empty appointment
-          if (!hasConfirmed) {
+          // If no confirmed slots exist, delete the now-empty appointment —
+          // unless payments reference it (B8): the empty shell is cheaper
+          // than a destroyed audit trail; the orphan sweep reports it.
+          if (!hasConfirmed && appointment._count.payment === 0) {
             await tx.appointment.delete({
               where: { id: appointment.id },
             });


### PR DESCRIPTION
## Stacked on #843 — completes the four-PR sequence from the slots/sessions audit

## The critical fix: cancellation finally moves money (B1)

The cancel route updated statuses and soft-cancelled slots but **never refunded anyone**, and org cancellation policies existed in the schema unread. Now: checkout freezes tiered refund terms onto `Appointment.cancellationPolicySnapshot` (the #843 column) — 24h+ = 100%, 2–24h = 50%, <2h = 0%, consultant-initiated always 100% — and cancel computes from the **booking-time snapshot** (later policy edits never retroactively change a buyer's terms) and drives `refundPayment`, the canonical Serializable refund orchestrator. Failed refunds surface loudly; the cancel still stands.

## The race fixes (B2 + the webhook side)

- Cancel and reschedule status transitions are **CAS-guarded** (the #825 doctrine, finally applied to the one place it was missing): cancellable/reschedulable only from live states, double-cancel 409s before re-running refunds, slots flip only from SCHEDULED.
- `confirmApprovalStatus` no longer resurrects a CANCELLED booking from a late capture — the old else-branch moved *any* status to APPROVED. A terminal-state capture now raises `CAPTURE_AFTER_TERMINAL_STATE` for the refund path.

## Lifecycle made explicit

Reschedule stamps replaced slots `completionStatus: RESCHEDULED` (the keep-and-wire decision recorded in #843) — reschedule-limbo is no longer indistinguishable from checkout-tentative. Plus the activity-log entry reschedule never had (`APPOINTMENT_RESCHEDULED`), and initiators stop receiving notifications about their own reschedules (B15).

## `Closes #830` — the orphan re-drive

`reconcile-orphaned-confirmations` (fail-closed locked core + GH wrapper + 30-min workflow per ADR 05) finds SUCCEEDED payments whose slots are still tentative — the crash-between-capture-and-confirmation orphan class — and re-drives `confirmExistingAppointment` under the webhook's own Serializable+retry discipline. The #827 first-confirmed-wins guard stays in force: a genuine double-booking loser is reported for refund, never force-confirmed.

## The smaller register items

B8 — reallocation never hard-deletes appointments carrying Payment rows (`onDelete: Cascade` was destroying the payment audit trail). B11 — class enrollment rejects partially-scheduled classes instead of silently shorting the buyer sessions. B13 — slot-level consultant soft-deletion recheck.

## Verification

1309/1309 tests (11 new policy tests; cancel/reschedule harnesses migrated to the CAS shapes), `tsc --noEmit` clean, `next build` green. Live two-tab verification rides the chaos runbook once Supabase reconnects.

Closes #830
Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)