### PR TITLE
feat(loading): add missing loading.tsx for 24 route segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ migrations/
 
 # Screenshots and feedback (large binaries / local notes)
 highlight-reel-screenshots/
-feedback/
+/feedback/
 
 # dependencies
 /node_modules

--- a/app/auth/forgot-password/loading.tsx
+++ b/app/auth/forgot-password/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-5">
+        <div className="h-7 w-40 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 w-28 animate-pulse rounded-md bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/app/auth/forgot-password/loading.tsx
+++ b/app/auth/forgot-password/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center bg-neutral-950 p-4">
       <div className="w-full max-w-md space-y-5">
         <div className="h-7 w-40 animate-pulse rounded-md bg-muted" />
         <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />

--- a/app/auth/reset-password/loading.tsx
+++ b/app/auth/reset-password/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-5">
+        <div className="h-7 w-40 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 w-28 animate-pulse rounded-md bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/app/auth/reset-password/loading.tsx
+++ b/app/auth/reset-password/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center bg-neutral-950 p-4">
       <div className="w-full max-w-md space-y-5">
         <div className="h-7 w-40 animate-pulse rounded-md bg-muted" />
         <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />

--- a/app/auth/signin/loading.tsx
+++ b/app/auth/signin/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen">
+      <div className="hidden animate-pulse bg-muted lg:block lg:w-1/2" />
+      <div className="flex w-full flex-col items-center justify-center p-8 lg:w-1/2">
+        <div className="w-full max-w-md space-y-6">
+          <div className="h-8 w-32 animate-pulse rounded-md bg-muted" />
+          <div className="space-y-3">
+            <div className="h-10 animate-pulse rounded-md bg-muted" />
+            <div className="h-10 animate-pulse rounded-md bg-muted" />
+          </div>
+          <div className="h-10 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/signin/loading.tsx
+++ b/app/auth/signin/loading.tsx
@@ -2,7 +2,7 @@ export default function Loading() {
   return (
     <div className="flex min-h-screen">
       <div className="hidden animate-pulse bg-muted lg:block lg:w-1/2" />
-      <div className="flex w-full flex-col items-center justify-center p-8 lg:w-1/2">
+      <div className="flex w-full flex-col items-center justify-center bg-neutral-950 p-8 lg:w-1/2">
         <div className="w-full max-w-md space-y-6">
           <div className="h-8 w-32 animate-pulse rounded-md bg-muted" />
           <div className="space-y-3">

--- a/app/auth/signup/loading.tsx
+++ b/app/auth/signup/loading.tsx
@@ -1,0 +1,19 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen">
+      <div className="hidden animate-pulse bg-muted lg:block lg:w-1/2" />
+      <div className="flex w-full flex-col items-center justify-center p-8 lg:w-1/2">
+        <div className="w-full max-w-md space-y-6">
+          <div className="h-8 w-32 animate-pulse rounded-md bg-muted" />
+          <div className="space-y-3">
+            <div className="h-10 animate-pulse rounded-md bg-muted" />
+            <div className="h-10 animate-pulse rounded-md bg-muted" />
+            <div className="h-10 animate-pulse rounded-md bg-muted" />
+            <div className="h-10 animate-pulse rounded-md bg-muted" />
+          </div>
+          <div className="h-10 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/signup/loading.tsx
+++ b/app/auth/signup/loading.tsx
@@ -2,7 +2,7 @@ export default function Loading() {
   return (
     <div className="flex min-h-screen">
       <div className="hidden animate-pulse bg-muted lg:block lg:w-1/2" />
-      <div className="flex w-full flex-col items-center justify-center p-8 lg:w-1/2">
+      <div className="flex w-full flex-col items-center justify-center bg-neutral-950 p-8 lg:w-1/2">
         <div className="w-full max-w-md space-y-6">
           <div className="h-8 w-32 animate-pulse rounded-md bg-muted" />
           <div className="space-y-3">

--- a/app/auth/verify-email/loading.tsx
+++ b/app/auth/verify-email/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-5">
+        <div className="h-7 w-40 animate-pulse rounded-md bg-muted" />
+        <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 w-28 animate-pulse rounded-md bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/app/auth/verify-email/loading.tsx
+++ b/app/auth/verify-email/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center bg-neutral-950 p-4">
       <div className="w-full max-w-md space-y-5">
         <div className="h-7 w-40 animate-pulse rounded-md bg-muted" />
         <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />

--- a/app/checkout/checkout-failure/loading.tsx
+++ b/app/checkout/checkout-failure/loading.tsx
@@ -1,0 +1,19 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-2xl space-y-6 rounded-2xl p-8">
+        <div className="mx-auto h-16 w-16 animate-pulse rounded-full bg-muted" />
+        <div className="mx-auto h-6 w-48 animate-pulse rounded-md bg-muted" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          ))}
+        </div>
+        <div className="flex gap-4">
+          <div className="h-10 flex-1 animate-pulse rounded-md bg-muted" />
+          <div className="h-10 flex-1 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/checkout-success/loading.tsx
+++ b/app/checkout/checkout-success/loading.tsx
@@ -1,0 +1,19 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-2xl space-y-6 rounded-2xl p-8">
+        <div className="mx-auto h-16 w-16 animate-pulse rounded-full bg-muted" />
+        <div className="mx-auto h-6 w-48 animate-pulse rounded-md bg-muted" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          ))}
+        </div>
+        <div className="flex gap-4">
+          <div className="h-10 flex-1 animate-pulse rounded-md bg-muted" />
+          <div className="h-10 flex-1 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/plans/class/[planId]/loading.tsx
+++ b/app/checkout/plans/class/[planId]/loading.tsx
@@ -1,0 +1,25 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 space-y-4">
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="space-y-2">
+              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
+            </div>
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          ))}
+        </div>
+        <div className="w-full space-y-4 lg:w-80">
+          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/plans/class/[planId]/loading.tsx
+++ b/app/checkout/plans/class/[planId]/loading.tsx
@@ -1,25 +1,30 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8">
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <div className="flex-1 space-y-4">
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
-            <div className="space-y-2">
-              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
-              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
-            </div>
+    <>
+      <div className="flex flex-col gap-6 border-r border-border bg-gradient-to-br from-muted via-background to-muted p-6 sm:p-8">
+        <div className="flex items-center gap-4">
+          <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="space-y-2">
+            <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
           </div>
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-4 w-full animate-pulse rounded-md bg-muted"
+            />
           ))}
         </div>
