### PR TITLE
fix: RSC boundary serialization + chaos CI skip guard

### DIFF
--- a/.github/workflows/alert-dispute-deadlines.yml
+++ b/.github/workflows/alert-dispute-deadlines.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/alert-orphaned-payments.yml
+++ b/.github/workflows/alert-orphaned-payments.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/archive-webhook-events.yml
+++ b/.github/workflows/archive-webhook-events.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/auto-complete-appointments.yml
+++ b/.github/workflows/auto-complete-appointments.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/auto-renew-contracts.yml
+++ b/.github/workflows/auto-renew-contracts.yml
@@ -15,6 +15,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/cleanup-auth-tokens.yml
+++ b/.github/workflows/cleanup-auth-tokens.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/cleanup-invalid-appointments.yml
+++ b/.github/workflows/cleanup-invalid-appointments.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/cleanup-old-stream-recordings.yml
+++ b/.github/workflows/cleanup-old-stream-recordings.yml
@@ -14,6 +14,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/cleanup-stale-pending-consultations.yml
+++ b/.github/workflows/cleanup-stale-pending-consultations.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/cleanup-tentative-slots.yml
+++ b/.github/workflows/cleanup-tentative-slots.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/create-payout-batch.yml
+++ b/.github/workflows/create-payout-batch.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/databreach-deadline-alerts.yml
+++ b/.github/workflows/databreach-deadline-alerts.yml
@@ -15,6 +15,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       # Email dispatch is opt-in. When DATABREACH_ALERT_EMAIL or
       # RESEND_API_KEY are absent the cron falls back to structured-log

--- a/.github/workflows/deactivate-expired-discounts.yml
+++ b/.github/workflows/deactivate-expired-discounts.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/dispatch-outbound-webhooks.yml
+++ b/.github/workflows/dispatch-outbound-webhooks.yml
@@ -15,6 +15,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/expire-contracts.yml
+++ b/.github/workflows/expire-contracts.yml
@@ -14,6 +14,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/expire-stale-requests.yml
+++ b/.github/workflows/expire-stale-requests.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/irp-uploader.yml
+++ b/.github/workflows/irp-uploader.yml
@@ -22,6 +22,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       # ClearTax GSP credentials. When absent the underlying connector
       # returns { status: "FAILED", reason: "STUB" } and the uploader

--- a/.github/workflows/mark-expired-recordings.yml
+++ b/.github/workflows/mark-expired-recordings.yml
@@ -13,6 +13,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/msme-payment-alerts.yml
+++ b/.github/workflows/msme-payment-alerts.yml
@@ -15,6 +15,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       # Email dispatch is opt-in. When MSME_ALERT_EMAIL or RESEND_API_KEY
       # are absent, the cron falls back to structured-log only — finance

--- a/.github/workflows/process-data-exports.yml
+++ b/.github/workflows/process-data-exports.yml
@@ -15,6 +15,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/.github/workflows/process-payouts.yml
+++ b/.github/workflows/process-payouts.yml
@@ -21,6 +21,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
       # RazorpayX credentials for payouts

--- a/.github/workflows/process-waitlist-expirations.yml
+++ b/.github/workflows/process-waitlist-expirations.yml
@@ -14,6 +14,9 @@ on:
 
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  # #476 cron locks load lib/redis at import — every job entry needs these
+  UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+  UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
   DIRECT_URL: ${{ secrets.DIRECT_URL }}
   RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
   NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}

--- a/.github/workflows/prune-audit-logs.yml
+++ b/.github/workflows/prune-audit-logs.yml
@@ -13,6 +13,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/reconcile-document-storage.yml
+++ b/.github/workflows/reconcile-document-storage.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
       # Supabase credentials (required for storage operations)

--- a/.github/workflows/reconcile-ledgers.yml
+++ b/.github/workflows/reconcile-ledgers.yml
@@ -20,6 +20,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/reconcile-slot-availability.yml
+++ b/.github/workflows/reconcile-slot-availability.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
     steps:

--- a/.github/workflows/send-waitlist-reminders.yml
+++ b/.github/workflows/send-waitlist-reminders.yml
@@ -13,6 +13,9 @@ on:
 
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  # #476 cron locks load lib/redis at import — every job entry needs these
+  UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+  UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
   DIRECT_URL: ${{ secrets.DIRECT_URL }}
   RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
   NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}

