### PR TITLE
fix(reliability): keep Postgres connect+query budget under Netlify's function ceiling + env-tunable timeouts

### DIFF
--- a/lib/maintenance-edge.ts
+++ b/lib/maintenance-edge.ts
@@ -58,7 +58,10 @@ const CACHE_TTL_MS = 30_000; // 30 seconds
 // Per-request fail-open budget for the edge Upstash read. This runs in
 // middleware on (almost) every request and falls back to OFF on timeout, so a
 // slow Upstash should give up fast rather than add latency to live traffic.
-const REDIS_FETCH_TIMEOUT_MS = 700;
+const REDIS_FETCH_TIMEOUT_MS = (() => {
+  const v = Number(process.env.REDIS_FETCH_TIMEOUT_MS);
+  return Number.isFinite(v) && v > 0 ? v : 700;
+})();
 
 /**
  * Direct Upstash REST call — edge-safe, no SDK needed.

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -47,12 +47,16 @@ const pgTimeoutMs = (name: string, fallback: number): number => {
 };
 // ~3s: well under the function ceiling, comfortably above a normal cold connect.
 const PG_CONNECT_TIMEOUT_MS = pgTimeoutMs("PG_CONNECT_TIMEOUT_MS", 3000);
-// ~8s query budget. query_timeout is CLIENT-SIDE and is the only one that bounds
-// a query *through* the txn pooler — Supavisor silently ignores the
-// statement_timeout startup param (verified: SHOW statement_timeout stays at the
-// 2min server default). statement_timeout is kept as defense-in-depth for direct
-// session-mode connects (DIRECT_URL :5432), where it applies and cancels server-side.
-const PG_QUERY_TIMEOUT_MS = pgTimeoutMs("PG_QUERY_TIMEOUT_MS", 8000);
+// ~6s query budget — keeps the worst case (3s connect + 6s query = 9s) under
+// Netlify's ~10s function ceiling. query_timeout is CLIENT-SIDE and is the only
+// one that bounds a query *through* the txn pooler — Supavisor silently ignores
+// the statement_timeout startup param (verified: SHOW statement_timeout stays at
+// the 2min server default). statement_timeout is set ~1s BELOW query_timeout
+// below as defense-in-depth for direct session-mode connects (DIRECT_URL :5432):
+// the server then aborts first with a clean error that keeps the pooled
+// connection synchronized/reusable, instead of node-postgres tearing it down on
+// a client-side query_timeout.
+const PG_QUERY_TIMEOUT_MS = pgTimeoutMs("PG_QUERY_TIMEOUT_MS", 6000);
 
 const adapter = new PrismaPg({
   // Use pooled connection (DATABASE_URL) for runtime queries to avoid connection exhaustion
@@ -60,7 +64,9 @@ const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL || process.env.DIRECT_URL,
   connectionTimeoutMillis: PG_CONNECT_TIMEOUT_MS,
   query_timeout: PG_QUERY_TIMEOUT_MS,
-  statement_timeout: PG_QUERY_TIMEOUT_MS,
+  // ~1s below query_timeout so the server cancels first on the direct session-mode
+  // path (clean error, connection stays poolable); ignored on the txn pooler (#912 review).
+  statement_timeout: Math.max(1000, PG_QUERY_TIMEOUT_MS - 1000),
   // pg.Pool defaults to 10 clients PER function instance; at Netlify's 125
   // concurrent invocations that can dwarf Supavisor's client cap. Set
   // PG_POOL_MAX=1 (or 2) in serverless deploy env; unset = pg default for

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -27,7 +27,10 @@ type RatelimitRedis = ConstructorParameters<typeof Ratelimit>[0]["redis"];
 // (see applyRateLimit). The Ratelimit default timeout is 5000ms, so a slow or
 // unreachable Upstash would stall the request 5s before allowing it through;
 // 500ms keeps the fail-open fallback fast.
-const LIMITER_TIMEOUT_MS = 500;
+const LIMITER_TIMEOUT_MS = (() => {
+  const v = Number(process.env.LIMITER_TIMEOUT_MS);
+  return Number.isFinite(v) && v > 0 ? v : 500;
+})();
 
 function makeLimiter(
   requests: number,


### PR DESCRIPTION
Follow-up to the already-merged #912 — addresses the CodeRabbit and Gemini review comments that arrived after #912 had been merged. Three small reliability hardenings, all confined to the files #912 already touched.

**1. The Postgres time budget now fits under the function ceiling (CodeRabbit, Major).** The `query_timeout` default drops from 8s to **6s**, so the worst case of a 3s connect plus a 6s query (9s total) stays under Netlify's ~10s function ceiling. #912 shipped an 8s budget, which combined with the 3s connect budget could reach 11s and still trip the very timeout #912 set out to prevent.

**2. `statement_timeout` now sits ~1s below `query_timeout` (Gemini).** On the direct session-mode path (`DIRECT_URL`, port 5432) the server cancels first with a clean error, which keeps the pooled connection synchronized and reusable instead of letting node-postgres tear it down on a client-side `query_timeout`. It remains a no-op through the Supavisor transaction pooler, which ignores `statement_timeout`.

**3. The edge and limiter timeouts are now environment-overridable (Gemini).** `LIMITER_TIMEOUT_MS` and `REDIS_FETCH_TIMEOUT_MS` read from the environment with a safe default, matching the `PG_*_TIMEOUT_MS` pattern introduced in #912, so these budgets can be tuned in production without a redeploy.

There is no behavioural change beyond the tightened defaults. It touches only `lib/prisma.ts`, `lib/rate-limit.ts`, and `lib/maintenance-edge.ts`, so it is conflict-free with the rest of the merge train.

Follow-up to #912.