-        <div className="w-full space-y-4 lg:w-80">
-          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+      </div>
+      <div className="flex flex-col gap-8 bg-card p-6 sm:p-8">
+        <div className="h-48 animate-pulse rounded-xl bg-muted" />
+        <div className="space-y-4">
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/checkout/plans/consultation/[planId]/loading.tsx
+++ b/app/checkout/plans/consultation/[planId]/loading.tsx
@@ -1,0 +1,25 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 space-y-4">
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="space-y-2">
+              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
+            </div>
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          ))}
+        </div>
+        <div className="w-full space-y-4 lg:w-80">
+          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/plans/consultation/[planId]/loading.tsx
+++ b/app/checkout/plans/consultation/[planId]/loading.tsx
@@ -1,25 +1,30 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8">
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <div className="flex-1 space-y-4">
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
-            <div className="space-y-2">
-              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
-              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
-            </div>
+    <>
+      <div className="flex flex-col gap-6 border-r border-border bg-gradient-to-br from-muted via-background to-muted p-6 sm:p-8">
+        <div className="flex items-center gap-4">
+          <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="space-y-2">
+            <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
           </div>
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-4 w-full animate-pulse rounded-md bg-muted"
+            />
           ))}
         </div>
-        <div className="w-full space-y-4 lg:w-80">
-          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+      </div>
+      <div className="flex flex-col gap-8 bg-card p-6 sm:p-8">
+        <div className="h-48 animate-pulse rounded-xl bg-muted" />
+        <div className="space-y-4">
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/checkout/plans/subscription/[planId]/loading.tsx
+++ b/app/checkout/plans/subscription/[planId]/loading.tsx
@@ -1,0 +1,25 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 space-y-4">
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="space-y-2">
+              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
+            </div>
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          ))}
+        </div>
+        <div className="w-full space-y-4 lg:w-80">
+          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/plans/subscription/[planId]/loading.tsx
+++ b/app/checkout/plans/subscription/[planId]/loading.tsx
@@ -1,25 +1,30 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8">
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <div className="flex-1 space-y-4">
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
-            <div className="space-y-2">
-              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
-              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
-            </div>
+    <>
+      <div className="flex flex-col gap-6 border-r border-border bg-gradient-to-br from-muted via-background to-muted p-6 sm:p-8">
+        <div className="flex items-center gap-4">
+          <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="space-y-2">
+            <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
           </div>
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-4 w-full animate-pulse rounded-md bg-muted"
+            />
           ))}
         </div>
