### PR TITLE
perf(db): add covering indexes for unindexed foreign keys

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -201,6 +201,7 @@ model SupportResponse {
   updatedAt DateTime @updatedAt
 
   @@index([supportTicketId])
+  @@index([userId])
 }
 
 model SupportTicketAttachment {
@@ -648,6 +649,7 @@ model Organization {
   @@index([canSponsor, canHost])
   @@index([canHost, isPublic, status])
   @@index([dataResidencyRegion])
+  @@index([parentOrganizationId])
   @@map("organizations")
 }
 
@@ -704,6 +706,8 @@ model Invitation {
   // Prisma `partialIndexes` preview (buggy at 7.7.0 — prisma/prisma#29263,
   // #29415) reaches stable.
   @@index([organizationId, email, status])
+  @@index([inviterId])
+  @@index([userId])
   @@map("invitations")
 }
 
@@ -763,6 +767,7 @@ model Membership {
   @@index([consulteeProfileId])
   @@index([consultantProfileId])
   @@index([departmentLabel])
+  @@index([rateCardOverrideId])
 }
 
 /// Per-organization membership role. Every value here is intentionally
@@ -977,6 +982,9 @@ model Contract {
 
   @@index([organizationId, status])
   @@index([effectiveFrom, effectiveTo])
+  @@index([billingAccountId])
+  @@index([purchaseOrderId])
+  @@index([rateCardId])
 }
 
 enum ContractStatus {
@@ -1695,6 +1703,9 @@ model OrganizationInvoice {
   @@index([organizationId, fiscalYear, issuedAt])
   @@index([billingCycleStart, billingCycleEnd])
   @@index([status, dueDate, markedOverdueAt])
+  @@index([billingAccountId])
+  @@index([contractId])
+  @@index([purchaseOrderId])
 }
 
 // Typed line items for OrganizationInvoice — replaces the `items` Json
@@ -1852,6 +1863,7 @@ model OrgDomainClaim {
   verificationToken String?
   verifiedAt        DateTime?
 
+  @@index([organizationId])
   @@map("org_domain_claims")
 }
 
@@ -2307,6 +2319,7 @@ model ConsultantReview {
   // reviews._count; without this the per-profile aggregate seq-scans the
   // whole review table. Also serves the FK join + rating>=4 social-proof reads.
   @@index([consultantProfileId])
+  @@index([consulteeProfileId])
 }
 
 model ConsulteeProfile {
@@ -2615,6 +2628,7 @@ model ConsultationPlan {
 
   @@index([organizationId])
   @@index([visibility, organizationId])
+  @@index([consultantProfileId])
 }
 
 model Consultation {
@@ -2699,6 +2713,7 @@ model SubscriptionPlan {
 
   @@index([organizationId])
   @@index([visibility, organizationId])
+  @@index([consultantProfileId])
 }
 
 model Subscription {
@@ -3647,6 +3662,7 @@ model Payment {
   @@index([billableToOrgInvoiceId])
   @@index([parentPaymentId])
   @@index([discountCodeId])
+  @@index([billingAccountId])
 }
 
 // Stackable funding leg. Each row captures one source contribution to a
@@ -4062,6 +4078,7 @@ model TDSRecord {
   @@index([consultantProfileId, financialYear])
   @@index([financialYear, quarter])
   @@index([reportedInForm26Q])
+  @@index([payoutId])
 }
 
 // #778 §D / #784 — effective-dated TDS rate lookup, law-aware. The Income-tax
@@ -4451,6 +4468,7 @@ model Collaborator {
   @@index([webinarPlanId])
   @@index([classPlanId])
   @@index([status])
+  @@index([invitedById])
 }
 
 enum CollaboratorType {
@@ -4832,6 +4850,7 @@ model SsoProvider {
   // refuses. See audit Phase B.4.
   @@unique([providerId])
   @@unique([organizationId, domain])
+  @@index([userId])
   @@map("ssoProvider")
 }
 
@@ -5040,6 +5059,8 @@ model ErasureRequest {
   notes              String?       @db.Text
 
   @@index([status, requestedAt])
+  @@index([processedByAdminId])
+  @@index([userId])
 }
 
 enum ErasureStatus {
@@ -5153,6 +5174,8 @@ model OverageEvent {
   // #781 §D — per-assignment settlement/reconcile scans
   @@index([programAssignmentId, chargeStatus, createdAt])
   @@index([chargeStatus, lastChargeAttemptAt])
+  @@index([invoiceLineItemId])
+  @@index([paymentId])
 }
 
 /// #769 Comment 4 — multi-jurisdiction tax prep. Today every org is IN;


### PR DESCRIPTION
## What

Adds a covering `@@index` on every foreign-key column that the Supabase **performance advisor** (`unindexed_foreign_keys`) flagged as lacking one — **23 columns across 16 models**.

## Why

Follow-up to the edge-timeout reliability work (`a9b677ee`). Postgres does **not** auto-create an index for a foreign key, so an uncovered FK forces a sequential scan on lookups, joins, and — critically — on cascading deletes/updates of the parent row. Covering these FKs means fewer and faster queries, so DB connections are returned to the Supavisor pooler sooner and pooler pressure drops.

This is an **index-only schema change**: no columns, types, or data are touched. The indexes materialize on the **next `prisma db push` / the planned pre-MVP reset** — they are intentionally not pushed here because the dev DB is shared.

## Indexes added (23)

Each one covers the identically-named FK constraint flagged by the advisor.

| Model | Index | Covers FK lookups / joins / cascades on |
| --- | --- | --- |
| Collaborator | `@@index([invitedById])` | inviter user |
| ConsultantReview | `@@index([consulteeProfileId])` | reviewed consultee profile |
| ConsultationPlan | `@@index([consultantProfileId])` | owning consultant profile |
| Contract | `@@index([billingAccountId])` | billing account |
| Contract | `@@index([purchaseOrderId])` | purchase order |
| Contract | `@@index([rateCardId])` | rate card |
| ErasureRequest | `@@index([processedByAdminId])` | processing admin |
| ErasureRequest | `@@index([userId])` | subject user |
| Invitation | `@@index([inviterId])` | inviter user |
| Invitation | `@@index([userId])` | invited user |
| Membership | `@@index([rateCardOverrideId])` | rate-card override |
| OrgDomainClaim | `@@index([organizationId])` | owning organization |
| Organization | `@@index([parentOrganizationId])` | parent organization (self-ref) |
| OrganizationInvoice | `@@index([billingAccountId])` | billing account |
| OrganizationInvoice | `@@index([contractId])` | contract |
| OrganizationInvoice | `@@index([purchaseOrderId])` | purchase order |
| OverageEvent | `@@index([invoiceLineItemId])` | invoice line item |
| OverageEvent | `@@index([paymentId])` | payment |
| Payment | `@@index([billingAccountId])` | billing account |
| SsoProvider | `@@index([userId])` | owning user |
| SubscriptionPlan | `@@index([consultantProfileId])` | owning consultant profile |
| SupportResponse | `@@index([userId])` | responding user |
| TDSRecord | `@@index([payoutId])` | payout |

## Intentionally skipped

**None.** Supabase's `unindexed_foreign_keys` linter already excludes any FK served by a left-prefix of an existing composite index, so every one of the 23 findings is genuinely uncovered. Cross-checking each against the existing `@@index`/`@@unique` declarations in `schema.prisma` confirmed there were no FKs to skip.

## Validation

- `npx prisma validate` — schema valid
- `npx prisma generate` — client generated (v7.7.0)
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` — exit 0, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database indexing for frequently used records, which should make common lookups and filtered views faster and more responsive.
  * Optimized queries across several areas of the app, including invitations, contracts, invoices, payments, subscriptions, and account-related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->