### PR TITLE
fix: exact timezone offsets + canonical overnight resolution + CHECK-constraint sidecar

### DIFF
--- a/__tests__/schedule/overnight-status.test.ts
+++ b/__tests__/schedule/overnight-status.test.ts
@@ -1,0 +1,130 @@
+// #503 item 2 — canonical overnight resolution truth-table.
+import {
+  isNextDayOfWeek,
+  localTimesCrossMidnight,
+  resolveOvernightStatus,
+} from "@/utils/schedule/overnight";
+import type { DayOfWeek as DayOfWeekType } from "@prisma/client";
+
+// Value-level mirror — importing the Prisma enum object would drag the
+// client into jsdom.
+const DayOfWeek = {
+  SUNDAY: "SUNDAY",
+  MONDAY: "MONDAY",
+  TUESDAY: "TUESDAY",
+  WEDNESDAY: "WEDNESDAY",
+  THURSDAY: "THURSDAY",
+  FRIDAY: "FRIDAY",
+  SATURDAY: "SATURDAY",
+} as const satisfies Record<DayOfWeekType, DayOfWeekType>;
+
+describe("resolveOvernightStatus — day-pair (DB weekly) shape", () => {
+  it("same-day pair is not overnight", () => {
+    const r = resolveOvernightStatus({
+      startDay: DayOfWeek.MONDAY,
+      endDay: DayOfWeek.MONDAY,
+    });
+    expect(r).toEqual({ isOvernight: false, crossesMidnightUtc: false });
+  });
+
+  it("next-day pair is overnight", () => {
+    const r = resolveOvernightStatus({
+      startDay: DayOfWeek.MONDAY,
+      endDay: DayOfWeek.TUESDAY,
+    });
+    expect(r).toEqual({ isOvernight: true, crossesMidnightUtc: true });
+  });
+
+  it("week-wrap pair (Saturday → Sunday) is overnight", () => {
+    const r = resolveOvernightStatus({
+      startDay: DayOfWeek.SATURDAY,
+      endDay: DayOfWeek.SUNDAY,
+    });
+    expect(r.isOvernight).toBe(true);
+  });
+});
+
+describe("resolveOvernightStatus — UTC-minutes shape", () => {
+  it("end after start is not overnight", () => {
+    expect(
+      resolveOvernightStatus({ startTimeUtc: 600, endTimeUtc: 720 }).isOvernight,
+    ).toBe(false);
+  });
+
+  it("end before start is overnight (Mon 22:00 → Tue 02:00)", () => {
+    expect(
+      resolveOvernightStatus({ startTimeUtc: 1320, endTimeUtc: 120 }).isOvernight,
+    ).toBe(true);
+  });
+
+  it("end at midnight (0) is overnight", () => {
+    expect(
+      resolveOvernightStatus({ startTimeUtc: 1380, endTimeUtc: 0 }).isOvernight,
+    ).toBe(true);
+  });
+
+  it("equal start/end (24h wrap) is overnight in minutes-space", () => {
+    expect(
+      resolveOvernightStatus({ startTimeUtc: 600, endTimeUtc: 600 }).isOvernight,
+    ).toBe(true);
+  });
+});
+
+describe("resolveOvernightStatus — local UI shape", () => {
+  it("23:00 → 02:00 crosses local midnight", () => {
+    const r = resolveOvernightStatus({ startTime: "23:00", endTime: "02:00" });
+    expect(r).toEqual({ isOvernight: true, crossesMidnightUtc: false });
+  });
+
+  it("09:00 → 17:00 does not cross", () => {
+    expect(
+      resolveOvernightStatus({ startTime: "09:00", endTime: "17:00" })
+        .isOvernight,
+    ).toBe(false);
+  });
+
+  it("zero-length local slot is NOT overnight (invalid input, not 24h)", () => {
+    expect(
+      resolveOvernightStatus({ startTime: "10:00", endTime: "10:00" })
+        .isOvernight,
+    ).toBe(false);
+  });
+
+  it("same-day local times with isOvernightUTC flag are overnight", () => {
+    const r = resolveOvernightStatus({
+      startTime: "01:00",
+      endTime: "05:00",
+      isOvernightUTC: true,
+    });
+    expect(r).toEqual({ isOvernight: true, crossesMidnightUtc: true });
+  });
+
+  it("empty strings are not overnight", () => {
+    expect(
+      resolveOvernightStatus({ startTime: "", endTime: "" }).isOvernight,
+    ).toBe(false);
+  });
+});
+
+describe("localTimesCrossMidnight", () => {
+  it.each([
+    ["22:30", "01:15", true],
+    ["00:00", "23:59", false],
+    ["23:59", "00:00", true],
+    ["garbage", "10:00", false],
+  ])("%s → %s = %s", (start, end, expected) => {
+    expect(localTimesCrossMidnight(start, end)).toBe(expected);
+  });
+});
+
+describe("isNextDayOfWeek", () => {
+  it.each([
+    [DayOfWeek.MONDAY, DayOfWeek.TUESDAY, true],
+    [DayOfWeek.SATURDAY, DayOfWeek.SUNDAY, true],
+    [DayOfWeek.SUNDAY, DayOfWeek.MONDAY, true],
+    [DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, false],
+    [DayOfWeek.MONDAY, DayOfWeek.MONDAY, false],
+  ])("%s → %s = %s", (start, end, expected) => {
+    expect(isNextDayOfWeek(start, end)).toBe(expected);
+  });
+});