-        <div className="w-full space-y-4 lg:w-80">
-          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+      </div>
+      <div className="flex flex-col gap-8 bg-card p-6 sm:p-8">
+        <div className="h-48 animate-pulse rounded-xl bg-muted" />
+        <div className="space-y-4">
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/checkout/plans/webinar/[planId]/loading.tsx
+++ b/app/checkout/plans/webinar/[planId]/loading.tsx
@@ -1,0 +1,25 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-8">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 space-y-4">
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="space-y-2">
+              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
+            </div>
+          </div>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          ))}
+        </div>
+        <div className="w-full space-y-4 lg:w-80">
+          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/plans/webinar/[planId]/loading.tsx
+++ b/app/checkout/plans/webinar/[planId]/loading.tsx
@@ -1,25 +1,30 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8">
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <div className="flex-1 space-y-4">
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
-            <div className="space-y-2">
-              <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
-              <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
-            </div>
+    <>
+      <div className="flex flex-col gap-6 border-r border-border bg-gradient-to-br from-muted via-background to-muted p-6 sm:p-8">
+        <div className="flex items-center gap-4">
+          <div className="h-12 w-12 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="space-y-2">
+            <div className="h-5 w-40 animate-pulse rounded-md bg-muted" />
+            <div className="h-4 w-28 animate-pulse rounded-md bg-muted" />
           </div>
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="h-4 w-full animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-4 w-full animate-pulse rounded-md bg-muted"
+            />
           ))}
         </div>
-        <div className="w-full space-y-4 lg:w-80">
-          <div className="h-36 animate-pulse rounded-xl bg-muted" />
+      </div>
+      <div className="flex flex-col gap-8 bg-card p-6 sm:p-8">
+        <div className="h-48 animate-pulse rounded-xl bg-muted" />
+        <div className="space-y-4">
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
           <div className="h-24 animate-pulse rounded-xl bg-muted" />
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/dashboard/admin/feedback/loading.tsx
+++ b/app/dashboard/admin/feedback/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/consultant/[consultantId]/loading.tsx
+++ b/app/dashboard/consultant/[consultantId]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/dashboard/consultant/loading.tsx
+++ b/app/dashboard/consultant/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/loading.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/consultee/[consulteeId]/loading.tsx
+++ b/app/dashboard/consultee/[consulteeId]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/dashboard/consultee/loading.tsx
+++ b/app/dashboard/consultee/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/dashboard/staff/[staffId]/(features)/feedback/loading.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/feedback/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/staff/[staffId]/loading.tsx
+++ b/app/dashboard/staff/[staffId]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/dashboard/staff/loading.tsx
+++ b/app/dashboard/staff/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/explore/activities/hackathons/[hackathonId]/loading.tsx
+++ b/app/explore/activities/hackathons/[hackathonId]/loading.tsx
@@ -1,0 +1,18 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl space-y-10 px-4 py-8">
+      <div className="h-64 w-full animate-pulse rounded-2xl bg-muted" />
+      <div className="space-y-3">
+        <div className="h-6 w-40 animate-pulse rounded-md bg-muted" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-12 animate-pulse rounded-md bg-muted" />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-32 animate-pulse rounded-xl bg-muted" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/explore/activities/hackathons/[hackathonId]/loading.tsx
+++ b/app/explore/activities/hackathons/[hackathonId]/loading.tsx
@@ -1,6 +1,9 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-10 px-4 py-8">
+    <div
+      className="mx-auto w-full max-w-7xl space-y-10 px-4 py-8"
+      style={{ paddingTop: "160px" }}
+    >
       <div className="h-64 w-full animate-pulse rounded-2xl bg-muted" />
       <div className="space-y-3">
         <div className="h-6 w-40 animate-pulse rounded-md bg-muted" />

