### PR TITLE
fix: checkout lock budgets + tentative TTL + waitlist CAS + input bounds and limiters

### DIFF
--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -4,6 +4,7 @@ import { notifyGeneralAnnouncement } from "@/lib/novu";
 import { CreateAnnouncementSchema } from "@/schemas/announcements";
 
 import { getSession } from "@/lib/auth-server";
+import { assertBodySize } from "@/lib/validation/limits";
 /**
  * GET /api/announcements
  * Public endpoint to get active announcements
@@ -60,6 +61,10 @@ export async function POST(request: NextRequest) {
         { status: 403 },
       );
     }
+
+    // #831 — cap request body before parsing
+    const tooLarge = assertBodySize(request);
+    if (tooLarge) return tooLarge;
 
     const body = await request.json();
     const result = CreateAnnouncementSchema.safeParse(body);

--- a/app/api/events/classes/[classId]/allocate/route.ts
+++ b/app/api/events/classes/[classId]/allocate/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 export async function PATCH(
   request: NextRequest,
@@ -36,6 +37,13 @@ export async function PATCH(
       classId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/classes/[classId]/validate/route.ts
+++ b/app/api/events/classes/[classId]/validate/route.ts
@@ -19,6 +19,7 @@ import {
 import { ZodError } from "zod";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 interface ValidationResult extends SlotConflictResult {
   weeklyDistributionErrors: {
@@ -59,6 +60,13 @@ export async function POST(
       classId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/consultations/[consultationId]/allocate/route.ts
+++ b/app/api/events/consultations/[consultationId]/allocate/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 export async function PATCH(
   request: NextRequest,
@@ -37,6 +38,13 @@ export async function PATCH(
       consultationId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/consultations/[consultationId]/validate/route.ts
+++ b/app/api/events/consultations/[consultationId]/validate/route.ts
@@ -19,6 +19,7 @@ import {
 import { ZodError } from "zod";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 const consultationInclude = {
   consultationPlan: {
@@ -56,6 +57,13 @@ export async function POST(
       consultationId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/subscriptions/[subscriptionId]/allocate/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/allocate/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 export async function PATCH(
   request: NextRequest,
@@ -36,6 +37,13 @@ export async function PATCH(
       subscriptionId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/subscriptions/[subscriptionId]/validate/route.ts
+++ b/app/api/events/subscriptions/[subscriptionId]/validate/route.ts
@@ -21,6 +21,7 @@ import {
 import { ZodError } from "zod";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 interface ValidationResult extends SlotConflictResult {
   subscriptionValidation?: {
@@ -80,6 +81,13 @@ export async function POST(
       subscriptionId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/webinars/[webinarId]/allocate/route.ts
+++ b/app/api/events/webinars/[webinarId]/allocate/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/schemas/slotAllocation/validationSchemas";
 import { ZodError } from "zod";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 export async function PATCH(
   request: NextRequest,
@@ -36,6 +37,13 @@ export async function PATCH(
       webinarId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/webinars/[webinarId]/validate/route.ts
+++ b/app/api/events/webinars/[webinarId]/validate/route.ts
@@ -19,6 +19,7 @@ import {
 import { ZodError } from "zod";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 import { requireApiAuth, authorizeEventAccess } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 
 const webinarInclude = {
   webinarPlan: {
@@ -51,6 +52,13 @@ export async function POST(
       webinarId,
     );
     if (authzError) return authzError;
+
+    // #831 — event mutations previously had no limiter
+    const rl = await applyRateLimit(
+      eventMutationLimiter,
+      authResult.session.user.id,
+    );
+    if (rl) return rl;
 
     // LAYER 1: Zod Schema Validation (type-safe, automatic type inference)
     try {

--- a/app/api/events/webinars/route.ts
+++ b/app/api/events/webinars/route.ts
@@ -7,6 +7,7 @@ import {
   isPrivileged,
   forbiddenResponse,
 } from "@/lib/auth-helpers";
+import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
 import { resolveOrgScope } from "@/lib/api/scope/parse";
 
 export async function GET(request: NextRequest) {
@@ -285,6 +286,10 @@ export async function POST(request: Request) {
   const authResult = await requireApiAuth();
   if (authResult.error) return authResult.error;
   const { session } = authResult;
+
+  // #831 — event mutations previously had no limiter
+  const rl = await applyRateLimit(eventMutationLimiter, session.user.id);
+  if (rl) return rl;
 
   try {
     const body = await request.json();

--- a/app/api/report/route.ts
+++ b/app/api/report/route.ts
@@ -7,8 +7,27 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { ModerationReportType } from "@prisma/client";
 import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
+import {
+  assertBodySize,
+  MAX_TEXT_LENGTH,
+  MAX_TITLE_LENGTH,
+} from "@/lib/validation/limits";
+import { z } from "zod";
 
 import { getSession } from "@/lib/auth-server";
+
+// #831 — raw destructuring accepted unbounded strings; every user-typed
+// field now carries a .max()
+const CreateReportSchema = z.object({
+  type: z.nativeEnum(ModerationReportType),
+  reason: z.string().min(1).max(MAX_TITLE_LENGTH),
+  description: z.string().max(MAX_TEXT_LENGTH).optional(),
+  targetUserId: z.string().min(1).max(MAX_TITLE_LENGTH),
+  contentText: z.string().max(MAX_TEXT_LENGTH).optional(),
+  contentUrl: z.string().max(MAX_TITLE_LENGTH).optional(),
+  reviewId: z.string().max(MAX_TITLE_LENGTH).optional(),
+});
+
 /**
  * POST /api/report
  * Submit a content report
@@ -24,7 +43,17 @@ export async function POST(req: NextRequest) {
     const rl = await applyRateLimit(spamLimiter, `report:${session.user.id}`);
     if (rl) return rl;
 
+    const tooLarge = assertBodySize(req);
+    if (tooLarge) return tooLarge;
+
     const body = await req.json();
+    const parsed = CreateReportSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
     const {
       type,
       reason,
@@ -33,7 +62,7 @@ export async function POST(req: NextRequest) {
       contentText,
       contentUrl,
       reviewId,
-    } = body;
+    } = parsed.data;
 
     // Validate required fields
     if (!type || !reason || !targetUserId) {

--- a/app/api/trials/route.ts
+++ b/app/api/trials/route.ts
@@ -248,11 +248,13 @@ export async function POST(request: NextRequest) {
       ) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
-
-      // Rate limit: 3 trial requests per 24 hours per consultee (prevents inbox flooding)
-      const rl = await applyRateLimit(trialRequestLimiter, session.user.id);
-      if (rl) return rl;
     }
+
+    // Rate limit: 3 trial requests per 24 hours per creator. #831 — applied
+    // uniformly: a privileged session can still flood consultant inboxes,
+    // so role no longer bypasses the limiter.
+    const rl = await applyRateLimit(trialRequestLimiter, session.user.id);
+    if (rl) return rl;
 
     // Check if a trial already exists for this consultee-consultant pair
     const existingTrial = await prisma.trialSession.findUnique({

--- a/app/api/user/feedbacks/route.ts
+++ b/app/api/user/feedbacks/route.ts
@@ -5,6 +5,7 @@ import { CreateFeedbackSchema } from "@/schemas/feedbacks";
 import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
+import { assertBodySize } from "@/lib/validation/limits";
 export async function GET() {
   try {
     const session = await getSession();
@@ -53,6 +54,10 @@ export async function POST(req: NextRequest) {
       `feedbacks:${session.user.id}`,
     );
     if (rl) return rl;
+
+    // #831 — cap request body before parsing
+    const tooLarge = assertBodySize(req);
+    if (tooLarge) return tooLarge;
 
     const body = await req.json();
     const result = CreateFeedbackSchema.safeParse(body);

--- a/app/api/user/support-tickets/[ticketId]/responses/route.ts
+++ b/app/api/user/support-tickets/[ticketId]/responses/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "lib/prisma";
 import { getSession } from "@/lib/auth-server";
+import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
+import { assertBodySize } from "@/lib/validation/limits";
+import { CreateSupportResponseSchema } from "@/schemas/support";
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ ticketId: string }> },
@@ -15,8 +18,24 @@ export async function POST(
       );
     }
 
+    // #831 — raw body.message was unbounded and unlimited
+    const rl = await applyRateLimit(
+      spamLimiter,
+      `ticket-response:${session.user.id}`,
+    );
+    if (rl) return rl;
+    const tooLarge = assertBodySize(req);
+    if (tooLarge) return tooLarge;
+
     const { ticketId } = resolvedParams;
-    const body = await req.json();
+    const parsed = CreateSupportResponseSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const body = parsed.data;
 
     // Verify the ticket exists and belongs to the user
     const ticket = await prisma.supportTicket.findFirst({

--- a/app/api/user/support-tickets/route.ts
+++ b/app/api/user/support-tickets/route.ts
@@ -5,6 +5,7 @@ import { CreateSupportTicketSchema } from "@/schemas/support";
 import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
 
 import { getSession } from "@/lib/auth-server";
+import { assertBodySize } from "@/lib/validation/limits";
 export async function GET() {
   try {
     const session = await getSession();
@@ -74,6 +75,10 @@ export async function POST(req: NextRequest) {
     // Rate limit: 5 support tickets per hour per user
     const rl = await applyRateLimit(spamLimiter, `tickets:${session.user.id}`);
     if (rl) return rl;
+
+    // #831 — cap request body before parsing
+    const tooLarge = assertBodySize(req);
+    if (tooLarge) return tooLarge;
 
     const body = await req.json();
     const result = CreateSupportTicketSchema.safeParse(body);

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -12,6 +12,7 @@ import { waitlistLimiter, applyRateLimit } from "@/lib/rate-limit";
 import { resolveOrgScope } from "@/lib/api/scope/parse";
 
 import { getSession } from "@/lib/auth-server";
+import { assertBodySize } from "@/lib/validation/limits";
 /**
  * POST /api/waitlist - Join a waitlist
  */
