### PR TITLE
fix(build): make Sentry source-map upload non-fatal (unblock dev/Netlify deploys)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -176,6 +176,19 @@ export default withSentryConfig(withBundleAnalyzer(nextConfig), {
  // Only print logs for uploading source maps in CI
  silent: !process.env.CI,
 
+ // #900 — the build/deploy must NOT fail because the Sentry source-map upload
+ // failed (e.g. an expired/invalid SENTRY_AUTH_TOKEN on Netlify). With an
+ // errorHandler the Sentry plugin logs and CONTINUES instead of exiting
+ // non-zero; source maps just won't upload until the token is rotated, but the
+ // build always succeeds. (next build succeeds locally — the upload only runs
+ // where the token is set, so this surfaced as a Netlify-only build failure.)
+ errorHandler: (err) => {
+   console.warn(
+     "[sentry] source-map upload step failed (non-fatal):",
+     err?.message ?? err,
+   );
+ },
+
  // For all available options, see:
  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 


### PR DESCRIPTION
## The problem
`dev`'s Netlify deploy — and every dev-based PR preview — is **failing the build** (`next build` exits 2). Production is still up on the last good deploy, but **new code isn't reaching production**.

## Why
The build succeeds **locally**, so it's environment-specific. `next.config.mjs` runs the Sentry source-map upload during `next build` (`widenClientFileUpload: true`), and that step errors on an **expired/invalid `SENTRY_AUTH_TOKEN`** on Netlify (the token rotation deferred under #900). The upload only runs where the token is set, which is why it's a Netlify-only failure.

## The fix
Add a Sentry `errorHandler` so the plugin **logs and continues** instead of exiting non-zero. The build/deploy always succeeds; source maps simply won't upload until the token is rotated.

## Follow-up (not this PR)
Rotate `SENTRY_AUTH_TOKEN` in Netlify (#900) so source maps actually upload again.

**Merge this first** — it unblocks `dev`'s deploy and the green-CI of the other open PRs (#898, #914, #915, #917).

🤖 Generated with [Claude Code](https://claude.com/claude-code)