--- a/.github/workflows/stream-sync.yml
+++ b/.github/workflows/stream-sync.yml
@@ -14,6 +14,9 @@ jobs:
     env:
       # Database connection (required for Prisma)
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
       # Stream Chat API credentials

--- a/.github/workflows/transfer-expiring-recordings.yml
+++ b/.github/workflows/transfer-expiring-recordings.yml
@@ -13,6 +13,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       STREAM_API_KEY: ${{ secrets.STREAM_API_KEY }}
       STREAM_API_SECRET: ${{ secrets.STREAM_API_SECRET }}

--- a/.github/workflows/wallet-low-balance.yml
+++ b/.github/workflows/wallet-low-balance.yml
@@ -18,6 +18,9 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       NOVU_SECRET_KEY: ${{ secrets.NOVU_SECRET_KEY }}
 

--- a/lib/data/explore-programs.ts
+++ b/lib/data/explore-programs.ts
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import prisma from "@/lib/prisma";
+import { toPlain } from "@/lib/data/serialize";
 import type { Prisma } from "@prisma/client";
 import { marketplaceVisibilityWhere } from "@/lib/api/plans/visibility";
 import { generateProgramImageUrl } from "@/app/explore/programs/utils";
@@ -263,7 +264,8 @@ export const getCuratedPrograms = cache(
       );
     }
 
-    return programs.slice(0, limit);
+    // toPlain — extended plan rows carry an inspect symbol (see serialize.ts)
+    return toPlain(programs.slice(0, limit));
   },
 );
 

--- a/lib/data/home.ts
+++ b/lib/data/home.ts
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import prisma from "@/lib/prisma";
+import { toPlain } from "@/lib/data/serialize";
 import { fetchImagesFromSupabaseStorage } from "@/lib/supabase";
 
 /**
@@ -44,15 +45,10 @@ export const getHomeExperts = cache(async () => {
       },
     },
   });
-  // BigInt `price` (paise) is non-serializable across Server→Client.
-  // Convert to Number — paise comfortably fits Number.MAX_SAFE_INTEGER.
-  return consultants.map((c) => ({
-    ...c,
-    subscriptionPlans: c.subscriptionPlans.map((p) => ({
-      ...p,
-      price: Number(p.price),
-    })),
-  }));
+  // price is already number at the JS boundary (#780 result extension);
+  // toPlain strips the extension's inspect symbol so the rows can cross
+  // the RSC boundary.
+  return toPlain(consultants);
 });
 
 export const getHomeReviews = cache(async () => {
@@ -74,7 +70,7 @@ export const getHomeReviews = cache(async () => {
     },
     orderBy: { rating: "desc" },
   });
-  return reviews;
+  return toPlain(reviews);
 });
 
 export const getHomeImages = cache(async () => {

--- a/lib/data/org-member-arrangement.ts
+++ b/lib/data/org-member-arrangement.ts
@@ -8,6 +8,7 @@
  * money-safety rule).
  */
 import prisma from "@/lib/prisma";
+import { toPlain } from "@/lib/data/serialize";
 import type { PayoutRecipient } from "@prisma/client";
 
 // #748-parity — 10-min join window matches JoinButton.getJoinState. The real
@@ -184,5 +185,6 @@ export async function getMyArrangementData(params: {
       (x, y) => new Date(x.startsAt).getTime() - new Date(y.startsAt).getTime(),
     );
 
-  return { orgDefaultCard, payoutAccount, earnings, upcomingSessions };
+  // toPlain — rateCard/earnings rows carry an inspect symbol (see serialize.ts)
+  return toPlain({ orgDefaultCard, payoutAccount, earnings, upcomingSessions });
 }

--- a/lib/data/org-member-program.ts
+++ b/lib/data/org-member-program.ts
@@ -9,6 +9,7 @@
  * what they owe.
  */
 import prisma from "@/lib/prisma";
+import { toPlain } from "@/lib/data/serialize";
 
 // #748-parity — 10-min join window matches JoinButton.getJoinState. Real join
 // (Stream client) lives on the consultee dashboard; the page links there.
@@ -184,12 +185,13 @@ export async function getMyProgramData(params: {
     })
   ).filter((p) => !assignedProgramIds.has(p.id));
 
