### PR TITLE
fix: B2C CAS transition map — approval/decline/expiry/completion guards + #677 PM-1 closeout

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,6 +45,16 @@ RESEND_API_KEY=""
 # Razorpay API credentials for payment processing
 RAZORPAY_KEY_ID=""
 RAZORPAY_SECRET=""
+# Webhook signing secret from the Razorpay dashboard (Settings > Webhooks)
+RAZORPAY_WEBHOOK_SECRET=""
+
+# #677 PM-1 — RazorpayX PRODUCTION payout credentials (live disbursements +
+# payout webhook verification). Falls back to RAZORPAY_KEY_ID/RAZORPAY_SECRET
+# when unset; account number has no fallback and is required for live payouts.
+RAZORPAYX_KEY_ID=""
+RAZORPAYX_KEY_SECRET=""
+RAZORPAYX_ACCOUNT_NUMBER=""
+RAZORPAYX_WEBHOOK_SECRET=""
 
 # #771 D2 / Batch 5 — Razorpay Route (routed wallet settlement). SCAFFOLD ONLY:
 # leave ENABLE_ROUTED_WALLET=false until the CA/RBI opinion lands and Route is

--- a/__tests__/booking-algorithm/rescheduleCancel.test.ts
+++ b/__tests__/booking-algorithm/rescheduleCancel.test.ts
@@ -495,7 +495,11 @@ describe("Reschedule Route Handler - POST", () => {
 
       // Verify slots marked tentative by appointmentId (non-subscription path)
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
-        where: { appointmentId: "apt-1" },
+        where: {
+          appointmentId: "apt-1",
+          // #837 — reschedule never resurrects COMPLETED/CANCELLED history
+          completionStatus: { in: ["SCHEDULED", "RESCHEDULED"] },
+        },
         data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
 
@@ -546,7 +550,10 @@ describe("Reschedule Route Handler - POST", () => {
 
       // Should mark all appointment slots tentative
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
-        where: { appointmentId: { in: ["apt-1", "apt-2"] } },
+        where: {
+          appointmentId: { in: ["apt-1", "apt-2"] },
+          completionStatus: { in: ["SCHEDULED", "RESCHEDULED"] },
+        },
         data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
 
@@ -584,7 +591,10 @@ describe("Reschedule Route Handler - POST", () => {
       // specified slot ID. This ensures multi-slot sessions (e.g. 1.5h = 3 × 30-min slots)
       // are rescheduled atomically — a partial-tentative session would be inconsistent.
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
-        where: { appointmentId: { in: ["apt-1"] } },
+        where: {
+          appointmentId: { in: ["apt-1"] },
+          completionStatus: { in: ["SCHEDULED", "RESCHEDULED"] },
+        },
         data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
     });
@@ -662,12 +672,16 @@ describe("Reschedule Route Handler - POST", () => {
       expect(body.rescheduleType).toBe("entire_booking");
 
       expect(mockTx.slotOfAppointment.updateMany).toHaveBeenCalledWith({
-        where: { appointmentId: "apt-1" },
+        where: {
+          appointmentId: "apt-1",
+          // #837 — reschedule never resurrects COMPLETED/CANCELLED history
+          completionStatus: { in: ["SCHEDULED", "RESCHEDULED"] },
+        },
         data: { isTentative: true, completionStatus: "RESCHEDULED" },
       });
 
       expect(mockTx.webinar.updateMany).toHaveBeenCalledWith({
-        where: { id: "web-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
+        where: { id: "web-1", status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
         data: { status: "SCHEDULED" },
       });
     });
@@ -688,7 +702,7 @@ describe("Reschedule Route Handler - POST", () => {
       expect(body.success).toBe(true);
 
       expect(mockTx.class.updateMany).toHaveBeenCalledWith({
-        where: { id: "cls-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
+        where: { id: "cls-1", status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
         data: { status: "SCHEDULED" },
       });
     });
@@ -938,7 +952,7 @@ describe("Cancel Route Handler - POST", () => {
       expect(res.status).toBe(200);
 
       expect(mockTx.webinar.updateMany).toHaveBeenCalledWith({
-        where: { id: "web-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
+        where: { id: "web-1", status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
         data: { status: "CANCELLED" },
       });
 
@@ -962,7 +976,7 @@ describe("Cancel Route Handler - POST", () => {
       expect(res.status).toBe(200);
 
       expect(mockTx.class.updateMany).toHaveBeenCalledWith({
-        where: { id: "cls-1", status: { notIn: ["CANCELLED", "COMPLETED"] } },
+        where: { id: "cls-1", status: { in: ["SCHEDULED", "IN_PROGRESS"] } },
         data: { status: "CANCELLED" },
       });
 

--- a/__tests__/booking-algorithm/slotAllocationService.test.ts
+++ b/__tests__/booking-algorithm/slotAllocationService.test.ts
@@ -62,8 +62,18 @@ import {
 
 function makeMockTx() {
   return {
-    consultation: { findUnique: jest.fn(), update: jest.fn() },
-    subscription: { findUnique: jest.fn(), update: jest.fn() },
+    // #836 — updateEventStatus routes through the CAS transition helpers,
+    // which call updateMany and read the returned count.
+    consultation: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    subscription: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
     webinar: { findUnique: jest.fn(), update: jest.fn() },
     class: { findUnique: jest.fn(), update: jest.fn() },
     // #440 — createAppointments denormalizes the consultant onto each slot.
@@ -431,9 +441,9 @@ describe("Manual allocation", () => {
       slots: ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"],
     });
 
-    expect(mockTx.consultation.update).toHaveBeenCalledWith(
+    expect(mockTx.consultation.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "consult-1" },
+        where: expect.objectContaining({ id: "consult-1" }),
         data: expect.objectContaining({
           requestStatus: RequestStatus.APPROVED,
         }),
@@ -691,9 +701,9 @@ describe("Requested slot allocation", () => {
       mode: "requested",
     });
 
-    expect(mockTx.consultation.update).toHaveBeenCalledWith(
+    expect(mockTx.consultation.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "consult-1" },
+        where: expect.objectContaining({ id: "consult-1" }),
         data: expect.objectContaining({
           requestStatus: RequestStatus.APPROVED,
         }),
@@ -1115,16 +1125,16 @@ describe("updateEventStatus", () => {
       slots: ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"],
     });
 
-    expect(mockTx.subscription.update).toHaveBeenCalledWith(
+    expect(mockTx.subscription.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "sub-1" },
+        where: expect.objectContaining({ id: "sub-1" }),
         data: expect.objectContaining({
           requestStatus: RequestStatus.APPROVED,
         }),
       }),
     );
     // Should NOT overwrite existing scheduling period
-    const updateData = mockTx.subscription.update.mock.calls[0][0].data;
+    const updateData = mockTx.subscription.updateMany.mock.calls[0][0].data;
     expect(updateData.schedulingPeriodStartsAt).toBeUndefined();
   });
 
@@ -1149,7 +1159,7 @@ describe("updateEventStatus", () => {
       slots: ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"],
     });
 
-    const updateData = mockTx.subscription.update.mock.calls[0][0].data;
+    const updateData = mockTx.subscription.updateMany.mock.calls[0][0].data;
     expect(updateData.schedulingPeriodStartsAt).toBeDefined();
     expect(updateData.schedulingPeriodEndsAt).toBeDefined();
   });
@@ -1491,8 +1501,14 @@ describe("Edge cases", () => {
 
       // Correct model was queried
       expect(freshTx[eventType].findUnique).toHaveBeenCalled();
-      // Correct model was updated
-      expect(freshTx[eventType].update).toHaveBeenCalled();
+      // Correct model was updated — consultation/subscription go through
+      // the #836 CAS transition helpers (updateMany); webinar/class still
+      // use a plain update in updateEventStatus.
+      const mutator =
+        eventType === "consultation" || eventType === "subscription"
+          ? freshTx[eventType].updateMany
+          : freshTx[eventType].update;
+      expect(mutator).toHaveBeenCalled();
     }
   });
 });

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/payments/operations/cancellation-policy";
 import {
   CANCELLABLE_FROM,
+  CLASS_EVENT_ALLOWED_FROM,
   EVENT_ALLOWED_FROM,
 } from "@/lib/booking/transitions";
 export async function POST(
@@ -242,7 +243,7 @@ export async function POST(
             await tx.class.updateMany({
               where: {
                 id: appointment.class.id,
-                status: { in: EVENT_ALLOWED_FROM.CANCELLED },
+                status: { in: CLASS_EVENT_ALLOWED_FROM.CANCELLED },
               },
               data: { status: "CANCELLED" },
             })

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -15,6 +15,10 @@ import {
   computeRefundPct,
   parsePolicySnapshot,
 } from "@/lib/payments/operations/cancellation-policy";
+import {
+  CANCELLABLE_FROM,
+  EVENT_ALLOWED_FROM,
+} from "@/lib/booking/transitions";
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ appointmentId: string }> },
@@ -194,12 +198,7 @@ export async function POST(
     // REJECTED/EXPIRED (nothing to cancel). The guard rides the WHERE and is
     // re-evaluated under the row lock (B2/B16 — the #825 CAS doctrine), so a
     // cancel racing the capture webhook resolves to exactly one winner.
-    const CANCELLABLE_FROM = [
-      "PENDING",
-      "APPROVED",
-      "APPROVED_PENDING_PAYMENT",
-      "SCHEDULED",
-    ] as const;
+    // The set lives in lib/booking/transitions.ts so the map is canonical (#836).
 
     // Transaction for critical database operations only (with increased timeout)
     const result = await prisma.$transaction(
@@ -227,11 +226,13 @@ export async function POST(
             })
           ).count;
         } else if (appointment.webinar) {
+          // Explicit allowed-from (was notIn) — robust against future enum
+          // additions (#837).
           moved = (
             await tx.webinar.updateMany({
               where: {
                 id: appointment.webinar.id,
-                status: { notIn: ["CANCELLED", "COMPLETED"] },
+                status: { in: EVENT_ALLOWED_FROM.CANCELLED },
               },
               data: { status: "CANCELLED" },
             })
@@ -241,7 +242,7 @@ export async function POST(
             await tx.class.updateMany({
               where: {
                 id: appointment.class.id,
-                status: { notIn: ["CANCELLED", "COMPLETED"] },
+                status: { in: EVENT_ALLOWED_FROM.CANCELLED },
               },
               data: { status: "CANCELLED" },
             })

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -12,6 +12,7 @@ import { notifyAppointmentRescheduled } from "@/lib/novu/service";
 import { logActivity } from "@/lib/activity/log-activity";
 import { getAppUrl } from "@/lib/url";
 import {
+  CLASS_EVENT_ALLOWED_FROM,
   EVENT_ALLOWED_FROM,
   RESCHEDULABLE_FROM,
   SLOT_RESCHEDULABLE_FROM,
@@ -345,7 +346,7 @@ export async function POST(
             await tx.class.updateMany({
               where: {
                 id: appointment.class.id,
-                status: { in: EVENT_ALLOWED_FROM.SCHEDULED },
+                status: { in: CLASS_EVENT_ALLOWED_FROM.SCHEDULED },
               },
               data: { status: "SCHEDULED" },
             })

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -11,6 +11,11 @@ import {
 import { notifyAppointmentRescheduled } from "@/lib/novu/service";
 import { logActivity } from "@/lib/activity/log-activity";
 import { getAppUrl } from "@/lib/url";
+import {
+  EVENT_ALLOWED_FROM,
+  RESCHEDULABLE_FROM,
+  SLOT_RESCHEDULABLE_FROM,
+} from "@/lib/booking/transitions";
 
 const MINIMUM_HOURS_BEFORE_RESCHEDULE = 24;
 
@@ -246,9 +251,12 @@ export async function POST(
           const affectedAppointmentIds = Array.from(
             new Set(slotsToReschedule.map((s) => s.appointmentId)),
           );
+          // From-state guard on every slot flip: a reschedule must never
+          // resurrect COMPLETED/CANCELLED history to RESCHEDULED (#837).
           await tx.slotOfAppointment.updateMany({
             where: {
               appointmentId: { in: affectedAppointmentIds },
+              completionStatus: { in: SLOT_RESCHEDULABLE_FROM },
             },
             data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
@@ -262,7 +270,10 @@ export async function POST(
           ).map((a) => a.id);
 
           await tx.slotOfAppointment.updateMany({
-            where: { appointmentId: { in: allAppointmentIds } },
+            where: {
+              appointmentId: { in: allAppointmentIds },
+              completionStatus: { in: SLOT_RESCHEDULABLE_FROM },
+            },
             data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         } else if (derivedType === "CLASS" && appointment.class) {
@@ -275,26 +286,27 @@ export async function POST(
           ).map((a) => a.id);
 
           await tx.slotOfAppointment.updateMany({
-            where: { appointmentId: { in: allAppointmentIds } },
+            where: {
+              appointmentId: { in: allAppointmentIds },
+              completionStatus: { in: SLOT_RESCHEDULABLE_FROM },
+            },
             data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         } else {
           // Non-multi-appointment: mark all slots in the single appointment
           await tx.slotOfAppointment.updateMany({
-            where: { appointmentId },
+            where: {
+              appointmentId,
+              completionStatus: { in: SLOT_RESCHEDULABLE_FROM },
+            },
             data: { isTentative: true, completionStatus: "RESCHEDULED" },
           });
         }
 
         // Update status based on appointment type — CAS-guarded (B2): a
         // reschedule racing a cancel/completion must not resurrect the
-        // booking; count 0 means the from-state was terminal → 409.
-        const RESCHEDULABLE_FROM = [
-          "PENDING",
-          "APPROVED",
-          "APPROVED_PENDING_PAYMENT",
-          "SCHEDULED",
-        ] as const;
+        // booking; count 0 means the from-state was terminal → 409. The
+        // set lives in lib/booking/transitions.ts so the map is canonical.
         let movedStatus = 1; // group events validated below
         if (appointment.consultation) {
           movedStatus = (
@@ -317,11 +329,13 @@ export async function POST(
             })
           ).count;
         } else if (appointment.webinar) {
+          // Explicit allowed-from (was notIn) — robust against future enum
+          // additions (#837).
           movedStatus = (
             await tx.webinar.updateMany({
               where: {
                 id: appointment.webinar.id,
-                status: { notIn: ["CANCELLED", "COMPLETED"] },
+                status: { in: EVENT_ALLOWED_FROM.SCHEDULED },
               },
               data: { status: "SCHEDULED" },
             })
@@ -331,7 +345,7 @@ export async function POST(
             await tx.class.updateMany({
               where: {
                 id: appointment.class.id,
-                status: { notIn: ["CANCELLED", "COMPLETED"] },
+                status: { in: EVENT_ALLOWED_FROM.SCHEDULED },
               },
               data: { status: "SCHEDULED" },
             })

--- a/app/api/events/consultations/[consultationId]/route.ts
+++ b/app/api/events/consultations/[consultationId]/route.ts
@@ -15,6 +15,9 @@ import {
   lockConsultationApproval,
   unlockApproval,
 } from "@/utils/appointmentlock";
+import { transitionConsultationRequest } from "@/lib/booking/transitions";
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
+import { MAX_TEXT_LENGTH } from "@/lib/validation/limits";
 import { sendPaymentLinkEmail } from "@/lib/email";
 import {
   requireApiAuth,
@@ -210,15 +213,17 @@ export async function PUT(
     const body = await request.json();
 
     // Validate body to prevent arbitrary field injection
+    // #836 — requestStatus is NOT writable here: status changes flow only
+    // through PATCH, where the allowed-from guard rides the WHERE clause.
+    // #831 — user-typed strings carry a .max()
     const consultationPutSchema = z
       .object({
-        requestStatus: z.nativeEnum(RequestStatus).optional(),
-        requestNotes: z.string().nullish(),
+        requestNotes: z.string().max(MAX_TEXT_LENGTH).nullish(),
         bookingSource: z
           .enum(["DIRECT_CHECKOUT", "REQUEST_SUBMITTED"])
           .optional(),
-        feedbackFromConsultee: z.string().nullish(),
-        feedbackFromConsultant: z.string().nullish(),
+        feedbackFromConsultee: z.string().max(MAX_TEXT_LENGTH).nullish(),
+        feedbackFromConsultant: z.string().max(MAX_TEXT_LENGTH).nullish(),
         rating: z.number().min(1).max(5).nullish(),
         planId: z.string().optional(),
       })
@@ -239,7 +244,6 @@ export async function PUT(
     const consultationData = await prisma.consultation.update({
       where: { id: consultationId },
       data: {
-        requestStatus: validatedBody.requestStatus,
         requestNotes: validatedBody.requestNotes,
         bookingSource: validatedBody.bookingSource,
         feedbackFromConsultee: validatedBody.feedbackFromConsultee,
@@ -578,12 +582,15 @@ export async function PATCH(
             }
           }
 
-          // Update consultation status
-          const consultation = await tx.consultation.update({
+          // #836 — allowed-from guard rides the WHERE; the idempotency
+          // pre-checks above are only friendly error text. updateMany
+          // returns no row, so re-read for the heavy include.
+          await transitionConsultationRequest(tx, {
             where: { id: consultationId },
-            data: {
-              requestStatus: status,
-            },
+            to: status,
+          });
+          const consultation = await tx.consultation.findUniqueOrThrow({
+            where: { id: consultationId },
             include: {
               consultationPlan: {
                 include: {
@@ -635,16 +642,19 @@ export async function PATCH(
               // No payment - generate payment link
               const paymentResult = await generatePaymentLink(consultation);
 
-              // Update status to APPROVED_PENDING_PAYMENT
-              const updatedConsultation = await tx.consultation.update({
+              // Update status to APPROVED_PENDING_PAYMENT — guarded (#836)
+              await transitionConsultationRequest(tx, {
                 where: { id: consultationId },
+                to: RequestStatus.APPROVED_PENDING_PAYMENT,
                 data: {
-                  requestStatus: RequestStatus.APPROVED_PENDING_PAYMENT,
                   pendingPaymentUrl: paymentResult.checkoutUrl,
                   requestNotes: consultation.requestNotes
                     ? `${consultation.requestNotes}\n\n[System] Payment link generated and sent to user.`
                     : `[System] Payment link generated and sent to user.`,
                 },
+              });
+              const updatedConsultation = await tx.consultation.findUniqueOrThrow({
+                where: { id: consultationId },
                 include: {
                   consultationPlan: {
                     include: {
@@ -780,6 +790,12 @@ export async function PATCH(
       }
     }
   } catch (error) {
+    if (error instanceof IllegalTransitionError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.httpStatus },
+      );
+    }
     console.error(
       "Error updating consultation:",
       error instanceof Error ? error.message : "Unknown error",

--- a/app/api/events/consultations/route.ts
+++ b/app/api/events/consultations/route.ts
@@ -1,6 +1,9 @@
 import prisma from "@/lib/prisma";
 import { RequestStatus } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
+import { transitionConsultationRequest } from "@/lib/booking/transitions";
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 import {
   requireApiAuth,
   isPrivileged,
@@ -124,6 +127,10 @@ export async function PATCH(request: NextRequest) {
     if (authResult.error) return authResult.error;
     const { session } = authResult;
 
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(eventMutationLimiter, session.user.id);
+    if (rl) return rl;
+
     const body = await request.json();
     const { id, status } = body;
 
@@ -173,9 +180,13 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const consultation = await prisma.consultation.update({
+    // #836 — allowed-from guard rides the WHERE; updateMany returns no row,
+    // so re-read for the heavy include.
+    await prisma.$transaction((tx) =>
+      transitionConsultationRequest(tx, { where: { id }, to: status }),
+    );
+    const consultation = await prisma.consultation.findUniqueOrThrow({
       where: { id },
-      data: { requestStatus: status },
       include: {
         consultationPlan: {
           include: {
@@ -206,6 +217,12 @@ export async function PATCH(request: NextRequest) {
 
     return NextResponse.json({ data: consultation });
   } catch (error) {
+    if (error instanceof IllegalTransitionError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.httpStatus },
+      );
+    }
     console.error("Error updating consultation:", error);
     return NextResponse.json(
       { error: "An error occurred while updating consultation" },

--- a/app/api/events/subscriptions/[subscriptionId]/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/route.ts
@@ -13,6 +13,8 @@ import {
   lockSubscriptionApproval,
   unlockApproval,
 } from "@/utils/appointmentlock";
+import { transitionSubscriptionRequest } from "@/lib/booking/transitions";
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
 import { sendPaymentLinkEmail } from "@/lib/email";
 import {
   notifySubscriptionStarted,
@@ -222,7 +224,6 @@ export async function PUT(
       data: {
         schedulingPeriodStartsAt: validatedData.schedulingPeriodStartsAt,
         schedulingPeriodEndsAt: validatedData.schedulingPeriodEndsAt,
-        requestStatus: validatedData.requestStatus,
         requestNotes: validatedData.requestNotes,
         feedbackFromConsultee: validatedData.feedbackFromConsultee,
         feedbackFromConsultant: validatedData.feedbackFromConsultant,
@@ -528,12 +529,15 @@ export async function PATCH(
             }
           }
 
-          // Update subscription status
-          const subscription = await tx.subscription.update({
+          // #836 — allowed-from guard rides the WHERE; the idempotency
+          // pre-checks above are only friendly error text. updateMany
+          // returns no row, so re-read for the heavy include.
+          await transitionSubscriptionRequest(tx, {
             where: { id: subscriptionId },
-            data: {
-              requestStatus: status,
-            },
+            to: status,
+          });
+          const subscription = await tx.subscription.findUniqueOrThrow({
+            where: { id: subscriptionId },
             include: {
               subscriptionPlan: {
                 include: {
@@ -602,11 +606,11 @@ export async function PATCH(
                 endDate,
               );
 
-              // Update status to APPROVED_PENDING_PAYMENT
-              const updatedSubscription = await tx.subscription.update({
+              // Update status to APPROVED_PENDING_PAYMENT — guarded (#836)
+              await transitionSubscriptionRequest(tx, {
                 where: { id: subscriptionId },
+                to: RequestStatus.APPROVED_PENDING_PAYMENT,
                 data: {
-                  requestStatus: RequestStatus.APPROVED_PENDING_PAYMENT,
                   schedulingPeriodStartsAt: startDate,
                   schedulingPeriodEndsAt: endDate,
                   pendingPaymentUrl: paymentResult.checkoutUrl,
@@ -614,6 +618,9 @@ export async function PATCH(
                     ? `${subscription.requestNotes}\n\n[System] Payment link generated and sent to user.`
                     : `[System] Payment link generated and sent to user.`,
                 },
+              });
+              const updatedSubscription = await tx.subscription.findUniqueOrThrow({
+                where: { id: subscriptionId },
                 include: {
                   subscriptionPlan: {
                     include: {
@@ -806,6 +813,12 @@ export async function PATCH(
       }
     }
   } catch (error) {
+    if (error instanceof IllegalTransitionError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.httpStatus },
+      );
+    }
     console.error(
       "Error updating subscription:",
       error instanceof Error ? error.message : "Unknown error",

--- a/app/api/events/subscriptions/route.ts
+++ b/app/api/events/subscriptions/route.ts
@@ -13,6 +13,9 @@ import {
   isPrivileged,
   forbiddenResponse,
 } from "@/lib/auth-helpers";
+import { transitionSubscriptionRequest } from "@/lib/booking/transitions";
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 export async function GET(request: NextRequest) {
   // Require authentication
@@ -136,6 +139,10 @@ export async function PATCH(request: NextRequest) {
     if (authResult.error) return authResult.error;
     const { session } = authResult;
 
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(eventMutationLimiter, session.user.id);
+    if (rl) return rl;
+
     const body = await request.json();
     const result = UpdateSubscriptionStatusSchema.safeParse(body);
     if (!result.success) {
@@ -209,14 +216,20 @@ export async function PATCH(request: NextRequest) {
     );
 
     try {
-      // Update subscription status and dates
-      const subscription = await prisma.subscription.update({
+      // #836 — allowed-from guard rides the WHERE; updateMany returns no
+      // row, so re-read for the heavy include.
+      await prisma.$transaction((tx) =>
+        transitionSubscriptionRequest(tx, {
+          where: { id },
+          to: status,
+          data: {
+            schedulingPeriodStartsAt: startDate,
+            schedulingPeriodEndsAt: endDate,
+          },
+        }),
+      );
+      const subscription = await prisma.subscription.findUniqueOrThrow({
         where: { id },
-        data: {
-          requestStatus: status,
-          schedulingPeriodStartsAt: startDate,
-          schedulingPeriodEndsAt: endDate,
-        },
         include: {
           subscriptionPlan: {
             include: {
@@ -310,6 +323,12 @@ export async function PATCH(request: NextRequest) {
       throw error;
     }
   } catch (error) {
+    if (error instanceof IllegalTransitionError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.httpStatus },
+      );
+    }
     console.error(
       "Error updating subscription:",
       error instanceof Error ? error.message : "Unknown error",

--- a/docs/enterprise/50-operations/06-live-payout-go-live-runbook.md
+++ b/docs/enterprise/50-operations/06-live-payout-go-live-runbook.md
@@ -47,7 +47,10 @@ is real money on the first run — so the prerequisites below are hard gates.
 - [ ] **RazorpayX account live** + KYB complete; the platform's RazorpayX
       balance is funded to cover the first batch.
 - [ ] **Production secrets set** in the deploy env: `RAZORPAY_KEY_ID`,
-      `RAZORPAY_KEY_SECRET` (RazorpayX-enabled), `RAZORPAYX_WEBHOOK_SECRET`.
+      `RAZORPAY_SECRET` (RazorpayX-enabled), `RAZORPAYX_WEBHOOK_SECRET`.
+      The canonical secret name is `RAZORPAY_SECRET`; the reconciliation
+      scripts accept the legacy `RAZORPAY_KEY_SECRET` as a fallback only, so
+      new environments must not rely on it (#677 PM-1).
 - [ ] **Payout accounts VERIFIED** for every org/consultant in the first batch
       (`OrganizationPayoutAccount.status === "VERIFIED"`; the contact +
       fund-account side-channel finished provisioning).

--- a/jobs/payments/reconcile-payment-status.ts
+++ b/jobs/payments/reconcile-payment-status.ts
@@ -37,7 +37,11 @@ function outputToGitHubActions(result: PaymentReconciliationResult): void {
     fs.appendFileSync(outputFile, outputs + "\n");
   }
 
-  if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
+  // #677 PM-1 — match the canonical name the underlying script reads
+  if (
+    !process.env.RAZORPAY_KEY_ID ||
+    !(process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET)
+  ) {
     console.log(
       `::warning::Razorpay credentials not configured — Razorpay records were skipped`,
     );

--- a/jobs/payouts/handle-stuck-payouts.ts
+++ b/jobs/payouts/handle-stuck-payouts.ts
@@ -40,7 +40,11 @@ function outputToGitHubActions(result: StuckPayoutsResult): void {
     fs.appendFileSync(outputFile, outputs + "\n");
   }
 
-  if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
+  // #677 PM-1 — match the canonical name the underlying script reads
+  if (
+    !process.env.RAZORPAY_KEY_ID ||
+    !(process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET)
+  ) {
     console.log(
       `::warning::Razorpay credentials not configured — Razorpay records were skipped`,
     );

--- a/jobs/payouts/reconcile-payout-status.ts
+++ b/jobs/payouts/reconcile-payout-status.ts
@@ -37,7 +37,11 @@ function outputToGitHubActions(result: PayoutReconciliationResult): void {
     fs.appendFileSync(outputFile, outputs + "\n");
   }
 
-  if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
+  // #677 PM-1 — match the canonical name the underlying script reads
+  if (
+    !process.env.RAZORPAY_KEY_ID ||
+    !(process.env.RAZORPAY_SECRET ?? process.env.RAZORPAY_KEY_SECRET)
+  ) {
     console.log(
       `::warning::Razorpay credentials not configured — Razorpay records were skipped`,
     );

--- a/lib/booking/transitions.ts
+++ b/lib/booking/transitions.ts
@@ -1,0 +1,129 @@
+import type { Tx } from "@/lib/prisma";
+/**
+ * Central guarded status transitions for the B2C booking lifecycles — the
+ * consumer-side sibling of `lib/enterprise/transitions.ts` (#836, #837).
+ *
+ * Same doctrine (docs/enterprise/70-design-decisions/13-postgres-native-concurrency.md):
+ * the allowed-from set is baked into the UPDATE's WHERE clause, so an illegal
+ * transition — a capture webhook racing a cancel, a stale consultant tab
+ * approving a cancelled request, a double-submitted decline — matches zero
+ * rows instead of corrupting state. The WHERE clause is the state machine;
+ * app-level pre-checks are only friendly error text.
+ *
+ * Maps are keyed by TARGET state: `ALLOWED_FROM[to]` lists the only states
+ * the row may currently be in. Dependency-light (Prisma types only).
+ */
+import type {
+  ClassStatus,
+  Prisma,
+  RequestStatus,
+  SlotCompletionStatus,
+  WebinarStatus,
+} from "@prisma/client";
+
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
+
+//////////////////////////////////////////////// Consultation / Subscription ////////////////////////////////////////////////
+
+// PENDING is the entry state; its only legal re-entry is the payment-link
+// expiry/regeneration reset (#836). Reschedule also re-enters PENDING but
+// from the wider RESCHEDULABLE_FROM set below — that flow owns its own edge
+// because rescheduling a SCHEDULED booking back to PENDING is policy-gated
+// (24h window), not a generic transition.
+export const REQUEST_ALLOWED_FROM: Record<RequestStatus, RequestStatus[]> = {
+  PENDING: ["APPROVED_PENDING_PAYMENT"],
+  APPROVED: ["PENDING", "APPROVED_PENDING_PAYMENT"],
+  APPROVED_PENDING_PAYMENT: ["PENDING", "APPROVED"],
+  SCHEDULED: ["APPROVED", "APPROVED_PENDING_PAYMENT"],
+  COMPLETED: ["APPROVED", "SCHEDULED"],
+  REJECTED: ["PENDING", "APPROVED_PENDING_PAYMENT"],
+  CANCELLED: ["PENDING", "APPROVED", "APPROVED_PENDING_PAYMENT", "SCHEDULED"],
+  EXPIRED: ["PENDING", "APPROVED_PENDING_PAYMENT"],
+};
+
+// Hoisted from cancel/reschedule routes (#838) so the map is the single
+// source of legality. CANCELLED's allowed-from IS the cancellable set.
+export const CANCELLABLE_FROM = REQUEST_ALLOWED_FROM.CANCELLED;
+export const RESCHEDULABLE_FROM: RequestStatus[] = [
+  "PENDING",
+  "APPROVED",
+  "APPROVED_PENDING_PAYMENT",
+  "SCHEDULED",
+];
+
+// Allocation re-stamps APPROVED when re-allocating an already-approved event
+// (reschedule / in-progress reallocation), so the self-edge is legal THERE
+// via `fromIn` — the guard's only job on that path is keeping terminal
+// states dead. The PATCH approval path uses the strict map (#836).
+export const ALLOCATION_APPROVABLE_FROM: RequestStatus[] = [
+  "PENDING",
+  "APPROVED_PENDING_PAYMENT",
+  "APPROVED",
+];
+
+export async function transitionConsultationRequest(
+  tx: Pick<Tx, "consultation">,
+  args: {
+    where: { id: string };
+    to: RequestStatus;
+    data?: Omit<Prisma.ConsultationUncheckedUpdateManyInput, "requestStatus">;
+    /** Narrow or widen the from-set for flow-specific edges (overage-transitions idiom). */
+    fromIn?: RequestStatus[];
+  },
+): Promise<void> {
+  const res = await tx.consultation.updateMany({
+    where: {
+      ...args.where,
+      requestStatus: { in: args.fromIn ?? REQUEST_ALLOWED_FROM[args.to] },
+    },
+    data: { requestStatus: args.to, ...args.data },
+  });
+  if (res.count === 0) throw new IllegalTransitionError("Consultation", args.to);
+}
+
+export async function transitionSubscriptionRequest(
+  tx: Pick<Tx, "subscription">,
+  args: {
+    where: { id: string };
+    to: RequestStatus;
+    data?: Omit<Prisma.SubscriptionUncheckedUpdateManyInput, "requestStatus">;
+    /** Narrow or widen the from-set for flow-specific edges (overage-transitions idiom). */
+    fromIn?: RequestStatus[];
+  },
+): Promise<void> {
+  const res = await tx.subscription.updateMany({
+    where: {
+      ...args.where,
+      requestStatus: { in: args.fromIn ?? REQUEST_ALLOWED_FROM[args.to] },
+    },
+    data: { requestStatus: args.to, ...args.data },
+  });
+  if (res.count === 0) throw new IllegalTransitionError("Subscription", args.to);
+}
+
+//////////////////////////////////////////////// Webinar / Class ////////////////////////////////////////////////
+
+// WebinarStatus and ClassStatus are enum-identical; one map serves both.
+// SCHEDULED←SCHEDULED is reschedule re-entry. The sets are deliberately the
+// exact complement of the old `notIn: [CANCELLED, COMPLETED]` guards —
+// explicit allowed-from is robust against future enum additions (#837).
+export const EVENT_ALLOWED_FROM: Record<WebinarStatus, WebinarStatus[]> = {
+  SCHEDULED: ["SCHEDULED", "IN_PROGRESS"],
+  IN_PROGRESS: ["SCHEDULED"],
+  COMPLETED: ["SCHEDULED", "IN_PROGRESS"],
+  CANCELLED: ["SCHEDULED", "IN_PROGRESS"],
+};
+// Type-level proof the two enums stay in lockstep.
+export const CLASS_EVENT_ALLOWED_FROM: Record<ClassStatus, ClassStatus[]> =
+  EVENT_ALLOWED_FROM;
+
+//////////////////////////////////////////////// SlotOfAppointment ////////////////////////////////////////////////
+
+// A reschedule may re-mark a SCHEDULED or already-RESCHEDULED slot tentative,
+// but must never resurrect COMPLETED/CANCELLED history or touch UNVERIFIED
+// past sessions (#837 — a COMPLETED past session inside a still-active
+// subscription stayed COMPLETED on cancel but was resurrected on reschedule).
+export const SLOT_RESCHEDULABLE_FROM: SlotCompletionStatus[] = [
+  "SCHEDULED",
+  "RESCHEDULED",
+];

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -13,6 +13,7 @@ import {
 } from "@prisma/client";
 import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
 import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
+import { REQUEST_ALLOWED_FROM } from "@/lib/booking/transitions";
 import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import { recordSystemError } from "@/lib/enterprise/system-events";
 import { validateWebhookMetadata } from "@/schemas/webhooks/metadata";
@@ -1317,16 +1318,24 @@ async function cleanupFailedPaymentAppointment(tx: Tx, appointmentId: string) {
       });
       if (remainingSlots === 0) {
         // Soft-delete: transition to EXPIRED status instead of hard-deleting
-        // to preserve audit trails for support/disputes/refunds
+        // to preserve audit trails for support/disputes/refunds.
+        // #836 — guard rides the WHERE: never expire an APPROVED or terminal
+        // booking from this cleanup path; zero rows means it already moved on.
         if (appointment.consultation) {
-          await tx.consultation.update({
-            where: { id: appointment.consultation.id },
+          await tx.consultation.updateMany({
+            where: {
+              id: appointment.consultation.id,
+              requestStatus: { in: REQUEST_ALLOWED_FROM.EXPIRED },
+            },
             data: { requestStatus: RequestStatus.EXPIRED },
           });
         }
         if (appointment.subscription) {
-          await tx.subscription.update({
-            where: { id: appointment.subscription.id },
+          await tx.subscription.updateMany({
+            where: {
+              id: appointment.subscription.id,
+              requestStatus: { in: REQUEST_ALLOWED_FROM.EXPIRED },
+            },
             data: { requestStatus: RequestStatus.EXPIRED },
           });
         }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -74,6 +74,9 @@ export const eligibilityLimiter = makeLimiter(20, "1 m", "rl:eligibility");
 /** 30 per minute — GET /api/slots/availability/[consultantId] (IP-based, public booking flow) */
 export const availabilityLimiter = makeLimiter(30, "1 m", "rl:availability");
 
+/** 10 per minute — event mutations: /api/events/* POST/PATCH + [id]/validate + [id]/allocate (#831) */
+export const eventMutationLimiter = makeLimiter(10, "1 m", "rl:event-mutation");
+
 // ============================================================================
 // Enterprise (arch-4) — per-org / per-IP buckets for org-specific surfaces.
 //

--- a/lib/validation/limits.ts
+++ b/lib/validation/limits.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Shared input bounds for consumer-facing mutation routes (#831).
+ *
+ * Every user-typed string must carry a `.max()` — unbounded text is a
+ * 10MB-payload DoS surface (Postgres TOAST bloat + log amplification).
+ * One constant block so the numbers stay uniform across schemas.
+ */
+export const MAX_TITLE_LENGTH = 200;
+export const MAX_TEXT_LENGTH = 2_000;
+export const MAX_SHORT_FIELD_LENGTH = 50;
+
+/** Default request-body ceiling for JSON mutation routes. */
+export const MAX_BODY_BYTES = 64 * 1024;
+
+/**
+ * Reject oversized request bodies before parsing (#831).
+ * Returns a 413 NextResponse when content-length exceeds the cap, else null.
+ * Content-length is attacker-suppliable but Netlify enforces it on the
+ * function payload, so a lying header still cannot smuggle a larger body.
+ */
+export function assertBodySize(
+  req: { headers: { get(name: string): string | null } },
+  maxBytes: number = MAX_BODY_BYTES,
+): NextResponse | null {
+  const len = Number(req.headers.get("content-length") ?? 0);
+  if (Number.isFinite(len) && len > maxBytes) {
+    return NextResponse.json(
+      { error: "Request body too large" },
+      { status: 413 },
+    );
+  }
+  return null;
+}

--- a/schemas/subscriptions.ts
+++ b/schemas/subscriptions.ts
@@ -1,18 +1,20 @@
 import { z } from "zod";
 import { RequestStatusEnum } from "./enums";
+import { MAX_TEXT_LENGTH } from "@/lib/validation/limits";
 
 export const UpdateSubscriptionStatusSchema = z.object({
   id: z.string().min(1, "Subscription ID is required"),
   status: RequestStatusEnum,
 });
 
+// #836 — requestStatus is NOT writable via PUT: status changes flow only
+// through PATCH, where the allowed-from guard rides the WHERE clause.
 export const UpdateSubscriptionSchema = z.object({
   schedulingPeriodStartsAt: z.string().optional(),
   schedulingPeriodEndsAt: z.string().optional(),
-  requestStatus: RequestStatusEnum.optional(),
-  requestNotes: z.string().optional(),
-  feedbackFromConsultee: z.string().optional(),
-  feedbackFromConsultant: z.string().optional(),
+  requestNotes: z.string().max(MAX_TEXT_LENGTH).optional(), // #831
+  feedbackFromConsultee: z.string().max(MAX_TEXT_LENGTH).optional(),
+  feedbackFromConsultant: z.string().max(MAX_TEXT_LENGTH).optional(),
   rating: z.number().min(0).max(5).optional(),
   planId: z.string().optional(),
 });

--- a/scripts/appointments/auto-complete-appointments.ts
+++ b/scripts/appointments/auto-complete-appointments.ts
@@ -28,6 +28,7 @@ import {
 import { notifyAppointmentCompleted } from "../../lib/novu/service";
 import { getAppUrl } from "../../lib/url";
 import { withCronLock } from "@/lib/cron/with-cron-lock";
+import { REQUEST_ALLOWED_FROM } from "@/lib/booking/transitions";
 
 // Only complete appointments that ended at least 1 hour ago
 // This gives buffer time for any post-session activities
@@ -266,10 +267,19 @@ async function completeConsultations(): Promise<{
         `   Last slot ended: ${lastSlot?.endsAt?.toISOString() || "Unknown"}`,
       );
 
-      await prisma.consultation.update({
-        where: { id: consultation.id },
+      // #836 — guard rides the WHERE: a cancel landing between the sweep's
+      // read and this write must not be overwritten by COMPLETED.
+      const moved = await prisma.consultation.updateMany({
+        where: {
+          id: consultation.id,
+          requestStatus: { in: REQUEST_ALLOWED_FROM.COMPLETED },
+        },
         data: { requestStatus: RequestStatus.COMPLETED },
       });
+      if (moved.count === 0) {
+        console.log(`   ⏭️ Skipped — status changed since sweep read`);
+        continue;
+      }
 
       console.log(`   ✅ Marked as COMPLETED`);
       completed++;
@@ -387,10 +397,19 @@ async function completeSubscriptions(): Promise<{
         `   Last slot ended: ${latestEnd?.toISOString() || "Unknown"}`,
       );
 
-      await prisma.subscription.update({
-        where: { id: subscription.id },
+      // #836 — guard rides the WHERE: a cancel landing between the sweep's
+      // read and this write must not be overwritten by COMPLETED.
+      const moved = await prisma.subscription.updateMany({
+        where: {
+          id: subscription.id,
+          requestStatus: { in: REQUEST_ALLOWED_FROM.COMPLETED },
+        },
         data: { requestStatus: RequestStatus.COMPLETED },
       });
+      if (moved.count === 0) {
+        console.log(`   ⏭️ Skipped — status changed since sweep read`);
+        continue;
+      }
 
       console.log(`   ✅ Marked as COMPLETED`);
       completed++;

--- a/scripts/appointments/expire-stale-requests.ts
+++ b/scripts/appointments/expire-stale-requests.ts
@@ -19,6 +19,11 @@ import prisma from "../../lib/prisma";
 import { RequestStatus } from "@prisma/client";
 import { withCronLock } from "@/lib/cron/with-cron-lock";
 
+// The per-cohort WHERE guards below (PENDING by requestedAt,
+// APPROVED_PENDING_PAYMENT by updatedAt) are deliberate subsets of
+// REQUEST_ALLOWED_FROM.EXPIRED in lib/booking/transitions.ts (#836) —
+// each cohort has its own cutoff, so they are not merged into one sweep.
+
 // Expire requests in PENDING state for more than 30 days
 const PENDING_EXPIRATION_DAYS = 30;
 

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -29,6 +29,12 @@ import { SlotValidationService } from "./SlotValidationService";
 import { buildOccupiedAppointmentFilter } from "./occupancyPolicy";
 import { lockAutoAllocate, unlockAutoAllocate } from "@/utils/appointmentlock";
 import {
+  ALLOCATION_APPROVABLE_FROM,
+  transitionConsultationRequest,
+  transitionSubscriptionRequest,
+} from "@/lib/booking/transitions";
+import { IllegalTransitionError } from "@/lib/enterprise/transitions";
+import {
   DAY_OF_WEEK_TO_INDEX,
   isMinuteWithinWeeklySlot,
   TWENTY_FOUR_HOURS_IN_MS,
@@ -119,6 +125,11 @@ export class SlotAllocationService {
     }
     if (error instanceof AllocationConflictError) {
       return { errorCode: error.errorCode, httpStatus: error.httpStatus };
+    }
+    // #836 — consultee cancelled (or request expired) while the consultant
+    // was allocating; the whole allocation tx rolled back.
+    if (error instanceof IllegalTransitionError) {
+      return { errorCode: "ILLEGAL_TRANSITION", httpStatus: error.httpStatus };
     }
 
     // Prisma unique constraint violation (P2002) — concurrent duplicate booking race
@@ -1766,18 +1777,24 @@ export class SlotAllocationService {
     config: EventConfig,
   ): Promise<void> {
     switch (eventType) {
+      // #836 — allocation racing a cancel/expiry must not resurrect the
+      // request to APPROVED; the allowed-from guard rides the WHERE and a
+      // miss rolls back the whole allocation tx. fromIn keeps the APPROVED
+      // self-edge legal for re-allocation of an already-approved event.
       case "consultation":
-        await tx.consultation.update({
+        await transitionConsultationRequest(tx, {
           where: { id: eventId },
-          data: { requestStatus: RequestStatus.APPROVED },
+          to: RequestStatus.APPROVED,
+          fromIn: ALLOCATION_APPROVABLE_FROM,
         });
         break;
 
       case "subscription":
-        await tx.subscription.update({
+        await transitionSubscriptionRequest(tx, {
           where: { id: eventId },
+          to: RequestStatus.APPROVED,
+          fromIn: ALLOCATION_APPROVABLE_FROM,
           data: {
-            requestStatus: RequestStatus.APPROVED,
             // FIX: Only set schedulingPeriod if not already configured
             // This prevents overwriting the user's scheduling period with the first allocated slot
             // which could cause slots to appear outside the intended scheduling window

--- a/utils/slotAllocation/types.ts
+++ b/utils/slotAllocation/types.ts
@@ -79,6 +79,7 @@ export type AllocationErrorCode =
   | "NOT_FOUND" // event/consultant missing — 400
   | "INVALID_MODE" // unknown allocation mode — 400
   | "LOCK_CONTENTION" // Redis lock busy — 409
+  | "ILLEGAL_TRANSITION" // event left the approvable state mid-allocation (#836) — 409
   | "UNKNOWN_ERROR"; // infra / unexpected — 500
 
 /**


### PR DESCRIPTION
First PR of the four-PR B2C hardening train (precedent: #825→#826→#838). Stack: this → #B → #C → #D, merged bottom-up.

## What this does

`lib/booking/transitions.ts` is the consumer-side sibling of `lib/enterprise/transitions.ts`: allowed-from maps keyed by target state, baked into `updateMany` WHERE clauses, so an illegal transition matches zero rows instead of corrupting state. It closes the #836 read-then-decide race and every adjacent unguarded `requestStatus` writer found while wiring it:

- Consultation/subscription **PATCH approval flows** — both the `[id]` routes and the previously fully-unguarded **collection-route PATCHes** — go through `transitionConsultationRequest`/`transitionSubscriptionRequest`; `IllegalTransitionError` maps to 409.
- `SlotAllocationService.updateEventStatus` (the actual #836 race: allocation racing a cancel resurrected the request to APPROVED). `ALLOCATION_APPROVABLE_FROM` keeps the APPROVED self-edge legal there because re-allocation of an approved event is a supported flow.
- The webhook tentative-expiry path and the auto-complete sweep get from-state guards (a cancel landing mid-sweep must not be overwritten by COMPLETED/EXPIRED).
- `requestStatus` is **removed from both PUT surfaces** — status changes flow only through the guarded PATCH path (no frontend caller sent it; verified by grep).
- Reschedule slot flips carry `completionStatus: { in: SLOT_RESCHEDULABLE_FROM } ` so COMPLETED/CANCELLED history is never resurrected; webinar/class transitions use explicit allowed-from sets instead of `notIn`.

Also finishes **#677 PM-1**: the three GH-Actions wrapper warning gates now match the canonical `RAZORPAY_SECRET` (legacy name accepted as fallback only), `.env.sample` documents the RazorpayX + webhook secrets, and the payout go-live runbook names the right variable. PM-2 was verified already fixed on dev (deterministic `payout_${payoutId}`); no code change.

`lib/validation/limits.ts` and the `eventMutationLimiter` land here because routes this PR touches consume them; the rest of #831 rides PR-B.

## Verification

- Service-level CAS proofs against the dev DB: legal transition succeeds once; replay throws `IllegalTransitionError`; CANCELLED→APPROVED refused; two concurrent declines → exactly one winner; terminal webinar untouched by guarded flip.
- Env-gate matrix on the payout-reconcile wrapper: canonical-only → no warning; legacy-only (canonical truly unset) → no warning; neither → warning.
- `__tests__/booking-algorithm/` updated to the guarded WHERE shapes — 472/472 pass; full Jest suite 1337/1337; `tsc` clean at this commit in isolation.

Closes #836
Part of #837
Part of #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-mutation rate limiting and centralized guarded booking-state transitions
  * Validation limits and request body-size guard for event APIs

* **Bug Fixes**
  * Hardened reschedule/cancel flows and allocation logic to avoid illegal/racing state changes
  * Improved failed-payment cleanup and auto-complete to respect allowed prior states
  * Introduced a specific error code for illegal transition cases

* **Documentation**
  * Clarified production payout secret naming and fallback behavior in runbook

* **Chores**
  * Added production payout environment variable configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->