@@ -29,6 +30,10 @@ export async function POST(request: NextRequest) {
     // Rate limit: 5 waitlist joins per hour per user
     const rl = await applyRateLimit(waitlistLimiter, session.user.id);
     if (rl) return rl;
+
+    // #831 — cap request body before parsing
+    const tooLarge = assertBodySize(request);
+    if (tooLarge) return tooLarge;
 
     const body = await request.json();
     const { webinarId, classId, preferences } = body;

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -21,6 +21,8 @@ import {
   unlockSlotBooking,
   lockEventCheckout,
   unlockEventCheckout,
+  extendLock,
+  CHECKOUT_LOCK_TTL_MS,
   ApprovalLock,
 } from "@/utils/appointmentlock";
 import { validateSlotTiming } from "@/lib/payments/utils/slot-validation";
@@ -895,7 +897,11 @@ async function acquireCheckoutLock(
       }),
     );
 
-    return await lockSlotBooking(consultantProfileId, data.slotStartTimeInUTC);
+    return await lockSlotBooking(
+      consultantProfileId,
+      data.slotStartTimeInUTC,
+      CHECKOUT_LOCK_TTL_MS[appointmentType], // #832 — per-type budget
+    );
   }
 
   // Strategy B: Event-based locking (WEBINAR, CLASS, scheduling-period SUBSCRIPTION)