--- a/app/explore/enterprise/organisations/[orgSlug]/loading.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/loading.tsx
@@ -1,23 +1,24 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-[1100px] space-y-6 px-4 py-6">
-      <div className="h-40 w-full animate-pulse rounded-xl bg-muted" />
-      <div className="flex items-center gap-4">
-        <div className="h-20 w-20 animate-pulse rounded-full bg-muted" />
-        <div className="space-y-2">
-          <div className="h-6 w-48 animate-pulse rounded-md bg-muted" />
+    <div className="min-h-screen bg-muted">
+      <div className="relative h-48 overflow-hidden bg-gradient-to-br from-zinc-800 to-zinc-900 md:h-64" />
+      <div className="mx-auto max-w-[1100px] px-4 md:px-8">
+        <div className="py-4">
           <div className="h-4 w-32 animate-pulse rounded-md bg-muted" />
         </div>
-      </div>
-      <div className="flex gap-6">
-        <div className="grid flex-1 gap-4 sm:grid-cols-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-40 animate-pulse rounded-xl bg-muted" />
-          ))}
+        <div className="relative -mt-16 mb-8 rounded-2xl border border-border bg-card p-6 shadow-sm md:p-8">
+          <div className="flex flex-col items-start gap-5 sm:flex-row">
+            <div className="h-20 w-20 flex-shrink-0 animate-pulse rounded-2xl bg-muted" />
+            <div className="flex-1 space-y-3">
+              <div className="h-7 w-56 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-40 animate-pulse rounded-md bg-muted" />
+              <div className="h-4 w-3/4 animate-pulse rounded-md bg-muted" />
+            </div>
+          </div>
         </div>
-        <div className="w-72 space-y-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-28 animate-pulse rounded-xl bg-muted" />
+        <div className="grid gap-4 pb-8 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-40 animate-pulse rounded-xl bg-card" />
           ))}
         </div>
       </div>

--- a/app/explore/enterprise/organisations/[orgSlug]/loading.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/loading.tsx
@@ -1,0 +1,26 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-[1100px] space-y-6 px-4 py-6">
+      <div className="h-40 w-full animate-pulse rounded-xl bg-muted" />
+      <div className="flex items-center gap-4">
+        <div className="h-20 w-20 animate-pulse rounded-full bg-muted" />
+        <div className="space-y-2">
+          <div className="h-6 w-48 animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-32 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+      <div className="flex gap-6">
+        <div className="grid flex-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-40 animate-pulse rounded-xl bg-muted" />
+          ))}
+        </div>
+        <div className="w-72 space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-28 animate-pulse rounded-xl bg-muted" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/r/[code]/loading.tsx
+++ b/app/r/[code]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+    </div>
+  );
+}

