### PR TITLE
feat(referrals): #880 reward economics — role-weighted amounts, consultant waiver, budget cap (A/B/C)

### DIFF
--- a/__tests__/referrals/service.test.ts
+++ b/__tests__/referrals/service.test.ts
@@ -20,9 +20,23 @@ const mockTx = {
     updateMany: jest.fn(),
     update: jest.fn(),
   },
-  referralCredit: { create: jest.fn() },
+  referralCredit: { create: jest.fn(), findMany: jest.fn() },
   referralCode: { update: jest.fn() },
+  referralProgramConfig: { upsert: jest.fn(), update: jest.fn() },
+  user: { findUnique: jest.fn() },
 };
+
+// #880 — default program config (active, unlimited budget, ₹300 ramp stage).
+const THIS_MONTH = new Date().toISOString().slice(0, 7);
+const activeConfig = (over: Record<string, unknown> = {}) => ({
+  id: "singleton",
+  isActive: true,
+  monthlyBudgetPaise: null,
+  currentPeriod: THIS_MONTH,
+  currentMonthSpentPaise: 0,
+  referrerRewardPaise: 30000,
+  ...over,
+});
 
 jest.mock("../../lib/prisma", () => ({
   __esModule: true,
@@ -120,7 +134,13 @@ describe("REF-3 — processQualifyingAction claims reward atomically", () => {
     mockTx.referral.updateMany.mockReset();
     mockTx.referral.update.mockReset();
     mockTx.referralCredit.create.mockReset();
+    mockTx.referralCredit.findMany.mockReset().mockResolvedValue([]);
     mockTx.referralCode.update.mockReset();
+    mockTx.referralProgramConfig.upsert
+      .mockReset()
+      .mockResolvedValue(activeConfig());
+    mockTx.referralProgramConfig.update.mockReset();
+    mockTx.user.findUnique.mockReset().mockResolvedValue({ role: "CONSULTEE" });
   });
 
   const signedUpReferral = {
@@ -178,5 +198,86 @@ describe("REF-3 — processQualifyingAction claims reward atomically", () => {
       }),
     );
     expect(mockTx.referralCredit.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("#880 — role weighting, caps and program budget", () => {
+  beforeEach(() => {
+    mockTx.referral.findUnique.mockReset();
+    mockTx.referral.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    mockTx.referralCredit.create.mockReset();
+    mockTx.referralCredit.findMany.mockReset().mockResolvedValue([]);
+    mockTx.referralCode.update.mockReset();
+    mockTx.referralProgramConfig.upsert
+      .mockReset()
+      .mockResolvedValue(activeConfig());
+    mockTx.referralProgramConfig.update.mockReset();
+    mockTx.user.findUnique.mockReset().mockResolvedValue({ role: "CONSULTEE" });
+  });
+
+  const baseReferral = {
+    id: "ref-1",
+    status: "SIGNED_UP",
+    signedUpAt: new Date(),
+    referralCodeId: "code-1",
+    referredUserId: "referee-1",
+    referrerRewardAmount: 30000,
+    refereeRewardAmount: 30000,
+    referralCode: { userId: "referrer-1" },
+  };
+
+  it("skips the booking credit for a consultant referee (they get the waiver)", async () => {
+    mockTx.referral.findUnique.mockResolvedValue(baseReferral);
+    mockTx.user.findUnique.mockResolvedValue({ role: "CONSULTANT" });
+
+    await processQualifyingAction("referee-1", "first_paid_booking_received");
+
+    expect(mockTx.referralCredit.create).toHaveBeenCalledTimes(1);
+    expect(mockTx.referralCredit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ source: "REFERRAL_BONUS" }),
+      }),
+    );
+  });
+
+  it("grants nothing and does not claim when the program is paused", async () => {
+    mockTx.referral.findUnique.mockResolvedValue(baseReferral);
+    mockTx.referralProgramConfig.upsert.mockResolvedValue(
+      activeConfig({ isActive: false }),
+    );
+
+    await processQualifyingAction("referee-1", "first_paid_booking");
+
+    expect(mockTx.referral.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.referralCredit.create).not.toHaveBeenCalled();
+  });
+
+  it("defers (no claim) when the monthly budget is exhausted", async () => {
+    mockTx.referral.findUnique.mockResolvedValue(baseReferral);
+    mockTx.referralProgramConfig.upsert.mockResolvedValue(
+      activeConfig({ monthlyBudgetPaise: 10000, currentMonthSpentPaise: 10000 }),
+    );
+
+    await processQualifyingAction("referee-1", "first_paid_booking");
+
+    expect(mockTx.referral.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.referralCredit.create).not.toHaveBeenCalled();
+  });
+
+  it("clamps the referrer grant by the annual per-referrer cap", async () => {
+    mockTx.referral.findUnique.mockResolvedValue(baseReferral);
+    // Already earned ₹9,990 this year → only ₹10 (1000 paise) of headroom.
+    mockTx.referralCredit.findMany.mockResolvedValue([{ amount: 999000 }]);
+
+    await processQualifyingAction("referee-1", "first_paid_booking");
+
+    expect(mockTx.referralCredit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          source: "REFERRAL_BONUS",
+          amount: 1000,
+        }),
+      }),
+    );
   });
 });