-  return {
+  // toPlain — assignment/utilization rows carry an inspect symbol (see serialize.ts)
+  return toPlain({
     assignments,
     utilizations,
     upcomingSessions,
     outstandingOveragePaise,
     overagePaiseByAssignment,
     eligiblePrograms,
-  };
+  });
 }

--- a/lib/data/plan-details.ts
+++ b/lib/data/plan-details.ts
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import prisma from "@/lib/prisma";
+import { toPlain } from "@/lib/data/serialize";
 
 /**
  * Server-side data access for webinar and class detail pages.
@@ -83,7 +84,8 @@ export async function fetchWebinarPlanDetail(webinarPlanId: string) {
       },
     },
   });
-  return plan;
+  // toPlain — extended plan rows carry an inspect symbol (see serialize.ts)
+  return toPlain(plan);
 }
 
 /** Cached wrapper for Server Components. */
@@ -164,7 +166,8 @@ export async function fetchClassPlanDetail(classPlanId: string) {
       },
     },
   });
-  return plan;
+  // toPlain — extended plan rows carry an inspect symbol (see serialize.ts)
+  return toPlain(plan);
 }
 
 /** Cached wrapper for Server Components. */

--- a/lib/data/serialize.ts
+++ b/lib/data/serialize.ts
@@ -1,0 +1,22 @@
+/**
+ * RSC boundary serializer.
+ *
+ * Rows from models with #780/#781 result extensions (every money model)
+ * are Proxy-backed and carry Prisma's Symbol(nodejs.util.inspect.custom);
+ * object spread copies the enumerable symbol, and React's serializer then
+ * rejects the row ("Only plain objects can be passed to Client
+ * Components"). structuredClone cannot help — Proxies are not cloneable —
+ * so this walks own enumerable string-keyed props into genuinely plain
+ * objects, preserving Dates as Dates. Every lib/data return that can reach
+ * a client component passes through here.
+ */
+export function toPlain<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Date) return new Date(value.getTime()) as T;
+  if (Array.isArray(value)) return value.map(toPlain) as unknown as T;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    out[key] = toPlain((value as Record<string, unknown>)[key]);
+  }
+  return out as T;
+}

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-approve-decline-race.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-approve-decline-race.ts
@@ -14,9 +14,12 @@ import {
   check,
   finish,
   loginAs,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 async function run() {
+  await ensureServerOrSkip();
+
   const pending = await prisma.consultation.findFirst({
     where: { requestStatus: "PENDING" },
     select: { id: true },

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-cancel-vs-reschedule-race.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-cancel-vs-reschedule-race.ts
@@ -16,9 +16,12 @@ import {
   finish,
   histogram,
   loginAs,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 async function run() {
+  await ensureServerOrSkip();
+
   // Fixture: a consultation appointment in a cancellable state with live slots.
   const appointment = await prisma.appointment.findFirst({
     where: {

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-multi-device-login.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-multi-device-login.ts
@@ -13,9 +13,12 @@ import {
   finish,
   fireConcurrent,
   loginAs,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 async function run() {
+  await ensureServerOrSkip();
+
   const email = process.env.CHAOS_USER_EMAIL ?? "daniel.anderson@outlook.com";
 
   const sessions = await fireConcurrent(5, async () => {

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-onboarding-double-submit-org.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-onboarding-double-submit-org.ts
@@ -15,9 +15,12 @@ import {
   finish,
   fireConcurrent,
   loginAs,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 async function run() {
+  await ensureServerOrSkip();
+
   const admin = await loginAs(
     process.env.CHAOS_ADMIN_EMAIL ?? "olivia.brown@protonmail.com",
   );

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-reschedule-storm.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-reschedule-storm.ts
@@ -17,9 +17,12 @@ import {
   fireConcurrent,
   histogram,
   loginAs,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 async function run() {
+  await ensureServerOrSkip();
+
   const appointment = await prisma.appointment.findFirst({
     where: {
       consultation: { requestStatus: { in: ["PENDING", "APPROVED"] } },

--- a/tests/typescript/race-conditions/scenarios/09-webhook-storm/test-webhook-bulk-replay.ts
+++ b/tests/typescript/race-conditions/scenarios/09-webhook-storm/test-webhook-bulk-replay.ts
@@ -21,11 +21,14 @@ import {
   finish,
   fireConcurrent,
   histogram,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 const SECRET = process.env.RAZORPAY_WEBHOOK_SECRET;
 
 async function run() {
+  await ensureServerOrSkip();
+
   if (!SECRET) {
     console.log("⏭️  SKIP — RAZORPAY_WEBHOOK_SECRET not set");
     process.exit(0);

--- a/tests/typescript/race-conditions/scenarios/09-webhook-storm/test-webhook-out-of-order.ts
+++ b/tests/typescript/race-conditions/scenarios/09-webhook-storm/test-webhook-out-of-order.ts
@@ -17,6 +17,7 @@ import {
   BASE_URL,
   check,
   finish,
+  ensureServerOrSkip,
 } from "../../utilities/api-client";
 
 const SECRET = process.env.RAZORPAY_WEBHOOK_SECRET;
@@ -49,6 +50,8 @@ async function deliver(payload: string) {
 }
 
 async function run() {
+  await ensureServerOrSkip();
+
   if (!SECRET) {
     console.log("⏭️  SKIP — RAZORPAY_WEBHOOK_SECRET not set");
     process.exit(0);

--- a/tests/typescript/race-conditions/utilities/api-client.ts
+++ b/tests/typescript/race-conditions/utilities/api-client.ts
@@ -13,6 +13,26 @@
 export const BASE_URL = process.env.CHAOS_BASE_URL ?? "http://localhost:3000";
 const SEED_PASSWORD = process.env.SEED_PASSWORD ?? "SeedPass123!";
 
+/**
+ * The simulated 01-06 categories run anywhere, but these real-API scenarios
+ * need a live server. The CI race-tests workflow runs `npm run test:race`
+ * with no server, so every scenario calls this first and SKIPs (exit 0)
+ * when the target is unreachable — same semantics as the missing-fixture
+ * SKIPs. The pre-launch staging run sets CHAOS_BASE_URL and runs for real.
+ */
+export async function ensureServerOrSkip(): Promise<void> {
+  try {
+    await fetch(`${BASE_URL}/api/auth/get-session`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch {
+    console.log(
+      `⏭️  SKIP — no server reachable at ${BASE_URL} (set CHAOS_BASE_URL or start \`npm run dev\`)`,
+    );
+    process.exit(0);
+  }
+}
+
 export interface Session {
   cookie: string;
   email: string;


### PR DESCRIPTION
Two dev-green fixes:

**RSC serialization (the home-page console error).** Rows from models with #780/#781 result extensions are Proxy-backed and carry `Symbol(nodejs.util.inspect.custom)`; spreading or returning them from server components makes React's serializer reject the payload ("Only plain objects can be passed to Client Components" at `FeaturedExpertsLoader`). `structuredClone` cannot clone Proxies, so the new `lib/data/serialize.ts#toPlain` walks rows into genuinely plain objects (Dates preserved), and every `lib/data` return that reaches a client component passes through it: home, explore-programs, plan-details, and both org-member loaders. `explore-experts` already mapped fields explicitly and `consultant-detail` already JSON-roundtrips — both left as-is. Verified live: home, /explore/programs, /explore/experts, and both plan-detail pages render with zero serialization errors in the server log.

**Race-tests CI guard.** The Race Condition Tests workflow (push-to-dev) runs `npm run test:race` with no app server, and the master-runner auto-discovers the new 07/09 real-API categories — which failed the workflow on the #848 merge push. Every real-API scenario now calls `ensureServerOrSkip()` first and exits 0 with a SKIP line when the target is unreachable; the pre-launch staging run sets `CHAOS_BASE_URL` and runs for real. Verified both paths (live server → pass; unreachable → clean SKIP).

tsc clean, 1337/1337 Jest tests pass, lint adds no errors.

Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 24 GitHub Actions workflows to include Redis credential environment variables for improved job execution reliability.

* **Refactor**
  * Introduced new `toPlain()` serialization utility for converting database objects to plain, serializable structures at server-client boundaries.
  * Applied serialization conversion across data-fetching functions to ensure compatibility with React Server Components.

* **Tests**
  * Added server availability checks to 7 race-condition test scenarios.
  * Implemented new `ensureServerOrSkip()` helper utility for conditional test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->