--- a/app/settings/change-password/loading.tsx
+++ b/app/settings/change-password/loading.tsx
@@ -1,13 +1,19 @@
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-md space-y-4 p-6">
-      <div className="h-7 w-48 animate-pulse rounded-md bg-muted" />
-      <div className="space-y-3">
-        <div className="h-10 animate-pulse rounded-md bg-muted" />
-        <div className="h-10 animate-pulse rounded-md bg-muted" />
-        <div className="h-10 animate-pulse rounded-md bg-muted" />
+    <div className="min-h-screen flex items-center justify-center bg-muted px-4">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-card p-8 shadow-md">
+        <div className="space-y-3 text-center">
+          <div className="mx-auto h-12 w-12 animate-pulse rounded-full bg-muted" />
+          <div className="mx-auto h-7 w-48 animate-pulse rounded-md bg-muted" />
+          <div className="mx-auto h-4 w-64 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="space-y-4">
+          <div className="h-10 animate-pulse rounded-md bg-muted" />
+          <div className="h-10 animate-pulse rounded-md bg-muted" />
+          <div className="h-10 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="h-10 w-full animate-pulse rounded-md bg-muted" />
       </div>
-      <div className="h-10 w-32 animate-pulse rounded-md bg-muted" />
     </div>
   );
 }

--- a/app/settings/change-password/loading.tsx
+++ b/app/settings/change-password/loading.tsx
@@ -1,0 +1,13 @@
+export default function Loading() {
+  return (
+    <div className="mx-auto w-full max-w-md space-y-4 p-6">
+      <div className="h-7 w-48 animate-pulse rounded-md bg-muted" />
+      <div className="space-y-3">
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+        <div className="h-10 animate-pulse rounded-md bg-muted" />
+      </div>
+      <div className="h-10 w-32 animate-pulse rounded-md bg-muted" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **24 new `loading.tsx` files** added to close the gap between 145 `page.tsx` routes and 121 existing `loading.tsx` files
- **`.gitignore` fix**: scoped `feedback/` → `/feedback/` so dashboard feedback route segments are no longer silently excluded from tracking

### Files by group

| Group | Files | Pattern |
|---|---|---|
| Dashboard feedback pages | `admin/feedback`, `consultee/.../feedback`, `staff/.../feedback` | `PageSkeleton` from `DashboardSkeletons` |
| Dashboard root redirects | `consultant/`, `consultant/[id]/`, `consultee/`, `consultee/[id]/`, `staff/`, `staff/[id]/` | Centred spinner |
| Auth pages | `signin`, `signup` (split two-column), `forgot-password`, `verify-email`, `reset-password` (centred card) | Inline `animate-pulse` |
| Checkout plan detail | `plans/class/[id]`, `consultation/[id]`, `subscription/[id]`, `webinar/[id]` | Two-column avatar+rows / pricing+payment |
| Checkout status | `checkout-failure`, `checkout-success` | Centred card with icon + action buttons |
| Explore detail | `hackathons/[id]` (hero+timeline+grid), `organisations/[orgSlug]` (banner+header+two-col) | Inline `animate-pulse` |
| Other | `r/[code]` (referral redirect), `settings/change-password` | Spinner / centred card |

All new files follow the project's existing conventions: `animate-pulse bg-muted` for content skeletons, `bg-muted border-t-foreground` for spinners, and shared `PageSkeleton` for dashboard feature pages.

## Test plan

- [ ] `next build` passes with no TS/import errors
- [ ] Throttle to Slow 3G in DevTools → navigate to `/auth/signin` — two-column form skeleton appears before page loads
- [ ] Navigate to `/checkout/plans/class/<id>` — two-column avatar+detail skeleton appears
- [ ] Navigate to `/dashboard/consultant` — spinner briefly shows before redirect to home
- [ ] Navigate to `/dashboard/admin/feedback` — `PageSkeleton` appears before table loads
- [ ] Navigate to `/explore/enterprise/organisations/<slug>` — banner + header + grid skeleton appears
- [ ] `find app -name "loading.tsx" | wc -l` should now report **135**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading screens across authentication, checkout, dashboard, explore, and settings pages.
  * Improved loading feedback with skeleton placeholders and spinners for key routes, including sign-in, sign-up, password flows, plan pages, and profile dashboards.

* **Bug Fixes**
  * Corrected the root ignore rule for feedback-related files so only the intended top-level folder is excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->