### PR TITLE
fix(reliability): fast pg timeout + tighter edge Upstash budgets to prevent edge-function timeouts

### DIFF
--- a/lib/maintenance-edge.ts
+++ b/lib/maintenance-edge.ts
@@ -55,6 +55,11 @@ let cachedState: MaintenanceState | null = null;
 let cacheTimestamp = 0;
 const CACHE_TTL_MS = 30_000; // 30 seconds
 
+// Per-request fail-open budget for the edge Upstash read. This runs in
+// middleware on (almost) every request and falls back to OFF on timeout, so a
+// slow Upstash should give up fast rather than add latency to live traffic.
+const REDIS_FETCH_TIMEOUT_MS = 700;
+
 /**
  * Direct Upstash REST call — edge-safe, no SDK needed.
  */
@@ -66,7 +71,7 @@ async function redisGet(key: string): Promise<string | null> {
   const res = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
     headers: { Authorization: `Bearer ${token}` },
     cache: "no-store",
-    signal: AbortSignal.timeout(1500),
+    signal: AbortSignal.timeout(REDIS_FETCH_TIMEOUT_MS),
   });
 
   if (!res.ok) return null;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -37,10 +37,30 @@ function dn<K extends string>(field: K) {
   };
 }
 
+// A saturated Supavisor (txn pooler :6543) made pg hang 5–9.6s on connect
+// (EAUTHTIMEOUT), surfacing to users as "the edge function timed out". The two
+// budgets below fail fast instead, so a stuck pooler can't pin a Netlify
+// function up to its ~10s ceiling. Both env-gated (positive ms wins, else default).
+const pgTimeoutMs = (name: string, fallback: number): number => {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+};
+// ~3s: well under the function ceiling, comfortably above a normal cold connect.
+const PG_CONNECT_TIMEOUT_MS = pgTimeoutMs("PG_CONNECT_TIMEOUT_MS", 3000);
+// ~8s query budget. query_timeout is CLIENT-SIDE and is the only one that bounds
+// a query *through* the txn pooler — Supavisor silently ignores the
+// statement_timeout startup param (verified: SHOW statement_timeout stays at the
+// 2min server default). statement_timeout is kept as defense-in-depth for direct
+// session-mode connects (DIRECT_URL :5432), where it applies and cancels server-side.
+const PG_QUERY_TIMEOUT_MS = pgTimeoutMs("PG_QUERY_TIMEOUT_MS", 8000);
+
 const adapter = new PrismaPg({
   // Use pooled connection (DATABASE_URL) for runtime queries to avoid connection exhaustion
   // DIRECT_URL is only for migrations (handled by prisma.config.ts)
   connectionString: process.env.DATABASE_URL || process.env.DIRECT_URL,
+  connectionTimeoutMillis: PG_CONNECT_TIMEOUT_MS,
+  query_timeout: PG_QUERY_TIMEOUT_MS,
+  statement_timeout: PG_QUERY_TIMEOUT_MS,
   // pg.Pool defaults to 10 clients PER function instance; at Netlify's 125
   // concurrent invocations that can dwarf Supavisor's client cap. Set
   // PG_POOL_MAX=1 (or 2) in serverless deploy env; unset = pg default for

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -23,6 +23,12 @@ import { NextResponse } from "next/server";
 
 type RatelimitRedis = ConstructorParameters<typeof Ratelimit>[0]["redis"];
 
+// These limiters run in edge middleware on every matched request and fail OPEN
+// (see applyRateLimit). The Ratelimit default timeout is 5000ms, so a slow or
+// unreachable Upstash would stall the request 5s before allowing it through;
+// 500ms keeps the fail-open fallback fast.
+const LIMITER_TIMEOUT_MS = 500;
+
 function makeLimiter(
   requests: number,
   window: `${number} ${"ms" | "s" | "m" | "h" | "d"}`,
@@ -32,6 +38,7 @@ function makeLimiter(
     redis: redis as RatelimitRedis,
     limiter: Ratelimit.slidingWindow(requests, window),
     prefix,
+    timeout: LIMITER_TIMEOUT_MS,
   });
 }
 


### PR DESCRIPTION
## What was breaking

`familiarisenow.com` was intermittently going down with **"the edge function timed out"** — a handful of short outages each month. This PR fixes the most common cause.

## Why it happened (plain English)

Every request runs server code that talks to our Postgres database. We don't connect to Postgres directly — we go through a **connection pooler** (Supabase's "Supavisor", the `…pooler.supabase.com:6543` host) that hands out a limited number of database connections.

Under traffic spikes the pooler runs out of connections to give. When that happens our database client doesn't fail quickly — it **hangs for 5–9 seconds** waiting (the log line is `EAUTHTIMEOUT: timeout while waiting for message`). Netlify kills any function that runs longer than ~10 seconds, so those hangs reach users as **"the edge function timed out."**

So the real problem isn't the "edge function" at all — it's the database pooler being saturated, and our code **waiting too long instead of failing fast.**

## What this PR changes

Three small, safe changes that make the system **fail fast instead of hanging**:

1. **`lib/prisma.ts` — database timeouts.** We now give up after **3s** trying to get a connection (`connectionTimeoutMillis`) and after **8s** on a single query (`query_timeout`), instead of hanging up to ~10s. Both are env-tunable (`PG_CONNECT_TIMEOUT_MS`, `PG_QUERY_TIMEOUT_MS`) so they can be adjusted without a code change.
   - ⚠️ **Subtlety worth knowing:** the usual Postgres `statement_timeout` is **silently ignored** through the Supavisor pooler in "transaction mode" (verified live). The thing that actually bounds a query *through the pooler* is the **client-side `query_timeout`**. We set both deliberately — `statement_timeout` still applies on the direct, non-pooled connection (`DIRECT_URL`, port 5432).
2. **`lib/rate-limit.ts` — edge rate-limiter timeout 5000ms → 500ms.** Runs at the edge on hot public routes and "fails open" (allows the request) on timeout, so a shorter timeout just means we stop waiting on Redis sooner.
3. **`lib/maintenance-edge.ts` — maintenance check 1500ms → 700ms.** Same idea: give up faster on a slow Redis read.

User-visible behavior is unchanged — these only cap how long we wait before failing/falling back.

## What this PR does NOT fix (follow-ups)

This stops the *hangs*, but the pooler can still hit its capacity ceiling under load. The structural fixes:
- **Bump the Supabase compute tier** — raises the pooler's connection cap. *This is the real capacity fix (dashboard action).*
- ✅ **Already applied (Netlify env):** `PG_POOL_MAX=1` was only set in the production context; dev/preview/branch deploys were each using pg's default of 10 connections against the *same* pooler, amplifying the saturation. Now capped to 1 in every context.
- ✅ **Observability (Netlify env):** `SENTRY_ENVIRONMENT`/`NEXT_PUBLIC_SENTRY_ENVIRONMENT` were unset, so errors weren't tagged by environment. Now set per context. Still TODO: a Sentry alert on `EAUTHTIMEOUT`/`prisma:error`. (Note: the literal "edge function timed out" is a Netlify platform event that kills the function before Sentry can capture it — watch Netlify function logs / the BetterStack drain for those; Sentry will catch the underlying pooler errors.)
- Add the 23 missing foreign-key indexes (shorter queries → connections released sooner).

## Validation

`npx tsc --noEmit` clean; targeted jest suites pass; and a live read-only probe against the production pooler confirmed the `statement_timeout`-ignored-vs-`query_timeout`-honored behavior above. These are pure value/config edits with no new imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
