### PR TITLE
fix(stream): stop expected "channel not found" misses from tripping the circuit breaker

### DIFF
--- a/__tests__/stream/stream-client.test.ts
+++ b/__tests__/stream/stream-client.test.ts
@@ -18,10 +18,19 @@ jest.mock("@stream-io/node-sdk", () => ({
 }));
 
 // #473 — stream-client now imports withCircuitBreaker from lib/redis. Mock it
-// (the real module pulls in the un-transformed @upstash/redis ESM) with a
-// pass-through so closed-breaker behaviour is exercised: operation runs as-is.
+// (the real module pulls in the un-transformed @upstash/redis ESM). A mutable
+// delegate lets the breaker-behaviour tests below override per-case; default is
+// a pass-through so closed-breaker behaviour is exercised (operation runs as-is).
+let mockWithCircuitBreaker: jest.Mock = jest.fn((op: () => unknown) => op());
 jest.mock("../../lib/redis", () => ({
-  withCircuitBreaker: jest.fn((op: () => unknown) => op()),
+  withCircuitBreaker: (...args: unknown[]) => mockWithCircuitBreaker(...args),
+}));
+
+// #899 — spy on Sentry so we can assert expected "channel not found" misses are
+// NOT reported while genuine Stream errors are.
+const mockCaptureException = jest.fn();
+jest.mock("@sentry/nextjs", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
 describe("Stream Client Module", () => {
@@ -37,6 +46,9 @@ describe("Stream Client Module", () => {
       NEXT_PUBLIC_STREAM_API_KEY: mockApiKey,
       STREAM_API_SECRET: mockApiSecret,
     };
+    // Restore the default pass-through breaker between tests.
+    mockWithCircuitBreaker = jest.fn((op: () => unknown) => op());
+    mockCaptureException.mockClear();
   });
 
   afterEach(() => {
@@ -269,6 +281,116 @@ describe("Stream Client Module", () => {
       // Reset and check
       resetClients();
       expect(isClientInitialized()).toBe(false);
+    });
+  });
+
+  // #899 — a Stream "channel not found" (code 16 / HTTP 404) is the EXPECTED
+  // lazy create-or-join miss; it must not trip the breaker nor reach Sentry.
+  describe("isExpectedStreamError", () => {
+    it.each([
+      ["code 16 (channel not found)", { code: 16 }, true],
+      ["HTTP 404", { status: 404 }, true],
+      ["code 16 + 404", { code: 16, status: 404 }, true],
+      ["other Stream error code", { code: 4, status: 400 }, false],
+      ["generic error (no code/status)", {}, false],
+    ])("classifies %s", async (_label, props, expected) => {
+      const { isExpectedStreamError } = await import("@/lib/stream-client");
+      expect(isExpectedStreamError(Object.assign(new Error("boom"), props))).toBe(
+        expected,
+      );
+    });
+
+    it("returns false for non-Error values", async () => {
+      const { isExpectedStreamError } = await import("@/lib/stream-client");
+      expect(isExpectedStreamError("nope")).toBe(false);
+      expect(isExpectedStreamError(null)).toBe(false);
+    });
+  });
+
+  describe("withStreamCircuitBreaker", () => {
+    const channelNotFound = () =>
+      Object.assign(
+        new Error('StreamChat error code 16: UpdateChannel failed: "Can\'t find channel"'),
+        { code: 16, status: 404 },
+      );
+
+    it("rethrows an expected 'channel not found' miss WITHOUT capturing it to Sentry", async () => {
+      const { withStreamCircuitBreaker } = await import("@/lib/stream-client");
+      const err = channelNotFound();
+
+      await expect(
+        withStreamCircuitBreaker(() => Promise.reject(err)),
+      ).rejects.toBe(err);
+
+      // #899 — the core fix: expected misses are not error-reported.
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    it("passes a shouldTrip predicate that excludes expected misses but trips on real errors", async () => {
+      let shouldTrip: ((e: unknown) => boolean) | undefined;
+      mockWithCircuitBreaker = jest.fn(
+        (op: () => unknown, _fb: unknown, st: (e: unknown) => boolean) => {
+          shouldTrip = st;
+          return op();
+        },
+      );
+
+      const { withStreamCircuitBreaker } = await import("@/lib/stream-client");
+      await withStreamCircuitBreaker(() => Promise.resolve("ok"));
+
+      expect(shouldTrip).toBeDefined();
+      // Expected misses must NOT trip the breaker...
+      expect(shouldTrip!(channelNotFound())).toBe(false);
+      expect(shouldTrip!(Object.assign(new Error("x"), { status: 404 }))).toBe(
+        false,
+      );
+      // ...genuine outages must.
+      expect(shouldTrip!(new Error("ECONNREFUSED"))).toBe(true);
+    });
+
+    it("captures a genuine Stream error to Sentry and rethrows it", async () => {
+      const { withStreamCircuitBreaker } = await import("@/lib/stream-client");
+      const err = Object.assign(new Error("Stream 500"), { code: 500, status: 500 });
+
+      await expect(
+        withStreamCircuitBreaker(() => Promise.reject(err)),
+      ).rejects.toBe(err);
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        err,
+        expect.objectContaining({ tags: { subsystem: "stream" } }),
+      );
+    });
+
+    it("throws StreamUnavailableError (and reports it) when the breaker is OPEN with no fallback", async () => {
+      mockWithCircuitBreaker = jest.fn(() =>
+        Promise.reject(new Error("Redis circuit breaker is OPEN - service unavailable")),
+      );
+
+      const { withStreamCircuitBreaker, StreamUnavailableError } =
+        await import("@/lib/stream-client");
+
+      await expect(
+        withStreamCircuitBreaker(() => Promise.resolve("never")),
+      ).rejects.toBeInstanceOf(StreamUnavailableError);
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.any(StreamUnavailableError),
+        expect.objectContaining({ level: "warning" }),
+      );
+    });
+
+    it("runs the fallback (no throw, no Sentry) when the breaker is OPEN", async () => {
+      mockWithCircuitBreaker = jest.fn(() =>
+        Promise.reject(new Error("Redis circuit breaker is OPEN - service unavailable")),
+      );
+
+      const { withStreamCircuitBreaker } = await import("@/lib/stream-client");
+      const result = await withStreamCircuitBreaker(
+        () => Promise.resolve("never"),
+        () => "degraded",
+      );
+
+      expect(result).toBe("degraded");
+      expect(mockCaptureException).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -95,11 +95,16 @@ const CIRCUIT_CONFIG = {
  *
  * @param operation - The Redis operation to execute
  * @param fallback - Optional fallback value if circuit is open
+ * @param shouldTrip - Optional predicate; when it returns false for a thrown
+ *   error, that error is rethrown WITHOUT counting toward the breaker (an
+ *   expected/application-level failure is not an outage). Defaults to "trip on
+ *   any error".
  * @returns Result of operation or fallback
  */
 export async function withCircuitBreaker<T>(
   operation: () => Promise<T>,
   fallback?: () => T,
+  shouldTrip?: (error: unknown) => boolean,
 ): Promise<T> {
   // Check circuit state
   if (circuitBreaker.state === "OPEN") {
@@ -163,6 +168,12 @@ export async function withCircuitBreaker<T>(
 
     return result;
   } catch (error) {
+    // #899 — a caller-classified expected error (e.g. Stream "channel not
+    // found") proves the backend is up; rethrow without touching breaker state
+    // so 404-style misses don't dilute the outage signal and trip the shared
+    // breaker for everyone.
+    if (shouldTrip && !shouldTrip(error)) throw error;
+
     // Failure handling
     circuitBreaker.failures++;
     circuitBreaker.lastFailure = Date.now();

--- a/lib/stream-client.ts
+++ b/lib/stream-client.ts
@@ -157,23 +157,44 @@ export class StreamUnavailableError extends Error {
 }
 
 /**
+ * #899 — a Stream "channel not found" (error code 16 / HTTP 404) is the EXPECTED
+ * miss on the lazy create-or-join path: callers probe with addMembers/query
+ * before getOrCreate, so a not-yet-created webinar/class channel always 404s the
+ * first time. It proves Stream is up and responding, so it must NOT trip the
+ * circuit breaker or be reported to Sentry as an error — only genuine outages
+ * (network/timeout/5xx) should. (stream-chat ErrorFromResponse exposes .code/.status.)
+ */
+export function isExpectedStreamError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const e = error as { code?: number | null; status?: number };
+  return e.code === 16 || e.status === 404;
+}
+
+/**
  * #473 — wrap a hot-path Stream network call in the shared circuit breaker so a
  * Stream outage fast-fails (sub-ms) instead of every dashboard load eating the
  * full 30s client timeout and cascading.
  *
- * Closed-breaker behaviour is identical to calling `operation` directly: a real
- * Stream error rejects with the original error (we pass NO fallback to
- * withCircuitBreaker, so it rethrows). Only when the breaker is already OPEN
- * does withCircuitBreaker reject with its generic "circuit breaker is OPEN"
- * Error — we intercept that to run the caller's `fallback` (graceful
- * degradation) or throw the typed StreamUnavailableError so callers can branch.
+ * Closed-breaker behaviour is identical to calling `operation` directly, except
+ * an expected "channel not found" miss (#899) is classified via `shouldTrip` so
+ * it neither counts toward the breaker nor reaches Sentry — it rejects with the
+ * original error for the caller's create/fallback branch. Other real Stream
+ * errors reject with the original error and are captured. Only when the breaker
+ * is already OPEN does withCircuitBreaker reject with its generic "circuit
+ * breaker is OPEN" Error — we intercept that to run the caller's `fallback`
+ * (graceful degradation) or throw the typed StreamUnavailableError.
  */
 export async function withStreamCircuitBreaker<T>(
   operation: () => Promise<T>,
   fallback?: () => T,
 ): Promise<T> {
   try {
-    return await withCircuitBreaker(operation);
+    // #899 — expected "channel not found" misses must not trip the breaker.
+    return await withCircuitBreaker(
+      operation,
+      undefined,
+      (e) => !isExpectedStreamError(e),
+    );
   } catch (error) {
     // Distinguish "breaker is OPEN, we never tried" from a real Stream error.
     if (
@@ -188,8 +209,12 @@ export async function withStreamCircuitBreaker<T>(
       });
       throw unavailable;
     }
-    // Genuine Stream/operation error — capture and rethrow.
-    Sentry.captureException(error, { tags: { subsystem: "stream" } });
+    // #899 — an expected miss (channel not found) is normal on the lazy
+    // create-or-join path: rethrow for the caller's create/fallback branch
+    // without Sentry noise. Only genuine Stream errors are captured.
+    if (!isExpectedStreamError(error)) {
+      Sentry.captureException(error, { tags: { subsystem: "stream" } });
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Context

These Stream errors spiked in Sentry (`practitionist/familiarise_web`) while testing the booking flow with Chrome DevTools against a production build — every event was `environment: development`, `user.geo` New Delhi, from the `familiarise_web-reschedule` worktree, all on `POST /dashboard/consultee/[consulteeId]/home` (which runs `syncUserEventChannels`).

| Sentry | Error | Events |
|---|---|---|
| FAMILIARISE_WEB-5 | `ErrorFromResponse: StreamChat error code 16: UpdateChannel failed … Can't find channel team:webinar-…` | 6 |
| FAMILIARISE_WEB-6 | `StreamUnavailableError: Stream circuit breaker is OPEN` | 11 |
| FAMILIARISE_WEB-7 | `StreamUnavailableError: Stream circuit breaker is OPEN` | 5 |

## Diagnosis (per error)

**FAMILIARISE_WEB-5 — REAL code bug.** On the lazy channel-sync path, `addUserToEventChannel` (and `addUserToDmChannel`, `checkEventChannelExists`) probe a channel by calling `channel.addMembers()` / `channel.query()` *before* creating it. Stream maps `addMembers` to an `UpdateChannel` API call, so a not-yet-created webinar/class channel returns **error code 16 / HTTP 404** the first time. The lazy create-fallback then creates it — so the control flow is fine — but the expected miss was being `Sentry.captureException`-ed inside `withStreamCircuitBreaker` as if it were a genuine error. Webinar/class channels are *never* eagerly created (per #899), so this 404 fires on essentially every first sync. The stack trace (`addMembers → _update → doAxiosRequest → errorFromResponse`) confirms the path.

**FAMILIARISE_WEB-6 / -7 — REAL code bug (same root, F1 of #899).** That same expected code-16 miss was wrapped in `withStreamCircuitBreaker → withCircuitBreaker`, whose `catch` increments the failure counter on *any* throw. The breaker is **shared** (Redis + Stream). Syncing ≥5 channel-less events trips it OPEN after ~5 misses, and every subsequent Stream call (and Redis op) fast-fails with `StreamUnavailableError`. The event counts line up exactly: ~6 code-16 misses, then the cascade.

The seeded webinars-without-Stream-channels was the *test condition that exposed* the bug, but the bug itself (expected misses counted as outages + reported as errors) is real and would fire in production on any first-time channel sync.

**FAMILIARISE_WEB-4 (`TypeError: Failed to fetch`, consultant home) — NOT a code bug; test/env artifact.** Single event, `subsystem: client`, a browser-side aborted/failed `fetch` during the DevTools session (minified vendor frames, no actionable first-party culprit). Almost certainly an in-flight request aborted by navigation/reload, or the client surfacing of a server-side 500 from the breaker cascade above. No standalone client fix is warranted; fixing the server-side cascade removes the most likely trigger. Left unfixed by design.

## Fix

Classify Stream **code 16 / HTTP 404 ("channel not found")** as an *expected, non-outage* error:

- `lib/redis.ts` — `withCircuitBreaker` gains an optional `shouldTrip(error)` predicate. When it returns `false`, the error is rethrown **without** touching breaker state (no failure count, no trip). Default behaviour (trip on any error) is unchanged; Redis callers are unaffected.
- `lib/stream-client.ts` — new `isExpectedStreamError(error)` (code 16 || status 404); `withStreamCircuitBreaker` passes `shouldTrip = !isExpectedStreamError` and **skips `Sentry.captureException`** for those misses. Genuine Stream errors and the breaker-OPEN path (`StreamUnavailableError` / `fallback`) are unchanged.

The lazy create-or-join control flow is untouched — callers still fall through to create the channel; they just no longer poison the shared breaker or spam Sentry.

## Validation

- `npx jest __tests__/stream` → **146/146 pass** (11 new specs for `isExpectedStreamError` + `withStreamCircuitBreaker`: expected-miss → not reported & doesn't trip; genuine error → captured; breaker-open → `StreamUnavailableError`/fallback). `stream-client.ts` now at 100% coverage.
- `npx tsc --noEmit` clean (raised heap).
- Server-side error-classification change with no UI surface; validated by deterministic unit tests + code reasoning rather than Chrome/mock-data. A confirmation pass re-running the original booking-flow test against a build of this branch (expect: channels created, breaker stays CLOSED, zero new Sentry events) is recommended but not required.

## Not addressed here (recommendations)

- The remaining #899 findings (F2–F19): webhook handler idempotency, the over-built dashboard sync that *causes* these first-time misses (event-driven channel setup), splitting the shared Redis/Stream breaker, `/api/stream/debug` gate. Tracked in #899.

Part of #899. Fixes FAMILIARISE_WEB-5, FAMILIARISE_WEB-6, FAMILIARISE_WEB-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing Stream channels so expected misses are ignored cleanly without noisy error reporting.
  * Real Stream and availability failures now surface more reliably, while the service keeps using fallback behavior when available.
  * Circuit-breaker behavior is now more accurate, avoiding false outage signals from expected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->