### PR TITLE
fix(stream,referrals,collaborators): recording-access-on-refund + referral correctness + co-host scheduling guard

### DIFF
--- a/__tests__/collaborators/availability.test.ts
+++ b/__tests__/collaborators/availability.test.ts
@@ -28,16 +28,19 @@ function makeDb(opts: {
     },
     slotOfAppointment: {
       findFirst: jest.fn().mockImplementation(({ where }) => {
-        // The per-collaborator profile id lives in the appointment OR filter;
-        // resolve a conflict if that collaborator is in the conflict set.
-        const profileId =
-          where.appointment.OR[0].consultation.consultationPlan
-            .consultantProfileId;
-        return Promise.resolve(
-          opts.conflictForProfileIds?.includes(profileId)
-            ? { id: "conflict-slot" }
-            : null,
+        // The appointment OR filter names a consultantProfileId per commitment
+        // clause. This works for both the batched detection query (every co-host
+        // in one OR) and the per-co-host probe (one co-host's clauses): resolve a
+        // conflict if any named profile is in the conflict set.
+        const orClauses: Array<{
+          consultation?: { consultationPlan?: { consultantProfileId?: string } };
+        }> = where.appointment.OR;
+        const clash = orClauses.some((clause) =>
+          opts.conflictForProfileIds?.includes(
+            clause.consultation?.consultationPlan?.consultantProfileId ?? "",
+          ),
         );
+        return Promise.resolve(clash ? { id: "conflict-slot" } : null);
       }),
     },
   };

--- a/__tests__/collaborators/availability.test.ts
+++ b/__tests__/collaborators/availability.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * AE-2 (#784) — co-hosts aren't slot participants, so nothing else catches a
+ * co-host being double-booked when an event is scheduled. These pin the guard:
+ * no-op without collaborators, throw when an accepted co-host overlaps.
+ */
+
+import {
+  assertCollaboratorsAvailable,
+  CollaboratorUnavailableError,
+} from "@/lib/collaborators/availability";
+
+function makeDb(opts: {
+  collaborators: Array<{ name: string | null; consultantProfileId: string }>;
+  conflictForProfileIds?: string[];
+}) {
+  return {
+    collaborator: {
+      findMany: jest.fn().mockResolvedValue(
+        opts.collaborators.map((c) => ({
+          consultantProfileId: c.consultantProfileId,
+          consultantProfile: { user: { name: c.name } },
+        })),
+      ),
+    },
+    slotOfAppointment: {
+      findFirst: jest.fn().mockImplementation(({ where }) => {
+        // The per-collaborator profile id lives in the appointment OR filter;
+        // resolve a conflict if that collaborator is in the conflict set.
+        const profileId =
+          where.appointment.OR[0].consultation.consultationPlan
+            .consultantProfileId;
+        return Promise.resolve(
+          opts.conflictForProfileIds?.includes(profileId)
+            ? { id: "conflict-slot" }
+            : null,
+        );
+      }),
+    },
+  };
+}
+
+const base = {
+  planType: "WEBINAR" as const,
+  planId: "plan-1",
+  startsAt: new Date("2026-07-01T10:00:00.000Z"),
+  endsAt: new Date("2026-07-01T11:00:00.000Z"),
+};
+
+describe("assertCollaboratorsAvailable", () => {
+  it("no-ops when the plan has no accepted collaborators", async () => {
+    const db = makeDb({ collaborators: [] });
+    await expect(
+      assertCollaboratorsAvailable(db as never, base),
+    ).resolves.toBeUndefined();
+    expect(db.slotOfAppointment.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("resolves when accepted co-hosts have no overlapping commitment", async () => {
+    const db = makeDb({
+      collaborators: [{ name: "Alice", consultantProfileId: "p1" }],
+    });
+    await expect(
+      assertCollaboratorsAvailable(db as never, base),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws naming the clashing co-host(s)", async () => {
+    const db = makeDb({
+      collaborators: [
+        { name: "Alice", consultantProfileId: "p1" },
+        { name: "Bob", consultantProfileId: "p2" },
+      ],
+      conflictForProfileIds: ["p2"],
+    });
+    await expect(
+      assertCollaboratorsAvailable(db as never, base),
+    ).rejects.toBeInstanceOf(CollaboratorUnavailableError);
+    await expect(
+      assertCollaboratorsAvailable(db as never, base),
+    ).rejects.toThrow("Bob");
+  });
+
+  it("excludes the event's own appointment from the conflict scan", async () => {
+    const db = makeDb({
+      collaborators: [{ name: "Alice", consultantProfileId: "p1" }],
+    });
+    await assertCollaboratorsAvailable(db as never, {
+      ...base,
+      excludeAppointmentId: "appt-self",
+    });
+    const where = db.slotOfAppointment.findFirst.mock.calls[0][0].where;
+    expect(where.appointmentId).toEqual({ not: "appt-self" });
+    expect(where.isTentative).toBe(false);
+  });
+});

--- a/__tests__/collaborators/availability.test.ts
+++ b/__tests__/collaborators/availability.test.ts
@@ -28,17 +28,30 @@ function makeDb(opts: {
     },
     slotOfAppointment: {
       findFirst: jest.fn().mockImplementation(({ where }) => {
-        // The appointment OR filter names a consultantProfileId per commitment
-        // clause. This works for both the batched detection query (every co-host
-        // in one OR) and the per-co-host probe (one co-host's clauses): resolve a
-        // conflict if any named profile is in the conflict set.
-        const orClauses: Array<{
-          consultation?: { consultationPlan?: { consultantProfileId?: string } };
-        }> = where.appointment.OR;
+        // Each commitment clause names a consultantProfileId via one of six
+        // shapes (consultation/subscription/webinar/class owner, plus webinar/
+        // class collaborator). Extract from ALL of them so a regression in any
+        // shape — notably the collaborator predicates — is actually exercised.
+        type Owned = { consultantProfileId?: string };
+        type Collab = {
+          collaborators?: { some?: { consultantProfileId?: string } };
+        };
+        type Clause = {
+          consultation?: { consultationPlan?: Owned };
+          subscription?: { subscriptionPlan?: Owned };
+          webinar?: { webinarPlan?: Owned & Collab };
+          class?: { classPlan?: Owned & Collab };
+        };
+        const profileIdOf = (c: Clause): string | undefined =>
+          c.consultation?.consultationPlan?.consultantProfileId ??
+          c.subscription?.subscriptionPlan?.consultantProfileId ??
+          c.webinar?.webinarPlan?.consultantProfileId ??
+          c.webinar?.webinarPlan?.collaborators?.some?.consultantProfileId ??
+          c.class?.classPlan?.consultantProfileId ??
+          c.class?.classPlan?.collaborators?.some?.consultantProfileId;
+        const orClauses: Clause[] = where.appointment.OR;
         const clash = orClauses.some((clause) =>
-          opts.conflictForProfileIds?.includes(
-            clause.consultation?.consultationPlan?.consultantProfileId ?? "",
-          ),
+          opts.conflictForProfileIds?.includes(profileIdOf(clause) ?? ""),
         );
         return Promise.resolve(clash ? { id: "conflict-slot" } : null);
       }),

--- a/__tests__/payments/refund-balance.test.ts
+++ b/__tests__/payments/refund-balance.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #689 — recording/resource access keys off SUCCEEDED payments, but a refund
+ * never flips paymentStatus (the enum has no REFUNDED). These pin the shared
+ * refund-aware entitlement: a fully-refunded buyer loses access, a partially
+ * refunded one keeps it, and FAILED/CANCELLED refunds don't count.
+ */
+
+import { RefundStatus } from "@prisma/client";
+import {
+  isPaymentEntitled,
+  refundedPaise,
+} from "@/lib/payments/utils/refund-balance";
+
+describe("refundedPaise", () => {
+  it("counts SUCCEEDED and PENDING refunds, ignores FAILED/CANCELLED", () => {
+    expect(
+      refundedPaise([
+        { amountPaise: 300, status: RefundStatus.SUCCEEDED },
+        { amountPaise: 200, status: RefundStatus.PENDING },
+        { amountPaise: 999, status: RefundStatus.FAILED },
+        { amountPaise: 999, status: RefundStatus.CANCELLED },
+      ]),
+    ).toBe(500);
+  });
+
+  it("is zero with no refunds", () => {
+    expect(refundedPaise([])).toBe(0);
+  });
+});
+
+describe("isPaymentEntitled", () => {
+  it("keeps access with no refunds", () => {
+    expect(isPaymentEntitled({ amount: 1000, refunds: [] })).toBe(true);
+  });
+
+  it("keeps access on a partial refund", () => {
+    expect(
+      isPaymentEntitled({
+        amount: 1000,
+        refunds: [{ amountPaise: 400, status: RefundStatus.SUCCEEDED }],
+      }),
+    ).toBe(true);
+  });
+
+  it("revokes access once refunds cover the full amount", () => {
+    expect(
+      isPaymentEntitled({
+        amount: 1000,
+        refunds: [{ amountPaise: 1000, status: RefundStatus.SUCCEEDED }],
+      }),
+    ).toBe(false);
+  });
+
+  it("revokes access when a refund is still PENDING but covers the amount", () => {
+    expect(
+      isPaymentEntitled({
+        amount: 1000,
+        refunds: [{ amountPaise: 1000, status: RefundStatus.PENDING }],
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps access when the only refund covering the amount FAILED", () => {
+    expect(
+      isPaymentEntitled({
+        amount: 1000,
+        refunds: [{ amountPaise: 1000, status: RefundStatus.FAILED }],
+      }),
+    ).toBe(true);
+  });
+});

--- a/__tests__/referrals/service.test.ts
+++ b/__tests__/referrals/service.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #692 referral correctness pins:
+ *  - REF-2: a refund must not restore credit onto a credit that has since
+ *    expired (resurrecting dead balance the expiry cron re-zeroes).
+ *  - REF-3: reward qualification claims atomically — the qualification window
+ *    is asserted in the updateMany WHERE, not as a separate app-side check.
+ */
+
+import { QUALIFICATION_WINDOW_DAYS } from "@/lib/referrals/constants";
+
+// processQualifyingAction runs inside withSerializableRetry(() => prisma.$transaction()).
+// Mock both so the body executes against a controllable fake tx.
+const mockTx = {
+  referral: {
+    findUnique: jest.fn(),
+    updateMany: jest.fn(),
+    update: jest.fn(),
+  },
+  referralCredit: { create: jest.fn() },
+  referralCode: { update: jest.fn() },
+};
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    $transaction: (fn: (tx: unknown) => unknown) => fn(mockTx),
+  },
+}));
+jest.mock("../../lib/db/serializable-retry", () => ({
+  withSerializableRetry: (fn: () => unknown) => fn(),
+}));
+
+import {
+  reverseCreditsForPayment,
+  processQualifyingAction,
+} from "@/lib/referrals/service";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("REF-2 — reverseCreditsForPayment skips expired credits", () => {
+  it("restores live credits and leaves expired ones untouched", async () => {
+    const past = new Date(Date.now() - DAY_MS); // already expired
+    const future = new Date(Date.now() + 30 * DAY_MS); // still valid
+
+    const tx = {
+      referralCreditUsage: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "use-expired",
+            creditId: "credit-expired",
+            amount: 500,
+            originalAmount: 500,
+            restoredAmount: 0,
+            credit: { expiresAt: past },
+          },
+          {
+            id: "use-live",
+            creditId: "credit-live",
+            amount: 300,
+            originalAmount: 300,
+            restoredAmount: 0,
+            credit: { expiresAt: future },
+          },
+        ]),
+        delete: jest.fn().mockResolvedValue({}),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      referralCredit: { update: jest.fn().mockResolvedValue({}) },
+    };
+
+    // Full refund (no refundAmount) → restore everything still live.
+    const restored = await reverseCreditsForPayment("pay-1", tx as never);
+
+    expect(restored).toBe(300); // only the live credit
+    expect(tx.referralCredit.update).toHaveBeenCalledTimes(1);
+    expect(tx.referralCredit.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "credit-live" } }),
+    );
+    // The expired credit must never be incremented back to life.
+    expect(tx.referralCredit.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "credit-expired" } }),
+    );
+    expect(tx.referralCreditUsage.delete).toHaveBeenCalledWith({
+      where: { id: "use-live" },
+    });
+  });
+
+  it("treats null expiresAt as never-expiring (restores it)", async () => {
+    const tx = {
+      referralCreditUsage: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "use-1",
+            creditId: "credit-1",
+            amount: 200,
+            originalAmount: 200,
+            restoredAmount: 0,
+            credit: { expiresAt: null },
+          },
+        ]),
+        delete: jest.fn().mockResolvedValue({}),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      referralCredit: { update: jest.fn().mockResolvedValue({}) },
+    };
+
+    const restored = await reverseCreditsForPayment("pay-2", tx as never);
+    expect(restored).toBe(200);
+    expect(tx.referralCredit.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("REF-3 — processQualifyingAction claims reward atomically", () => {
+  beforeEach(() => {
+    mockTx.referral.findUnique.mockReset();
+    mockTx.referral.updateMany.mockReset();
+    mockTx.referral.update.mockReset();
+    mockTx.referralCredit.create.mockReset();
+    mockTx.referralCode.update.mockReset();
+  });
+
+  const signedUpReferral = {
+    id: "ref-1",
+    status: "SIGNED_UP",
+    signedUpAt: new Date(),
+    referralCodeId: "code-1",
+    referredUserId: "referee-1",
+    referrerRewardAmount: 50000,
+    refereeRewardAmount: 20000,
+    referralCode: { userId: "referrer-1" },
+  };
+
+  it("rewards via a WHERE that asserts status + window, then issues both bonuses", async () => {
+    mockTx.referral.findUnique.mockResolvedValue(signedUpReferral);
+    mockTx.referral.updateMany.mockResolvedValue({ count: 1 });
+
+    await processQualifyingAction("referee-1", "first_paid_booking");
+
+    expect(mockTx.referral.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "ref-1",
+          status: "SIGNED_UP",
+          signedUpAt: expect.objectContaining({ gte: expect.any(Date) }),
+        }),
+        data: expect.objectContaining({ status: "REWARDED" }),
+      }),
+    );
+    // Referrer + referee bonuses both created.
+    expect(mockTx.referralCredit.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires (status+window guard) and pays nothing when the claim matches no row", async () => {
+    mockTx.referral.findUnique.mockResolvedValue({
+      ...signedUpReferral,
+      signedUpAt: new Date(Date.now() - (QUALIFICATION_WINDOW_DAYS + 5) * DAY_MS),
+    });
+    // Reward claim matches nothing (past window); expire claim flips one row.
+    mockTx.referral.updateMany
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+
+    await processQualifyingAction("referee-1", "first_paid_booking");
+
+    // Second updateMany is the expire path, guarded on a past-window SIGNED_UP row.
+    expect(mockTx.referral.updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "SIGNED_UP",
+          signedUpAt: expect.objectContaining({ lt: expect.any(Date) }),
+        }),
+        data: { status: "EXPIRED" },
+      }),
+    );
+    expect(mockTx.referralCredit.create).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/bookings/webinars/crud-with-plan/route.ts
+++ b/app/api/bookings/webinars/crud-with-plan/route.ts
@@ -7,6 +7,10 @@ import { findOrCreateTopics, transformNestedPlanTopics } from "@/lib/topics";
 import { handleSlotOpening } from "@/lib/waitlist/slot-handler";
 import { checkConsultantVerification } from "@/lib/verification";
 import { countWebinarParticipants } from "@/lib/payments/utils/participants";
