### PR TITLE
perf(write-path): waitlist batch-notify + #440 overlap exclusion constraint + last-seat regression proof

### DIFF
--- a/TESTING_PLAN.md
+++ b/TESTING_PLAN.md
@@ -265,7 +265,16 @@ npm run dev & npm run test:chaos:api      # real-API chaos: categories 07 + 09
 npm run test:race                         # full race-condition harness
 ```
 
-Chaos category 07 now includes `test-cancel-pending-vs-webhook` (#849).
+Chaos category 07 now includes `test-cancel-pending-vs-webhook` (#849) and
+`test-last-seat-storm` (capacity race regression — exactly one winner for a
+single free webinar seat).
+
+DB-level backstop (#440): the `slot_no_confirmed_overlap` exclusion
+constraint (applied via `npm run db:constraints`) rejects two CONFIRMED
+overlapping slots for one consultant at the database. Verify after any
+reset: a direct duplicate-window insert with `isTentative=false` and a set
+`consultantProfileId` must fail with an exclusion violation; tentative and
+back-to-back inserts must succeed.
 
 ## 6. Reporting
 

--- a/app/api/slots/request-for-approval/route.ts
+++ b/app/api/slots/request-for-approval/route.ts
@@ -168,6 +168,10 @@ export async function POST(req: NextRequest) {
         startsAt: chunkStart,
         endsAt: new Date(chunkStart.getTime() + SLOT_DURATION_MS),
         isTentative: true, // Mark as tentative since it's pending approval
+        // #440 — the overlap-guard column must be set at CREATE time even on
+        // tentative rows: approval/webhook confirm flips isTentative via
+        // updateMany, so whatever is on the row rides into confirmed state.
+        consultantProfileId,
         user: {
           connect: [
             { id: session.user.id }, // Consultee

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -868,6 +868,13 @@ async function createConsultation(tx: Tx, data: ConsultationData) {
     },
   });
 
+  // #440 — denormalize the consultant onto the confirmed slot for the
+  // DB-level overlap guard (the consultation's FK guarantees the plan row).
+  const planForGuard = await tx.consultationPlan.findUniqueOrThrow({
+    where: { id: data.planId },
+    select: { consultantProfileId: true },
+  });
+
   return await tx.appointment.create({
     data: {
       appointmentType: AppointmentsType.CONSULTATION,
@@ -877,6 +884,7 @@ async function createConsultation(tx: Tx, data: ConsultationData) {
           startsAt: new Date(data.slotStartTimeInUTC),
           endsAt: new Date(data.slotEndTimeInUTC),
           isTentative: false,
+          consultantProfileId: planForGuard.consultantProfileId,
           user: { connect: { id: data.userId } },
         },
       },

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -945,6 +945,9 @@ async function createSubscription(tx: Tx, data: SubscriptionData) {
         startsAt: new Date(data.slotStartTimeInUTC),
         endsAt: new Date(data.slotEndTimeInUTC),
         isTentative: false,
+        // #440 — same overlap-guard population as the consultation twin;
+        // a NULL here would bypass the exclusion constraint's scope.
+        consultantProfileId: plan.consultantProfileId,
         user: { connect: { id: data.userId } },
       },
     };

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -858,6 +858,8 @@ async function createAppointmentFromWebhook(
 // ============================================================================
 
 async function createConsultation(tx: Tx, data: ConsultationData) {
+  // #440 — the include rides the create so the overlap-guard column comes
+  // back without a second query inside the webhook transaction.
   const consultation = await tx.consultation.create({
     data: {
       consultationPlanId: data.planId,
@@ -866,13 +868,9 @@ async function createConsultation(tx: Tx, data: ConsultationData) {
       requestNotes: data.notes,
       bookingSource: "DIRECT_CHECKOUT",
     },
-  });
-
-  // #440 — denormalize the consultant onto the confirmed slot for the
-  // DB-level overlap guard (the consultation's FK guarantees the plan row).
-  const planForGuard = await tx.consultationPlan.findUniqueOrThrow({
-    where: { id: data.planId },
-    select: { consultantProfileId: true },
+    include: {
+      consultationPlan: { select: { consultantProfileId: true } },
+    },
   });
 
   return await tx.appointment.create({
@@ -884,7 +882,7 @@ async function createConsultation(tx: Tx, data: ConsultationData) {
           startsAt: new Date(data.slotStartTimeInUTC),
           endsAt: new Date(data.slotEndTimeInUTC),
           isTentative: false,
-          consultantProfileId: planForGuard.consultantProfileId,
+          consultantProfileId: consultation.consultationPlan.consultantProfileId,
           user: { connect: { id: data.userId } },
         },
       },

--- a/lib/waitlist/queue-manager.ts
+++ b/lib/waitlist/queue-manager.ts
@@ -107,6 +107,22 @@ export async function getNextInQueue(params: {
   webinarId?: string;
   classId?: string;
 }): Promise<WaitlistEntryWithDetails | null> {
+  const batch = await getNextBatchInQueue(params, 1);
+  return batch[0] ?? null;
+}
+
+/**
+ * Ordered head-of-queue batch — the batched sibling of getNextInQueue so
+ * handleSlotOpening can claim N candidates in one round trip instead of a
+ * findFirst-per-slot loop (write-path scale hardening).
+ */
+export async function getNextBatchInQueue(
+  params: {
+    webinarId?: string;
+    classId?: string;
+  },
+  take: number,
+): Promise<WaitlistEntryWithDetails[]> {
   const { webinarId, classId } = params;
 
   if (!webinarId && !classId) {
@@ -115,7 +131,7 @@ export async function getNextInQueue(params: {
 
   const eventFilter = webinarId ? { webinarId } : { classId };
 
-  const entry = await prisma.waitlist.findFirst({
+  return prisma.waitlist.findMany({
     where: {
       ...eventFilter,
       status: WaitlistStatus.WAITING,
@@ -124,6 +140,7 @@ export async function getNextInQueue(params: {
       { priority: "desc" }, // Higher priority first
       { joinedAt: "asc" }, // Earlier joiners first
     ],
+    take,
     include: {
       user: {
         select: {
@@ -155,8 +172,6 @@ export async function getNextInQueue(params: {
       },
     },
   });
-
-  return entry;
 }
 
 /**

--- a/lib/waitlist/slot-handler.ts
+++ b/lib/waitlist/slot-handler.ts
@@ -6,7 +6,7 @@
 import prisma from "@/lib/prisma";
 import { WaitlistStatus } from "@prisma/client";
 import {
-  getNextInQueue,
+  getNextBatchInQueue,
   updatePositions,
   calculatePosition,
 } from "./queue-manager";
@@ -49,96 +49,100 @@ export async function handleSlotOpening(params: SlotOpeningParams): Promise<{
   const notified: string[] = [];
   const errors: Array<{ userId: string; error: string }> = [];
 
-  // Notify up to `slotsAvailable` users
-  for (let i = 0; i < slotsAvailable; i++) {
-    const nextInQueue = await getNextInQueue({ webinarId, classId });
+  // Batched claim (write-path scale hardening): the old shape ran a
+  // findFirst + guarded updateMany PER SLOT with an `i--` retry on every
+  // race loss — a webinar cancellation freeing N seats against M concurrent
+  // openings cost O(N×M) query waves. Each round below is one ordered
+  // findMany + one $transaction of per-id CAS claims (a single round trip
+  // whose per-id counts say exactly which candidates THIS call won — a
+  // bulk updateMany can't report that). Losers shrink the next round's
+  // batch; the loop ends when the queue runs dry or all slots are claimed.
+  let remaining = slotsAvailable;
+  while (remaining > 0) {
+    const candidates = await getNextBatchInQueue(
+      { webinarId, classId },
+      remaining,
+    );
+    if (candidates.length === 0) break;
 
-    if (!nextInQueue) {
-      // No more users waiting
-      break;
-    }
+    const now = new Date();
+    const expiresAt = new Date(
+      now.getTime() + NOTIFICATION_WINDOW_HOURS * 60 * 60 * 1000,
+    );
 
-    try {
-      const now = new Date();
-      const expiresAt = new Date(
-        now.getTime() + NOTIFICATION_WINDOW_HOURS * 60 * 60 * 1000,
-      );
+    // Same per-entry CAS guard as before (status must still be WAITING),
+    // batched into one transaction.
+    const claims = await prisma.$transaction(
+      candidates.map((candidate) =>
+        prisma.waitlist.updateMany({
+          where: { id: candidate.id, status: WaitlistStatus.WAITING },
+          data: {
+            status: WaitlistStatus.NOTIFIED,
+            notifiedAt: now,
+            expiresAt,
+          },
+        }),
+      ),
+    );
+    const winners = candidates.filter((_, i) => claims[i].count === 1);
+    remaining -= winners.length;
 
-      // Use updateMany with a status guard to prevent double-notification under concurrent
-      // slot openings. If two calls race on the same top-of-queue user, only one updateMany
-      // will match (the other sees status already = NOTIFIED and returns count=0).
-      const updated = await prisma.waitlist.updateMany({
-        where: { id: nextInQueue.id, status: WaitlistStatus.WAITING },
-        data: {
-          status: WaitlistStatus.NOTIFIED,
-          notifiedAt: now,
-          expiresAt,
-        },
-      });
+    for (const winner of winners) {
+      try {
+        // Send notification email. A failed delivery is recorded but the
+        // claim stands — the 48h expiration cron recycles the spot, same
+        // backstop as before.
+        if (winner.user.email) {
+          const eventTitle =
+            winner.webinar?.webinarPlan.title ||
+            winner.class?.classPlan.title ||
+            "Event";
 
-      if (updated.count === 0) {
-        // This entry was already claimed by a concurrent slot-opening call.
-        // Decrement i so we retry this iteration and pick the next person in queue.
-        i--;
-        continue;
-      }
+          const eventType = winner.webinarId ? "webinar" : "class";
+          const eventId = winner.webinarId || winner.classId;
 
-      // Send notification email
-      if (nextInQueue.user.email) {
-        const eventTitle =
-          nextInQueue.webinar?.webinarPlan.title ||
-          nextInQueue.class?.classPlan.title ||
-          "Event";
+          // Get scheduled date if available
+          let scheduledDate: Date | undefined;
+          if (winner.webinar?.appointment?.slotsOfAppointment?.[0]) {
+            scheduledDate =
+              winner.webinar.appointment.slotsOfAppointment[0].startsAt;
+          } else if (winner.class?.appointments?.[0]?.slotsOfAppointment?.[0]) {
+            scheduledDate =
+              winner.class.appointments[0].slotsOfAppointment[0].startsAt;
+          }
 
-        const eventType = nextInQueue.webinarId ? "webinar" : "class";
-        const eventId = nextInQueue.webinarId || nextInQueue.classId;
-
-        // Get scheduled date if available
-        let scheduledDate: Date | undefined;
-        if (nextInQueue.webinar?.appointment?.slotsOfAppointment?.[0]) {
-          scheduledDate =
-            nextInQueue.webinar.appointment.slotsOfAppointment[0].startsAt;
-        } else if (
-          nextInQueue.class?.appointments?.[0]?.slotsOfAppointment?.[0]
-        ) {
-          scheduledDate =
-            nextInQueue.class.appointments[0].slotsOfAppointment[0].startsAt;
+          await sendWaitlistSpotAvailableEmail({
+            email: winner.user.email,
+            name: winner.user.name || "Valued User",
+            eventTitle,
+            eventType,
+            eventId: eventId!,
+            scheduledDate,
+            expiresAt,
+            waitlistId: winner.id,
+          });
         }
 
-        await sendWaitlistSpotAvailableEmail({
-          email: nextInQueue.user.email,
-          name: nextInQueue.user.name || "Valued User",
-          eventTitle,
-          eventType,
-          eventId: eventId!,
-          scheduledDate,
-          expiresAt,
-          waitlistId: nextInQueue.id,
-        });
+        notified.push(winner.userId);
+
+        console.log(
+          JSON.stringify({
+            event: "waitlist_user_notified",
+            waitlistId: winner.id,
+            userId: winner.userId,
+            webinarId,
+            classId,
+            reason,
+            expiresAt: expiresAt.toISOString(),
+            timestamp: new Date().toISOString(),
+          }),
+        );
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        errors.push({ userId: winner.userId, error: errorMessage });
+        console.error(`Error notifying waitlist user ${winner.userId}:`, error);
       }
-
-      notified.push(nextInQueue.userId);
-
-      console.log(
-        JSON.stringify({
-          event: "waitlist_user_notified",
-          waitlistId: nextInQueue.id,
-          userId: nextInQueue.userId,
-          webinarId,
-          classId,
-          reason,
-          expiresAt: expiresAt.toISOString(),
-          timestamp: new Date().toISOString(),
-        }),
-      );
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error";
-      errors.push({ userId: nextInQueue.userId, error: errorMessage });
-      console.error(
-        `Error notifying waitlist user ${nextInQueue.userId}:`,
-        error,
-      );
     }
   }
 

--- a/prisma/sql/check-constraints.sql
+++ b/prisma/sql/check-constraints.sql
@@ -40,3 +40,24 @@ ALTER TABLE "WebinarPlan" ADD CONSTRAINT "webinar_plan_max_participants_min" CHE
 ALTER TABLE "ClassPlan" DROP CONSTRAINT IF EXISTS "class_plan_max_participants_min";
 -- SPLIT
 ALTER TABLE "ClassPlan" ADD CONSTRAINT "class_plan_max_participants_min" CHECK ("maxParticipants" >= 1);
+
+-- SPLIT
+-- #440 — DB-level double-booking backstop for 1:1 bookings. The application
+-- guards (consultant allocation lock, #827 confirm-time recheck) are the
+-- first line; this exclusion constraint is the last line: two CONFIRMED
+-- slots for the same consultant may never overlap in time. Scoped to rows
+-- carrying the denormalized consultantProfileId — consultation/subscription
+-- slot creates set it; webinar/class attendee slots deliberately leave it
+-- NULL (many same-window rows per event are legitimate there) and legacy
+-- pre-#440 rows are NULL. tstzrange is '[)' so back-to-back slots don't
+-- conflict.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+-- SPLIT
+ALTER TABLE "SlotOfAppointment" DROP CONSTRAINT IF EXISTS "slot_no_confirmed_overlap";
+-- SPLIT
+ALTER TABLE "SlotOfAppointment" ADD CONSTRAINT "slot_no_confirmed_overlap"
+  EXCLUDE USING gist (
+    "consultantProfileId" WITH =,
+    tstzrange("startsAt", "endsAt") WITH &&
+  )
+  WHERE ("consultantProfileId" IS NOT NULL AND NOT "isTentative");

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-last-seat-storm.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-last-seat-storm.ts
@@ -104,12 +104,18 @@ async function run() {
     );
 
     const winners = results.filter((r) => r.status >= 200 && r.status < 300);
+    const losers = results.filter((r) => !(r.status >= 200 && r.status < 300));
     const serverErrors = results.filter((r) => r.status >= 500);
 
     check("no server errors", serverErrors.length === 0, histogram(results));
     check(
       "exactly one winner for the last seat",
       winners.length === 1,
+      histogram(results),
+    );
+    check(
+      "losers get clean client errors (4xx)",
+      losers.every((r) => r.status >= 400 && r.status < 500),
       histogram(results),
     );
 
@@ -148,28 +154,28 @@ async function run() {
     });
     const paymentIds = createdPayments.map((p) => p.id);
     // Financial children Restrict the payment (#781 §B) — a mock checkout
-    // mints earnings/utilization rows that must go first.
-    await prisma.consultantEarnings.deleteMany({
-      where: { paymentId: { in: paymentIds } },
-    });
-    await prisma.organizationEarnings.deleteMany({
-      where: { paymentId: { in: paymentIds } },
-    });
-    await prisma.bookingUtilization.deleteMany({
-      where: { paymentId: { in: paymentIds } },
-    });
-    await prisma.paymentLeg.deleteMany({
-      where: { paymentId: { in: paymentIds } },
-    });
-    await prisma.payment
-      .deleteMany({ where: { id: { in: paymentIds } } })
-      .catch((e) => {
-        // Degraded cleanup: leave the payment but make it inert for reruns
-        // (slots are disconnected below; occupancy is slot-based).
-        console.warn(
-          `⚠️ payment cleanup blocked by a remaining FK — rows left in place: ${e.message.split("\n")[0]}`,
-        );
+    // mints earnings/utilization rows that must go first. The whole phase is
+    // fenced so a failure here can never abort the slot/enrollment cleanup
+    // below (occupancy is slot-based; a leftover payment is inert).
+    try {
+      await prisma.consultantEarnings.deleteMany({
+        where: { paymentId: { in: paymentIds } },
       });
+      await prisma.organizationEarnings.deleteMany({
+        where: { paymentId: { in: paymentIds } },
+      });
+      await prisma.bookingUtilization.deleteMany({
+        where: { paymentId: { in: paymentIds } },
+      });
+      await prisma.paymentLeg.deleteMany({
+        where: { paymentId: { in: paymentIds } },
+      });
+      await prisma.payment.deleteMany({ where: { id: { in: paymentIds } } });
+    } catch (e) {
+      console.warn(
+        `⚠️ payment cleanup incomplete — rows left in place: ${e instanceof Error ? e.message.split("\n")[0] : String(e)}`,
+      );
+    }
     // Disconnect any stormer from the webinar's slots (winner or tentative
     // residue) so reruns start from the same occupancy.
     const slots = await prisma.slotOfAppointment.findMany({

--- a/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-last-seat-storm.ts
+++ b/tests/typescript/race-conditions/scenarios/07-real-api-booking/test-last-seat-storm.ts
@@ -1,0 +1,206 @@
+/**
+ * Test: Last-Seat Enrollment Storm (write-path scale hardening)
+ * Category: 07 - Real API booking races
+ *
+ * N users race concurrent checkouts for a webinar with exactly ONE free
+ * seat. The guard under test is the per-event checkout lock + the
+ * tentative-inclusive participant count in validateEventCapacity — verified
+ * in review to serialize the check-then-hold, this scenario pins that as a
+ * regression test. Invariants: exactly one winner, losers get a clean 4xx
+ * ("Webinar is full"), zero 5xx, and the confirmed participant count never
+ * exceeds maxParticipants.
+ *
+ * Uses mock payments (dev-only flag) so winners confirm instantly and the
+ * capacity math is synchronous.
+ */
+import "dotenv/config";
+import prisma from "../../../../../lib/prisma";
+import {
+  apiFetch,
+  check,
+  finish,
+  histogram,
+  loginAs,
+  ensureServerOrSkip,
+} from "../../utilities/api-client";
+import { countWebinarParticipants } from "../../../../../lib/payments/utils/participants";
+
+const STORM_SIZE = 3;
+
+async function run() {
+  await ensureServerOrSkip();
+
+  // Fixture: a webinar with an appointment and a plan we can shrink to
+  // exactly one free seat.
+  const webinar = await prisma.webinar.findFirst({
+    where: { appointment: { isNot: null }, status: "SCHEDULED" },
+    include: {
+      webinarPlan: {
+        include: { consultantProfile: { select: { userId: true } } },
+      },
+      appointment: {
+        include: { slotsOfAppointment: { include: { user: true } } },
+      },
+    },
+  });
+  if (!webinar?.appointment) {
+    console.log("⏭️  SKIP — no scheduled webinar with an appointment in seed data");
+    process.exit(0);
+  }
+
+  const consultantUserId = webinar.webinarPlan.consultantProfile?.userId;
+  const enrolledUserIds = new Set<string>(
+    webinar.appointment.slotsOfAppointment.flatMap((s) =>
+      s.user.map((u) => u.id),
+    ),
+  );
+  const currentParticipants = countWebinarParticipants(webinar.appointment, [
+    consultantUserId || "",
+  ]);
+
+  // Stormers: consultees not already enrolled.
+  const stormers = await prisma.user.findMany({
+    where: {
+      role: "CONSULTEE",
+      id: { notIn: Array.from(enrolledUserIds) },
+      consulteeProfile: { isNot: null },
+    },
+    select: { id: true, email: true },
+    take: STORM_SIZE,
+  });
+  if (stormers.length < STORM_SIZE) {
+    console.log("⏭️  SKIP — not enough unenrolled consultees in seed data");
+    process.exit(0);
+  }
+
+  // Arm: exactly one free seat.
+  const originalMax = webinar.webinarPlan.maxParticipants;
+  await prisma.webinarPlan.update({
+    where: { id: webinar.webinarPlan.id },
+    data: { maxParticipants: currentParticipants + 1 },
+  });
+
+  const testStart = new Date();
+  try {
+    const sessions = [];
+    for (const s of stormers) {
+      sessions.push(await loginAs(s.email!));
+    }
+
+    const results = await Promise.all(
+      sessions.map((session) =>
+        apiFetch(`/api/checkout`, {
+          method: "POST",
+          session,
+          body: JSON.stringify({
+            appointmentType: "WEBINAR",
+            planId: webinar.webinarPlanId,
+            eventId: webinar.id,
+            paymentGateway: "RAZORPAY",
+            isMockPayment: true,
+          }),
+        }),
+      ),
+    );
+
+    const winners = results.filter((r) => r.status >= 200 && r.status < 300);
+    const serverErrors = results.filter((r) => r.status >= 500);
+
+    check("no server errors", serverErrors.length === 0, histogram(results));
+    check(
+      "exactly one winner for the last seat",
+      winners.length === 1,
+      histogram(results),
+    );
+
+    // Capacity invariant straight from the DB.
+    const after = await prisma.webinar.findUniqueOrThrow({
+      where: { id: webinar.id },
+      include: {
+        webinarPlan: true,
+        appointment: {
+          include: { slotsOfAppointment: { include: { user: true } } },
+        },
+      },
+    });
+    const afterCount = countWebinarParticipants(after.appointment, [
+      consultantUserId || "",
+    ]);
+    check(
+      "participants never exceed maxParticipants",
+      afterCount <= after.webinarPlan.maxParticipants,
+      { afterCount, max: after.webinarPlan.maxParticipants },
+    );
+  } finally {
+    // Restore: plan capacity, the winner's enrollment + payment rows.
+    await prisma.webinarPlan.update({
+      where: { id: webinar.webinarPlan.id },
+      data: { maxParticipants: originalMax },
+    });
+    const stormerIds = stormers.map((s) => s.id);
+    const createdPayments = await prisma.payment.findMany({
+      where: {
+        userId: { in: stormerIds },
+        createdAt: { gte: testStart },
+        appointment: { webinarId: webinar.id },
+      },
+      select: { id: true },
+    });
+    const paymentIds = createdPayments.map((p) => p.id);
+    // Financial children Restrict the payment (#781 §B) — a mock checkout
+    // mints earnings/utilization rows that must go first.
+    await prisma.consultantEarnings.deleteMany({
+      where: { paymentId: { in: paymentIds } },
+    });
+    await prisma.organizationEarnings.deleteMany({
+      where: { paymentId: { in: paymentIds } },
+    });
+    await prisma.bookingUtilization.deleteMany({
+      where: { paymentId: { in: paymentIds } },
+    });
+    await prisma.paymentLeg.deleteMany({
+      where: { paymentId: { in: paymentIds } },
+    });
+    await prisma.payment
+      .deleteMany({ where: { id: { in: paymentIds } } })
+      .catch((e) => {
+        // Degraded cleanup: leave the payment but make it inert for reruns
+        // (slots are disconnected below; occupancy is slot-based).
+        console.warn(
+          `⚠️ payment cleanup blocked by a remaining FK — rows left in place: ${e.message.split("\n")[0]}`,
+        );
+      });
+    // Disconnect any stormer from the webinar's slots (winner or tentative
+    // residue) so reruns start from the same occupancy.
+    const slots = await prisma.slotOfAppointment.findMany({
+      where: {
+        appointmentId: webinar.appointment.id,
+        user: { some: { id: { in: stormerIds } } },
+      },
+      select: { id: true, user: { select: { id: true } }, createdAt: true },
+    });
+    for (const slot of slots) {
+      if (slot.createdAt >= testStart) {
+        await prisma.slotOfAppointment.delete({ where: { id: slot.id } });
+      } else {
+        await prisma.slotOfAppointment.update({
+          where: { id: slot.id },
+          data: {
+            user: {
+              disconnect: slot.user
+                .filter((u) => stormerIds.includes(u.id))
+                .map((u) => ({ id: u.id })),
+            },
+          },
+        });
+      }
+    }
+  }
+
+  finish("last-seat-storm");
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

PR-3 of the hardening train — write-path scale work, with each planned item **verified against live code/data before implementing**. Two survived; one was redesigned on evidence:

### 1. Waitlist batch-notify

`handleSlotOpening` ran a `findFirst` + guarded `updateMany` **per slot** with an `i--` retry on every race loss — N freed seats × M concurrent openings = O(N×M) query waves. Now each round is one ordered `findMany` (`getNextBatchInQueue`) + one `$transaction` of per-id CAS claims whose counts identify exactly which candidates this call won (a bulk `updateMany` can't report that). Same WAITING-guard semantics, same post-claim email error handling.

### 2. Capacity guard — RCA claim refuted, pinned as a regression test

The audit claimed a last-seat enrollment race. Verification: the per-event checkout lock wraps the whole check-then-hold and the participant counts **include tentative holds**, so checkout cannot oversell. Rather than churn safe code, the guarantee is now pinned by `test-last-seat-storm` (3 users race one free webinar seat) — **live-proven: exactly one winner, losers clean 4xx, zero 5xx, participants ≤ max.**

### 3. Allocation lock narrowing — rejected; the real backstop landed instead

The plan's premise ("narrow the consultant-level lock; the #440 DB overlap guard is the backstop") **failed verification**: `consultantProfileId` was populated on **0 of 668** slot rows and the exclusion constraint had never been applied — narrowing would have traded contention for real double-bookings (the allocation tx isn't Serializable). Landed in this PR:

- **`slot_no_confirmed_overlap`** `EXCLUDE USING gist` constraint via the `db:constraints` sidecar (btree_gist, `[)` ranges, scoped to non-tentative rows with the column set). Applied to dev and behavior-proven on all four cases: confirmed overlap **rejected**, tentative overlap allowed, back-to-back allowed.
- The two **population gaps** closed: `request-for-approval` tentative creates (the approve/confirm flip rides whatever the row carries) and the legacy webhook `createConsultation`. Checkout and `SlotAllocationService` already set it (the service even fail-fasts). Webinar/class attendee slots stay NULL **by design** (many same-window rows per event are legitimate); seeded rows stay NULL as pre-#440 legacy.

Lock narrowing is now a justified follow-up once the constraint soaks — issue to be filed referencing this PR.

## Verification

tsc clean · 1357/1357 jest · `test-last-seat-storm` live-run ALL CHECKS PASSED · constraint behavior proven with direct DB inserts (4 cases) · `npm run db:constraints` idempotent re-run green.

Progresses #440. Part of the post-#837 hardening train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for concurrent bookings and strengthened DB constraint to block overlapping confirmed consultant appointments.
  * Webhook booking flows now ensure overlap protection is applied at creation time to prevent race conditions.

* **Refactor**
  * Waitlist claim and notification flow now processes candidates in batches for more efficient claiming and notification.

* **Tests**
  * Added end-to-end race test validating single-seat checkout under concurrent load.

* **Documentation**
  * Expanded testing plan with the new last-seat storm scenario and DB verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->