@@ -914,7 +920,11 @@ async function acquireCheckoutLock(
       }),
     );
 
-    return await lockEventCheckout(appointmentType, data.eventId);
+    return await lockEventCheckout(
+      appointmentType,
+      data.eventId,
+      CHECKOUT_LOCK_TTL_MS[appointmentType], // #832 — per-type budget
+    );
   }
 
   // Scheduling period SUBSCRIPTION (no slots during checkout)
@@ -929,7 +939,11 @@ async function acquireCheckoutLock(
       }),
     );
 
-    return await lockEventCheckout(appointmentType, data.planId);
+    return await lockEventCheckout(
+      appointmentType,
+      data.planId,
+      CHECKOUT_LOCK_TTL_MS[appointmentType], // #832 — per-type budget
+    );
   }
 
   // Should not reach here if validation is correct
@@ -2063,6 +2077,25 @@ export async function handleCheckout(
     const isZeroAmountPayment = amount === 0 && creditsApplied > 0;
 
     // STEP 4: Create payment intent (INSIDE LOCK)
+
+    // #832 — one checked renewal at the long-latency boundary (gateway call
+    // + tentative-booking tx still ahead). A false return means the lock
+    // already expired and another buyer may hold it; proceeding is exactly
+    // the double-booking hazard the lock exists to prevent. A timer-based
+    // heartbeat is deliberately avoided: serverless freeze makes intervals
+    // unreliable, and the message must contain "already in progress" so
+    // classifyError maps it to LOCK_CONTENTION → 409.
+    if (lock) {
+      const renewed = await extendLock(
+        lock,
+        CHECKOUT_LOCK_TTL_MS[validatedData.appointmentType] ?? 60_000,
+      );
+      if (!renewed) {
+        throw new Error(
+          "Checkout took too long and its hold expired — another checkout for this slot may be already in progress. Please try again.",
+        );
+      }
+    }
 
     // Enterprise org funding skips the gateway entirely.
     if (isOrgSponsoredPayment) {

--- a/lib/waitlist/slot-handler.ts
+++ b/lib/waitlist/slot-handler.ts
@@ -195,8 +195,10 @@ export async function handleWaitlistResponse(params: {
 
   // Check if notification has expired
   if (entry.expiresAt && new Date() > entry.expiresAt) {
-    await prisma.waitlist.update({
-      where: { id: waitlistId },
+    // #834 — CAS: only NOTIFIED may expire; a racing respond/expire-cron
+    // already moved it on if count is 0.
+    await prisma.waitlist.updateMany({
+      where: { id: waitlistId, status: WaitlistStatus.NOTIFIED },
       data: {
         status: WaitlistStatus.EXPIRED,
         respondedAt: new Date(),
@@ -232,14 +234,21 @@ export async function handleWaitlistResponse(params: {
     }
 
     case "DECLINE": {
-      // User doesn't want the spot - remove from waitlist
-      await prisma.waitlist.update({
-        where: { id: waitlistId },
+      // #834 — CAS: two tabs declining concurrently must fire exactly one
+      // handleSlotOpening; the loser would double-notify the next in queue.
+      const declined = await prisma.waitlist.updateMany({
+        where: { id: waitlistId, status: WaitlistStatus.NOTIFIED },
         data: {
           status: WaitlistStatus.CANCELLED,
           respondedAt: now,
         },
       });
+      if (declined.count === 0) {
+        return {
+          success: false,
+          message: "This spot offer was already responded to.",
+        };
+      }
 
       // Notify next person in queue
       await handleSlotOpening({
@@ -256,14 +265,21 @@ export async function handleWaitlistResponse(params: {
     }
 
     case "SKIP": {
-      // User wants to skip this time - move to back of queue
-      await prisma.waitlist.update({
-        where: { id: waitlistId },
+      // #834 — CAS: a double-submitted SKIP must not insert two back-of-queue
+      // rows or double-fire handleSlotOpening.
+      const skipped = await prisma.waitlist.updateMany({
+        where: { id: waitlistId, status: WaitlistStatus.NOTIFIED },
         data: {
           status: WaitlistStatus.SKIPPED,
           respondedAt: now,
         },
       });
+      if (skipped.count === 0) {
+        return {
+          success: false,
+          message: "This spot offer was already responded to.",
+        };
+      }
 
       // Create a new waitlist entry at the back of the queue
       await prisma.waitlist.create({
@@ -308,8 +324,13 @@ export async function handleWaitlistResponse(params: {
  * Mark a waitlist entry as booked after successful payment
  */
 export async function markWaitlistAsBooked(waitlistId: string): Promise<void> {
-  await prisma.waitlist.update({
-    where: { id: waitlistId },
+  // #834 — CAS: webhook replays re-stamp, and a CANCELLED/EXPIRED entry must
+  // not be resurrected to BOOKED. Zero rows = already stamped or moved on.
+  const res = await prisma.waitlist.updateMany({
+    where: {
+      id: waitlistId,
+      status: { in: [WaitlistStatus.NOTIFIED, WaitlistStatus.WAITING] },
+    },
     data: {
       status: WaitlistStatus.BOOKED,
       bookedAt: new Date(),
@@ -319,7 +340,10 @@ export async function markWaitlistAsBooked(waitlistId: string): Promise<void> {
 
   console.log(
     JSON.stringify({
-      event: "waitlist_booking_completed",
+      event:
+        res.count === 0
+          ? "waitlist_booking_already_stamped"
+          : "waitlist_booking_completed",
       waitlistId,
       timestamp: new Date().toISOString(),
     }),
@@ -567,13 +591,24 @@ export async function leaveWaitlist(params: {
     };
   }
 
-  await prisma.waitlist.update({
-    where: { id: waitlistId },
+  // #834 — CAS: the pre-check above is friendly error text; the WHERE is
+  // what prevents a leave racing a respond/expire from double-firing.
+  const left = await prisma.waitlist.updateMany({
+    where: {
+      id: waitlistId,
+      status: { in: [WaitlistStatus.WAITING, WaitlistStatus.NOTIFIED] },
+    },
     data: {
       status: WaitlistStatus.CANCELLED,
       respondedAt: new Date(),
     },
   });
+  if (left.count === 0) {
+    return {
+      success: false,
+      message: "Cannot leave waitlist with current status",
+    };
+  }
 
   // If the entry was NOTIFIED, notify next person
   if (entry.status === WaitlistStatus.NOTIFIED) {

--- a/schemas/announcements.ts
+++ b/schemas/announcements.ts
@@ -1,13 +1,19 @@
 import { z } from "zod";
+import {
+  MAX_SHORT_FIELD_LENGTH,
+  MAX_TEXT_LENGTH,
+  MAX_TITLE_LENGTH,
+} from "@/lib/validation/limits";
 
+// #831 — every user-typed string carries a .max()
 export const CreateAnnouncementSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  content: z.string().min(1, "Content is required"),
+  title: z.string().min(1, "Title is required").max(MAX_TITLE_LENGTH),
+  content: z.string().min(1, "Content is required").max(MAX_TEXT_LENGTH),
   isActive: z.boolean().default(true),
   startDate: z.string().datetime().optional(),
   endDate: z.string().datetime().optional(),
-  backgroundColor: z.string().default("#000000"),
-  textColor: z.string().default("#FFFFFF"),
-  linkUrl: z.string().url().optional(),
-  linkText: z.string().optional(),
+  backgroundColor: z.string().max(MAX_SHORT_FIELD_LENGTH).default("#000000"),
+  textColor: z.string().max(MAX_SHORT_FIELD_LENGTH).default("#FFFFFF"),
+  linkUrl: z.string().url().max(MAX_TITLE_LENGTH).optional(),
+  linkText: z.string().max(MAX_TITLE_LENGTH).optional(),
 });

--- a/schemas/feedbacks.ts
+++ b/schemas/feedbacks.ts
@@ -1,15 +1,24 @@
 import { z } from "zod";
+import {
+  MAX_SHORT_FIELD_LENGTH,
+  MAX_TEXT_LENGTH,
+  MAX_TITLE_LENGTH,
+} from "@/lib/validation/limits";
 
+// #831 — every user-typed string carries a .max()
 export const CreateFeedbackSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  description: z.string().min(1, "Description is required"),
+  title: z.string().min(1, "Title is required").max(MAX_TITLE_LENGTH),
+  description: z
+    .string()
+    .min(1, "Description is required")
+    .max(MAX_TEXT_LENGTH),
   rating: z.number().int().min(1).max(5).optional(),
-  category: z.string().optional(),
+  category: z.string().max(MAX_SHORT_FIELD_LENGTH).optional(),
 });
 
 export const CreateReviewSchema = z.object({
   rating: z.number().int().min(1, "Rating is required").max(5),
-  reviewDescription: z.string().optional(),
+  reviewDescription: z.string().max(MAX_TEXT_LENGTH).optional(),
   consultantProfileId: z.string().min(1, "Consultant profile ID is required"),
   consulteeProfileId: z.string().min(1, "Consultee profile ID is required"),
 });

--- a/schemas/support.ts
+++ b/schemas/support.ts
@@ -4,12 +4,21 @@ import {
   SupportPriorityEnum,
   SupportIssueTypeEnum,
 } from "./enums";
+import {
+  MAX_SHORT_FIELD_LENGTH,
+  MAX_TEXT_LENGTH,
+  MAX_TITLE_LENGTH,
+} from "@/lib/validation/limits";
 
+// #831 — every user-typed string carries a .max()
 export const CreateSupportTicketSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  description: z.string().min(1, "Description is required"),
+  title: z.string().min(1, "Title is required").max(MAX_TITLE_LENGTH),
+  description: z
+    .string()
+    .min(1, "Description is required")
+    .max(MAX_TEXT_LENGTH),
   priority: SupportPriorityEnum.optional(),
-  category: z.string().optional(),
+  category: z.string().max(MAX_SHORT_FIELD_LENGTH).optional(),
   issueType: SupportIssueTypeEnum.optional(),
   consultationId: z.string().optional(),
   subscriptionId: z.string().optional(),
@@ -25,6 +34,6 @@ export const UpdateSupportTicketSchema = z.object({
 });
 
 export const CreateSupportResponseSchema = z.object({
-  message: z.string().trim().min(1, "Message is required"),
+  message: z.string().trim().min(1, "Message is required").max(MAX_TEXT_LENGTH),
   isInternal: z.boolean().default(false),
 });

--- a/schemas/trials.ts
+++ b/schemas/trials.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
 import { TrialSessionStatusEnum } from "./enums";
+import { MAX_TEXT_LENGTH } from "@/lib/validation/limits";
 
 export const CreateTrialSchema = z.object({
   consulteeProfileId: z.string().min(1, "Consultee profile ID is required"),
   consultantProfileId: z.string().min(1, "Consultant profile ID is required"),
   subscriptionPlanId: z.string().min(1, "Subscription plan ID is required"),
-  notes: z.string().optional(),
+  notes: z.string().max(MAX_TEXT_LENGTH).optional(), // #831
   // Enterprise (arch-4) — optional org attribution. When the booker is a
   // LEARNER of an org, passing the orgId here stamps the trial with
   // `TrialSession.organizationId` so analytics can segment org-tagged
@@ -26,7 +27,7 @@ export const UpdateTrialSchema = z.object({
       slotType: z.enum(["WEEKLY", "CUSTOM"]),
     })
     .optional(),
-  notes: z.string().optional(),
+  notes: z.string().max(MAX_TEXT_LENGTH).optional(), // #831
   // Required when status = CONVERTED — the subscription created via checkout
   subscriptionId: z.string().optional(),
 });

--- a/scripts/appointments/cleanup-tentative-slots.ts
+++ b/scripts/appointments/cleanup-tentative-slots.ts
@@ -2,7 +2,7 @@
  * Tentative Slot Cleanup - Core Logic
  *
  * Releases slots marked as isTentative=true that are associated with
- * abandoned booking flows (no successful payment after 7 days).
+ * abandoned booking flows (no successful payment after 24 hours, #833).
  *
  * This happens when:
  * - User started booking but never completed payment
@@ -21,8 +21,11 @@ import prisma from "../../lib/prisma";
 import { PaymentStatus } from "@prisma/client";
 import { withCronLock } from "@/lib/cron/with-cron-lock";
 
-// Release tentative slots older than 7 days with no successful payment
-const TENTATIVE_EXPIRATION_DAYS = 7;
+// #833 — hours, not days: gateway orders expire well inside a day, so a
+// 7-day hold locked users out of rebooking for most of a week. 24h keeps
+// margin over Payment.expiresAt and the 2-hourly cron cadence; the parent
+// status guard below still protects requests under consultant review.
+const TENTATIVE_EXPIRATION_HOURS = 24;
 
 export interface TentativeSlotCleanupResult {
   success: boolean;
@@ -49,11 +52,11 @@ async function cleanupTentativeSlotsUnlocked(): Promise<TentativeSlotCleanupResu
   const appointmentsAffected = new Set<string>();
 
   const expirationDate = new Date(
-    Date.now() - TENTATIVE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000,
+    Date.now() - TENTATIVE_EXPIRATION_HOURS * 60 * 60 * 1000,
   );
 
   console.log("🧹 Starting tentative slot cleanup...");
-  console.log(`   Expiration threshold: ${TENTATIVE_EXPIRATION_DAYS} days`);
+  console.log(`   Expiration threshold: ${TENTATIVE_EXPIRATION_HOURS} hours`);
 
   try {
     // Find tentative slots with no successful payment AND whose parent event

--- a/utils/appointmentlock.ts
+++ b/utils/appointmentlock.ts
@@ -51,6 +51,18 @@ const DEFAULT_RETRY_CONFIG: LockRetryConfig = {
 const DEFAULT_LOCK_TTL = 60000; // 60 seconds
 const DEFAULT_EVENT_SLOT_TTL = 300000; // 5 minutes for payment completion
 
+// #832 — one 60s budget cannot cover every checkout shape: a class checkout
+// writes N sessions × M slots plus a gateway round-trip and can outlive its
+// lock, silently admitting a second buyer. Sized per checkout type (mirrors
+// the LONG_JOB_TTL_MS precedent in lib/cron/with-cron-lock.ts); checkout
+// also renews once before the gateway call and aborts if ownership is lost.
+export const CHECKOUT_LOCK_TTL_MS: Record<string, number> = {
+  CONSULTATION: 60_000,
+  SUBSCRIPTION: 120_000,
+  WEBINAR: 120_000,
+  CLASS: 300_000,
+};
+
 // ============================================================================
 // Helper Functions
 // ============================================================================


### PR DESCRIPTION
Second PR of the B2C hardening train — stacked on #845.

## What this does

**#832 — checkout locks.** Per-type TTL budgets (`CHECKOUT_LOCK_TTL_MS`: CONSULTATION 60s, SUBSCRIPTION/WEBINAR 120s, CLASS 300s — a class checkout writes N sessions × M slots plus a gateway round-trip and outlived the flat 60s), plus ONE checked `extendLock` renewal immediately before the gateway call that **aborts 409 on ownership loss** — a lost lock means another buyer may hold it, and proceeding is exactly the double-booking hazard the lock exists to prevent. A timer heartbeat was rejected: serverless freeze makes intervals unreliable; the dormant atomic Lua `extendLock` helper finally gets its call site.

**#833 — tentative TTL.** `TENTATIVE_EXPIRATION_DAYS = 7` → `TENTATIVE_EXPIRATION_HOURS = 24`. Gateway orders expire well inside a day; the 7-day hold locked users out of rebooking for most of a week. The parent-status guard still protects requests under consultant review. The user-facing cancel-pending action is deferred to a follow-up issue.

**#834 (code half) — waitlist CAS.** `markWaitlistAsBooked`, DECLINE, SKIP, the expire branch, and `leaveWaitlist` all become guarded `updateMany`s: double-submits can no longer double-fire `handleSlotOpening` (double-notify), insert duplicate back-of-queue rows, or resurrect CANCELLED/EXPIRED entries to BOOKED on webhook replay. The multi-session enrollment loop was verified already inside the checkout tx; the join-table uniqueness rides PR-C's schema half.

**#831 — bounds + limiters.** Shared `.max()` constants on every user-typed string (the report route gains a zod schema — it destructured raw unbounded fields); 64KB `assertBodySize` caps; `eventMutationLimiter` (10/min) on the event POST/PATCH + all 8 validate/allocate routes that had zero limiter coverage; the support-ticket responses route gains `spamLimiter` + schema validation; the trial limiter now applies uniformly instead of exempting ADMIN/STAFF.

## Verification

- tsx proofs: CLASS lock PTTL ≈ 300s; `extendLock` refreshes an owned lock and returns false after ownership loss; terminal waitlist rows not flipped by guarded writes; 24h cleanup cohort sanity-checked read-only.
- Live API: 10MB body → 413; >2000-char description → 400; 11 rapid event PATCHes → 429 on the 11th.
- `tsc` clean at this commit in isolation; full Jest suite green on the stack tip.

Closes #831
Closes #832
Closes #833
Part of #834
Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout lock extension to prevent double-booking during long-running payments
  * Enhanced waitlist operations with concurrency-safe database updates to prevent race conditions and duplicate processing
  * Reduced tentative slot cleanup window from 7 days to 24 hours

* **New Features**
  * Added rate limiting to event mutation operations (validation and allocation endpoints)
  * Implemented request body size validation across multiple API endpoints
  * Enhanced input validation with maximum length constraints on user-supplied text fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->