### PR TITLE
fix(auth): server-render session to stop signed-out flash + cross-tab sync

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,10 @@ import Navbar from "@/components/Navbar";
 import NavigationProgress from "@/components/NavigationProgress";
 import { Toaster } from "@/components/ui/toaster";
 import { AnnouncementBarProvider } from "@/providers/AnnouncementBarProvider";
+import AuthSyncProvider from "@/providers/AuthSyncProvider";
 import { MaintenanceProvider } from "@/providers/MaintenanceProvider";
 import ReactQueryProvider from "@/providers/ReactQueryProvider";
+import { getSession } from "@/lib/auth-server";
 import type { Metadata, Viewport } from "next";
 import { Sora } from "next/font/google";
 
@@ -68,6 +70,11 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Resolve the session on the server so the Navbar renders the correct auth
+  // state on first paint (no signed-out flash). Cheap via the 5-min cookie
+  // cache; useSession() takes over client-side for live updates.
+  const initialSession = await getSession();
+
   return (
     <html lang="en" className={sora.variable} suppressHydrationWarning>
       <body
@@ -75,13 +82,14 @@ export default async function RootLayout({
         suppressHydrationWarning
       >
         <ReactQueryProvider>
+          <AuthSyncProvider />
           <MaintenanceProvider>
             <AnnouncementBarProvider>
               <NavigationProgress />
               <Toaster />
               <MaintenanceBanner />
               <AnnouncementBar />
-              <Navbar />
+              <Navbar initialSession={initialSession} />
               <HeaderSpacer />
               <div className="flex-1 w-full">{children}</div>
               <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,8 +72,14 @@ export default async function RootLayout({
 }>) {
   // Resolve the session on the server so the Navbar renders the correct auth
   // state on first paint (no signed-out flash). Cheap via the 5-min cookie
-  // cache; useSession() takes over client-side for live updates.
-  const initialSession = await getSession();
+  // cache; useSession() takes over client-side for live updates. Fail open: a
+  // transient auth/DB error must not 500 the whole app, including public pages.
+  let initialSession: Awaited<ReturnType<typeof getSession>> = null;
+  try {
+    initialSession = await getSession();
+  } catch {
+    initialSession = null;
+  }
 
   return (
     <html lang="en" className={sora.variable} suppressHydrationWarning>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -314,10 +314,16 @@ function DesktopNavItem({
 
 // ─── Main Navbar ─────────────────────────────────────────────────────────────
 
-const Navbar = () => {
+type NavbarSession = ReturnType<typeof useSession>["data"];
+
+const Navbar = ({ initialSession }: { initialSession?: NavbarSession }) => {
   const router = useRouter();
   const pathname = usePathname();
-  const { data: session } = useSession();
+  const { data, isPending } = useSession();
+  // Seed from the server-fetched session so the first paint shows the correct
+  // auth state instead of flashing the signed-out CTA until the client-side
+  // /get-session resolves. useSession takes over once it loads.
+  const session = isPending ? (data ?? initialSession ?? null) : data;
   const [isOpen, setIsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const { currency, symbol, setCurrency } = useCurrency();

--- a/docs/authentication/betterauth/03-sessions-and-hooks.md
+++ b/docs/authentication/betterauth/03-sessions-and-hooks.md
@@ -4,8 +4,8 @@
 |---|---|
 | Status | Stable |
 | Audience | All engineers |
-| Last reviewed | 2026-04-26 |
-| Source files | `lib/auth.ts` (lines 83–530), `lib/auth-server.ts`, `lib/auth-guard.ts` |
+| Last reviewed | 2026-06-17 |
+| Source files | `lib/auth.ts` (lines 83–530), `lib/auth-server.ts`, `lib/auth-guard.ts`, `lib/auth-client.ts`, `lib/auth-broadcast.ts`, `providers/AuthSyncProvider.tsx`, `app/layout.tsx`, `components/Navbar.tsx` |
 
 ## 1. Background
 
@@ -107,6 +107,16 @@ Defense-in-depth: mirrors the `session.create.before` logic to set `ssoEnforceme
 | **Error style** | `redirect()` — never returns | `NextResponse.json({ error }, { status })` |
 | **Functions** | `requireAuth`, `requireOnboarded`, `requireUserRole`, `requireNotOnboarded` | `requireApiAuth`, `requireAdminAuth`, `requireOrgAccess`, etc. |
 | **Session read** | `getSession()` or `getSession(true)` | `getSession(true)` always |
+
+### 2.5 Client Rendering and Cross-Tab Sync
+
+The client reads auth state through BetterAuth's `useSession()` hook, which fetches `/get-session` from the browser only after the page has hydrated. If a component renders the signed-out state while that fetch is in flight, the user sees a flash of the logged-out UI that then swaps to the logged-in UI a moment later. The shared `Navbar` previously did exactly this, which read as broken session persistence even though the cookie was present the whole time.
+
+Two pieces work together to make the rendered auth state correct and consistent across tabs:
+
+1. **Server seeding.** The root layout (`app/layout.tsx`) resolves the session on the server with `getSession()` and passes it to the `Navbar` as `initialSession`. The Navbar renders that server value while `useSession()` is still pending, so the first paint already shows the right state and there is no flash. Because this reads the session on every render of the root layout, it relies on the five-minute cookie cache to stay cheap, and it opts the layout into dynamic rendering.
+
+2. **Cross-tab propagation.** BetterAuth's client only broadcasts a session change to other tabs on sign-out and user-update, never on sign-in, and OAuth or SSO logins complete through a full-page redirect with no client fetch hook at all. As a result an already-open tab would not reflect a login elsewhere until it next regained focus (BetterAuth's built-in `visibilitychange` refetch). `AuthSyncProvider` (mounted once in the root layout) closes that gap: it detects this tab's logged-out to logged-in transition and pings peer tabs over a `BroadcastChannel`, and on receiving a ping it calls the `useSession` `refetch` so every consumer re-renders. The helper in `lib/auth-broadcast.ts` falls back to a `storage` event for browsers without `BroadcastChannel`. The provider renders nothing and shares the existing session atom, so it adds no extra `/get-session` request.
 
 ## 3. Operational Concerns
 

--- a/lib/auth-broadcast.ts
+++ b/lib/auth-broadcast.ts
@@ -1,0 +1,77 @@
+/**
+ * Cross-tab auth sync.
+ *
+ * BetterAuth's client only broadcasts a session change to other tabs on
+ * sign-out / update-user / update-session (better-auth `client/config.mjs`),
+ * never on sign-in — and OAuth/SSO complete via a full-page redirect with no
+ * client fetch listener at all. So an already-open tab keeps showing
+ * logged-out after you log in elsewhere until it next regains focus. We bridge
+ * that gap by emitting our own login/logout ping; peer tabs refetch on receipt.
+ *
+ * Prefers BroadcastChannel and falls back to a `storage`-event ping for
+ * browsers without it. SSR-safe (no-ops on the server). Best-effort throughout
+ * — a sync failure must never break auth.
+ */
+export const AUTH_SYNC_CHANNEL = "familiarise.auth";
+
+export type AuthSyncMessage = { type: "login" | "logout" };
+
+export function postAuthSync(message: AuthSyncMessage): void {
+  if (typeof window === "undefined") return;
+  try {
+    if ("BroadcastChannel" in window) {
+      const channel = new BroadcastChannel(AUTH_SYNC_CHANNEL);
+      channel.postMessage(message);
+      channel.close();
+      return;
+    }
+  } catch {
+    // fall through to the storage-event fallback
+  }
+  try {
+    // A value change is what fires `storage` in peer tabs, so stamp each ping.
+    localStorage.setItem(
+      AUTH_SYNC_CHANNEL,
+      JSON.stringify({ ...message, t: Date.now() }),
+    );
+  } catch {
+    // best-effort — ignore
+  }
+}
+
+export function subscribeAuthSync(
+  handler: (message: AuthSyncMessage) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const cleanups: Array<() => void> = [];
+
+  try {
+    if ("BroadcastChannel" in window) {
+      const channel = new BroadcastChannel(AUTH_SYNC_CHANNEL);
+      const onMessage = (event: MessageEvent) =>
+        handler(event.data as AuthSyncMessage);
+      channel.addEventListener("message", onMessage);
+      cleanups.push(() => {
+        channel.removeEventListener("message", onMessage);
+        channel.close();
+      });
+    }
+  } catch {
+    // ignore — storage fallback below still applies
+  }
+
+  // `storage` fires only in OTHER tabs of the same origin, which is exactly the
+  // peer-tab signal we want; it also covers browsers without BroadcastChannel.
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== AUTH_SYNC_CHANNEL || !event.newValue) return;
+    try {
+      handler(JSON.parse(event.newValue) as AuthSyncMessage);
+    } catch {
+      // ignore malformed payloads
+    }
+  };
+  window.addEventListener("storage", onStorage);
+  cleanups.push(() => window.removeEventListener("storage", onStorage));
+
+  return () => cleanups.forEach((fn) => fn());
+}

--- a/lib/auth-broadcast.ts
+++ b/lib/auth-broadcast.ts
@@ -16,6 +16,31 @@ export const AUTH_SYNC_CHANNEL = "familiarise.auth";
 
 export type AuthSyncMessage = { type: "login" | "logout" };
 
+// Last observed authed state, shared across tabs via localStorage. Lets a tab
+// tell a genuine login (null/false -> true, including the OAuth/SSO full-page
+// redirect) apart from a reload of an already-authed user, so a plain refresh
+// no longer fires a synthetic broadcast that spams peer-tab refetches.
+const AUTHED_FLAG_KEY = "familiarise.auth_authed";
+
+export function readAuthedFlag(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = localStorage.getItem(AUTHED_FLAG_KEY);
+    return value === null ? null : value === "true";
+  } catch {
+    return null;
+  }
+}
+
+export function writeAuthedFlag(authed: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(AUTHED_FLAG_KEY, authed ? "true" : "false");
+  } catch {
+    // best-effort — ignore
+  }
+}
+
 export function postAuthSync(message: AuthSyncMessage): void {
   if (typeof window === "undefined") return;
   try {

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -4,7 +4,9 @@ import { ssoClient } from "@better-auth/sso/client";
 import type { auth } from "@/lib/auth";
 
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL,
+  // Empty string would be a truthy-enough config that breaks URL resolution;
+  // coerce to undefined so BetterAuth falls back to the same-origin /api/auth.
+  baseURL: process.env.NEXT_PUBLIC_APP_URL || undefined,
   // ssoClient exposes authClient.signIn.sso(), which generates the OIDC PKCE
   // code_verifier/code_challenge pair and persists the verifier so the
   // callback can validate it. A raw POST to /api/auth/sign-in/sso would

--- a/providers/AuthSyncProvider.tsx
+++ b/providers/AuthSyncProvider.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useSession } from "@/lib/auth-client";
-import { postAuthSync, subscribeAuthSync } from "@/lib/auth-broadcast";
+import {
+  postAuthSync,
+  readAuthedFlag,
+  subscribeAuthSync,
+  writeAuthedFlag,
+} from "@/lib/auth-broadcast";
 
 /**
  * Keeps the auth session in sync across browser tabs.
@@ -17,8 +22,7 @@ import { postAuthSync, subscribeAuthSync } from "@/lib/auth-broadcast";
  * Renders nothing. See `lib/auth-broadcast.ts` for why this is needed.
  */
 export default function AuthSyncProvider() {
-  const { data: session, refetch } = useSession();
-  const prevAuthed = useRef<boolean | undefined>(undefined);
+  const { data: session, isPending, refetch } = useSession();
 
   useEffect(() => {
     return subscribeAuthSync(() => {
@@ -27,13 +31,21 @@ export default function AuthSyncProvider() {
   }, [refetch]);
 
   useEffect(() => {
+    // The loading phase is not a transition — wait for the session to resolve.
+    if (isPending) return;
+
     const authed = !!session?.user;
-    // Skip the first render (undefined) so initial hydration doesn't ping.
-    if (prevAuthed.current !== undefined && prevAuthed.current !== authed) {
+    // Compare against the cross-tab flag, not just this tab's previous render:
+    // a reload of an already-authed user matches the flag and stays silent,
+    // while a genuine login (incl. the OAuth/SSO redirect, which has no client
+    // fetch hook) flips it and pings peers. Skip when the flag is unset (first
+    // ever load) so we never broadcast without a real before-state.
+    const previous = readAuthedFlag();
+    if (previous !== null && previous !== authed) {
       postAuthSync({ type: authed ? "login" : "logout" });
     }
-    prevAuthed.current = authed;
-  }, [session]);
+    writeAuthedFlag(authed);
+  }, [isPending, session]);
 
   return null;
 }

--- a/providers/AuthSyncProvider.tsx
+++ b/providers/AuthSyncProvider.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSession } from "@/lib/auth-client";
+import { postAuthSync, subscribeAuthSync } from "@/lib/auth-broadcast";
+
+/**
+ * Keeps the auth session in sync across browser tabs.
+ *
+ * Mounted once at the root. It does two things:
+ *   1. Listens for login/logout pings from peer tabs and refetches this tab's
+ *      session so every `useSession()` consumer re-renders without a reload.
+ *   2. Detects this tab's own logged-out⇄logged-in transition (covers email
+ *      sign-in AND the OAuth/SSO redirect, which has no client fetch hook) and
+ *      pings peers so they refetch too.
+ *
+ * Renders nothing. See `lib/auth-broadcast.ts` for why this is needed.
+ */
+export default function AuthSyncProvider() {
+  const { data: session, refetch } = useSession();
+  const prevAuthed = useRef<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    return subscribeAuthSync(() => {
+      refetch?.();
+    });
+  }, [refetch]);
+
+  useEffect(() => {
+    const authed = !!session?.user;
+    // Skip the first render (undefined) so initial hydration doesn't ping.
+    if (prevAuthed.current !== undefined && prevAuthed.current !== authed) {
+      postAuthSync({ type: authed ? "login" : "logout" });
+    }
+    prevAuthed.current = authed;
+  }, [session]);
+
+  return null;
+}

--- a/providers/AuthSyncProvider.tsx
+++ b/providers/AuthSyncProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSession } from "@/lib/auth-client";
 import {
   postAuthSync,
@@ -23,6 +23,10 @@ import {
  */
 export default function AuthSyncProvider() {
   const { data: session, isPending, refetch } = useSession();
+  // In-memory fallback for the previous authed state, used when the cross-tab
+  // localStorage flag is unavailable (private mode / blocked storage) so
+  // BroadcastChannel sync still works there. Resets per page load.
+  const previousAuthedRef = useRef<boolean | undefined>(undefined);
 
   useEffect(() => {
     return subscribeAuthSync(() => {
@@ -35,15 +39,17 @@ export default function AuthSyncProvider() {
     if (isPending) return;
 
     const authed = !!session?.user;
-    // Compare against the cross-tab flag, not just this tab's previous render:
-    // a reload of an already-authed user matches the flag and stays silent,
-    // while a genuine login (incl. the OAuth/SSO redirect, which has no client
-    // fetch hook) flips it and pings peers. Skip when the flag is unset (first
-    // ever load) so we never broadcast without a real before-state.
-    const previous = readAuthedFlag();
-    if (previous !== null && previous !== authed) {
+    // Prefer the cross-tab flag (a reload of an already-authed user matches it
+    // and stays silent; a genuine login — incl. the OAuth/SSO redirect, which
+    // has no client fetch hook — flips it and pings peers). Fall back to the
+    // in-memory ref when the flag is unavailable, so broadcasting isn't gated
+    // off entirely when localStorage is blocked. Undefined previous = first
+    // observed state this load, so we never ping without a real before-state.
+    const previous = readAuthedFlag() ?? previousAuthedRef.current;
+    if (previous !== undefined && previous !== authed) {
       postAuthSync({ type: authed ? "login" : "logout" });
     }
+    previousAuthedRef.current = authed;
     writeAuthedFlag(authed);
   }, [isPending, session]);
 


### PR DESCRIPTION
## Problem

Logging in on one tab appeared not to persist to another, and a freshly loaded/reloaded tab showed the **"Sign in"** button first and only swapped to the profile avatar after a noticeable delay.

Root cause was **not** a cookie/persistence failure — the session cookie is httpOnly and shared across tabs the whole time. The `Navbar` is a client component that resolves auth state **only** through `useSession()`, which fetches `/get-session` *after* hydration, and it rendered the signed-out CTA while that fetch was in flight (it never checked `isPending`). The delay is amplified because `customSession` does real work (membership refetch + JIT) on every `/get-session`.

## Changes

- **Server-seed the session (the fix for the flash).** `app/layout.tsx` reads `getSession()` on the server and passes it to `<Navbar initialSession={…} />`. The Navbar renders the server value while `useSession()` is pending (`isPending ? (data ?? initialSession) : data`), so the **first paint is correct** with no flicker, and `useSession()` takes over for live updates. This opts the root layout into dynamic rendering; it stays cheap via the 5-minute cookie cache.
- **Cross-tab live sync.** `providers/AuthSyncProvider.tsx` + `lib/auth-broadcast.ts` propagate login/logout to peer tabs instantly. BetterAuth's client never broadcasts on sign-in, and OAuth/SSO complete via a full-page redirect with no client hook, so an already-open tab would otherwise update only on window-focus refetch. The provider renders nothing and shares the existing session atom (no extra `/get-session` request); it falls back to a `storage` event where `BroadcastChannel` is unavailable.
- **Config.** `lib/auth-client.ts` coerces an empty `NEXT_PUBLIC_APP_URL` to `undefined` so BetterAuth resolves the same-origin `/api/auth` instead of a broken base.
- **Docs.** New §2.5 in `docs/authentication/betterauth/03-sessions-and-hooks.md` documenting both mechanisms.

## Verification

- `tsc --noEmit` → 0 errors (the `initialSession` types line up between server `getSession()` and the Navbar prop).
- `eslint` clean on all touched files.
- Manual browser check (reviewer): load/reload while logged in → no signed-out flash; log in on tab A → tab B reflects it without a manual refresh; sign-out still propagates.

## Notes / follow-ups

- `NEXT_PUBLIC_APP_URL` should be set per environment (referral/absolute links); the empty-value fallback here just prevents breakage.
- Email-verification hardening and the referral first-touch capture/apply (which fixes the OAuth referral drop) are a **separate PR**, tracked in #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-tab authentication synchronization to keep login/logout state consistent across open tabs in real time.
  * Improved initial session handling by seeding authentication state on first render to avoid signed-out UI flashes.
* **Bug Fixes**
  * Hardened auth synchronization for server-side rendering and improved client base URL handling for more reliable same-origin fallback.
* **Documentation**
  * Updated authentication docs with details on initial session seeding and cross-tab synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->