--- a/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
@@ -306,7 +306,7 @@ export default function ConsultantReferralsPage({
             <div className="rounded-lg bg-zinc-50 px-4 py-3">
               <p className="text-zinc-500">Max Referrals</p>
               <p className="mt-1 font-medium text-zinc-900">
-                {code?.maxReferrals ?? 50}
+                {code?.maxReferrals ?? 25}
               </p>
             </div>
           </div>

--- a/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/referrals/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from "@/hooks/use-toast";
 import { WhatsAppIcon } from "@/components/icons/WhatsAppIcon";
 import {
   QUALIFICATION_WINDOW_DAYS,
+  CREDIT_EXPIRY_DAYS,
 } from "@/lib/referrals/constants";
 
 interface ReferralCode {
@@ -299,7 +300,7 @@ export default function ConsultantReferralsPage({
             <div className="rounded-lg bg-zinc-50 px-4 py-3">
               <p className="text-zinc-500">Credit Expiry</p>
               <p className="mt-1 font-medium text-zinc-900">
-                {CREDIT_EXPIRY_MONTHS} months
+                {CREDIT_EXPIRY_DAYS} days
               </p>
             </div>
             <div className="rounded-lg bg-zinc-50 px-4 py-3">

--- a/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
@@ -18,6 +18,7 @@ import { useToast } from "@/hooks/use-toast";
 import { WhatsAppIcon } from "@/components/icons/WhatsAppIcon";
 import {
   QUALIFICATION_WINDOW_DAYS,
+  CREDIT_EXPIRY_DAYS,
 } from "@/lib/referrals/constants";
 import { useCurrency } from "@/hooks/useCurrency";
 
@@ -307,7 +308,7 @@ export default function ConsulteeReferralsPage({
             </div>
             <div className="rounded-lg bg-zinc-50 px-4 py-3">
               <p className="text-zinc-500">Credit Expiry</p>
-              <p className="mt-1 font-medium text-zinc-900">{CREDIT_EXPIRY_MONTHS} months</p>
+              <p className="mt-1 font-medium text-zinc-900">{CREDIT_EXPIRY_DAYS} days</p>
             </div>
             <div className="rounded-lg bg-zinc-50 px-4 py-3">
               <p className="text-zinc-500">Max Referrals</p>

--- a/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
@@ -313,7 +313,7 @@ export default function ConsulteeReferralsPage({
             <div className="rounded-lg bg-zinc-50 px-4 py-3">
               <p className="text-zinc-500">Max Referrals</p>
               <p className="mt-1 font-medium text-zinc-900">
-                {code?.maxReferrals ?? 50}
+                {code?.maxReferrals ?? 25}
               </p>
             </div>
           </div>

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -42,6 +42,7 @@ import {
   processQualifyingAction,
   processConsultantBookingReferral,
 } from "@/lib/referrals/service";
+import { MIN_CREDIT_REDEMPTION_PAISE } from "@/lib/referrals/constants";
 import {
   createEarningsFromPayment,
   type AppointmentType,
@@ -508,8 +509,13 @@ export async function calculateAmountAndValidate(
 
     // Apply referral credits AFTER tax (credits act as a payment method, not a trade discount)
     // Both credits and amount are now in paise — no conversion needed
+    // #880 — credits redeem only when the order is ₹500+ so a credit never
+    // exceeds the value of the booking it discounts.
     let creditsApplied = 0;
-    if (validatedData.useReferralCredits && amount > 0) {
+    if (
+      validatedData.useReferralCredits &&
+      amount >= MIN_CREDIT_REDEMPTION_PAISE
+    ) {
       const { totalAvailable } = await getUserCredits(userId, tx);
       if (totalAvailable > 0) {
         creditsApplied = Math.min(totalAvailable, amount);

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -28,6 +28,7 @@ import { recordTdsReversal } from "@/lib/payments/tax/tds-service";
 import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 import { recordSystemError } from "@/lib/enterprise/system-events";
 import { isConsultantReferralWaiverActive } from "@/lib/referrals/service";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import type { RevenueSplit } from "@/types/collaborators";
 
 // ============================================
@@ -266,483 +267,503 @@ export async function createEarningsFromPayment({
 
   // FIX #9: Wrap earnings creation + balance updates in a transaction for atomicity.
   // Also handles P2002 unique constraint violations gracefully for idempotency.
+  // #896 — Serializable + P2034 retry so the waiver eligibility count() can't be
+  // read concurrently by two first-payments and double-waive the platform fee;
+  // matches the sibling money flows (processQualifyingAction/checkout).
   try {
-    return await prisma.$transaction(async (tx) => {
-      // Idempotency check inside transaction to prevent races
-      const existingEarnings = await tx.consultantEarnings.findFirst({
-        where: { paymentId: payment.id, consultantProfileId },
-      });
-      if (existingEarnings) {
-        console.warn(
-          `Earnings already exist for payment ${payment.id}. Skipping.`,
-        );
-        return existingEarnings.id;
-      }
+    return await withSerializableRetry(() =>
+      prisma.$transaction(
+        async (tx) => {
+          // Idempotency check inside transaction to prevent races
+          const existingEarnings = await tx.consultantEarnings.findFirst({
+            where: { paymentId: payment.id, consultantProfileId },
+          });
+          if (existingEarnings) {
+            console.warn(
+              `Earnings already exist for payment ${payment.id}. Skipping.`,
+            );
+            return existingEarnings.id;
+          }
 
-      // Check if this consultant belongs to a HOST/HYBRID org (3-way
-      // split). Settlement uses the rate card that was EFFECTIVE AT
-      // PAYMENT-CREATION TIME — hold periods can be days long, so by the
-      // time earnings are settled the live rate may have been bumped.
-      // Passing `payment.createdAt` keeps the split stable across that
-      // window.
-      const orgSplit = await resolveOrgSplit(
-        tx,
-        consultantProfileId,
-        grossAmount,
-        payment.createdAt,
-      );
-
-      // Determine platform fee and consultant pool based on whether org split applies.
-      // #778 §C-2 — floor the marketplace fee (was Math.round); the shaved paisa
-      // stays in the consultant pool (gross − fee), the pool's residual party.
-      // #880 — a referred consultant pays 0% platform commission on their first
-      // sessions (their referee instrument). Scoped to individual settlements;
-      // org-hosted splits keep their rate-card economics.
-      const waiveCommission =
-        !orgSplit &&
-        (await isConsultantReferralWaiverActive(tx, consultantProfileId));
-      const platformFeePaise = orgSplit
-        ? orgSplit.platformFeePaise
-        : waiveCommission
-          ? 0
-          : prorate(grossAmount, PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE, 100);
-      const totalConsultantPool = orgSplit
-        ? orgSplit.consultantSharePaise
-        : grossAmount - platformFeePaise;
-
-      // Calculate collaborator splits if applicable
-      let splits: RevenueSplit[] = [];
-      if (planType && planId) {
-        splits = await calculateRevenueSplit(
-          planType,
-          planId,
-          totalConsultantPool,
-        );
-      }
-
-      let ownerId: string | null = null;
-
-      // #773 — resolve every collaborator's HOST-org settlement UP FRONT so
-      // the ConsultantEarnings rows, the OrganizationEarnings rows and the
-      // booking journal are all built from one set of numbers. A settled
-      // collaborator is paid the NET of their org's rate card (floors per
-      // #778 §C; the org leg absorbs the remainder inside resolveOrgSplit);
-      // the org keeps its cut, the card's fee slice is platform revenue.
-      // Same-org collisions against @@unique([paymentId, organizationId]) are
-      // detected here deterministically instead of via a P2002 catch — v1
-      // semantics kept: the colliding collaborator stays unsettled (full
-      // share on ConsultantEarnings, no org accrual).
-      const collabSettlements = new Map<
-        string,
-        { sharePaise: number; orgSplit: OrgEarningsSplit }
-      >();
-      if (splits.length > 0) {
-        const plannedOrgRows = new Set<string>(
-          orgSplit && orgSplit.orgShare > 0 ? [orgSplit.organizationId] : [],
-        );
-        for (const split of splits) {
-          if (split.role === "OWNER" || split.share <= 0) continue;
-          const collabOrgSplit = await resolveOrgSplit(
+          // Check if this consultant belongs to a HOST/HYBRID org (3-way
+          // split). Settlement uses the rate card that was EFFECTIVE AT
+          // PAYMENT-CREATION TIME — hold periods can be days long, so by the
+          // time earnings are settled the live rate may have been bumped.
+          // Passing `payment.createdAt` keeps the split stable across that
+          // window.
+          const orgSplit = await resolveOrgSplit(
             tx,
-            split.consultantProfileId,
-            split.share,
+            consultantProfileId,
+            grossAmount,
             payment.createdAt,
           );
-          if (!collabOrgSplit) continue; // independent collaborator
-          if (
-            collabOrgSplit.orgShare > 0 &&
-            plannedOrgRows.has(collabOrgSplit.organizationId)
-          ) {
-            console.warn(
-              `[Earnings] Skipping collaborator org earnings for ${collabOrgSplit.organizationId} on payment ${payment.id}: row already exists for this (payment, org) pair (collab ${split.consultantProfileId}). Their personal share is unaffected.`,
-            );
-            continue;
-          }
-          if (collabOrgSplit.orgShare > 0) {
-            plannedOrgRows.add(collabOrgSplit.organizationId);
-          }
-          collabSettlements.set(split.consultantProfileId, {
-            sharePaise: split.share,
-            orgSplit: collabOrgSplit,
-          });
-        }
-      }
 
-      if (splits.length > 0) {
-        // #812 — floor every collaborator's shareBps and let the LAST split
-        // absorb the remainder, so the cached bps sum to exactly 10000. Rounding
-        // each independently (Math.round) could overshoot or undershoot 10000 by
-        // a few bps across collaborators, the same floor-then-absorb discipline
-        // the rest of the money math uses.
-        const shareBpsList = splits.map((s) =>
-          totalConsultantPool > 0
-            ? Math.floor((s.share / totalConsultantPool) * 10_000)
-            : 0,
-        );
-        if (totalConsultantPool > 0) {
-          const assigned = shareBpsList.reduce((a, b) => a + b, 0);
-          shareBpsList[shareBpsList.length - 1] += 10_000 - assigned;
-        }
+          // Determine platform fee and consultant pool based on whether org split applies.
+          // #778 §C-2 — floor the marketplace fee (was Math.round); the shaved paisa
+          // stays in the consultant pool (gross − fee), the pool's residual party.
+          // #880 — a referred consultant pays 0% platform commission on their first
+          // sessions (their referee instrument). Scoped to individual settlements;
+          // org-hosted splits keep their rate-card economics.
+          const waiveCommission =
+            !orgSplit &&
+            (await isConsultantReferralWaiverActive(tx, consultantProfileId));
+          const platformFeePaise = orgSplit
+            ? orgSplit.platformFeePaise
+            : waiveCommission
+              ? 0
+              : prorate(
+                  grossAmount,
+                  PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE,
+                  100,
+                );
+          const totalConsultantPool = orgSplit
+            ? orgSplit.consultantSharePaise
+            : grossAmount - platformFeePaise;
 
-        // Multi-party payment: create earnings for owner and each collaborator
-        for (let i = 0; i < splits.length; i++) {
-          const split = splits[i];
-          const isOwner = split.role === "OWNER";
-          const shareBps = shareBpsList[i];
-          const settlement = isOwner
-            ? undefined
-            : collabSettlements.get(split.consultantProfileId);
-
-          // #773 — a settled collaborator's row carries their org card's fee
-          // slice and the NET share (what the payout pipeline disburses); the
-          // org's cut lives on its OrganizationEarnings row. The cache must
-          // mirror the journal's legs or EARNINGS_LEDGER_DRIFT fires.
-          const creditedShare = settlement
-            ? settlement.orgSplit.consultantSharePaise
-            : split.share;
-          const earnings = await tx.consultantEarnings.create({
-            data: {
-              consultantProfileId: split.consultantProfileId,
-              paymentId: payment.id,
-              grossAmount: isOwner ? grossAmount : 0,
-              platformFeePaise: isOwner
-                ? platformFeePaise
-                : (settlement?.orgSplit.platformFeePaise ?? 0),
-              consultantSharePaise: creditedShare,
-              role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
-              shareBps,
-              status: EarningStatus.PENDING,
-              holdUntil,
-              currency: "INR",
-            },
-          });
-
-          if (split.role === "OWNER") {
-            ownerId = earnings.id;
-          }
-
-          console.log(
-            `Earnings created for ${split.role} (${split.consultantProfileId}): ${creditedShare / 100} from payment ${payment.id}${orgSplit ? " [HOST 3-way split]" : ""}${settlement ? " [collab org-settled]" : ""}`,
-          );
-        }
-      } else {
-        // Single-owner payment (no collaborators or not a webinar/class)
-        const earnings = await tx.consultantEarnings.create({
-          data: {
-            consultantProfileId,
-            paymentId: payment.id,
-            grossAmount,
-            platformFeePaise,
-            consultantSharePaise: totalConsultantPool,
-            status: EarningStatus.PENDING,
-            holdUntil,
-            currency: "INR",
-          },
-        });
-
-        ownerId = earnings.id;
-      }
-
-      // Create OrganizationEarnings row for the HOST/HYBRID org (3-way split).
-      // Skip when orgShare is 0 (Platform-only mode: platformCommissionRate = 1.0)
-      // — creating 0-value rows adds noise without value.
-      //
-      // PR-1d / #687: if the sponsoring org is still PENDING_VERIFICATION
-      // and has never paid an invoice, accruals start in PENDING_TRUST
-      // instead of PENDING. The `release-pending-trust-earnings` cron
-      // promotes them once the org is verified or first invoice clears.
-      if (orgSplit && orgSplit.orgShare > 0) {
-        const sponsorOrg = await tx.organization.findUnique({
-          where: { id: orgSplit.organizationId },
-          select: { status: true },
-        });
-        let initialStatus: EarningStatus = EarningStatus.PENDING;
-        if (sponsorOrg?.status === "PENDING_VERIFICATION") {
-          const paidInvoiceCount = await tx.organizationInvoice.count({
-            where: {
-              organizationId: orgSplit.organizationId,
-              status: "PAID",
-            },
-          });
-          if (paidInvoiceCount === 0) {
-            initialStatus = EarningStatus.PENDING_TRUST;
-          }
-        }
-
-        await tx.organizationEarnings.create({
-          data: {
-            organizationId: orgSplit.organizationId,
-            paymentId: payment.id,
-            grossAmountPaise: grossAmount,
-            platformFeePaise: orgSplit.platformFeePaise,
-            orgSharePaise: orgSplit.orgShare,
-            consultantSharePaise: orgSplit.consultantSharePaise,
-            refundedAmountPaise: 0,
-            status: initialStatus,
-            holdUntil,
-            currency: "INR",
-            // Rate-card snapshot: persist the exact split applied so
-            // payout reconciliation reads this row, never the live card.
-            rateCardIdApplied: orgSplit.rateCardIdApplied,
-            platformBpsApplied: orgSplit.platformBps,
-            orgBpsApplied: orgSplit.orgBps,
-            consultantBpsApplied: orgSplit.consultantBps,
-          },
-        });
-
-        console.log(
-          `Org earnings created for ${orgSplit.organizationId}: org=${orgSplit.orgShare / 100} consultant=${orgSplit.consultantSharePaise / 100} (recipient=${orgSplit.payoutRecipient}) from payment ${payment.id}`,
-        );
-      } else if (orgSplit && orgSplit.orgShare === 0) {
-        console.log(
-          `Platform-only mode for ${orgSplit.organizationId}: skipping 0-value org earnings for payment ${payment.id}`,
-        );
-      }
-
-      // ============================================
-      // A3 (Q3) / #773: per-collaborator HOST-org settlement
-      // ============================================
-      // Each ACCEPTED collaborator at a HOST org settles to *their own* org
-      // independently of the primary expert's org: the collaborator's pool
-      // share is the "gross" their org's rate card splits. Independent
-      // collaborators (no active EXPERT membership at a HOST org) get no row —
-      // their full share sits on ConsultantEarnings and pays out via the
-      // personal payout pipeline. Rows are written BEFORE the booking journal
-      // below so the posting can mirror every accrual it covers. Platform-only
-      // cards (orgShare == 0) still settle (fee + net) but write no 0-value
-      // org row. Same-org collisions were already resolved upstream (see
-      // collabSettlements), so every entry here inserts cleanly.
-      for (const [collabProfileId, s] of Array.from(
-        collabSettlements.entries(),
-      )) {
-        if (s.orgSplit.orgShare <= 0) {
-          console.log(
-            `Platform-only mode for collaborator org ${s.orgSplit.organizationId}: skipping 0-value org earnings for payment ${payment.id}`,
-          );
-          continue;
-        }
-
-        // PR-1d / #687 — same PENDING_TRUST gate as the primary org above.
-        const collabSponsorOrg = await tx.organization.findUnique({
-          where: { id: s.orgSplit.organizationId },
-          select: { status: true },
-        });
-        let collabInitialStatus: EarningStatus = EarningStatus.PENDING;
-        if (collabSponsorOrg?.status === "PENDING_VERIFICATION") {
-          const paidInvoiceCount = await tx.organizationInvoice.count({
-            where: {
-              organizationId: s.orgSplit.organizationId,
-              status: "PAID",
-            },
-          });
-          if (paidInvoiceCount === 0) {
-            collabInitialStatus = EarningStatus.PENDING_TRUST;
-          }
-        }
-
-        await tx.organizationEarnings.create({
-          data: {
-            organizationId: s.orgSplit.organizationId,
-            paymentId: payment.id,
-            // The collaborator's share is the "gross" that this org is
-            // splitting — NOT the booking's full gross. Persist it verbatim
-            // so reconciliation sees a consistent picture.
-            grossAmountPaise: s.sharePaise,
-            platformFeePaise: s.orgSplit.platformFeePaise,
-            orgSharePaise: s.orgSplit.orgShare,
-            consultantSharePaise: s.orgSplit.consultantSharePaise,
-            refundedAmountPaise: 0,
-            status: collabInitialStatus,
-            holdUntil,
-            currency: "INR",
-            rateCardIdApplied: s.orgSplit.rateCardIdApplied,
-            platformBpsApplied: s.orgSplit.platformBps,
-            orgBpsApplied: s.orgSplit.orgBps,
-            consultantBpsApplied: s.orgSplit.consultantBps,
-          },
-        });
-        console.log(
-          `Collaborator org earnings created for ${s.orgSplit.organizationId} (collab ${collabProfileId}): org=${s.orgSplit.orgShare / 100} consultant=${s.orgSplit.consultantSharePaise / 100} from payment ${payment.id}`,
-        );
-      }
-
-      // #771 D1/D5 / AF-3 — double-entry booking posting (full accrual, dual-write).
-      //   Dr funding legs (CASH/WALLET/ORG_RECEIVABLE) + PLATFORM_PROMO (referral
-      //   credits) + DISCOUNT  ==  Cr PLATFORM_FEE + CONSULTANT_PAYABLE(per party) +
-      //   ORG_PAYABLE(per org) + GST_PAYABLE.
-      // #776 — posted for BOTH the single-consultant AND multi-collaborator cases.
-      // #773 — the multi-collaborator posting now also covers the per-collab
-      // HOST-org settlements written above: each settled collaborator's
-      // CONSULTANT_PAYABLE is their NET share, their org gets its own
-      // ORG_PAYABLE leg, and the org-card fee slices fold into PLATFORM_FEE —
-      // so the journal's earnings-relevant credits equal the cached Earnings
-      // rows exactly (EARNINGS_LEDGER_DRIFT contract).
-      {
-        try {
-          const legs = await tx.paymentLeg.findMany({
-            where: { paymentId: payment.id },
-            select: { source: true, amountPaise: true },
-          });
-          const orgId = payment.organizationId ?? null;
-          const debits: Posting[] = [];
-          const pushDebit = (account: AccountRef, amountPaise: number) => {
-            if (amountPaise > 0)
-              debits.push({ account, direction: "DEBIT", amountPaise });
-          };
-          if (legs.length > 0) {
-            let card = 0;
-            let wallet = 0;
-            let receivable = 0;
-            let promo = 0;
-            for (const leg of legs) {
-              if (leg.amountPaise <= 0) continue;
-              switch (leg.source) {
-                case "CARD":
-                  card += leg.amountPaise;
-                  break;
-                case "WALLET":
-                  wallet += leg.amountPaise;
-                  break;
-                case "INVOICE_ACCRUAL":
-                case "OVERAGE_INVOICE_ACCRUAL":
-                  receivable += leg.amountPaise;
-                  break;
-                case "REFERRAL_CREDIT":
-                  promo += leg.amountPaise;
-                  break;
-                case "LICENSE":
-                  break; // 0 — no money moves
-                case "INVOICE_ACCRUAL_REVERSAL":
-                case "OVERAGE_INVOICE_ACCRUAL_REVERSAL":
-                  // #786 — negative refund counter-entries; they cannot exist
-                  // at booking time and are never funding. Skip explicitly
-                  // (the <= 0 guard above already drops them defensively).
-                  break;
-              }
-            }
-            pushDebit({ kind: "CASH" }, card);
-            pushDebit({ kind: "WALLET", organizationId: orgId }, wallet);
-            pushDebit(
-              { kind: "ORG_RECEIVABLE", organizationId: orgId },
-              receivable,
-            );
-            pushDebit({ kind: "PLATFORM_PROMO" }, promo);
-          } else {
-            // Back-compat: legacy single-source payments carry no legs.
-            pushDebit({ kind: "CASH" }, payment.amount);
-          }
-          // #776 — DISCOUNT is the platform-absorbed gap between gross
-          // (originalAmount + tax) and the funding actually applied. Base it on the
-          // sum of the funding-leg debits, NOT payment.amount: a referral-credit leg
-          // funds the booking (debited as PLATFORM_PROMO) yet is excluded from
-          // payment.amount (post-credit). Using `amount` double-counted the credit
-          // (PROMO + DISCOUNT), imbalancing the posting so it was silently dropped —
-          // every fully-credit-funded booking went un-journaled.
-          const fundingDebitTotal = debits.reduce(
-            (s, d) => s + d.amountPaise,
-            0,
-          );
-          pushDebit(
-            { kind: "DISCOUNT" },
-            Math.max(
-              0,
-              payment.originalAmount +
-                (payment.taxAmount ?? 0) -
-                fundingDebitTotal,
-            ),
-          );
-
-          const credits: Posting[] = [];
-          const pushCredit = (account: AccountRef, amountPaise: number) => {
-            if (amountPaise > 0)
-              credits.push({ account, direction: "CREDIT", amountPaise });
-          };
-          // #773 — the platform's total cut is the primary fee PLUS each
-          // settled collaborator's org-card fee slice, as one summed leg.
-          let platformFeeCreditPaise = platformFeePaise;
-          for (const s of Array.from(collabSettlements.values())) {
-            platformFeeCreditPaise += s.orgSplit.platformFeePaise;
-          }
-          pushCredit({ kind: "PLATFORM_FEE" }, platformFeeCreditPaise);
-          if (splits.length > 0) {
-            // Multi-party: one payable per party, mirroring the
-            // ConsultantEarnings rows. Settled collaborators are credited NET
-            // of their org's cut; each settled share decomposes exactly into
-            // fee + org + net (resolveOrgSplit), so Σ(payables + org legs +
-            // fee slices) === totalConsultantPool and the txn balances to the
-            // paise.
-            for (const split of splits) {
-              const settlement =
-                split.role === "OWNER"
-                  ? undefined
-                  : collabSettlements.get(split.consultantProfileId);
-              pushCredit(
-                {
-                  kind: "CONSULTANT_PAYABLE",
-                  consultantProfileId: split.consultantProfileId,
-                },
-                settlement
-                  ? settlement.orgSplit.consultantSharePaise
-                  : split.share,
-              );
-            }
-          } else {
-            pushCredit(
-              { kind: "CONSULTANT_PAYABLE", consultantProfileId },
+          // Calculate collaborator splits if applicable
+          let splits: RevenueSplit[] = [];
+          if (planType && planId) {
+            splits = await calculateRevenueSplit(
+              planType,
+              planId,
               totalConsultantPool,
             );
           }
-          if (orgSplit && orgSplit.orgShare > 0) {
-            pushCredit(
-              { kind: "ORG_PAYABLE", organizationId: orgSplit.organizationId },
-              orgSplit.orgShare,
+
+          let ownerId: string | null = null;
+
+          // #773 — resolve every collaborator's HOST-org settlement UP FRONT so
+          // the ConsultantEarnings rows, the OrganizationEarnings rows and the
+          // booking journal are all built from one set of numbers. A settled
+          // collaborator is paid the NET of their org's rate card (floors per
+          // #778 §C; the org leg absorbs the remainder inside resolveOrgSplit);
+          // the org keeps its cut, the card's fee slice is platform revenue.
+          // Same-org collisions against @@unique([paymentId, organizationId]) are
+          // detected here deterministically instead of via a P2002 catch — v1
+          // semantics kept: the colliding collaborator stays unsettled (full
+          // share on ConsultantEarnings, no org accrual).
+          const collabSettlements = new Map<
+            string,
+            { sharePaise: number; orgSplit: OrgEarningsSplit }
+          >();
+          if (splits.length > 0) {
+            const plannedOrgRows = new Set<string>(
+              orgSplit && orgSplit.orgShare > 0
+                ? [orgSplit.organizationId]
+                : [],
             );
-          }
-          // #773 — one ORG_PAYABLE per collaborator host org, mirroring the
-          // OrganizationEarnings rows written above.
-          for (const s of Array.from(collabSettlements.values())) {
-            if (s.orgSplit.orgShare > 0) {
-              pushCredit(
-                {
-                  kind: "ORG_PAYABLE",
-                  organizationId: s.orgSplit.organizationId,
-                },
-                s.orgSplit.orgShare,
+            for (const split of splits) {
+              if (split.role === "OWNER" || split.share <= 0) continue;
+              const collabOrgSplit = await resolveOrgSplit(
+                tx,
+                split.consultantProfileId,
+                split.share,
+                payment.createdAt,
               );
+              if (!collabOrgSplit) continue; // independent collaborator
+              if (
+                collabOrgSplit.orgShare > 0 &&
+                plannedOrgRows.has(collabOrgSplit.organizationId)
+              ) {
+                console.warn(
+                  `[Earnings] Skipping collaborator org earnings for ${collabOrgSplit.organizationId} on payment ${payment.id}: row already exists for this (payment, org) pair (collab ${split.consultantProfileId}). Their personal share is unaffected.`,
+                );
+                continue;
+              }
+              if (collabOrgSplit.orgShare > 0) {
+                plannedOrgRows.add(collabOrgSplit.organizationId);
+              }
+              collabSettlements.set(split.consultantProfileId, {
+                sharePaise: split.share,
+                orgSplit: collabOrgSplit,
+              });
             }
           }
-          // #812 — guard a missing taxAmount (NaN would imbalance the now-blocking
-          // posting and roll back the booking). Defaults to 0 in-schema, but
-          // legacy/imported rows may lack it.
-          pushCredit({ kind: "GST_PAYABLE" }, payment.taxAmount ?? 0);
 
-          await postLedgerTxn(tx, {
-            idempotencyKey: `booking:${payment.id}`,
-            kind: "BOOKING",
-            paymentId: payment.id,
-            postings: [...debits, ...credits],
-          });
-        } catch (err) {
-          console.error(
-            `[ledger] booking posting FAILED for payment ${payment.id} — rolling back the booking: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          // #812 — record the drift on its own connection (survives the rollback),
-          // then RE-THROW so the imbalance rolls back the whole booking
-          // transaction. The ledger is the source of truth: a booking that can't
-          // post a balanced journal must not be allowed to half-commit and drift.
-          void recordSystemError({
-            organizationId: payment.organizationId ?? null,
-            category: "LEDGER",
-            summary: `Booking ledger posting failed for payment ${payment.id}`,
-            err,
-            context: { paymentId: payment.id },
-          }).catch(() => {});
-          throw err;
-        }
-      }
+          if (splits.length > 0) {
+            // #812 — floor every collaborator's shareBps and let the LAST split
+            // absorb the remainder, so the cached bps sum to exactly 10000. Rounding
+            // each independently (Math.round) could overshoot or undershoot 10000 by
+            // a few bps across collaborators, the same floor-then-absorb discipline
+            // the rest of the money math uses.
+            const shareBpsList = splits.map((s) =>
+              totalConsultantPool > 0
+                ? Math.floor((s.share / totalConsultantPool) * 10_000)
+                : 0,
+            );
+            if (totalConsultantPool > 0) {
+              const assigned = shareBpsList.reduce((a, b) => a + b, 0);
+              shareBpsList[shareBpsList.length - 1] += 10_000 - assigned;
+            }
 
-      return ownerId;
-    });
+            // Multi-party payment: create earnings for owner and each collaborator
+            for (let i = 0; i < splits.length; i++) {
+              const split = splits[i];
+              const isOwner = split.role === "OWNER";
+              const shareBps = shareBpsList[i];
+              const settlement = isOwner
+                ? undefined
+                : collabSettlements.get(split.consultantProfileId);
+
+              // #773 — a settled collaborator's row carries their org card's fee
+              // slice and the NET share (what the payout pipeline disburses); the
+              // org's cut lives on its OrganizationEarnings row. The cache must
+              // mirror the journal's legs or EARNINGS_LEDGER_DRIFT fires.
+              const creditedShare = settlement
+                ? settlement.orgSplit.consultantSharePaise
+                : split.share;
+              const earnings = await tx.consultantEarnings.create({
+                data: {
+                  consultantProfileId: split.consultantProfileId,
+                  paymentId: payment.id,
+                  grossAmount: isOwner ? grossAmount : 0,
+                  platformFeePaise: isOwner
+                    ? platformFeePaise
+                    : (settlement?.orgSplit.platformFeePaise ?? 0),
+                  consultantSharePaise: creditedShare,
+                  role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
+                  shareBps,
+                  status: EarningStatus.PENDING,
+                  holdUntil,
+                  currency: "INR",
+                },
+              });
+
+              if (split.role === "OWNER") {
+                ownerId = earnings.id;
+              }
+
+              console.log(
+                `Earnings created for ${split.role} (${split.consultantProfileId}): ${creditedShare / 100} from payment ${payment.id}${orgSplit ? " [HOST 3-way split]" : ""}${settlement ? " [collab org-settled]" : ""}`,
+              );
+            }
+          } else {
+            // Single-owner payment (no collaborators or not a webinar/class)
+            const earnings = await tx.consultantEarnings.create({
+              data: {
+                consultantProfileId,
+                paymentId: payment.id,
+                grossAmount,
+                platformFeePaise,
+                consultantSharePaise: totalConsultantPool,
+                status: EarningStatus.PENDING,
+                holdUntil,
+                currency: "INR",
+              },
+            });
+
+            ownerId = earnings.id;
+          }
+
+          // Create OrganizationEarnings row for the HOST/HYBRID org (3-way split).
+          // Skip when orgShare is 0 (Platform-only mode: platformCommissionRate = 1.0)
+          // — creating 0-value rows adds noise without value.
+          //
+          // PR-1d / #687: if the sponsoring org is still PENDING_VERIFICATION
+          // and has never paid an invoice, accruals start in PENDING_TRUST
+          // instead of PENDING. The `release-pending-trust-earnings` cron
+          // promotes them once the org is verified or first invoice clears.
+          if (orgSplit && orgSplit.orgShare > 0) {
+            const sponsorOrg = await tx.organization.findUnique({
+              where: { id: orgSplit.organizationId },
+              select: { status: true },
+            });
+            let initialStatus: EarningStatus = EarningStatus.PENDING;
+            if (sponsorOrg?.status === "PENDING_VERIFICATION") {
+              const paidInvoiceCount = await tx.organizationInvoice.count({
+                where: {
+                  organizationId: orgSplit.organizationId,
+                  status: "PAID",
+                },
+              });
+              if (paidInvoiceCount === 0) {
+                initialStatus = EarningStatus.PENDING_TRUST;
+              }
+            }
+
+            await tx.organizationEarnings.create({
+              data: {
+                organizationId: orgSplit.organizationId,
+                paymentId: payment.id,
+                grossAmountPaise: grossAmount,
+                platformFeePaise: orgSplit.platformFeePaise,
+                orgSharePaise: orgSplit.orgShare,
+                consultantSharePaise: orgSplit.consultantSharePaise,
+                refundedAmountPaise: 0,
+                status: initialStatus,
+                holdUntil,
+                currency: "INR",
+                // Rate-card snapshot: persist the exact split applied so
+                // payout reconciliation reads this row, never the live card.
+                rateCardIdApplied: orgSplit.rateCardIdApplied,
+                platformBpsApplied: orgSplit.platformBps,
+                orgBpsApplied: orgSplit.orgBps,
+                consultantBpsApplied: orgSplit.consultantBps,
+              },
+            });
+
+            console.log(
+              `Org earnings created for ${orgSplit.organizationId}: org=${orgSplit.orgShare / 100} consultant=${orgSplit.consultantSharePaise / 100} (recipient=${orgSplit.payoutRecipient}) from payment ${payment.id}`,
+            );
+          } else if (orgSplit && orgSplit.orgShare === 0) {
+            console.log(
+              `Platform-only mode for ${orgSplit.organizationId}: skipping 0-value org earnings for payment ${payment.id}`,
+            );
+          }
+
+          // ============================================
+          // A3 (Q3) / #773: per-collaborator HOST-org settlement
+          // ============================================
+          // Each ACCEPTED collaborator at a HOST org settles to *their own* org
+          // independently of the primary expert's org: the collaborator's pool
+          // share is the "gross" their org's rate card splits. Independent
+          // collaborators (no active EXPERT membership at a HOST org) get no row —
+          // their full share sits on ConsultantEarnings and pays out via the
+          // personal payout pipeline. Rows are written BEFORE the booking journal
+          // below so the posting can mirror every accrual it covers. Platform-only
+          // cards (orgShare == 0) still settle (fee + net) but write no 0-value
+          // org row. Same-org collisions were already resolved upstream (see
+          // collabSettlements), so every entry here inserts cleanly.
+          for (const [collabProfileId, s] of Array.from(
+            collabSettlements.entries(),
+          )) {
+            if (s.orgSplit.orgShare <= 0) {
+              console.log(
+                `Platform-only mode for collaborator org ${s.orgSplit.organizationId}: skipping 0-value org earnings for payment ${payment.id}`,
+              );
+              continue;
+            }
+
+            // PR-1d / #687 — same PENDING_TRUST gate as the primary org above.
+            const collabSponsorOrg = await tx.organization.findUnique({
+              where: { id: s.orgSplit.organizationId },
+              select: { status: true },
+            });
+            let collabInitialStatus: EarningStatus = EarningStatus.PENDING;
+            if (collabSponsorOrg?.status === "PENDING_VERIFICATION") {
+              const paidInvoiceCount = await tx.organizationInvoice.count({
+                where: {
+                  organizationId: s.orgSplit.organizationId,
+                  status: "PAID",
+                },
+              });
+              if (paidInvoiceCount === 0) {
+                collabInitialStatus = EarningStatus.PENDING_TRUST;
+              }
+            }
+
+            await tx.organizationEarnings.create({
+              data: {
+                organizationId: s.orgSplit.organizationId,
+                paymentId: payment.id,
+                // The collaborator's share is the "gross" that this org is
+                // splitting — NOT the booking's full gross. Persist it verbatim
+                // so reconciliation sees a consistent picture.
+                grossAmountPaise: s.sharePaise,
+                platformFeePaise: s.orgSplit.platformFeePaise,
+                orgSharePaise: s.orgSplit.orgShare,
+                consultantSharePaise: s.orgSplit.consultantSharePaise,
+                refundedAmountPaise: 0,
+                status: collabInitialStatus,
+                holdUntil,
+                currency: "INR",
+                rateCardIdApplied: s.orgSplit.rateCardIdApplied,
+                platformBpsApplied: s.orgSplit.platformBps,
+                orgBpsApplied: s.orgSplit.orgBps,
+                consultantBpsApplied: s.orgSplit.consultantBps,
+              },
+            });
+            console.log(
+              `Collaborator org earnings created for ${s.orgSplit.organizationId} (collab ${collabProfileId}): org=${s.orgSplit.orgShare / 100} consultant=${s.orgSplit.consultantSharePaise / 100} from payment ${payment.id}`,
+            );
+          }
+
+          // #771 D1/D5 / AF-3 — double-entry booking posting (full accrual, dual-write).
+          //   Dr funding legs (CASH/WALLET/ORG_RECEIVABLE) + PLATFORM_PROMO (referral
+          //   credits) + DISCOUNT  ==  Cr PLATFORM_FEE + CONSULTANT_PAYABLE(per party) +
+          //   ORG_PAYABLE(per org) + GST_PAYABLE.
+          // #776 — posted for BOTH the single-consultant AND multi-collaborator cases.
+          // #773 — the multi-collaborator posting now also covers the per-collab
+          // HOST-org settlements written above: each settled collaborator's
+          // CONSULTANT_PAYABLE is their NET share, their org gets its own
+          // ORG_PAYABLE leg, and the org-card fee slices fold into PLATFORM_FEE —
+          // so the journal's earnings-relevant credits equal the cached Earnings
+          // rows exactly (EARNINGS_LEDGER_DRIFT contract).
+          {
+            try {
+              const legs = await tx.paymentLeg.findMany({
+                where: { paymentId: payment.id },
+                select: { source: true, amountPaise: true },
+              });
+              const orgId = payment.organizationId ?? null;
+              const debits: Posting[] = [];
+              const pushDebit = (account: AccountRef, amountPaise: number) => {
+                if (amountPaise > 0)
+                  debits.push({ account, direction: "DEBIT", amountPaise });
+              };
+              if (legs.length > 0) {
+                let card = 0;
+                let wallet = 0;
+                let receivable = 0;
+                let promo = 0;
+                for (const leg of legs) {
+                  if (leg.amountPaise <= 0) continue;
+                  switch (leg.source) {
+                    case "CARD":
+                      card += leg.amountPaise;
+                      break;
+                    case "WALLET":
+                      wallet += leg.amountPaise;
+                      break;
+                    case "INVOICE_ACCRUAL":
+                    case "OVERAGE_INVOICE_ACCRUAL":
+                      receivable += leg.amountPaise;
+                      break;
+                    case "REFERRAL_CREDIT":
+                      promo += leg.amountPaise;
+                      break;
+                    case "LICENSE":
+                      break; // 0 — no money moves
+                    case "INVOICE_ACCRUAL_REVERSAL":
+                    case "OVERAGE_INVOICE_ACCRUAL_REVERSAL":
+                      // #786 — negative refund counter-entries; they cannot exist
+                      // at booking time and are never funding. Skip explicitly
+                      // (the <= 0 guard above already drops them defensively).
+                      break;
+                  }
+                }
+                pushDebit({ kind: "CASH" }, card);
+                pushDebit({ kind: "WALLET", organizationId: orgId }, wallet);
+                pushDebit(
+                  { kind: "ORG_RECEIVABLE", organizationId: orgId },
+                  receivable,
+                );
+                pushDebit({ kind: "PLATFORM_PROMO" }, promo);
+              } else {
+                // Back-compat: legacy single-source payments carry no legs.
+                pushDebit({ kind: "CASH" }, payment.amount);
+              }
+              // #776 — DISCOUNT is the platform-absorbed gap between gross
+              // (originalAmount + tax) and the funding actually applied. Base it on the
+              // sum of the funding-leg debits, NOT payment.amount: a referral-credit leg
+              // funds the booking (debited as PLATFORM_PROMO) yet is excluded from
+              // payment.amount (post-credit). Using `amount` double-counted the credit
+              // (PROMO + DISCOUNT), imbalancing the posting so it was silently dropped —
+              // every fully-credit-funded booking went un-journaled.
+              const fundingDebitTotal = debits.reduce(
+                (s, d) => s + d.amountPaise,
+                0,
+              );
+              pushDebit(
+                { kind: "DISCOUNT" },
+                Math.max(
+                  0,
+                  payment.originalAmount +
+                    (payment.taxAmount ?? 0) -
+                    fundingDebitTotal,
+                ),
+              );
+
+              const credits: Posting[] = [];
+              const pushCredit = (account: AccountRef, amountPaise: number) => {
+                if (amountPaise > 0)
+                  credits.push({ account, direction: "CREDIT", amountPaise });
+              };
+              // #773 — the platform's total cut is the primary fee PLUS each
+              // settled collaborator's org-card fee slice, as one summed leg.
+              let platformFeeCreditPaise = platformFeePaise;
+              for (const s of Array.from(collabSettlements.values())) {
+                platformFeeCreditPaise += s.orgSplit.platformFeePaise;
+              }
+              pushCredit({ kind: "PLATFORM_FEE" }, platformFeeCreditPaise);
+              if (splits.length > 0) {
+                // Multi-party: one payable per party, mirroring the
+                // ConsultantEarnings rows. Settled collaborators are credited NET
+                // of their org's cut; each settled share decomposes exactly into
+                // fee + org + net (resolveOrgSplit), so Σ(payables + org legs +
+                // fee slices) === totalConsultantPool and the txn balances to the
+                // paise.
+                for (const split of splits) {
+                  const settlement =
+                    split.role === "OWNER"
+                      ? undefined
+                      : collabSettlements.get(split.consultantProfileId);
+                  pushCredit(
+                    {
+                      kind: "CONSULTANT_PAYABLE",
+                      consultantProfileId: split.consultantProfileId,
+                    },
+                    settlement
+                      ? settlement.orgSplit.consultantSharePaise
+                      : split.share,
+                  );
+                }
+              } else {
+                pushCredit(
+                  { kind: "CONSULTANT_PAYABLE", consultantProfileId },
+                  totalConsultantPool,
+                );
+              }
+              if (orgSplit && orgSplit.orgShare > 0) {
+                pushCredit(
+                  {
+                    kind: "ORG_PAYABLE",
+                    organizationId: orgSplit.organizationId,
+                  },
+                  orgSplit.orgShare,
+                );
+              }
+              // #773 — one ORG_PAYABLE per collaborator host org, mirroring the
+              // OrganizationEarnings rows written above.
+              for (const s of Array.from(collabSettlements.values())) {
+                if (s.orgSplit.orgShare > 0) {
+                  pushCredit(
+                    {
+                      kind: "ORG_PAYABLE",
+                      organizationId: s.orgSplit.organizationId,
+                    },
+                    s.orgSplit.orgShare,
+                  );
+                }
+              }
+              // #812 — guard a missing taxAmount (NaN would imbalance the now-blocking
+              // posting and roll back the booking). Defaults to 0 in-schema, but
+              // legacy/imported rows may lack it.
+              pushCredit({ kind: "GST_PAYABLE" }, payment.taxAmount ?? 0);
+
+              await postLedgerTxn(tx, {
+                idempotencyKey: `booking:${payment.id}`,
+                kind: "BOOKING",
+                paymentId: payment.id,
+                postings: [...debits, ...credits],
+              });
+            } catch (err) {
+              console.error(
+                `[ledger] booking posting FAILED for payment ${payment.id} — rolling back the booking: ${err instanceof Error ? err.message : String(err)}`,
+              );
+              // #812 — record the drift on its own connection (survives the rollback),
+              // then RE-THROW so the imbalance rolls back the whole booking
+              // transaction. The ledger is the source of truth: a booking that can't
+              // post a balanced journal must not be allowed to half-commit and drift.
+              void recordSystemError({
+                organizationId: payment.organizationId ?? null,
+                category: "LEDGER",
+                summary: `Booking ledger posting failed for payment ${payment.id}`,
+                err,
+                context: { paymentId: payment.id },
+              }).catch(() => {});
+              throw err;
+            }
+          }
+
+          return ownerId;
+        },
+        {
+          isolationLevel: "Serializable",
+          timeout: 10000,
+        },
+      ),
+    );
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -27,6 +27,7 @@ import { calculateRevenueSplit } from "@/lib/collaborators/service";
 import { recordTdsReversal } from "@/lib/payments/tax/tds-service";
 import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 import { recordSystemError } from "@/lib/enterprise/system-events";
+import { isConsultantReferralWaiverActive } from "@/lib/referrals/service";
 import type { RevenueSplit } from "@/types/collaborators";
 
 // ============================================
@@ -294,9 +295,17 @@ export async function createEarningsFromPayment({
       // Determine platform fee and consultant pool based on whether org split applies.
       // #778 §C-2 — floor the marketplace fee (was Math.round); the shaved paisa
       // stays in the consultant pool (gross − fee), the pool's residual party.
+      // #880 — a referred consultant pays 0% platform commission on their first
+      // sessions (their referee instrument). Scoped to individual settlements;
+      // org-hosted splits keep their rate-card economics.
+      const waiveCommission =
+        !orgSplit &&
+        (await isConsultantReferralWaiverActive(tx, consultantProfileId));
       const platformFeePaise = orgSplit
         ? orgSplit.platformFeePaise
-        : prorate(grossAmount, PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE, 100);
+        : waiveCommission
+          ? 0
+          : prorate(grossAmount, PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE, 100);
       const totalConsultantPool = orgSplit
         ? orgSplit.consultantSharePaise
         : grossAmount - platformFeePaise;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -239,6 +239,11 @@ function makeClient() {
       },
       gstTcsAdjustment: { amountPaise: f("amountPaise") },
       discountCode: { maxDiscount: fn("maxDiscount") },
+      referralProgramConfig: {
+        monthlyBudgetPaise: fn("monthlyBudgetPaise"),
+        currentMonthSpentPaise: f("currentMonthSpentPaise"),
+        referrerRewardPaise: f("referrerRewardPaise"),
+      },
       referralCode: {
         referrerReward: fn("referrerReward"),
         refereeReward: fn("refereeReward"),

--- a/lib/referrals/constants.ts
+++ b/lib/referrals/constants.ts
@@ -7,3 +7,7 @@ export const MIN_CREDIT_REDEMPTION_PAISE = 50000; // ₹500
 // #880 — a single referrer can earn at most this much in referral bonuses over
 // a trailing year, mirroring the annual caps Indian fintech programs use.
 export const ANNUAL_REWARD_CAP_PAISE = 1000000; // ₹10,000
+// #880 — a referred consultant's seller instrument: 0% platform commission on
+// their first N settled (paid) sessions, instead of a booking credit they can't
+// use. Applied to individual (non-org-hosted) consultants.
+export const CONSULTANT_WAIVER_SESSIONS = 3;

--- a/lib/referrals/constants.ts
+++ b/lib/referrals/constants.ts
@@ -1,2 +1,9 @@
 export const QUALIFICATION_WINDOW_DAYS = 30;
-export const CREDIT_EXPIRY_MONTHS = 6;
+// #880 — tightened from 6 months to bound outstanding referral-credit liability.
+export const CREDIT_EXPIRY_DAYS = 90;
+// #880 — referral credits redeem only on orders of ₹500+ so a credit never
+// exceeds the value of the transaction it discounts.
+export const MIN_CREDIT_REDEMPTION_PAISE = 50000; // ₹500
+// #880 — a single referrer can earn at most this much in referral bonuses over
+// a trailing year, mirroring the annual caps Indian fintech programs use.
+export const ANNUAL_REWARD_CAP_PAISE = 1000000; // ₹10,000

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -7,6 +7,7 @@ import {
   QUALIFICATION_WINDOW_DAYS,
   CREDIT_EXPIRY_DAYS,
   ANNUAL_REWARD_CAP_PAISE,
+  CONSULTANT_WAIVER_SESSIONS,
 } from "./constants";
 
 // #780 — bare model types still say bigint; the extended client returns number
@@ -343,11 +344,20 @@ export async function processQualifyingAction(
           }
         }
 
-        // FIX #437: Give referee their bonus (deferred from signup)
-        // Previously given immediately in applyReferralCode, now deferred to
-        // first paid booking to prevent fake account farming.
+        // FIX #437: Give referee their bonus (deferred from signup), but only
+        // for consultee referees. #880 — a consultant referee's instrument is a
+        // commission waiver on their first sessions (applied in earnings-service),
+        // not a booking credit a seller can't use, so skip the credit for them.
+        const refereeUser = await tx.user.findUnique({
+          where: { id: referral.referredUserId },
+          select: { role: true },
+        });
         const refereeReward = referral.refereeRewardAmount;
-        if (refereeReward && refereeReward > 0) {
+        if (
+          refereeUser?.role !== "CONSULTANT" &&
+          refereeReward &&
+          refereeReward > 0
+        ) {
           const expiresAt = new Date();
           expiresAt.setDate(expiresAt.getDate() + CREDIT_EXPIRY_DAYS);
 
@@ -713,6 +723,40 @@ export async function expireStaleCredits(): Promise<number> {
   });
 
   return result.count;
+}
+
+/**
+ * #880 — is this consultant eligible for the referral commission waiver on the
+ * session being settled? True when they are the referee of a live referral AND
+ * this is within their first CONSULTANT_WAIVER_SESSIONS settled (paid) sessions.
+ * The caller passes the same `tx` as the earnings write so the session count is
+ * consistent; org-hosted settlements are excluded by the caller.
+ */
+export async function isConsultantReferralWaiverActive(
+  tx: Tx,
+  consultantProfileId: string,
+): Promise<boolean> {
+  const profile = await tx.consultantProfile.findUnique({
+    where: { id: consultantProfileId },
+    select: { userId: true },
+  });
+  if (!profile) return false;
+
+  const referral = await tx.referral.findFirst({
+    where: {
+      referredUserId: profile.userId,
+      status: { in: ["SIGNED_UP", "REWARDED"] },
+    },
+    select: { id: true },
+  });
+  if (!referral) return false;
+
+  // Count excludes the row being created (idempotency guarantees this payment
+  // has none yet), so 0/1/2 prior sessions ⇒ waive, 3+ ⇒ full commission.
+  const priorSessions = await tx.consultantEarnings.count({
+    where: { consultantProfileId },
+  });
+  return priorSessions < CONSULTANT_WAIVER_SESSIONS;
 }
 
 /**

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -291,9 +291,11 @@ export async function processQualifyingAction(
             status: "REWARDED",
             qualifiedAt: new Date(),
             qualifyingAction: action,
-            referrerRewardPaidAt: new Date(),
-            // FIX #437: Both bonuses awarded together on first paid booking
-            refereeRewardPaidAt: new Date(),
+            // #896 — the *RewardPaidAt timestamps are set below, each only when a
+            // credit row is actually created for that side. The referrer grant can
+            // clamp to 0 (annual cap / monthly budget) and the referee grant is
+            // skipped entirely for CONSULTANT referees, so an unconditional "paid"
+            // stamp here would claim a payment that never happened.
           },
         });
 
@@ -315,6 +317,10 @@ export async function processQualifyingAction(
         // Running program spend for this qualification (referrer + referee),
         // used to honor the monthly budget cap and auto-pause on exhaustion.
         let spentNow = 0;
+
+        // #896 — only stamp *RewardPaidAt for a side that actually got a credit.
+        let referrerCredited = false;
+        let refereeCredited = false;
 
         // Give referrer their bonus. The amount comes from the program config
         // (the conservative-launch ramp, ₹300 → ₹500), clamped by the annual
@@ -370,6 +376,7 @@ export async function processQualifyingAction(
               },
             });
             spentNow += grant;
+            referrerCredited = true;
           }
         }
 
@@ -404,7 +411,21 @@ export async function processQualifyingAction(
               },
             });
             spentNow += grant;
+            refereeCredited = true;
           }
+        }
+
+        // #896 — stamp paid-at per side, each only when its credit landed. A
+        // clamped/skipped grant leaves the timestamp null so the row never
+        // claims a payment that didn't happen.
+        if (referrerCredited || refereeCredited) {
+          await tx.referral.update({
+            where: { id: referral.id },
+            data: {
+              ...(referrerCredited ? { referrerRewardPaidAt: new Date() } : {}),
+              ...(refereeCredited ? { refereeRewardPaidAt: new Date() } : {}),
+            },
+          });
         }
 
         // #880 — persist the budget window (lazy monthly rollover) and the
@@ -806,10 +827,20 @@ export async function isConsultantReferralWaiverActive(
   });
   if (!profile) return false;
 
+  // #896 — a still-SIGNED_UP referral only grants the waiver while it's inside
+  // the qualification window; past it the row is stale (the expire cron just
+  // hasn't run yet) and must not waive. REWARDED rows already qualified, so
+  // they carry no window check.
+  const windowCutoff = new Date(
+    Date.now() - QUALIFICATION_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  );
   const referral = await tx.referral.findFirst({
     where: {
       referredUserId: profile.userId,
-      status: { in: ["SIGNED_UP", "REWARDED"] },
+      OR: [
+        { status: "REWARDED" },
+        { status: "SIGNED_UP", signedUpAt: { gte: windowCutoff } },
+      ],
     },
     select: { id: true },
   });
@@ -817,8 +848,15 @@ export async function isConsultantReferralWaiverActive(
 
   // Count excludes the row being created (idempotency guarantees this payment
   // has none yet), so 0/1/2 prior sessions ⇒ waive, 3+ ⇒ full commission.
+  // #896 — exclude org-hosted settlements (the waiver only applies to non-org
+  // sessions, so a HYBRID consultant must not burn quota on org sessions) and
+  // REFUNDED earnings (a refunded session must not consume a waiver slot).
   const priorSessions = await tx.consultantEarnings.count({
-    where: { consultantProfileId },
+    where: {
+      consultantProfileId,
+      status: { not: "REFUNDED" },
+      payment: { organizationEarnings: { none: {} } },
+    },
   });
   return priorSessions < CONSULTANT_WAIVER_SESSIONS;
 }

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -3,7 +3,11 @@ import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import { Prisma as PrismaNamespace } from "@prisma/client";
 import type { ReferralCode, Referral, ReferralCredit } from "@prisma/client";
 import { sumPaise } from "@/lib/payments/utils/money";
-import { QUALIFICATION_WINDOW_DAYS, CREDIT_EXPIRY_MONTHS } from "./constants";
+import {
+  QUALIFICATION_WINDOW_DAYS,
+  CREDIT_EXPIRY_DAYS,
+  ANNUAL_REWARD_CAP_PAISE,
+} from "./constants";
 
 // #780 — bare model types still say bigint; the extended client returns number
 export type ReferralCodeRow = Omit<
@@ -31,11 +35,14 @@ export type ReferralCreditRow = Omit<
 };
 
 // Re-export so existing server-side consumers can still import from service
-export { QUALIFICATION_WINDOW_DAYS, CREDIT_EXPIRY_MONTHS };
+export { QUALIFICATION_WINDOW_DAYS, CREDIT_EXPIRY_DAYS };
 
 // Constants
-const DEFAULT_REFERRER_REWARD = 50000; // ₹500 in paise
-const DEFAULT_REFEREE_REWARD = 20000; // ₹200 in paise
+// #880 conservative launch: ₹300 each (the referrer reward ramps to ₹500 once
+// unit economics are validated). Role-weighting and the consultant commission
+// waiver arrive in later phases; these are the flat launch baselines.
+const DEFAULT_REFERRER_REWARD = 30000; // ₹300 in paise
+const DEFAULT_REFEREE_REWARD = 30000; // ₹300 in paise
 
 /**
  * Creates or returns an existing referral code for a user.
@@ -286,32 +293,54 @@ export async function processQualifyingAction(
           return;
         }
 
-        // Give referrer their bonus
+        // Give referrer their bonus, clamped by the annual per-referrer cap.
         const referrerReward = referral.referrerRewardAmount;
         if (referrerReward && referrerReward > 0) {
-          const expiresAt = new Date();
-          expiresAt.setMonth(expiresAt.getMonth() + CREDIT_EXPIRY_MONTHS);
-
-          await tx.referralCredit.create({
-            data: {
+          // #880 — bound a referrer's referral earnings to ANNUAL_REWARD_CAP
+          // over a trailing year; clamp (or skip) the grant if it would exceed.
+          const yearCutoff = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+          const priorCredits = await tx.referralCredit.findMany({
+            where: {
               userId: referral.referralCode.userId,
-              amount: referrerReward,
-              currency: "INR",
               source: "REFERRAL_BONUS",
-              referralId: referral.id,
-              remainingAmount: referrerReward,
-              expiresAt,
+              createdAt: { gte: yearCutoff },
             },
+            select: { amount: true },
           });
+          const earnedThisYear = priorCredits.reduce(
+            (sum, c) => sum + Number(c.amount),
+            0,
+          );
+          const grant = Math.min(
+            referrerReward,
+            Math.max(0, ANNUAL_REWARD_CAP_PAISE - earnedThisYear),
+          );
 
-          // Update referral code stats
-          await tx.referralCode.update({
-            where: { id: referral.referralCodeId },
-            data: {
-              successfulReferrals: { increment: 1 },
-              totalEarned: { increment: referrerReward },
-            },
-          });
+          if (grant > 0) {
+            const expiresAt = new Date();
+            expiresAt.setDate(expiresAt.getDate() + CREDIT_EXPIRY_DAYS);
+
+            await tx.referralCredit.create({
+              data: {
+                userId: referral.referralCode.userId,
+                amount: grant,
+                currency: "INR",
+                source: "REFERRAL_BONUS",
+                referralId: referral.id,
+                remainingAmount: grant,
+                expiresAt,
+              },
+            });
+
+            // Update referral code stats
+            await tx.referralCode.update({
+              where: { id: referral.referralCodeId },
+              data: {
+                successfulReferrals: { increment: 1 },
+                totalEarned: { increment: grant },
+              },
+            });
+          }
         }
 
         // FIX #437: Give referee their bonus (deferred from signup)
@@ -320,7 +349,7 @@ export async function processQualifyingAction(
         const refereeReward = referral.refereeRewardAmount;
         if (refereeReward && refereeReward > 0) {
           const expiresAt = new Date();
-          expiresAt.setMonth(expiresAt.getMonth() + CREDIT_EXPIRY_MONTHS);
+          expiresAt.setDate(expiresAt.getDate() + CREDIT_EXPIRY_DAYS);
 
           await tx.referralCredit.create({
             data: {

--- a/lib/referrals/service.ts
+++ b/lib/referrals/service.ts
@@ -254,6 +254,24 @@ export async function processQualifyingAction(
 
         if (!referral || referral.status !== "SIGNED_UP") return;
 
+        // #880 — program controls (single-row config). A paused program grants
+        // nothing and leaves the referral SIGNED_UP so it can still qualify once
+        // the program resumes. The monthly budget window rolls over lazily.
+        const period = new Date().toISOString().slice(0, 7); // YYYY-MM
+        const config = await tx.referralProgramConfig.upsert({
+          where: { id: "singleton" },
+          create: { id: "singleton", currentPeriod: period },
+          update: {},
+        });
+        if (!config.isActive) return;
+        const spentThisMonth =
+          config.currentPeriod === period ? config.currentMonthSpentPaise : 0;
+        const budgetRemaining =
+          config.monthlyBudgetPaise === null
+            ? Number.POSITIVE_INFINITY
+            : Math.max(0, config.monthlyBudgetPaise - spentThisMonth);
+        if (budgetRemaining <= 0) return; // month's budget exhausted → defer
+
         // REF-3 (#692) — claim the reward atomically: status still SIGNED_UP AND
         // within the qualification window, both asserted in the WHERE. Folding the
         // window into the guarded write (rather than an app-side Date.now() check
@@ -294,9 +312,18 @@ export async function processQualifyingAction(
           return;
         }
 
-        // Give referrer their bonus, clamped by the annual per-referrer cap.
-        const referrerReward = referral.referrerRewardAmount;
-        if (referrerReward && referrerReward > 0) {
+        // Running program spend for this qualification (referrer + referee),
+        // used to honor the monthly budget cap and auto-pause on exhaustion.
+        let spentNow = 0;
+
+        // Give referrer their bonus. The amount comes from the program config
+        // (the conservative-launch ramp, ₹300 → ₹500), clamped by the annual
+        // per-referrer cap and the remaining monthly budget.
+        const rampedReferrerReward =
+          config.referrerRewardPaise > 0
+            ? config.referrerRewardPaise
+            : (referral.referrerRewardAmount ?? 0);
+        if (rampedReferrerReward > 0) {
           // #880 — bound a referrer's referral earnings to ANNUAL_REWARD_CAP
           // over a trailing year; clamp (or skip) the grant if it would exceed.
           const yearCutoff = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
@@ -313,8 +340,9 @@ export async function processQualifyingAction(
             0,
           );
           const grant = Math.min(
-            referrerReward,
+            rampedReferrerReward,
             Math.max(0, ANNUAL_REWARD_CAP_PAISE - earnedThisYear),
+            budgetRemaining - spentNow,
           );
 
           if (grant > 0) {
@@ -341,6 +369,7 @@ export async function processQualifyingAction(
                 totalEarned: { increment: grant },
               },
             });
+            spentNow += grant;
           }
         }
 
@@ -358,18 +387,40 @@ export async function processQualifyingAction(
           refereeReward &&
           refereeReward > 0
         ) {
-          const expiresAt = new Date();
-          expiresAt.setDate(expiresAt.getDate() + CREDIT_EXPIRY_DAYS);
+          const grant = Math.min(refereeReward, budgetRemaining - spentNow);
+          if (grant > 0) {
+            const expiresAt = new Date();
+            expiresAt.setDate(expiresAt.getDate() + CREDIT_EXPIRY_DAYS);
 
-          await tx.referralCredit.create({
+            await tx.referralCredit.create({
+              data: {
+                userId: referral.referredUserId,
+                amount: grant,
+                currency: "INR",
+                source: "REFEREE_BONUS",
+                referralId: referral.id,
+                remainingAmount: grant,
+                expiresAt,
+              },
+            });
+            spentNow += grant;
+          }
+        }
+
+        // #880 — persist the budget window (lazy monthly rollover) and the
+        // spend, auto-pausing the program when the monthly budget is exhausted
+        // so later qualifications defer until an admin reviews.
+        if (config.monthlyBudgetPaise !== null || config.currentPeriod !== period) {
+          const newSpent = spentThisMonth + spentNow;
+          await tx.referralProgramConfig.update({
+            where: { id: config.id },
             data: {
-              userId: referral.referredUserId,
-              amount: refereeReward,
-              currency: "INR",
-              source: "REFEREE_BONUS",
-              referralId: referral.id,
-              remainingAmount: refereeReward,
-              expiresAt,
+              currentPeriod: period,
+              currentMonthSpentPaise: newSpent,
+              ...(config.monthlyBudgetPaise !== null &&
+              newSpent >= config.monthlyBudgetPaise
+                ? { isActive: false }
+                : {}),
             },
           });
         }
@@ -723,6 +774,19 @@ export async function expireStaleCredits(): Promise<number> {
   });
 
   return result.count;
+}
+
+/**
+ * #880 — proactively roll the monthly referral-budget window. A cron may call
+ * this; the qualification path also rolls it over lazily. Does NOT re-activate
+ * an auto-paused program — re-enabling is an explicit admin action.
+ */
+export async function resetReferralBudgetMonthly(): Promise<void> {
+  const period = new Date().toISOString().slice(0, 7);
+  await prisma.referralProgramConfig.updateMany({
+    where: { currentPeriod: { not: period } },
+    data: { currentPeriod: period, currentMonthSpentPaise: 0 },
+  });
 }
 
 /**

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4422,10 +4422,10 @@ model ReferralCreditUsage {
 model ReferralProgramConfig {
   id                     String   @id @default("singleton")
   isActive               Boolean  @default(true)
-  monthlyBudgetPaise     Int? // null = unlimited
+  monthlyBudgetPaise     BigInt? // null = unlimited
   currentPeriod          String   @default("") // "YYYY-MM" of the active budget window
-  currentMonthSpentPaise Int      @default(0)
-  referrerRewardPaise    Int      @default(30000) // ₹300 launch; ramp to 50000 (₹500)
+  currentMonthSpentPaise BigInt   @default(0)
+  referrerRewardPaise    BigInt   @default(30000) // ₹300 launch; ramp to 50000 (₹500)
   createdAt              DateTime @default(now())
   updatedAt              DateTime @updatedAt
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4398,6 +4398,21 @@ model ReferralCreditUsage {
   @@index([paymentId])
 }
 
+// #880 — single-row referral-program config (fixed id). Centralizes the
+// conservative-launch controls: the program on/off switch, a monthly budget cap
+// with auto-pause, and the ramped referrer reward. Paise stored as Int (well
+// within range for a referral budget) to keep the gate arithmetic in number.
+model ReferralProgramConfig {
+  id                     String   @id @default("singleton")
+  isActive               Boolean  @default(true)
+  monthlyBudgetPaise     Int? // null = unlimited
+  currentPeriod          String   @default("") // "YYYY-MM" of the active budget window
+  currentMonthSpentPaise Int      @default(0)
+  referrerRewardPaise    Int      @default(30000) // ₹300 launch; ramp to 50000 (₹500)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+}
+
 enum ReferralStatus {
   SIGNED_UP
   QUALIFIED

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4312,7 +4312,7 @@ model ReferralCode {
   totalReferrals      Int     @default(0)
   successfulReferrals Int     @default(0)
   totalEarned         BigInt  @default(0)
-  maxReferrals        Int     @default(50) // Maximum referrals allowed per code
+  maxReferrals        Int     @default(25) // #880 — tightened from 50 to bound farming/liability
   isActive            Boolean @default(true)
 
   user      User       @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)


### PR DESCRIPTION
Implements the **#880** referral reward-economics decisions (documented in `docs/referrals/04-reward-economics-and-decisions.md`) as three commits — Phase A, B, C.

## Phase A — conservative launch amounts + tightened guardrails (`ced2d404`)
- Reward defaults → conservative launch baseline (**₹300 referrer / ₹300 referee**); referrer ramps to ₹500 in Phase C.
- Credit expiry **6mo → 90d**; per-code referral cap **50 → 25**.
- **₹500 minimum order** before referral credits redeem — gated in TX1 (`calculateAmountAndValidate`) so the payment intent stays consistent with the credit decision.
- **Annual per-referrer cap (~₹10,000/yr)** — the referrer grant is clamped against a trailing-year sum of their referral bonuses.

## Phase B — role-weighted rewards + consultant commission waiver (`f07c318a`)
- **Role-weighted referee instrument** at qualification (`processQualifyingAction`): a *consultee* referee gets the booking credit; a *consultant* referee skips it (a seller can't use a booking credit) and instead gets the commission waiver.
- **Commission waiver**: a referred consultant pays **0% platform commission on their first 3 settled sessions**, injected at the commission point in `earnings-service.ts`. Scoped to individual (non-org-hosted) settlements; org rate-card splits are untouched. Eligibility is derived (`isConsultantReferralWaiverActive`): referee of a live referral + `<3` prior earnings.
- **Consultant qualifying trigger reuses the existing `first_paid_booking_received` proxy** (`processConsultantBookingReferral`) — consultants qualify on a paid booking *received*, since they sell rather than buy.

## Phase C — program budget cap, auto-pause + referrer ramp (`d676d78a`)
- New **`ReferralProgramConfig`** (single row): program on/off, monthly budget cap, current-period spend, ramped referrer reward.
- Qualification reads the config: a **paused** program grants nothing and leaves the referral `SIGNED_UP`; the monthly window **rolls over lazily**; grants are **clamped to remaining budget** and the program **auto-pauses** when exhausted.
- The **referrer reward amount now comes from the config (the ramp)**, clamped by the annual cap and the budget.
- `resetReferralBudgetMonthly()` for a cron (the path also rolls over lazily, so the budget works cron-independently).

## Verification
- **`tsc --noEmit` → 0 errors** (cold, cleared `.tsbuildinfo`, raised heap) and **eslint clean** (no errors) on all three phases.
- **Tests extended** (`__tests__/referrals/service.test.ts`): role-weighting (consultant referee skips the booking credit), paused-program, budget-exhausted, annual-cap clamping — alongside the existing REF-2/REF-3 pins. Jest can't run inside the worktree (`testPathIgnorePatterns` excludes `/.claude/worktrees/`), so the suite runs in **CI on the clean checkout**; the test file is type-checked locally.

## Notes / follow-ups
- **DB migration**: `ReferralProgramConfig` is added to the schema and the Prisma client is generated, but no `db push` was run (shared Supabase). The migration must be applied (or land in the pre-MVP reset) before the program config is used at runtime.
- **Session-completion accuracy**: the consultant qualifying + waiver key off the *paid-booking/earnings* proxy (reliable, on the money path). A Stream `session_ended` webhook to upgrade *booked → delivered* accuracy (the "webhook" half of the agreed mix) is a documented follow-up.
- **Lint**: a non-blocking `unused-imports` false-positive on `CREDIT_EXPIRY_DAYS` in the two referral dashboards (verifiably used in JSX; build-safe) — to confirm/clear in the review pass.

Part of #880. Org referrals remain deferred (attribution-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral program now enforces monthly budgets and annual per-referrer caps on rewards
  * Consultant referees are now eligible for commission waivers instead of booking credits

* **Changes**
  * Credit expiry period set to 90 days (updated display)
  * Minimum order threshold required to redeem referral credits
  * Maximum referrals per code reduced from 50 to 25
  * Rewards deferred when monthly budget is exhausted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->