+import {
+  assertCollaboratorsAvailable,
+  CollaboratorUnavailableError,
+} from "@/lib/collaborators/availability";
 
 import { getSession } from "@/lib/auth-server";
 // Schema for POST request body based on WebinarPlanSchema
@@ -693,6 +697,17 @@ export async function PATCH(request: NextRequest) {
             // Check if recalculation happened
             const appointment = updatedWebinar.appointment;
 
+            // AE-2 (#784) — block (re)scheduling onto a time any ACCEPTED co-host
+            // is already committed to; co-hosts aren't slot participants, so no
+            // other guard catches their double-booking. Throws → 409 below.
+            await assertCollaboratorsAvailable(tx, {
+              planType: "WEBINAR",
+              planId: id,
+              startsAt: startTime,
+              endsAt: endTime,
+              excludeAppointmentId: appointment?.id ?? null,
+            });
+
             if (appointment) {
               // Update existing appointment slots
               if (
@@ -851,6 +866,11 @@ export async function PATCH(request: NextRequest) {
       );
     }
     // --- End Zod Error Handling ---
+
+    // AE-2 — co-host clash is a conflict, not a server error.
+    if (error instanceof CollaboratorUnavailableError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
 
     console.error("Error updating webinar with plan:", error);
 

--- a/app/api/stream/meetings/[streamCallId]/recording-info/route.ts
+++ b/app/api/stream/meetings/[streamCallId]/recording-info/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { isPaymentEntitled } from "@/lib/payments/utils/refund-balance";
 
 import { getSession } from "@/lib/auth-server";
 type RouteParams = {
@@ -143,7 +144,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
             enrollmentConditions.push({ classId });
           }
 
-          const hasEnrollment = await prisma.payment.findFirst({
+          const enrollments = await prisma.payment.findMany({
             where: {
               userId: session.user.id,
               paymentStatus: "SUCCEEDED",
@@ -151,9 +152,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
                 OR: enrollmentConditions,
               },
             },
+            select: {
+              amount: true,
+              refunds: { select: { amountPaise: true, status: true } },
+            },
           });
 
-          if (!hasEnrollment) {
+          // #689 — a fully-refunded enrollment is no longer access.
+          if (!enrollments.some(isPaymentEntitled)) {
             return NextResponse.json(
               { error: "Access denied" },
               { status: 403 },

--- a/app/api/stream/recordings/[recordingId]/route.ts
+++ b/app/api/stream/recordings/[recordingId]/route.ts
@@ -10,6 +10,7 @@ import { RecordingService } from "@/lib/stream/recording-service";
 import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 import prisma from "@/lib/prisma";
 import { streamLogger } from "@/lib/stream-logger";
+import { isPaymentEntitled } from "@/lib/payments/utils/refund-balance";
 
 import { getSession } from "@/lib/auth-server";
 type RouteParams = {
@@ -82,35 +83,29 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         }
       }
     } else if (session.user.role === "CONSULTEE") {
-      // Consultee can access recordings for sessions they participated in
+      // Consultee can access recordings for sessions they participated in.
       // Use plan-level entitlement: the recording's appointment is the consultant's
-      // allocation slot, not the attendee's enrollment slot, so we check by plan ID
-      if (appointment?.webinar?.webinarPlan?.id) {
-        const payment = await prisma.payment.findFirst({
+      // allocation slot, not the attendee's enrollment slot, so we check by plan ID.
+      const planFilter = appointment?.webinar?.webinarPlan?.id
+        ? { webinar: { webinarPlanId: appointment.webinar.webinarPlan.id } }
+        : appointment?.class?.classPlan?.id
+          ? { class: { classPlanId: appointment.class.classPlan.id } }
+          : null;
+      if (planFilter) {
+        const payments = await prisma.payment.findMany({
           where: {
             userId: session.user.id,
             paymentStatus: "SUCCEEDED",
-            appointment: {
-              webinar: {
-                webinarPlanId: appointment.webinar.webinarPlan.id,
-              },
-            },
+            appointment: planFilter,
+          },
+          select: {
+            amount: true,
+            refunds: { select: { amountPaise: true, status: true } },
           },
         });
-        hasAccess = !!payment;
-      } else if (appointment?.class?.classPlan?.id) {
-        const payment = await prisma.payment.findFirst({
-          where: {
-            userId: session.user.id,
-            paymentStatus: "SUCCEEDED",
-            appointment: {
-              class: {
-                classPlanId: appointment.class.classPlan.id,
-              },
-            },
-          },
-        });
-        hasAccess = !!payment;
+        // #689 — a SUCCEEDED payment fully reversed by refunds is no longer an
+        // entitlement; access needs at least one net-positive purchase for the plan.
+        hasAccess = payments.some(isPaymentEntitled);
       }
     } else if (session.user.role === "ADMIN" || session.user.role === "STAFF") {
       // Admin and staff can access all recordings

--- a/lib/collaborators/availability.ts
+++ b/lib/collaborators/availability.ts
@@ -1,0 +1,110 @@
+import prisma, { type Tx } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+/**
+ * AE-2 (#784) — collaborator double-booking guard.
+ *
+ * A webinar/class co-host commits real time, but co-hosts are NOT slot
+ * participants (only the plan owner is denormalized onto SlotOfAppointment),
+ * so neither the `slot_no_confirmed_overlap` exclusion constraint nor the
+ * owner-scoped availability checks ever see them. Scheduling an event at a time
+ * a co-host is already committed elsewhere therefore goes undetected. This guard
+ * is called at the event's time-commit so a clash is rejected (→ 409).
+ */
+
+export class CollaboratorUnavailableError extends Error {
+  constructor(public readonly names: string[]) {
+    super(`Co-host(s) unavailable at the selected time: ${names.join(", ")}`);
+    this.name = "CollaboratorUnavailableError";
+  }
+}
+
+/**
+ * A co-host's existing commitments: appointments they own, or have ACCEPTED a
+ * collaboration on. Mirrors the booked-slots query behind
+ * /api/collaborators/[consultantProfileId]/availability.
+ */
+function commitmentWhere(
+  consultantProfileId: string,
+): Prisma.AppointmentWhereInput {
+  return {
+    OR: [
+      { consultation: { consultationPlan: { consultantProfileId } } },
+      { subscription: { subscriptionPlan: { consultantProfileId } } },
+      { webinar: { webinarPlan: { consultantProfileId } } },
+      { class: { classPlan: { consultantProfileId } } },
+      {
+        webinar: {
+          webinarPlan: {
+            collaborators: { some: { consultantProfileId, status: "ACCEPTED" } },
+          },
+        },
+      },
+      {
+        class: {
+          classPlan: {
+            collaborators: { some: { consultantProfileId, status: "ACCEPTED" } },
+          },
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Throws CollaboratorUnavailableError if any ACCEPTED co-host on the plan has a
+ * confirmed commitment overlapping [startsAt, endsAt). No-op when the plan has
+ * no accepted collaborators. Run inside the scheduling transaction so the read
+ * is consistent with the slot write that follows.
+ */
+export async function assertCollaboratorsAvailable(
+  db: Tx | typeof prisma,
+  params: {
+    planType: "WEBINAR" | "CLASS";
+    planId: string;
+    startsAt: Date;
+    endsAt: Date;
+    /** The event's own appointment, excluded so its slots don't self-conflict. */
+    excludeAppointmentId?: string | null;
+  },
+): Promise<void> {
+  const { planType, planId, startsAt, endsAt, excludeAppointmentId } = params;
+
+  const collaborators = await db.collaborator.findMany({
+    where: {
+      status: "ACCEPTED",
+      ...(planType === "WEBINAR"
+        ? { webinarPlanId: planId }
+        : { classPlanId: planId }),
+    },
+    select: {
+      consultantProfileId: true,
+      consultantProfile: { select: { user: { select: { name: true } } } },
+    },
+  });
+  if (collaborators.length === 0) return;
+
+  const clashing: string[] = [];
+  for (const c of collaborators) {
+    const conflict = await db.slotOfAppointment.findFirst({
+      where: {
+        // Half-open overlap: existing.start < new.end AND existing.end > new.start.
+        startsAt: { lt: endsAt },
+        endsAt: { gt: startsAt },
+        isTentative: false,
+        ...(excludeAppointmentId
+          ? { appointmentId: { not: excludeAppointmentId } }
+          : {}),
+        appointment: commitmentWhere(c.consultantProfileId),
+      },
+      select: { id: true },
+    });
+    if (conflict) {
+      clashing.push(c.consultantProfile.user.name ?? c.consultantProfileId);
+    }
+  }
+
+  if (clashing.length > 0) {
+    throw new CollaboratorUnavailableError(clashing);
+  }
+}

--- a/lib/collaborators/availability.ts
+++ b/lib/collaborators/availability.ts
@@ -24,31 +24,29 @@ export class CollaboratorUnavailableError extends Error {
  * collaboration on. Mirrors the booked-slots query behind
  * /api/collaborators/[consultantProfileId]/availability.
  */
-function commitmentWhere(
+function commitmentClauses(
   consultantProfileId: string,
-): Prisma.AppointmentWhereInput {
-  return {
-    OR: [
-      { consultation: { consultationPlan: { consultantProfileId } } },
-      { subscription: { subscriptionPlan: { consultantProfileId } } },
-      { webinar: { webinarPlan: { consultantProfileId } } },
-      { class: { classPlan: { consultantProfileId } } },
-      {
-        webinar: {
-          webinarPlan: {
-            collaborators: { some: { consultantProfileId, status: "ACCEPTED" } },
-          },
+): Prisma.AppointmentWhereInput[] {
+  return [
+    { consultation: { consultationPlan: { consultantProfileId } } },
+    { subscription: { subscriptionPlan: { consultantProfileId } } },
+    { webinar: { webinarPlan: { consultantProfileId } } },
+    { class: { classPlan: { consultantProfileId } } },
+    {
+      webinar: {
+        webinarPlan: {
+          collaborators: { some: { consultantProfileId, status: "ACCEPTED" } },
         },
       },
-      {
-        class: {
-          classPlan: {
-            collaborators: { some: { consultantProfileId, status: "ACCEPTED" } },
-          },
+    },
+    {
+      class: {
+        classPlan: {
+          collaborators: { some: { consultantProfileId, status: "ACCEPTED" } },
         },
       },
-    ],
-  };
+    },
+  ];
 }
 
 /**
@@ -84,19 +82,41 @@ export async function assertCollaboratorsAvailable(
   });
   if (collaborators.length === 0) return;
 
+  // A confirmed, non-soft-deleted slot overlapping the window. deletedAt:null on
+  // both the slot and its appointment keeps cancelled/soft-deleted bookings from
+  // surfacing as phantom clashes.
+  const overlapWhere = (
+    appointment: Prisma.AppointmentWhereInput,
+  ): Prisma.SlotOfAppointmentWhereInput => ({
+    // Half-open overlap: existing.start < new.end AND existing.end > new.start.
+    startsAt: { lt: endsAt },
+    endsAt: { gt: startsAt },
+    isTentative: false,
+    deletedAt: null,
+    ...(excludeAppointmentId
+      ? { appointmentId: { not: excludeAppointmentId } }
+      : {}),
+    appointment: { deletedAt: null, ...appointment },
+  });
+
+  // Fast path: one query asking whether ANY co-host clashes — no N+1 on the
+  // common no-conflict scheduling path.
+  const anyClash = await db.slotOfAppointment.findFirst({
+    where: overlapWhere({
+      OR: collaborators.flatMap((c) =>
+        commitmentClauses(c.consultantProfileId),
+      ),
+    }),
+    select: { id: true },
+  });
+  if (!anyClash) return;
+
+  // A clash exists and will block scheduling; resolve which co-host(s) for the
+  // 409 message. This per-co-host probe runs only in that rare blocking case.
   const clashing: string[] = [];
   for (const c of collaborators) {
     const conflict = await db.slotOfAppointment.findFirst({
-      where: {
-        // Half-open overlap: existing.start < new.end AND existing.end > new.start.
-        startsAt: { lt: endsAt },
-        endsAt: { gt: startsAt },
-        isTentative: false,
-        ...(excludeAppointmentId
-          ? { appointmentId: { not: excludeAppointmentId } }
-          : {}),
-        appointment: commitmentWhere(c.consultantProfileId),
-      },
+      where: overlapWhere({ OR: commitmentClauses(c.consultantProfileId) }),
       select: { id: true },
     });
     if (conflict) {

--- a/lib/payments/utils/refund-balance.ts
+++ b/lib/payments/utils/refund-balance.ts
@@ -1,0 +1,39 @@
+import { RefundStatus } from "@prisma/client";
+
+/**
+ * Refund-aware entitlement, shared across access-control paths (#689).
+ *
+ * `PaymentStatus` has no REFUNDED value — a refunded payment stays SUCCEEDED and
+ * the money movement lives only in `Refund` rows. So a `paymentStatus: SUCCEEDED`
+ * filter alone still matches a fully-refunded buyer; every access check that
+ * grants entitlement off a SUCCEEDED payment must net the refunds too.
+ */
+
+type RefundLike = { amountPaise: number; status: RefundStatus };
+
+/**
+ * Paise already reversed on a payment. A refund counts once it's SUCCEEDED or
+ * in-flight (PENDING); FAILED/CANCELLED never moved money. Mirrors the
+ * refundable computation in `lib/payments/operations/refund.ts`.
+ */
+export function refundedPaise(refunds: RefundLike[]): number {
+  return refunds
+    .filter(
+      (r) =>
+        r.status === RefundStatus.SUCCEEDED || r.status === RefundStatus.PENDING,
+    )
+    .reduce((acc, r) => acc + r.amountPaise, 0);
+}
+
+/**
+ * True while a SUCCEEDED payment is still a live entitlement. A full refund
+ * (refunds cover the whole amount) made the buyer whole, so access is revoked;
+ * a partial refund keeps access (net-positive purchase). Chargeback-driven
+ * revocation (disputes LOST/CHARGE_REFUNDED) is deferred.
+ */
+export function isPaymentEntitled(payment: {
+  amount: number;
+  refunds: RefundLike[];
+}): boolean {
+  return refundedPaise(payment.refunds) < payment.amount;
+}

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -498,7 +498,9 @@ export async function reverseCreditsForPayment(
     // balance (getUserCredits filters expiry; the expiry cron re-zeroes it).
     // Skip + log; the usage row stays so the credit reads as still consumed.
     // (Issuing fresh credit on refund-of-expired is a product decision, not done here.)
-    const creditExpiresAt = usage.credit.expiresAt;
+    // Optional-chain the relation defensively: if a credit row is ever absent
+    // we treat it as non-expired and fall through to the normal restore.
+    const creditExpiresAt = usage.credit?.expiresAt;
     if (creditExpiresAt && creditExpiresAt.getTime() < now.getTime()) {
       skippedExpired += usage.amount;
       continue;
@@ -559,9 +561,10 @@ export async function reverseCreditsForPayment(
     );
   }
   if (skippedExpired > 0) {
-    // REF-2 — visibility: credit value not returned because it had expired.
+    // REF-2 — visibility: credit value (in paise) not returned because the
+    // underlying credit had already expired.
     console.log(
-      `⏭️  Skipped restoring ${skippedExpired} expired referral credit(s) for refunded payment ${paymentId}`,
+      `⏭️  Skipped restoring ${skippedExpired} paise of expired referral credit for refunded payment ${paymentId}`,
     );
   }
 

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -498,9 +498,9 @@ export async function reverseCreditsForPayment(
     // balance (getUserCredits filters expiry; the expiry cron re-zeroes it).
     // Skip + log; the usage row stays so the credit reads as still consumed.
     // (Issuing fresh credit on refund-of-expired is a product decision, not done here.)
-    // Optional-chain the relation defensively: if a credit row is ever absent
-    // we treat it as non-expired and fall through to the normal restore.
-    const creditExpiresAt = usage.credit?.expiresAt;
+    // `credit` is a required FK relation that the findMany above always includes,
+    // so it is never null here — no optional chain needed.
+    const creditExpiresAt = usage.credit.expiresAt;
     if (creditExpiresAt && creditExpiresAt.getTime() < now.getTime()) {
       skippedExpired += usage.amount;
       continue;

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -246,23 +246,21 @@ export async function processQualifyingAction(
 
         if (!referral || referral.status !== "SIGNED_UP") return;
 
-        // Check if within qualification window
-        const daysSinceSignup = Math.floor(
-          (Date.now() - referral.signedUpAt.getTime()) / (1000 * 60 * 60 * 24),
+        // REF-3 (#692) — claim the reward atomically: status still SIGNED_UP AND
+        // within the qualification window, both asserted in the WHERE. Folding the
+        // window into the guarded write (rather than an app-side Date.now() check
+        // separate from the status guard) makes reward-vs-expire a single decision
+        // against the committed row, closing the gap where a stale read or the
+        // expireStaleReferrals cron disagrees with the app-computed window.
+        const windowCutoff = new Date(
+          Date.now() - QUALIFICATION_WINDOW_DAYS * 24 * 60 * 60 * 1000,
         );
-
-        if (daysSinceSignup > QUALIFICATION_WINDOW_DAYS) {
-          await tx.referral.update({
-            where: { id: referral.id },
-            data: { status: "EXPIRED" },
-          });
-          return;
-        }
-
-        // Conditional update: only succeeds if status is still SIGNED_UP.
-        // This prevents concurrent calls from both creating rewards.
         const updated = await tx.referral.updateMany({
-          where: { id: referral.id, status: "SIGNED_UP" },
+          where: {
+            id: referral.id,
+            status: "SIGNED_UP",
+            signedUpAt: { gte: windowCutoff },
+          },
           data: {
             status: "REWARDED",
             qualifiedAt: new Date(),
@@ -273,8 +271,20 @@ export async function processQualifyingAction(
           },
         });
 
-        // If no rows updated, another concurrent call already processed this
-        if (updated.count === 0) return;
+        // No reward claimed → either a concurrent call already processed it, or
+        // it's past the window. Expire it iff it's still an un-rewarded SIGNED_UP
+        // past the cutoff (the status guard makes this a no-op against a REWARDED row).
+        if (updated.count === 0) {
+          await tx.referral.updateMany({
+            where: {
+              id: referral.id,
+              status: "SIGNED_UP",
+              signedUpAt: { lt: windowCutoff },
+            },
+            data: { status: "EXPIRED" },
+          });
+          return;
+        }
 
         // Give referrer their bonus
         const referrerReward = referral.referrerRewardAmount;
@@ -443,9 +453,11 @@ export async function reverseCreditsForPayment(
   refundAmount?: number,
   originalPaymentAmount?: number,
 ): Promise<number> {
-  // Find all usage records for this payment from the ledger
+  // Find all usage records for this payment from the ledger. Carry the credit's
+  // expiry so we don't restore onto a credit that has since lapsed (REF-2).
   const usageRecords = await tx.referralCreditUsage.findMany({
     where: { paymentId },
+    include: { credit: { select: { expiresAt: true } } },
   });
 
   if (usageRecords.length === 0) return 0;
@@ -475,9 +487,22 @@ export async function reverseCreditsForPayment(
   }
 
   let totalRestored = 0;
+  let skippedExpired = 0;
+  const now = new Date();
 
   for (const usage of usageRecords) {
     if (usage.amount <= 0) continue;
+
+    // REF-2 (#692) — never resurrect an expired credit. If the credit lapsed
+    // after it was applied, restoring remainingAmount onto it just leaves dead
+    // balance (getUserCredits filters expiry; the expiry cron re-zeroes it).
+    // Skip + log; the usage row stays so the credit reads as still consumed.
+    // (Issuing fresh credit on refund-of-expired is a product decision, not done here.)
+    const creditExpiresAt = usage.credit.expiresAt;
+    if (creditExpiresAt && creditExpiresAt.getTime() < now.getTime()) {
+      skippedExpired += usage.amount;
+      continue;
+    }
 
     let restoreAmount: number;
 
@@ -531,6 +556,12 @@ export async function reverseCreditsForPayment(
   if (totalRestored > 0) {
     console.log(
       `🔄 Restored ${totalRestored} referral credits for ${isPartialRefund ? "partially " : ""}refunded payment ${paymentId}`,
+    );
+  }
+  if (skippedExpired > 0) {
+    // REF-2 — visibility: credit value not returned because it had expired.
+    console.log(
+      `⏭️  Skipped restoring ${skippedExpired} expired referral credit(s) for refunded payment ${paymentId}`,
     );
   }
 

--- a/lib/stream/recording-service.ts
+++ b/lib/stream/recording-service.ts
@@ -7,6 +7,7 @@ import { getStreamVideoClient } from "@/lib/stream-client";
 import prisma from "@/lib/prisma";
 import { Prisma, RecordingStatus } from "@prisma/client";
 import { streamLogger } from "@/lib/stream-logger";
+import { isPaymentEntitled } from "@/lib/payments/utils/refund-balance";
 import { generateRecordingTitle } from "@/lib/stream/recording-utils";
 import type {
   RecordingRow,
@@ -385,6 +386,8 @@ export class RecordingService {
         },
       },
       select: {
+        amount: true,
+        refunds: { select: { amountPaise: true, status: true } },
         appointment: {
           select: {
             webinar: { select: { webinarPlanId: true } },
@@ -394,16 +397,20 @@ export class RecordingService {
       },
     });
 
+    // #689 — drop fully-refunded purchases before deriving entitled plans; a
+    // SUCCEEDED payment whose refunds cover it no longer grants recording access.
+    const entitled = enrolledAppointments.filter(isPaymentEntitled);
+
     const webinarPlanIds = Array.from(
       new Set(
-        enrolledAppointments
+        entitled
           .map((e) => e.appointment?.webinar?.webinarPlanId)
           .filter((id): id is string => !!id),
       ),
     );
     const classPlanIds = Array.from(
       new Set(
-        enrolledAppointments
+        entitled
           .map((e) => e.appointment?.class?.classPlanId)
           .filter((id): id is string => !!id),
       ),
@@ -906,6 +913,8 @@ export class RecordingService {
           },
         },
         include: {
+          // #689 — net refunds so a fully-refunded enrollment doesn't re-sync recordings.
+          refunds: { select: { amountPaise: true, status: true } },
           appointment: {
             include: {
               slotsOfAppointment: {
@@ -957,6 +966,7 @@ export class RecordingService {
 
       for (const payment of paidEnrollments) {
         if (!payment.appointment) continue;
+        if (!isPaymentEntitled(payment)) continue; // #689 — skip fully-refunded
         for (const slot of payment.appointment.slotsOfAppointment) {
           if (slot.meetingSession && slot.meetingSession.streamCallId) {
             meetingSessions.push(slot.meetingSession);


### PR DESCRIPTION
## Money/access correctness — launch-blockers (batch 1 of 2)

The first of two PRs productionizing the customer-facing subsystems. This one carries the cross-subsystem **P0/P1 money + access correctness** fixes, each with unit tests. The remaining launch-blockers (Documents rate-limit/status-gate/reconcile, Stream circuit-breaker + attendance + recording-expiry email, email DLQ, Better Stack telemetry, and the broader co-host scheduling guard) follow in the next PR.

### STR-1 (P0) — refunded users kept recording access
`PaymentStatus` has no `REFUNDED` value, so a refunded payment stays `SUCCEEDED` and the reversal lives only in `Refund` rows. Every recording-entitlement check filtered on `paymentStatus: SUCCEEDED` alone, so a fully-refunded buyer kept access. New shared helper `lib/payments/utils/refund-balance.ts` (`isPaymentEntitled`) nets refunds against the payment amount and is wired into **all four** entitlement paths:
- `app/api/stream/recordings/[recordingId]/route.ts` (single recording)
- `lib/stream/recording-service.ts` → `getPaidPlanIds` (consultee list + resources API) and `syncRecordingsForConsultee`
- `app/api/stream/meetings/[streamCallId]/recording-info/route.ts`

A full refund revokes access; a partial refund retains it. Chargeback-driven revocation is deliberately deferred.

### REF-2 (P1) — refund restored expired credits
`reverseCreditsForPayment` restored `remainingAmount` onto credits regardless of expiry, resurrecting balance the expiry cron re-zeroes. It now skips (and logs) any credit that expired after it was applied; the usage row stays so the credit reads as consumed.

### REF-3 (P1) — qualification-window TOCTOU
The window was checked in app code (`Date.now()` vs `signedUpAt`) separately from the status guard. It's now folded into the reward `updateMany` WHERE (`signedUpAt >= cutoff`), making reward-vs-expire a single atomic guarded claim against the committed row.

### AE-2 (partial, P1) — co-host double-booking at webinar scheduling
Co-hosts aren't slot participants, so neither the `#440` exclusion constraint nor owner-scoped checks ever saw them — a co-host could be silently double-booked. New `lib/collaborators/availability.ts` (`assertCollaboratorsAvailable`) rejects scheduling a webinar onto a time an accepted co-host is already committed to (→ 409), wired into the webinar `crud-with-plan` PATCH. The robust architectural extension (owner DB-guard on group-event slots + co-host validation across the class/reschedule commit paths) lands in the next PR.

### Verification
- `tsc --noEmit`: 0 errors
- 15 new unit tests (refund-balance, referrals REF-2/REF-3, collaborator availability) — pass
- 219 existing stream + payments tests — pass (no regressions)

Part of #689, #692, #784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * Added refund-aware access checks so fully refunded successful payments no longer grant meeting/recording access.
  * Prevented webinar/class co-host double-bookings during rescheduling; conflicts now return a clear 409 with the clashing co-host name.
  * Improved referral qualification and credit restoration behavior to be transaction-guarded and to respect credit expiration.
* **Tests**
  * Added Jest coverage for collaborator availability conflict detection, refund/entitlement calculations, and referral qualification/credit restoration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->