### PR TITLE
fix(dpdp): align seed consent purpose codes with the fail-closed Stream gate

### DIFF
--- a/actions/stream/chat/event-channel.action.ts
+++ b/actions/stream/chat/event-channel.action.ts
@@ -19,6 +19,7 @@ import {
 import { upsertUserToStream, upsertUsersToStream } from "./user.action";
 import { MANAGED_CHANNEL_PREFIXES } from "@/lib/stream-channel-ids";
 import { getDmChannelId } from "@/lib/stream-utils";
+import { ConsentRequiredError } from "@/lib/compliance/dpdp";
 
 // Validation schemas
 const eventTypeSchema = z.enum([
@@ -475,8 +476,27 @@ export async function syncUserEventChannels(
   const startTime = Date.now();
 
   try {
-    // Upsert the user to Stream first
-    await upsertUserToStream(userId);
+    // Upsert the user to Stream first. A DPDP consent gate (no/withdrawn
+    // STREAM_DATA_PROCESSING consent) is a deliberate refusal, NOT a failure:
+    // degrade gracefully by skipping the whole Stream sync rather than letting
+    // it bubble as an unhandled error through the dashboard-load path. The gate
+    // is unchanged — we simply don't crash the page for a non-consenting user.
+    try {
+      await upsertUserToStream(userId);
+    } catch (err) {
+      if (err instanceof ConsentRequiredError) {
+        streamLogger.info("Skipping channel sync — Stream consent not granted", {
+          userId,
+          purposeCode: err.purposeCode,
+        });
+        // Mark sync "completed" for this session so we don't retry the gated
+        // upsert on every navigation; a re-grant clears caches via the consent
+        // flow and a forced re-sync re-attempts it.
+        initialSyncCompletedUsers.add(userId);
+        return { success: true, skipped: true };
+      }
+      throw err;
+    }
 
     // Grab the Stream server client (needed for reconciliation query)
     const client = getStreamChatClient();

--- a/actions/stream/chat/user.action.ts
+++ b/actions/stream/chat/user.action.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/stream-client";
 import { streamLogger } from "@/lib/stream-logger";
 import { markUserSynced, isUserSynced } from "@/lib/stream-cache";
-import { checkConsent } from "@/lib/compliance/dpdp";
+import { checkConsent, ConsentRequiredError } from "@/lib/compliance/dpdp";
 
 // Input validation schemas
 const userIdSchema = z.string().min(1, "User ID is required");
@@ -56,9 +56,11 @@ export const upsertUserToStream = async (userId: string) => {
 
     // DPDP Act 2023: refuse to hand user PII over to Stream.io when the
     // user has withdrawn (or never granted) consent for STREAM_DATA_PROCESSING.
-    // The signup hook auto-stamps this; an in-app withdrawal via
-    // /api/organizations/[orgId]/consent revokes it and `checkConsent`
-    // returns false, killing future video/chat sessions until re-granted.
+    // The signup hook auto-stamps this; a full opt-out via the org consent
+    // flow (DELETE /api/organizations/[orgId]/consent with no purposeCode)
+    // revokes it and `checkConsent` returns false, killing future video/chat
+    // sessions. There is no personal self-service re-grant page today; consent
+    // is re-established by an org admin via that consent route (#701).
     const hasStreamConsent = await checkConsent({
       userId: user.id,
       purposeCode: "STREAM_DATA_PROCESSING",
@@ -67,8 +69,9 @@ export const upsertUserToStream = async (userId: string) => {
       streamLogger.warn("Refusing Stream upsert — STREAM_DATA_PROCESSING consent absent", {
         userId: user.id,
       });
-      throw new Error(
-        "Stream video/chat consent is required. Please re-grant data processing consent under Account → Privacy.",
+      throw new ConsentRequiredError(
+        "STREAM_DATA_PROCESSING",
+        "Video and chat are unavailable because data-processing consent for messaging has not been granted (or was withdrawn). Consent is established at signup and managed by your organization administrator.",
       );
     }
 

--- a/actions/stream/chat/user.action.ts
+++ b/actions/stream/chat/user.action.ts
@@ -11,6 +11,7 @@ import {
 import { streamLogger } from "@/lib/stream-logger";
 import { markUserSynced, isUserSynced } from "@/lib/stream-cache";
 import { checkConsent, ConsentRequiredError } from "@/lib/compliance/dpdp";
+import { PURPOSE_CODES } from "@/lib/compliance/purpose-codes";
 
 // Input validation schemas
 const userIdSchema = z.string().min(1, "User ID is required");
@@ -63,14 +64,14 @@ export const upsertUserToStream = async (userId: string) => {
     // is re-established by an org admin via that consent route (#701).
     const hasStreamConsent = await checkConsent({
       userId: user.id,
-      purposeCode: "STREAM_DATA_PROCESSING",
+      purposeCode: PURPOSE_CODES.STREAM_DATA_PROCESSING,
     });
     if (!hasStreamConsent) {
       streamLogger.warn("Refusing Stream upsert — STREAM_DATA_PROCESSING consent absent", {
         userId: user.id,
       });
       throw new ConsentRequiredError(
-        "STREAM_DATA_PROCESSING",
+        PURPOSE_CODES.STREAM_DATA_PROCESSING,
         "Video and chat are unavailable because data-processing consent for messaging has not been granted (or was withdrawn). Consent is established at signup and managed by your organization administrator.",
       );
     }
@@ -164,7 +165,7 @@ export const upsertUsersToStream = async (userIds: string[]) => {
         user: u,
         hasConsent: await checkConsent({
           userId: u.id,
-          purposeCode: "STREAM_DATA_PROCESSING",
+          purposeCode: PURPOSE_CODES.STREAM_DATA_PROCESSING,
         }),
       })),
     );

--- a/actions/stream/chat/user.action.ts
+++ b/actions/stream/chat/user.action.ts
@@ -107,6 +107,12 @@ export const upsertUserToStream = async (userId: string) => {
 
     return streamUser;
   } catch (error) {
+    // A consent gate is a deliberate refusal (already warn-logged above), not
+    // an infra failure — rethrow without an error-level log so it doesn't
+    // pollute error-monitoring dashboards with false positives.
+    if (error instanceof ConsentRequiredError) {
+      throw error;
+    }
     streamLogger.error("Failed to upsert user to Stream", error, {
       userId: validatedUserId,
     });

--- a/app/api/organizations/[orgId]/consent/route.ts
+++ b/app/api/organizations/[orgId]/consent/route.ts
@@ -23,6 +23,7 @@ import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { buildConsentArtifact, withdrawConsent } from "@/lib/compliance/dpdp";
+import { normalizePurposeCode } from "@/lib/compliance/purpose-codes";
 
 // Schedule VIII of the Indian Constitution enumerates 22 languages.
 // Plus English as the lingua franca for enterprise UIs. Accept ISO 639-1
@@ -105,6 +106,14 @@ export async function POST(
   }
   const body = parsed.data;
 
+  // Normalise any legacy kebab-case codes to the single canonical taxonomy
+  // (lib/compliance/purpose-codes.ts) before they hit storage, so the
+  // fail-closed runtime gate and the dashboard never diverge again. Unknown
+  // free-form codes pass through unchanged (still accepted by the schema).
+  const purposeCodes = Array.from(
+    new Set(body.purposeCodes.map(normalizePurposeCode)),
+  );
+
   // Cross-org check: caller must be recording consent for an actual
   // member of this org.
   const member = await prisma.membership.findUnique({
@@ -123,7 +132,7 @@ export async function POST(
   const draft = buildConsentArtifact({
     userId: body.userId,
     dataFiduciary: `org:${orgId}`,
-    purposeCodes: body.purposeCodes,
+    purposeCodes,
     language: body.language,
     consentManager: body.consentManager ?? null,
     version: body.version,
@@ -148,7 +157,7 @@ export async function POST(
         description: `Consent granted for member ${member.id}`,
         details: {
           membershipId: member.id,
-          purposeCodes: body.purposeCodes,
+          purposeCodes,
           language: body.language,
           version: body.version,
           hash: draft.hash,
@@ -202,7 +211,13 @@ export async function DELETE(
       { status: 400 },
     );
   }
-  const { userId, purposeCode } = parsed.data;
+  const { userId } = parsed.data;
+  // Normalise a legacy kebab-case scope to canonical so a withdrawal targets
+  // the same code the gate/storage uses (e.g. third-party-sharing-with-stream
+  // → STREAM_DATA_PROCESSING).
+  const purposeCode = parsed.data.purposeCode
+    ? normalizePurposeCode(parsed.data.purposeCode)
+    : undefined;
 
   // Cross-org guard: same logic as POST — only members of this org can
   // have their consent withdrawn through this endpoint.

--- a/app/api/organizations/[orgId]/consent/route.ts
+++ b/app/api/organizations/[orgId]/consent/route.ts
@@ -106,12 +106,25 @@ export async function POST(
   }
   const body = parsed.data;
 
-  // Normalise any legacy kebab-case codes to the single canonical taxonomy
-  // (lib/compliance/purpose-codes.ts) before they hit storage, so the
-  // fail-closed runtime gate and the dashboard never diverge again. Unknown
-  // free-form codes pass through unchanged (still accepted by the schema).
+  // Normalise to the single canonical taxonomy (lib/compliance/purpose-codes.ts)
+  // before storage, so the fail-closed runtime gate and the dashboard never
+  // diverge again. `normalizePurposeCode` returns undefined for codes that are
+  // neither a legacy alias nor already canonical — reject the whole request
+  // rather than silently storing/dropping them, so non-canonical strings can
+  // never re-enter the taxonomy.
+  const normalized = body.purposeCodes.map((c) => ({
+    raw: c,
+    code: normalizePurposeCode(c),
+  }));
+  const unknown = normalized.filter((n) => n.code === undefined).map((n) => n.raw);
+  if (unknown.length > 0) {
+    return NextResponse.json(
+      { error: "Unknown purpose code(s)", detail: { unknown } },
+      { status: 400 },
+    );
+  }
   const purposeCodes = Array.from(
-    new Set(body.purposeCodes.map(normalizePurposeCode)),
+    new Set(normalized.map((n) => n.code as string)),
   );
 
   // Cross-org check: caller must be recording consent for an actual
@@ -214,10 +227,19 @@ export async function DELETE(
   const { userId } = parsed.data;
   // Normalise a legacy kebab-case scope to canonical so a withdrawal targets
   // the same code the gate/storage uses (e.g. third-party-sharing-with-stream
-  // → STREAM_DATA_PROCESSING).
-  const purposeCode = parsed.data.purposeCode
-    ? normalizePurposeCode(parsed.data.purposeCode)
-    : undefined;
+  // → STREAM_DATA_PROCESSING). An unknown code must 400 — NOT fall back to
+  // undefined, which `withdrawConsent` reads as "withdraw ALL consents" and
+  // would silently escalate a scoped request into a full opt-out.
+  let purposeCode: string | undefined;
+  if (parsed.data.purposeCode) {
+    purposeCode = normalizePurposeCode(parsed.data.purposeCode);
+    if (purposeCode === undefined) {
+      return NextResponse.json(
+        { error: "Unknown purpose code", detail: { purposeCode: parsed.data.purposeCode } },
+        { status: 400 },
+      );
+    }
+  }
 
   // Cross-org guard: same logic as POST — only members of this org can
   // have their consent withdrawn through this endpoint.

--- a/app/api/organizations/[orgId]/consent/route.ts
+++ b/app/api/organizations/[orgId]/consent/route.ts
@@ -23,7 +23,10 @@ import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { buildConsentArtifact, withdrawConsent } from "@/lib/compliance/dpdp";
-import { normalizePurposeCode } from "@/lib/compliance/purpose-codes";
+import {
+  normalizePurposeCode,
+  type PurposeCode,
+} from "@/lib/compliance/purpose-codes";
 
 // Schedule VIII of the Indian Constitution enumerates 22 languages.
 // Plus English as the lingua franca for enterprise UIs. Accept ISO 639-1
@@ -123,8 +126,9 @@ export async function POST(
       { status: 400 },
     );
   }
+  // Unknowns rejected above, so every `code` is a narrowed PurposeCode here.
   const purposeCodes = Array.from(
-    new Set(normalized.map((n) => n.code as string)),
+    new Set(normalized.map((n) => n.code as PurposeCode)),
   );
 
   // Cross-org check: caller must be recording consent for an actual
@@ -230,7 +234,7 @@ export async function DELETE(
   // → STREAM_DATA_PROCESSING). An unknown code must 400 — NOT fall back to
   // undefined, which `withdrawConsent` reads as "withdraw ALL consents" and
   // would silently escalate a scoped request into a full opt-out.
-  let purposeCode: string | undefined;
+  let purposeCode: PurposeCode | undefined;
   if (parsed.data.purposeCode) {
     purposeCode = normalizePurposeCode(parsed.data.purposeCode);
     if (purposeCode === undefined) {

--- a/app/dashboard/organization/[orgId]/consent/page.tsx
+++ b/app/dashboard/organization/[orgId]/consent/page.tsx
@@ -48,6 +48,11 @@ import {
   ResponsiveTable,
   type ResponsiveColumn,
 } from "@/components/ui/responsive-table";
+import {
+  ALL_PURPOSE_CODES,
+  PURPOSE_CODE_META,
+  PURPOSE_CODES,
+} from "@/lib/compliance/purpose-codes";
 
 type ConsentArtifact = {
   id: string;
@@ -67,15 +72,12 @@ type Member = {
   role: string;
 };
 
-// Granular purpose taxonomy per the DPDP stub (lib/compliance/dpdp.ts).
-// Free-form codes are still accepted by the API; this is the curated set
-// the dashboard offers as one-click toggles.
-const PURPOSE_CODES = [
-  "session-booking",
-  "marketing",
-  "analytics",
-  "third-party-sharing-with-stream",
-] as const;
+// Granular purpose taxonomy — the SINGLE canonical set shared with the
+// runtime gate (lib/compliance/purpose-codes.ts). The dashboard offers each
+// canonical code as a one-click toggle; crucially the Stream toggle now
+// grants/withdraws STREAM_DATA_PROCESSING, so a user CAN re-grant the consent
+// the fail-closed video/chat gate reads. Free-form codes are still accepted by
+// the API, but the UI only ever emits canonical codes.
 
 // Schedule VIII languages we surface in v1 (English + the most common
 // Indian-enterprise locales). The API accepts any ISO 639-1/2 code.
@@ -112,7 +114,7 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
   // a purpose-code toggle list, and a language select.
   const [grantUserId, setGrantUserId] = useState("");
   const [grantPurposes, setGrantPurposes] = useState<Set<string>>(
-    new Set(["session-booking"]),
+    new Set([PURPOSE_CODES.PRIMARY_PROCESSING]),
   );
   const [grantLanguage, setGrantLanguage] = useState("en");
   const [actionError, setActionError] = useState<string | null>(null);
@@ -170,7 +172,7 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
     onSuccess: () => {
       setActionError(null);
       setGrantUserId("");
-      setGrantPurposes(new Set(["session-booking"]));
+      setGrantPurposes(new Set([PURPOSE_CODES.PRIMARY_PROCESSING]));
       setGrantLanguage("en");
       qc.invalidateQueries({ queryKey: ["org-consents", orgId] });
     },
@@ -209,6 +211,11 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
     });
   };
 
+  // Friendly label for a stored code; falls back to the raw value so any
+  // legacy/free-form code still renders.
+  const purposeLabel = (code: string) =>
+    PURPOSE_CODE_META[code as keyof typeof PURPOSE_CODE_META]?.label ?? code;
+
   const rows = consents.data ?? [];
   const active = rows.filter((r) => r.withdrawnAt === null);
   const history = rows.filter((r) => r.withdrawnAt !== null);
@@ -242,10 +249,10 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
               variant="secondary"
               className="bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
             >
-              {p}
+              {purposeLabel(p)}
               <button
                 type="button"
-                title={`Withdraw "${p}"`}
+                title={`Withdraw "${purposeLabel(p)}"`}
                 className="ml-1 text-emerald-700/70 hover:text-emerald-900 dark:text-emerald-300/70 dark:hover:text-emerald-200"
                 disabled={withdraw.isPending}
                 onClick={() =>
@@ -311,7 +318,7 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
               variant="secondary"
               className="bg-muted text-muted-foreground"
             >
-              {p}
+              {purposeLabel(p)}
             </Badge>
           ))}
         </div>
@@ -388,12 +395,14 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
               <div className="flex flex-col gap-1.5">
                 <Label>Purposes</Label>
                 <div className="flex flex-wrap gap-2">
-                  {PURPOSE_CODES.map((code) => {
+                  {ALL_PURPOSE_CODES.map((code) => {
                     const on = grantPurposes.has(code);
+                    const meta = PURPOSE_CODE_META[code];
                     return (
                       <button
                         key={code}
                         type="button"
+                        title={meta.description}
                         onClick={() => togglePurpose(code)}
                         className={
                           on
@@ -402,7 +411,7 @@ export default function ConsentPage({ params }: Readonly<PageProps>) {
                         }
                         aria-pressed={on}
                       >
-                        {code}
+                        {meta.label}
                       </button>
                     );
                   })}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -17,6 +17,7 @@ import { syncSubscriber } from "@/lib/novu/subscriber";
 import { shouldRejectSession, lookupEnforcedOrg } from "@/lib/sso/enforce-session";
 import { applyMembershipRoleEffects } from "@/lib/api/organizations/membership-transitions";
 import { buildConsentArtifact } from "@/lib/compliance/dpdp";
+import { PURPOSE_CODES } from "@/lib/compliance/purpose-codes";
 
 export const auth = betterAuth({
   secret: process.env.BETTER_AUTH_SECRET,
@@ -239,15 +240,15 @@ export const auth = betterAuth({
             // DPDP Act 2023: stamp a ConsentArtifact for the essential
             // purposes covered by the signup action (account creation
             // requires data processing for service delivery + video/chat
-            // handoff to Stream.io). MARKETING_COMMS / analytics consent
+            // handoff to Stream.io). MARKETING_COMMS / ANALYTICS consent
             // is not stamped here — those require an explicit checkbox
             // on the signup form (P1 follow-up; see #701). When a user
             // hits the in-app withdrawal flow (/api/.../consent), this
             // artifact is superseded and `checkConsent` fails closed.
             try {
               for (const purposeCode of [
-                "PRIMARY_PROCESSING",
-                "STREAM_DATA_PROCESSING",
+                PURPOSE_CODES.PRIMARY_PROCESSING,
+                PURPOSE_CODES.STREAM_DATA_PROCESSING,
               ] as const) {
                 const draft = buildConsentArtifact({
                   userId: user.id,

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -67,6 +67,7 @@
 
 import { createHash } from "node:crypto";
 import prisma from "@/lib/prisma";
+import type { PurposeCode } from "./purpose-codes";
 
 /**
  * Thrown when a purpose-scoped action is blocked because the user has not
@@ -76,8 +77,8 @@ import prisma from "@/lib/prisma";
  * without weakening the gate itself.
  */
 export class ConsentRequiredError extends Error {
-  readonly purposeCode: string;
-  constructor(purposeCode: string, message: string) {
+  readonly purposeCode: PurposeCode;
+  constructor(purposeCode: PurposeCode, message: string) {
     super(message);
     this.name = "ConsentRequiredError";
     this.purposeCode = purposeCode;

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -17,8 +17,10 @@
  *
  * 1. Consent artifact per purpose:
  *      - User explicitly grants consent for each data-processing purpose.
- *      - Purposes must be granular (e.g. "session-booking", "marketing",
- *        "analytics", "third-party-sharing-with-stream").
+ *      - Purposes must be granular and drawn from the SINGLE canonical
+ *        taxonomy in `lib/compliance/purpose-codes.ts` (PURPOSE_CODES):
+ *        PRIMARY_PROCESSING, SESSION_BOOKING, STREAM_DATA_PROCESSING,
+ *        MARKETING_COMMS, ANALYTICS. Do not introduce ad-hoc string literals.
  *      - Notice must be presented in English + any of the 22 Schedule VIII
  *        languages the user selects. Store language code on the artifact.
  *
@@ -186,8 +188,8 @@ export async function checkConsent(params: {
  *
  * Narrow-scoped withdrawal (a single purposeCode) stamps `withdrawnAt`
  * only on artifacts whose purposeCode list contains the target. This
- * lets a user revoke "marketing" without losing their core
- * "session-booking" consent.
+ * lets a user revoke MARKETING_COMMS without losing their core
+ * PRIMARY_PROCESSING consent (canonical codes: lib/compliance/purpose-codes.ts).
  */
 export async function withdrawConsent(params: {
   userId: string;

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -88,7 +88,10 @@ export class ConsentRequiredError extends Error {
 export interface ConsentGrantInput {
   userId: string;
   dataFiduciary: string;
-  purposeCodes: string[];
+  // Canonical codes only — callers normalize raw/dynamic input at the
+  // boundary (normalizePurposeCode) so the taxonomy is enforced at compile
+  // time, not just by the runtime gate (#895).
+  purposeCodes: PurposeCode[];
   language: string; // ISO 639-1 or Schedule VIII code
   consentManager?: string | null;
   version: number;
@@ -98,7 +101,7 @@ export interface ConsentGrantInput {
 export interface ConsentArtifactDraft {
   userId: string;
   dataFiduciary: string;
-  purposeCodes: string[];
+  purposeCodes: PurposeCode[];
   language: string;
   consentManager: string | null;
   version: number;
@@ -163,7 +166,7 @@ export function buildConsentArtifact(input: ConsentGrantInput): ConsentArtifactD
  */
 export async function checkConsent(params: {
   userId: string;
-  purposeCode: string;
+  purposeCode: PurposeCode;
 }): Promise<boolean> {
   const { userId, purposeCode } = params;
   const now = new Date();
@@ -194,7 +197,7 @@ export async function checkConsent(params: {
  */
 export async function withdrawConsent(params: {
   userId: string;
-  purposeCode?: string;
+  purposeCode?: PurposeCode;
 }): Promise<{ withdrawnCount: number }> {
   const { userId, purposeCode } = params;
   const now = new Date();

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -66,6 +66,22 @@
 import { createHash } from "node:crypto";
 import prisma from "@/lib/prisma";
 
+/**
+ * Thrown when a purpose-scoped action is blocked because the user has not
+ * granted (or has withdrawn) the required consent. Typed so callers can
+ * distinguish a deliberate DPDP gate from an infra failure and degrade
+ * gracefully (skip the processing) instead of erroring the whole path —
+ * without weakening the gate itself.
+ */
+export class ConsentRequiredError extends Error {
+  readonly purposeCode: string;
+  constructor(purposeCode: string, message: string) {
+    super(message);
+    this.name = "ConsentRequiredError";
+    this.purposeCode = purposeCode;
+  }
+}
+
 export interface ConsentGrantInput {
   userId: string;
   dataFiduciary: string;

--- a/lib/compliance/index.ts
+++ b/lib/compliance/index.ts
@@ -32,4 +32,5 @@ export * from "./msme";
 export * from "./gst";
 export * from "./irp";
 export * from "./dpdp";
+export * from "./purpose-codes";
 export * from "./form15";

--- a/lib/compliance/purpose-codes.ts
+++ b/lib/compliance/purpose-codes.ts
@@ -1,0 +1,92 @@
+/**
+ * DPDP (Digital Personal Data Protection Act 2023) — canonical consent
+ * purpose-code taxonomy. SINGLE source of truth for every code stored on a
+ * `ConsentArtifact.purposeCodes[]` and every `checkConsent` gate.
+ *
+ * Why one taxonomy: DPDP §6 requires consent to be specific (not bundled) and
+ * revocable, and Rule 3 requires an itemised, plain-language purpose notice.
+ * The data fiduciary (this app, the controller) defines the purposes; the
+ * processor (Stream.io) must act within them. Two parallel taxonomies — the
+ * runtime UPPER_SNAKE gate vs. the org-UI kebab-case toggles — meant a user
+ * could withdraw "third-party-sharing-with-stream" in the UI without ever
+ * touching the STREAM_DATA_PROCESSING code the gate reads, and had no UI path
+ * to re-grant it. The UPPER_SNAKE side wins because the fail-closed gate
+ * already depends on it; the kebab-case codes were dashboard-only and never
+ * consulted at runtime.
+ *
+ * NOTE: kept independent of dpdp.ts (no Prisma import) so it can be imported
+ * from server actions, route handlers, client components, and the seed alike
+ * without dragging the Prisma client into the client bundle.
+ */
+
+export const PURPOSE_CODES = {
+  /** Core service/account processing required to deliver the platform. */
+  PRIMARY_PROCESSING: "PRIMARY_PROCESSING",
+  /** Handoff of user PII to Stream.io for video/chat (third-party processor). */
+  STREAM_DATA_PROCESSING: "STREAM_DATA_PROCESSING",
+  /** Marketing/promotional communications. */
+  MARKETING_COMMS: "MARKETING_COMMS",
+  /** Product/usage analytics. */
+  ANALYTICS: "ANALYTICS",
+  /** Booking/scheduling of consultation sessions. */
+  SESSION_BOOKING: "SESSION_BOOKING",
+} as const;
+
+export type PurposeCode = (typeof PURPOSE_CODES)[keyof typeof PURPOSE_CODES];
+
+/** Every canonical code as a flat array (e.g. for zod enums, UI lists). */
+export const ALL_PURPOSE_CODES = Object.values(PURPOSE_CODES) as PurposeCode[];
+
+/**
+ * Human-readable labels + descriptions for the org consent dashboard. The
+ * description doubles as the itemised purpose text DPDP Rule 3 requires the
+ * notice to carry.
+ */
+export const PURPOSE_CODE_META: Record<
+  PurposeCode,
+  { label: string; description: string }
+> = {
+  [PURPOSE_CODES.PRIMARY_PROCESSING]: {
+    label: "Service & account",
+    description:
+      "Process your data to create and run your account and deliver the platform's core features.",
+  },
+  [PURPOSE_CODES.SESSION_BOOKING]: {
+    label: "Session booking",
+    description:
+      "Schedule, manage, and run consultation sessions you book or are booked into.",
+  },
+  [PURPOSE_CODES.STREAM_DATA_PROCESSING]: {
+    label: "Video & chat (Stream.io)",
+    description:
+      "Share the data needed for live video and chat with our messaging processor (Stream.io). Required for video/chat to work.",
+  },
+  [PURPOSE_CODES.MARKETING_COMMS]: {
+    label: "Marketing communications",
+    description:
+      "Send you marketing and promotional messages about products and offers.",
+  },
+  [PURPOSE_CODES.ANALYTICS]: {
+    label: "Analytics",
+    description: "Use your usage data to measure and improve the product.",
+  },
+} as const;
+
+/**
+ * Migration map from the legacy kebab-case dashboard taxonomy to the canonical
+ * codes. Retained so any historical artifacts (or external callers still
+ * sending the old strings) can be normalised on read/write. The DB itself is
+ * NOT backfilled here (pre-MVP reset coming); this is the lookup table.
+ */
+export const LEGACY_PURPOSE_CODE_MAP: Record<string, PurposeCode> = {
+  "session-booking": PURPOSE_CODES.SESSION_BOOKING,
+  "marketing": PURPOSE_CODES.MARKETING_COMMS,
+  "analytics": PURPOSE_CODES.ANALYTICS,
+  "third-party-sharing-with-stream": PURPOSE_CODES.STREAM_DATA_PROCESSING,
+  "account-management": PURPOSE_CODES.PRIMARY_PROCESSING,
+};
+
+/** Normalise a possibly-legacy purpose code to its canonical form. */
+export function normalizePurposeCode(code: string): string {
+  return LEGACY_PURPOSE_CODE_MAP[code] ?? code;
+}

--- a/lib/compliance/purpose-codes.ts
+++ b/lib/compliance/purpose-codes.ts
@@ -86,7 +86,19 @@ export const LEGACY_PURPOSE_CODE_MAP: Record<string, PurposeCode> = {
   "account-management": PURPOSE_CODES.PRIMARY_PROCESSING,
 };
 
-/** Normalise a possibly-legacy purpose code to its canonical form. */
-export function normalizePurposeCode(code: string): string {
-  return LEGACY_PURPOSE_CODE_MAP[code] ?? code;
+/** Canonical-code membership set, for O(1) "is this already canonical?" checks. */
+const CANONICAL_PURPOSE_CODE_SET = new Set<PurposeCode>(ALL_PURPOSE_CODES);
+
+/**
+ * Normalise a possibly-legacy purpose code to its canonical form. Returns
+ * `undefined` for codes that are neither a known legacy alias nor already
+ * canonical — callers MUST drop/reject those rather than storing them, so
+ * non-canonical strings can never re-enter the taxonomy and recreate drift.
+ */
+export function normalizePurposeCode(code: string): PurposeCode | undefined {
+  const mapped = LEGACY_PURPOSE_CODE_MAP[code];
+  if (mapped) return mapped;
+  return CANONICAL_PURPOSE_CODE_SET.has(code as PurposeCode)
+    ? (code as PurposeCode)
+    : undefined;
 }

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -768,18 +768,24 @@ async function seedConsentArtifacts(users: UserWithProfiles[]) {
   // checks before handing PII to Stream; without it every seeded user fails the
   // Stream upsert on dashboard load. Codes come from the single canonical
   // taxonomy (lib/compliance/purpose-codes.ts) the whole app now shares.
+  // One artifact PER purpose code (mirror the signup hook in lib/auth.ts).
+  // A single artifact bundling both codes would let a scoped withdrawal of
+  // one code revoke the other, since withdrawConsent stamps the whole artifact
+  // matching the target code. language "en-IN" for consistency with signup.
   for (const u of users) {
-    const draft = buildConsentArtifact({
-      userId: u.id,
-      dataFiduciary: "Familiarise Pvt Ltd",
-      purposeCodes: [
-        PURPOSE_CODES.PRIMARY_PROCESSING,
-        PURPOSE_CODES.STREAM_DATA_PROCESSING,
-      ],
-      language: "en",
-      version: 1,
-    });
-    await prisma.consentArtifact.create({ data: draft });
+    for (const purposeCode of [
+      PURPOSE_CODES.PRIMARY_PROCESSING,
+      PURPOSE_CODES.STREAM_DATA_PROCESSING,
+    ] as const) {
+      const draft = buildConsentArtifact({
+        userId: u.id,
+        dataFiduciary: "Familiarise Pvt Ltd",
+        purposeCodes: [purposeCode],
+        language: "en-IN",
+        version: 1,
+      });
+      await prisma.consentArtifact.create({ data: draft });
+    }
   }
   console.log(`[15a]   ✓ ConsentArtifact seeded for ${users.length} users`);
 }

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -187,7 +187,9 @@ export async function createOrganizations(
   }
 
   // -------------------------------------------------------- CONSENT ARTIFACTS
-  await seedConsentArtifacts(users.slice(0, 10));
+  // ALL seeded users, not just the first 10 — every user the runtime touches
+  // (Stream upsert on dashboard load) needs the gate to pass.
+  await seedConsentArtifacts(users);
 
   // ---------------------------------------------------- TOUR OWNER (#723)
   // Dedicated ORG_WORKSPACE account with deterministic credentials so tour
@@ -759,11 +761,18 @@ async function seedSoloConsultant(user: UserWithProfiles) {
 // ---------------------------------------------------------------------------
 
 async function seedConsentArtifacts(users: UserWithProfiles[]) {
+  // Stamp the CANONICAL runtime purpose codes that `checkConsent` (fail-closed)
+  // gates on — mirror the signup hook (lib/auth.ts) so seeded users behave like
+  // real signups. STREAM_DATA_PROCESSING is what actions/stream/chat/user.action.ts
+  // checks before handing PII to Stream; without it every seeded user fails the
+  // Stream upsert on dashboard load. The kebab-case codes the org consent
+  // dashboard offers (session-booking/marketing/analytics/...) are a SEPARATE
+  // taxonomy not consulted at runtime, so they are not seeded here.
   for (const u of users) {
     const draft = buildConsentArtifact({
       userId: u.id,
       dataFiduciary: "Familiarise Pvt Ltd",
-      purposeCodes: ["account-management", "session-booking", "analytics"],
+      purposeCodes: ["PRIMARY_PROCESSING", "STREAM_DATA_PROCESSING"],
       language: "en",
       version: 1,
     });

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -52,6 +52,7 @@ import {
 } from "@prisma/client";
 import prisma from "../../lib/prisma";
 import { buildConsentArtifact } from "../../lib/compliance/dpdp";
+import { PURPOSE_CODES } from "../../lib/compliance/purpose-codes";
 import { postLedgerTxn } from "../../lib/payments/ledger/post";
 import type { UserWithProfiles } from "./1a-create-users";
 
@@ -761,18 +762,20 @@ async function seedSoloConsultant(user: UserWithProfiles) {
 // ---------------------------------------------------------------------------
 
 async function seedConsentArtifacts(users: UserWithProfiles[]) {
-  // Stamp the CANONICAL runtime purpose codes that `checkConsent` (fail-closed)
+  // Stamp the canonical runtime purpose codes that `checkConsent` (fail-closed)
   // gates on — mirror the signup hook (lib/auth.ts) so seeded users behave like
   // real signups. STREAM_DATA_PROCESSING is what actions/stream/chat/user.action.ts
   // checks before handing PII to Stream; without it every seeded user fails the
-  // Stream upsert on dashboard load. The kebab-case codes the org consent
-  // dashboard offers (session-booking/marketing/analytics/...) are a SEPARATE
-  // taxonomy not consulted at runtime, so they are not seeded here.
+  // Stream upsert on dashboard load. Codes come from the single canonical
+  // taxonomy (lib/compliance/purpose-codes.ts) the whole app now shares.
   for (const u of users) {
     const draft = buildConsentArtifact({
       userId: u.id,
       dataFiduciary: "Familiarise Pvt Ltd",
-      purposeCodes: ["PRIMARY_PROCESSING", "STREAM_DATA_PROCESSING"],
+      purposeCodes: [
+        PURPOSE_CODES.PRIMARY_PROCESSING,
+        PURPOSE_CODES.STREAM_DATA_PROCESSING,
+      ],
       language: "en",
       version: 1,
     });


### PR DESCRIPTION
## Problem

Every **seeded** user fails the runtime Stream consent gate. `upsertUserToStream` (`actions/stream/chat/user.action.ts`) calls `checkConsent({ purposeCode: "STREAM_DATA_PROCESSING" })`, which is **fail-closed**, then throws — telling the user to "re-grant consent under **Account → Privacy**", a page that does not exist. The Stream upsert runs on dashboard load, so seeded accounts hit this on first navigation.

Underneath that bug sat a deeper one: the app carried **two incompatible consent purpose-code taxonomies**, and the org consent UI used the *other* one — so an opted-out user had **no UI path to re-grant Stream consent**. This PR fixes the seed bug **and** unifies the taxonomy.

## Root cause: TWO incompatible purpose-code taxonomies

| Side | Codes | Read/written by |
| --- | --- | --- |
| **Runtime / code (UPPER_SNAKE)** | `PRIMARY_PROCESSING`, `STREAM_DATA_PROCESSING`, `MARKETING_COMMS` (referenced) | `checkConsent` gate (`actions/stream/chat/user.action.ts`), signup hook (`lib/auth.ts`), seed (`prisma/seedFiles/15a-create-organizations.ts`) |
| **Org consent UI (kebab-case)** | `session-booking`, `marketing`, `analytics`, `third-party-sharing-with-stream` | `app/dashboard/organization/[orgId]/consent/page.tsx` + `route.ts` |

The fail-closed gate only ever checks `STREAM_DATA_PROCESSING`, which the UI **never granted** (its closest code, `third-party-sharing-with-stream`, is not consulted at runtime). A full opt-out withdrew `STREAM_DATA_PROCESSING`, after which there was no UI path to restore it.

## Resolution — ONE canonical taxonomy (UPPER_SNAKE wins)

The runtime UPPER_SNAKE codes are adopted as canonical (the gate already depends on them) and exposed as a **single source of truth**: `lib/compliance/purpose-codes.ts` (`PURPOSE_CODES` const + `PurposeCode` type + `ALL_PURPOSE_CODES` + per-code label/description + `LEGACY_PURPOSE_CODE_MAP` / `normalizePurposeCode`). It has no Prisma import, so server actions, the route handler, the client page, and the seed all import the same constant. Every path now references it — **no more string literals**.

### Canonical set + before/after mapping

| Canonical code (new) | Intent | Legacy kebab-case (old UI) |
| --- | --- | --- |
| `PRIMARY_PROCESSING` | Core service / account processing | `account-management` |
| `SESSION_BOOKING` | Booking/scheduling consultation sessions | `session-booking` |
| `STREAM_DATA_PROCESSING` | Video/chat PII handoff to Stream.io (third-party processor) | `third-party-sharing-with-stream` |
| `MARKETING_COMMS` | Marketing/promotional communications | `marketing` |
| `ANALYTICS` | Product/usage analytics | `analytics` |

### Org-UI re-grant fix (the gap, closed)

The org consent dashboard toggles now iterate the **canonical** taxonomy (with friendly labels/descriptions, the raw value kept as render fallback for legacy rows). The **Video & chat** toggle grants/withdraws `STREAM_DATA_PROCESSING` — so an org admin **can re-grant** the exact consent the fail-closed gate reads. The org consent route normalises incoming `purposeCodes` (POST) and the withdrawal scope (DELETE) through `normalizePurposeCode`, so storage and the gate can never diverge again. The route's API contract shape and `requireOrgAccess` auth are unchanged — only the codes.

> **Org-toggle → canonical-code mapping:** Service & account → `PRIMARY_PROCESSING`, Session booking → `SESSION_BOOKING`, Video & chat (Stream.io) → `STREAM_DATA_PROCESSING`, Marketing communications → `MARKETING_COMMS`, Analytics → `ANALYTICS`.

## This is app-side, not Stream-side (web-search confirmed)

Stream (getstream.io) does **not** require any consent flag to create/update a user. `upsertUser`/`connectUser` need only an `id`; there is **no consent toggle in the Stream dashboard** that gates user creation. Stream is the **data processor** and the app is the **data controller** — Stream provides export/delete APIs for GDPR rights but leaves consent to the app. So this gate is purely the app's DPDP Act 2023 design.

- Stream GDPR docs (Node): https://getstream.io/chat/docs/node/gdpr/
- Stream update_users / upsert API: https://getstream.io/chat/docs/python/update_users/
- Stream Security & Privacy FAQ: https://getstream.io/security/faq/

## Why one taxonomy is the right call (DPDP Act 2023 / consent best practice)

- DPDP Act 2023 **§6** requires consent to be **specific, not bundled, and revocable**, demonstrated by a clear affirmative action — granular per-purpose toggles, which a single well-named taxonomy makes auditable.
- **Rule 3** requires a standalone, **itemised, plain-language** purpose notice; the canonical code's `description` is exactly that itemised text, carried in one place.
- The **data fiduciary (controller)** defines the purposes and the **processor (Stream.io)** must act within them — so the controller's gate and its consent UI must speak the **same** purpose vocabulary. Two divergent taxonomies broke that and silently stranded users.
- Single-source-of-truth taxonomies are the documented best practice for consent record-keeping and consistency (cf. W3C Data Privacy Vocabulary).

Sources:
- DPDP consent best practices (DPO India): https://www.dpo-india.com/Blogs/consent-management-india-dpdp-act/
- DPDP §4/§6 + Rule 3 notice requirements: https://www.dpdpa.com/dpdpa2023/chapter-2/section4.html , https://www.dpdpa.com/dpdparules/rule3.html
- DPDP Rules 2025 practical guide: https://www.scrut.io/post/dpdp-rules
- W3C Data Privacy Vocabularies & Controls CG (machine-readable purpose taxonomy): https://www.w3.org/community/dpvcg/
- Controller-defines-purpose / processor-acts-within: https://usercentrics.com/knowledge-hub/gdpr-controller-vs-processor/

## Changes

- **New `lib/compliance/purpose-codes.ts`** — canonical `PURPOSE_CODES` + helpers; exported from the `lib/compliance` barrel.
- **`lib/compliance/dpdp.ts`** — docblock + `withdrawConsent` comment point to the canonical taxonomy; `ConsentRequiredError` (from the first commit) retained.
- **Seed (`prisma/seedFiles/15a-create-organizations.ts`)** — stamps `[PURPOSE_CODES.PRIMARY_PROCESSING, PURPOSE_CODES.STREAM_DATA_PROCESSING]` for **all** seeded users (slice cap already dropped in the first commit).
- **Signup hook (`lib/auth.ts`)** — references `PURPOSE_CODES.*` instead of literals.
- **Stream actions (`user.action.ts`)** — gate + typed error reference `PURPOSE_CODES.STREAM_DATA_PROCESSING`.
- **Org consent page (`…/consent/page.tsx`)** — canonical toggles with labels; the Stream toggle re-grants `STREAM_DATA_PROCESSING`; badges render via label lookup.
- **Org consent route (`…/consent/route.ts`)** — normalises POST `purposeCodes` and DELETE scope to canonical; contract shape + auth unchanged.

(First commit, retained: seed↔runtime alignment, graceful `ConsentRequiredError` handling in `syncUserEventChannels`, corrected error message.)

## ⚠️ Flagged for a product call (NOT silently decided)

- **`SESSION_BOOKING` vs `PRIMARY_PROCESSING` overlap.** I kept `SESSION_BOOKING` as a distinct purpose (it maps cleanly from the old `session-booking` toggle), but booking is arguably *part of* core service delivery already covered by `PRIMARY_PROCESSING`. If product considers booking non-severable from core service, drop `SESSION_BOOKING` and fold it into `PRIMARY_PROCESSING`. Flagged, not decided.
- **A different forward-looking taxonomy exists in the docs.** `docs/compliance/08-dpdp-and-privacy.md` (§A) proposes a *future consumer-side* `ConsumerConsentArtifact` with **differently named** UPPER_SNAKE codes: `BOOKING`, `PAYMENT_PROCESSING`, `SESSION_RECORDING`, `MARKETING_EMAILS`, `ANALYTICS_THIRD_PARTY`. That model **does not exist in the schema yet** and is not consulted at runtime, so I unified on the codes the live gate actually reads rather than the doc's proposal. When `ConsumerConsentArtifact` lands, the two taxonomies should be reconciled (e.g. `SESSION_BOOKING`↔`BOOKING`, `MARKETING_COMMS`↔`MARKETING_EMAILS`, `ANALYTICS`↔`ANALYTICS_THIRD_PARTY`). Flagged.
- **Cookie consent is a separate concern, left untouched.** `analytics`/`marketing` in staff/profile settings are `CookiePreference` columns (booleans), not DPDP `ConsentArtifact` purpose codes — out of scope.

## Verification

- `npx eslint` on all changed files: **0 errors**.
- `tsc --noEmit` across the project: **0 errors**.
- No DB touched; no re-seed. **Fail-closed gate not weakened.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the consent dashboard to use a canonical purpose list, with friendlier labels/tooltips and an expanded purposes picker.
* **Bug Fixes**
  * Normalized and validated purpose codes during consent creation and withdrawal for consistent storage and correct withdrawal scope.
  * Improved Stream user synchronization to respect admin DPDP consent gating, skipping users to prevent repeated failed sync attempts.
  * Seeded DPDP consent artifacts for all eligible users (not just a subset) using the canonical purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