--- a/__tests__/schedule/timezone-offset.test.ts
+++ b/__tests__/schedule/timezone-offset.test.ts
@@ -1,0 +1,101 @@
+// #503 item 1 — getTimezoneOffsetMinutes over a real IANA lookup, with
+// DST-boundary behaviour pinned via the `at` parameter.
+
+// slotTimeUtils imports the Prisma enum as a value; stub the client so
+// jsdom never loads the engine.
+jest.mock("@prisma/client", () => ({
+  DayOfWeek: {
+    SUNDAY: "SUNDAY",
+    MONDAY: "MONDAY",
+    TUESDAY: "TUESDAY",
+    WEDNESDAY: "WEDNESDAY",
+    THURSDAY: "THURSDAY",
+    FRIDAY: "FRIDAY",
+    SATURDAY: "SATURDAY",
+  },
+  Prisma: {},
+}));
+
+import { getTimezoneOffsetMinutes } from "@/utils/slotAllocation/slotTimeUtils";
+
+describe("getTimezoneOffsetMinutes", () => {
+  it("IST is +330 year-round (no DST)", () => {
+    expect(
+      getTimezoneOffsetMinutes("Asia/Kolkata", new Date("2026-01-15T12:00:00Z")),
+    ).toBe(330);
+    expect(
+      getTimezoneOffsetMinutes("Asia/Kolkata", new Date("2026-07-15T12:00:00Z")),
+    ).toBe(330);
+  });
+
+  it("America/New_York is -300 in winter (EST) and -240 in summer (EDT)", () => {
+    expect(
+      getTimezoneOffsetMinutes(
+        "America/New_York",
+        new Date("2026-01-15T12:00:00Z"),
+      ),
+    ).toBe(-300);
+    expect(
+      getTimezoneOffsetMinutes(
+        "America/New_York",
+        new Date("2026-07-15T12:00:00Z"),
+      ),
+    ).toBe(-240);
+  });
+
+  it("flips exactly at the 2026 US spring-forward boundary (Mar 8, 07:00 UTC)", () => {
+    expect(
+      getTimezoneOffsetMinutes(
+        "America/New_York",
+        new Date("2026-03-08T06:59:00Z"), // 01:59 EST
+      ),
+    ).toBe(-300);
+    expect(
+      getTimezoneOffsetMinutes(
+        "America/New_York",
+        new Date("2026-03-08T07:00:00Z"), // 03:00 EDT
+      ),
+    ).toBe(-240);
+  });
+
+  it("flips exactly at the 2026 US fall-back boundary (Nov 1, 06:00 UTC)", () => {
+    expect(
+      getTimezoneOffsetMinutes(
+        "America/New_York",
+        new Date("2026-11-01T05:59:00Z"), // 01:59 EDT
+      ),
+    ).toBe(-240);
+    expect(
+      getTimezoneOffsetMinutes(
+        "America/New_York",
+        new Date("2026-11-01T06:00:00Z"), // 01:00 EST
+      ),
+    ).toBe(-300);
+  });
+
+  it("handles the +14 extreme (Pacific/Kiritimati) without clamping", () => {
+    expect(
+      getTimezoneOffsetMinutes(
+        "Pacific/Kiritimati",
+        new Date("2026-06-01T00:00:00Z"),
+      ),
+    ).toBe(840);
+  });
+
+  it("returns 0 for an invalid timezone string", () => {
+    expect(getTimezoneOffsetMinutes("Not/AZone")).toBe(0);
+    expect(getTimezoneOffsetMinutes("")).toBe(0);
+  });
+
+  it("half-hour and 45-minute offsets are exact", () => {
+    expect(
+      getTimezoneOffsetMinutes("Asia/Kathmandu", new Date("2026-06-01T00:00:00Z")),
+    ).toBe(345);
+    expect(
+      getTimezoneOffsetMinutes(
+        "Australia/Adelaide",
+        new Date("2026-01-15T00:00:00Z"), // ACDT (southern-hemisphere summer)
+      ),
+    ).toBe(630);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:pull": "prisma db pull",
     "db:push": "prisma db push",
     "db:triggers": "npx tsx -r dotenv/config scripts/db/apply-ledger-triggers.ts",
+    "db:constraints": "npx tsx -r dotenv/config scripts/db/apply-check-constraints.ts",
     "db:seed": "npx tsx prisma/seed.ts",
     "db:seed:small": "SEED_MODE=small npx tsx prisma/seed.ts",
     "db:seed:medium": "SEED_MODE=medium npx tsx prisma/seed.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3271,6 +3271,10 @@ model PlanMaterial {
 model SlotOfAppointment {
   id String @id @default(uuid())
 
+  /// #834 — the implicit m:n join table's unique index on (A,B) is
+  /// load-bearing: it makes concurrent waitlist/checkout `connect` calls
+  /// double-assignment-safe. Restored automatically at every push/reset;
+  /// do not convert to an explicit join model without re-declaring it.
   user User[] @relation("SlotOfAppointmentToUser")
 
   startsAt    DateTime @db.Timestamptz

--- a/prisma/sql/check-constraints.sql
+++ b/prisma/sql/check-constraints.sql
@@ -1,0 +1,42 @@
+-- #676 A1–A4 — data-integrity CHECK constraints for booking/payment tables.
+--
+-- Prisma 7 has no @@check in PSL, so these ride the same sidecar pattern as
+-- ledger-triggers.sql: idempotent statements split on `-- SPLIT`, applied via
+-- `npm run db:constraints` after every push/reset (NOT against the shared dev
+-- DB mid-cycle — the pre-MVP reset applies them to a clean schema).
+--
+-- Payment amounts use >= 0, not > 0: credit-covered checkouts and
+-- org-sponsored bookings legitimately write amount = 0 (free_/org_ synthetic
+-- payment intents in lib/payments/operations/checkout.ts).
+
+ALTER TABLE "SlotOfAppointment" DROP CONSTRAINT IF EXISTS "slot_time_order";
+-- SPLIT
+ALTER TABLE "SlotOfAppointment" ADD CONSTRAINT "slot_time_order" CHECK ("endsAt" > "startsAt");
+-- SPLIT
+ALTER TABLE "Payment" DROP CONSTRAINT IF EXISTS "payment_amounts_nonnegative";
+-- SPLIT
+ALTER TABLE "Payment" ADD CONSTRAINT "payment_amounts_nonnegative" CHECK ("amount" >= 0 AND "originalAmount" >= 0 AND "taxAmount" >= 0);
+-- SPLIT
+ALTER TABLE "ConsultationPlan" DROP CONSTRAINT IF EXISTS "consultation_plan_price_nonnegative";
+-- SPLIT
+ALTER TABLE "ConsultationPlan" ADD CONSTRAINT "consultation_plan_price_nonnegative" CHECK ("price" >= 0);
+-- SPLIT
+ALTER TABLE "SubscriptionPlan" DROP CONSTRAINT IF EXISTS "subscription_plan_price_nonnegative";
+-- SPLIT
+ALTER TABLE "SubscriptionPlan" ADD CONSTRAINT "subscription_plan_price_nonnegative" CHECK ("price" >= 0);
+-- SPLIT
+ALTER TABLE "WebinarPlan" DROP CONSTRAINT IF EXISTS "webinar_plan_price_nonnegative";
+-- SPLIT
+ALTER TABLE "WebinarPlan" ADD CONSTRAINT "webinar_plan_price_nonnegative" CHECK ("price" >= 0);
+-- SPLIT
+ALTER TABLE "ClassPlan" DROP CONSTRAINT IF EXISTS "class_plan_price_nonnegative";
+-- SPLIT
+ALTER TABLE "ClassPlan" ADD CONSTRAINT "class_plan_price_nonnegative" CHECK ("price" >= 0);
+-- SPLIT
+ALTER TABLE "WebinarPlan" DROP CONSTRAINT IF EXISTS "webinar_plan_max_participants_min";
+-- SPLIT
+ALTER TABLE "WebinarPlan" ADD CONSTRAINT "webinar_plan_max_participants_min" CHECK ("maxParticipants" >= 1);
+-- SPLIT
+ALTER TABLE "ClassPlan" DROP CONSTRAINT IF EXISTS "class_plan_max_participants_min";
+-- SPLIT
+ALTER TABLE "ClassPlan" ADD CONSTRAINT "class_plan_max_participants_min" CHECK ("maxParticipants" >= 1);

--- a/scripts/db/apply-check-constraints.ts
+++ b/scripts/db/apply-check-constraints.ts
@@ -1,0 +1,48 @@
+/**
+ * #676 A1–A4 — apply booking/payment CHECK constraints (prisma/sql/check-constraints.sql).
+ *
+ * `prisma db push` / `prisma migrate` do NOT manage these, so this must run
+ * after every push/reset (same sidecar pattern as apply-ledger-triggers.ts).
+ * Idempotent (DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT).
+ *
+ * Usage: `npm run db:constraints`            — apply
+ *        `npm run db:constraints -- --dry-run` — print statements only
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import prisma from "../../lib/prisma";
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const sqlPath = join(process.cwd(), "prisma", "sql", "check-constraints.sql");
+  const raw = readFileSync(sqlPath, "utf8");
+
+  // Prisma's $executeRawUnsafe runs one statement per call (extended protocol),
+  // so split the file on the `-- SPLIT` markers and run each non-empty statement.
+  const statements = raw
+    .split(/^--\s*SPLIT\s*$/m)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !/^(--.*\n?)*$/.test(s));
+
+  for (const stmt of statements) {
+    if (dryRun) {
+      console.log(stmt.replace(/^(--.*\n)+/, "").trim());
+      continue;
+    }
+    await prisma.$executeRawUnsafe(stmt);
+  }
+
+  console.log(
+    dryRun
+      ? `🔎 Dry run: ${statements.length} statements from ${sqlPath} (nothing executed)`
+      : `✅ Applied CHECK constraints (${statements.length} statements) from ${sqlPath}`,
+  );
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch((err) => {
+    console.error("❌ Failed to apply CHECK constraints:", err);
+    return prisma.$disconnect().finally(() => process.exit(1));
+  });

--- a/utils/dateTimeUtils.ts
+++ b/utils/dateTimeUtils.ts
@@ -1,4 +1,5 @@
 import { toZonedTime, fromZonedTime } from "date-fns-tz";
+import { localTimesCrossMidnight } from "@/utils/schedule/overnight";
 
 export const DAYS_OF_WEEK = [
   "MONDAY",
@@ -63,27 +64,9 @@ export const getLocalDateString = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
-export const isOvernight = (startTime: string, endTime: string): boolean => {
-  // Handle empty strings
-  if (!startTime || !endTime) return false;
-
-  const [startHour, startMinute] = startTime.split(":").map(Number);
-  const [endHour, endMinute] = endTime.split(":").map(Number);
-
-  // Check if numbers are valid
-  if (
-    isNaN(startHour) ||
-    isNaN(startMinute) ||
-    isNaN(endHour) ||
-    isNaN(endMinute)
-  ) {
-    return false;
-  }
-
-  const startMinutes = startHour * 60 + startMinute;
-  const endMinutes = endHour * 60 + endMinute;
-  return endMinutes < startMinutes;
-};
+// #503 item 2 — canonical rule lives in utils/schedule/overnight.ts.
+export const isOvernight = (startTime: string, endTime: string): boolean =>
+  localTimesCrossMidnight(startTime, endTime);
 
 export const formatDayDisplay = (day: DayOfWeek): string => {
   return day.charAt(0) + day.slice(1).toLowerCase();

--- a/utils/schedule/formatting.ts
+++ b/utils/schedule/formatting.ts
@@ -11,6 +11,7 @@ import {
   sortSlotsByTime,
 } from "@/utils/dateTimeUtils";
 import { dateToMinuteUtc } from "@/utils/slotAllocation/slotTimeUtils";
+import { resolveOvernightStatus } from "@/utils/schedule/overnight";
 import { isValidTimeRange } from "@/utils/timeSlotValidation";
 import { DayOfWeek } from "@prisma/client";
 import type { CustomSlot, SlotsType, WeeklySlot } from "./types";
@@ -171,10 +172,12 @@ function formatWeeklySlot(
 
   const baseDate = "1970-01-01";
   const nextDate = "1970-01-02";
-  // Slot is overnight if local times cross midnight OR if it was overnight in
-  // UTC but appears same-day after timezone conversion (isOvernightUTC flag).
-  const overnight =
-    isOvernight(slot.startTime, slot.endTime) || !!slot.isOvernightUTC;
+  // #503 item 2 — canonical resolver replaces the inline OR of two rules.
+  const { isOvernight: overnight } = resolveOvernightStatus({
+    startTime: slot.startTime,
+    endTime: slot.endTime,
+    isOvernightUTC: slot.isOvernightUTC,
+  });
 
   const startUTC = convertTimezoneToUtc(slot.startTime, baseDate, timezone);
   if (!startUTC) return [];
@@ -205,7 +208,10 @@ function formatWeeklySlot(
   }
 
   // Determine if actually overnight in UTC from the minutes
-  const isOvernightInUtc = startMin >= endMin;
+  const isOvernightInUtc = resolveOvernightStatus({
+    startTimeUtc: startMin,
+    endTimeUtc: endMin,
+  }).isOvernight;
 
   if (isOvernightInUtc) {
     return [

--- a/utils/schedule/overnight.ts
+++ b/utils/schedule/overnight.ts
@@ -1,0 +1,96 @@
+import type { DayOfWeek } from "@prisma/client";
+
+/**
+ * Canonical overnight-slot resolution (#503 item 2).
+ *
+ * Overnight status used to be computed four different ways (local HH:mm
+ * comparison, UTC-minutes comparison, day-pair comparison, and the
+ * isOvernightUTC flag) across formatting, validation, and overlap code —
+ * an easy source of double-counted or missed midnight crossings. This
+ * module is the single source of the rule; everything else delegates.
+ *
+ * Edge semantics, preserved from the call sites being unified:
+ * - UTC-minutes shape: end <= start is overnight (a 24h slot is a full-day
+ *   wrap, and end 00:00 stores as 0).
+ * - Local HH:mm shape: end < start is overnight (a zero-length slot is
+ *   invalid input, not a 24h slot — isValidTimeRange rejects it upstream).
+ * - Day-pair shape: startDay !== endDay is overnight; legality of the pair
+ *   (end must be the NEXT day) stays with validateWeeklySlotTimeOrder.
+ */
+
+// Type-only Prisma import keeps this module dependency-light (same idiom as
+// lib/enterprise/transitions.ts) — Jest/jsdom must not drag in the client.
+const DAY_ORDER: DayOfWeek[] = [
+  "SUNDAY",
+  "MONDAY",
+  "TUESDAY",
+  "WEDNESDAY",
+  "THURSDAY",
+  "FRIDAY",
+  "SATURDAY",
+];
+
+/** Check if endDay is the next day of the week after startDay. */
+export function isNextDayOfWeek(
+  startDay: DayOfWeek,
+  endDay: DayOfWeek,
+): boolean {
+  const startIdx = DAY_ORDER.indexOf(startDay);
+  const endIdx = DAY_ORDER.indexOf(endDay);
+  if (startIdx === -1 || endIdx === -1) return false;
+  return (startIdx + 1) % 7 === endIdx;
+}
+
+/** Local "HH:mm" pair crosses midnight (strict — zero-length is not overnight). */
+export function localTimesCrossMidnight(
+  startTime: string,
+  endTime: string,
+): boolean {
+  if (!startTime || !endTime) return false;
+  const [startHour, startMinute] = startTime.split(":").map(Number);
+  const [endHour, endMinute] = endTime.split(":").map(Number);
+  if (
+    isNaN(startHour) ||
+    isNaN(startMinute) ||
+    isNaN(endHour) ||
+    isNaN(endMinute)
+  ) {
+    return false;
+  }
+  return endHour * 60 + endMinute < startHour * 60 + startMinute;
+}
+
+export interface OvernightStatus {
+  /** The slot crosses midnight in its own (authoritative) frame. */
+  isOvernight: boolean;
+  /** The slot is known to cross midnight specifically in UTC. */
+  crossesMidnightUtc: boolean;
+}
+
+type DbWeeklyShape = { startDay: DayOfWeek; endDay: DayOfWeek };
+type UtcMinutesShape = { startTimeUtc: number; endTimeUtc: number };
+type LocalUiShape = {
+  startTime: string;
+  endTime: string;
+  isOvernightUTC?: boolean;
+};
+
+export function resolveOvernightStatus(
+  slot: DbWeeklyShape | UtcMinutesShape | LocalUiShape,
+): OvernightStatus {
+  if ("startDay" in slot) {
+    const crosses = slot.startDay !== slot.endDay;
+    return { isOvernight: crosses, crossesMidnightUtc: crosses };
+  }
+  if ("startTimeUtc" in slot) {
+    const crosses = slot.endTimeUtc <= slot.startTimeUtc;
+    return { isOvernight: crosses, crossesMidnightUtc: crosses };
+  }
+  // Local UI shape: overnight if the local times wrap OR the slot was
+  // overnight in UTC but appears same-day after timezone conversion.
+  const localCross = localTimesCrossMidnight(slot.startTime, slot.endTime);
+  return {
+    isOvernight: localCross || !!slot.isOvernightUTC,
+    crossesMidnightUtc: !!slot.isOvernightUTC,
+  };
+}

--- a/utils/slotAllocation/slotTimeUtils.ts
+++ b/utils/slotAllocation/slotTimeUtils.ts
@@ -12,6 +12,10 @@
  */
 
 import { DayOfWeek, Prisma } from "@prisma/client";
+import {
+  isNextDayOfWeek,
+  resolveOvernightStatus,
+} from "@/utils/schedule/overnight";
 
 /** 24 hours expressed in milliseconds */
 export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
@@ -91,18 +95,9 @@ const DAY_ORDER: DayOfWeek[] = [
   DayOfWeek.SATURDAY,
 ];
 
-/**
- * Check if endDay is the next day of the week after startDay.
- */
-export function isNextDayOfWeek(
-  startDay: DayOfWeek,
-  endDay: DayOfWeek,
-): boolean {
-  const startIdx = DAY_ORDER.indexOf(startDay);
-  const endIdx = DAY_ORDER.indexOf(endDay);
-  if (startIdx === -1 || endIdx === -1) return false;
-  return (startIdx + 1) % 7 === endIdx;
-}
+// #503 item 2 — canonical impl lives in utils/schedule/overnight.ts;
+// re-exported here for existing callers.
+export { isNextDayOfWeek };
 
 /**
  * Validate time ordering for weekly slots, accounting for overnight (cross-midnight) slots.
@@ -274,7 +269,7 @@ export function slotsOverlap(
   // Same-day slots produce 1 range; overnight slots produce 2 ranges.
   const toRanges = (s: typeof a): Array<[number, number, number]> => {
     const startIdx = DAY_ORDER.indexOf(s.startDay);
-    if (s.startDay === s.endDay) {
+    if (!resolveOvernightStatus(s).isOvernight) {
       return [[startIdx, s.startTimeUtc, s.endTimeUtc]];
     }
     // Overnight: startDay startTimeUtc→1440, endDay 0→endTimeUtc
@@ -303,15 +298,30 @@ export function slotsOverlap(
  * Returns the offset such that: localTime = utcTime + offsetMinutes.
  * e.g. "Asia/Kolkata" → 330, "America/New_York" (EST) → -300.
  * Returns 0 on invalid or unrecognised timezone strings.
+ *
+ * #503 item 1 — Intl longOffset replaces the old toLocaleString
+ * string-parsing heuristic, which drifted around DST transitions. The
+ * offset token ("GMT-05:00") is machine-formatted, exact at the given
+ * instant even on transition boundaries (date-fns-tz's getTimezoneOffset
+ * was rejected: it resolves at calendar-day granularity near transitions).
+ * `at` pins the instant so DST-boundary behaviour is testable; the
+ * 0-on-invalid and ±840 clamp contracts are preserved for callers.
  */
-export function getTimezoneOffsetMinutes(timezone: string): number {
+export function getTimezoneOffsetMinutes(
+  timezone: string,
+  at: Date = new Date(),
+): number {
   try {
-    const date = new Date();
-    const utcStr = date.toLocaleString("en-US", { timeZone: "UTC" });
-    const tzStr = date.toLocaleString("en-US", { timeZone: timezone });
-    const offset = Math.round(
-      (new Date(tzStr).getTime() - new Date(utcStr).getTime()) / 60000,
-    );
+    const token = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "longOffset",
+    })
+      .formatToParts(at)
+      .find((p) => p.type === "timeZoneName")?.value;
+    const m = token ? /^GMT(?:([+-])(\d{2}):(\d{2}))?$/.exec(token) : null;
+    if (!m || !m[1]) return 0; // unparseable, or plain "GMT" (UTC)
+    const sign = m[1] === "-" ? -1 : 1;
+    const offset = sign * (Number(m[2]) * 60 + Number(m[3]));
     // Clamp to valid UTC offset range (UTC-14 to UTC+14 = -840 to +840 minutes)
     if (offset < -840 || offset > 840) {
       console.warn(
@@ -352,7 +362,10 @@ export function isMinuteWithinWeeklySlot(
   if (availDay === undefined) return false;
 
   const candidateEndMinutes = candidateMinutes + slotDurationMinutes;
-  const isOvernight = availEndTimeUtc <= availStartTimeUtc;
+  const { isOvernight } = resolveOvernightStatus({
+    startTimeUtc: availStartTimeUtc,
+    endTimeUtc: availEndTimeUtc,
+  });
 
   // availDay is the LOCAL day-of-week. The UTC day of the slot's start may
   // differ when the consultant's midnight isn't aligned with UTC midnight.

--- a/utils/timeSlotValidation.ts
+++ b/utils/timeSlotValidation.ts
@@ -1,4 +1,5 @@
 import type { SlotType } from "@/utils/schedule/types";
+import { resolveOvernightStatus } from "@/utils/schedule/overnight";
 
 // Configuration constants
 const VALIDATION_CONFIG = {
@@ -22,10 +23,10 @@ const getMinutes = (time: string): number | null => {
     : null;
 };
 
-// Helper to check if a slot spans midnight
-const isOvernightSlot = (startMinutes: number, endMinutes: number): boolean => {
-  return endMinutes <= startMinutes;
-};
+// Helper to check if a slot spans midnight — #503 item 2, canonical rule
+const isOvernightSlot = (startMinutes: number, endMinutes: number): boolean =>
+  resolveOvernightStatus({ startTimeUtc: startMinutes, endTimeUtc: endMinutes })
+    .isOvernight;
 
 // Calculate slot duration handling overnight slots
 const calculateSlotDuration = (


### PR DESCRIPTION
Third PR of the B2C hardening train — stacked on #846.

## What this does

**#503 item 1 — exact offsets.** `getTimezoneOffsetMinutes` now reads Intl's machine-formatted `longOffset` token (`GMT-05:00`), exact to the instant even at DST boundaries, with an optional `at` param so boundary behaviour is testable. The old `toLocaleString` string-parsing heuristic drifted around transitions. **date-fns-tz was probed and rejected**: its `getTimezoneOffset` resolves at calendar-day granularity on transition days (returned EDT at 00:30 EST on 2026-03-08). The 0-on-invalid and ±840 clamp contracts are preserved for callers — this is behaviour-preserving for IST.

**#503 item 2 — one overnight rule.** Overnight-slot status was computed four divergent ways (local HH:mm strict-`<`, UTC-minutes `<=`, day-pair `!==`, and the `isOvernightUTC` flag OR'd in ad hoc). `utils/schedule/overnight.ts` is now the single source — `resolveOvernightStatus` with three input shapes and documented edge semantics — and formatting, validation, slot-overlap, and `dateTimeUtils` all delegate. Type-only Prisma imports keep it dependency-light (the enterprise-transitions idiom).

**#676 A1–A4 — CHECK constraints.** Prisma 7 has no `@@check`, so they ride the same sidecar pattern as the ledger triggers: `prisma/sql/check-constraints.sql` (idempotent, `-- SPLIT` separated) + `npm run db:constraints` (with `--dry-run`), applied at the pre-MVP reset, never against the shared dev DB mid-cycle. Payment amounts use `>= 0` deliberately: credit-covered and org-sponsored checkouts legitimately write `amount = 0` (verified in code and data).

**#834 (schema half).** A `///` doc-comment marks the `SlotOfAppointment↔User` implicit join-table uniqueness as load-bearing for double-assignment safety; it is restored automatically at every push/reset.

## Verification

28 new table-driven tests (`__tests__/schedule/`): IST year-round, both 2026 US DST boundaries to the minute, Pacific/Kiritimati +14:00, Asia/Kathmandu +5:45, invalid→0, and the overnight truth table across all three shapes. All 105 schedule tests pass; `prisma validate` clean; `db:constraints --dry-run` prints all 16 statements; `tsc` clean at this commit in isolation.

Part of #503
Part of #676
Part of #834
Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened data integrity with automatic validation for non-negative prices and amounts across payment and plan types
  * Enhanced appointment slot validation to ensure valid time ordering and minimum participant requirements

* **Tests**
  * Added comprehensive test coverage for overnight slot detection across multiple scheduling scenarios
  * Added extensive timezone offset calculation tests, including DST transitions and non-hourly timezone handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->