### PR TITLE
chore: k6 smoke test + serverless pg pool-size knob

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,10 @@
 DATABASE_URL=""
 # Direct connection to Supabase database (used for migrations)
 DIRECT_URL=""
+# pg.Pool max clients per process. Leave unset locally (pg default 10).
+# Set to 1 or 2 in serverless deploys: 125 concurrent Netlify functions ×
+# 10 default clients would dwarf Supavisor's client cap.
+PG_POOL_MAX=""
 
 # Facebook OAuth credentials for authentication
 FACEBOOK_CLIENT_ID=""

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,45 @@
+name: Load Test (Smoke)
+
+# Manual-only: load tests are run deliberately against a staging clone, never
+# on a schedule against shared/dev data. See load-tests/smoke.js and the
+# capacity ladder (docs/enterprise/50-operations/08-capacity-ladder.md).
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Target base URL (staging clone — never production)"
+        required: true
+      consultant_id:
+        description: "A consultantProfile id with availability in the target DB"
+        required: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install k6
+        run: |
+          sudo gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \
+            --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update && sudo apt-get install -y k6
+
+      - name: Run smoke test
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url }}
+          CONSULTANT_ID: ${{ github.event.inputs.consultant_id }}
+          TEST_EMAIL: ${{ secrets.LOAD_TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.LOAD_TEST_PASSWORD }}
+        run: |
+          k6 run \
+            --env BASE_URL="$BASE_URL" \
+            --env TEST_EMAIL="$TEST_EMAIL" \
+            --env TEST_PASSWORD="$TEST_PASSWORD" \
+            --env CONSULTANT_ID="$CONSULTANT_ID" \
+            load-tests/smoke.js

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -40,6 +40,13 @@ const adapter = new PrismaPg({
   // Use pooled connection (DATABASE_URL) for runtime queries to avoid connection exhaustion
   // DIRECT_URL is only for migrations (handled by prisma.config.ts)
   connectionString: process.env.DATABASE_URL || process.env.DIRECT_URL,
+  // pg.Pool defaults to 10 clients PER function instance; at Netlify's 125
+  // concurrent invocations that can dwarf Supavisor's client cap. Set
+  // PG_POOL_MAX=1 (or 2) in serverless deploy env; unset = pg default for
+  // long-lived local dev/jobs.
+  ...(Number(process.env.PG_POOL_MAX) > 0
+    ? { max: Number(process.env.PG_POOL_MAX) }
+    : {}),
 });
 
 function makeClient() {

--- a/load-tests/smoke.js
+++ b/load-tests/smoke.js
@@ -1,0 +1,130 @@
+// k6 smoke test — verifies the hottest read endpoints hold up under moderate
+// concurrency and exposes Supabase connection-pool pressure before real users
+// do (capacity ladder: docs/enterprise/50-operations/08-capacity-ladder.md,
+// ADR 14). Correctness-under-race is NOT this script's job — that lives in
+// tests/typescript/race-conditions (npm run test:chaos:api).
+//
+// Run (local):   k6 run --env BASE_URL=http://localhost:3000 \
+//                       --env TEST_EMAIL=<seed-email> \
+//                       --env TEST_PASSWORD=<seed-password> \
+//                       --env CONSULTANT_ID=<consultantProfile id> \
+//                       load-tests/smoke.js
+// Run (staging): point BASE_URL at the staging clone; never at production.
+
+import http from "k6/http";
+import { check, sleep, group } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const errorRate = new Rate("errors");
+const slotAvailabilityTrend = new Trend("slot_availability_duration");
+
+export const options = {
+  stages: [
+    { duration: "30s", target: 20 }, // warm-up ramp
+    { duration: "60s", target: 50 }, // sustained load
+    { duration: "30s", target: 100 }, // spike
+    { duration: "30s", target: 0 }, // ramp down
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<3000"],
+    errors: ["rate<0.05"],
+    // availability is the public booking hot path (rate-limited 30/min/IP —
+    // expect 429s to register as errors if a single-IP run exceeds that)
+    slot_availability_duration: ["p(95)<1500"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+const TEST_EMAIL = __ENV.TEST_EMAIL || "";
+const TEST_PASSWORD = __ENV.TEST_PASSWORD || "";
+const CONSULTANT_ID = __ENV.CONSULTANT_ID || "";
+
+export function setup() {
+  if (!TEST_EMAIL || !TEST_PASSWORD || !CONSULTANT_ID) {
+    throw new Error(
+      "Set TEST_EMAIL, TEST_PASSWORD and CONSULTANT_ID env vars (seed data).",
+    );
+  }
+  const loginRes = http.post(
+    `${BASE_URL}/api/auth/sign-in/email`,
+    JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD }),
+    {
+      headers: { "Content-Type": "application/json", Origin: BASE_URL },
+    },
+  );
+  check(loginRes, { "login succeeded": (r) => r.status === 200 });
+  const sessionCookie =
+    loginRes.cookies["better-auth.session_token"]?.[0]?.value;
+  if (!sessionCookie) {
+    throw new Error("Login failed — no session cookie. Check credentials.");
+  }
+  return { sessionCookie };
+}
+
+export default function (data) {
+  const headers = {
+    "Content-Type": "application/json",
+    Cookie: `better-auth.session_token=${data.sessionCookie}`,
+  };
+
+  // 1. Health (cheap, surfaces database reachability + maintenance phase)
+  group("health", function () {
+    const res = http.get(`${BASE_URL}/api/health`);
+    const ok = check(res, {
+      "health 200": (r) => r.status === 200,
+      "database connected": (r) => {
+        try {
+          return JSON.parse(r.body).database === "connected";
+        } catch {
+          return false;
+        }
+      },
+    });
+    errorRate.add(!ok);
+  });
+
+  sleep(0.5);
+
+  // 2. Slot availability (public booking hot path)
+  group("slot_availability", function () {
+    const res = http.get(
+      `${BASE_URL}/api/slots/availability/${CONSULTANT_ID}`,
+      { headers },
+    );
+    slotAvailabilityTrend.add(res.timings.duration);
+    const ok = check(res, {
+      "availability 200": (r) => r.status === 200,
+    });
+    errorRate.add(!ok);
+  });
+
+  sleep(0.5);
+
+  // 3. Consultant search (browse hot path)
+  group("consultant_search", function () {
+    const res = http.get(`${BASE_URL}/api/user/consultants?limit=20&page=1`, {
+      headers,
+    });
+    const ok = check(res, { "search 200": (r) => r.status === 200 });
+    errorRate.add(!ok);
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: JSON.stringify(
+      {
+        vus_max: data.metrics.vus_max?.values?.max,
+        http_req_duration_p95: data.metrics.http_req_duration?.values?.["p(95)"],
+        error_rate: data.metrics.errors?.values?.rate,
+        total_requests: data.metrics.http_reqs?.values?.count,
+        slot_availability_p95:
+          data.metrics.slot_availability_duration?.values?.["p(95)"],
+      },
+      null,
+      2,
+    ),
+  };
+}


### PR DESCRIPTION
Implements the two actionable gaps identified in `CONCURRENCY_AND_LOAD_REPORT.md` (everything else in the report is already shipped or explicitly post-MVP — gap analysis in the PR conversation on #837's train):

1. **Serverless pool-size knob.** The report's `connection_limit=1` advice predates the pg driver adapter — with `@prisma/adapter-pg`, the relevant control is `pg.Pool#max`, which defaults to **10 clients per function instance**; at Netlify's 125-concurrent ceiling that can dwarf Supavisor's client cap. `PG_POOL_MAX` makes it configurable (unset = pg default for long-lived local dev/jobs; set 1–2 in serverless deploy env). Verified live with `PG_POOL_MAX=1`. `DATABASE_URL` confirmed already transaction-mode (port 6543, `pgbouncer=true`).
2. **k6 smoke test** (`load-tests/smoke.js` + manual-dispatch workflow): ramps 20→50→100 VUs across the three real read hot paths (health, slot availability, consultant search) with BetterAuth login in setup, p95 < 3s / error-rate < 5% thresholds. The report's draft script referenced endpoints that don't exist (`/api/checkout/context`) and its k6 booking-race script duplicated what `tests/typescript/race-conditions` already covers properly — both adapted out.

Needs `LOAD_TEST_EMAIL` / `LOAD_TEST_PASSWORD` repo secrets before the first dispatch; `PG_POOL_MAX=1` should be set in the Netlify deploy env alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PostgreSQL connection pool configuration option with deployment guidance.

* **Chores**
  * Added automated load testing workflow for performance monitoring.
  * Added smoke test script for validating application health and performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->