### PR TITLE
fix(build): build-time DB connect timeout so prerendering survives a slow pooler

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -45,8 +45,19 @@ const pgTimeoutMs = (name: string, fallback: number): number => {
   const v = Number(process.env[name]);
   return Number.isFinite(v) && v > 0 ? v : fallback;
 };
-// ~3s: well under the function ceiling, comfortably above a normal cold connect.
-const PG_CONNECT_TIMEOUT_MS = pgTimeoutMs("PG_CONNECT_TIMEOUT_MS", 3000);
+// `next build` statically prerenders DB-backed pages (e.g. /explore/programs),
+// which connect through this same saturated pooler — but at build there is no
+// user and no function ceiling, so the 3s runtime fail-fast wrongly aborts the
+// prerender ("timeout exceeded when trying to connect" → build exit 2). The
+// build phase gets a generous connect budget; runtime keeps the fast fail-fast.
+// Env override (PG_CONNECT_TIMEOUT_MS) still wins in either phase.
+const IS_NEXT_BUILD = process.env.NEXT_PHASE === "phase-production-build";
+// ~3s at runtime (well under the function ceiling, above a normal cold connect);
+// ~30s at build (room for a cold/saturated pooler — pre-#912 had no timeout).
+const PG_CONNECT_TIMEOUT_MS = pgTimeoutMs(
+  "PG_CONNECT_TIMEOUT_MS",
+  IS_NEXT_BUILD ? 30000 : 3000,
+);
 // ~8s query budget. query_timeout is CLIENT-SIDE and is the only one that bounds
 // a query *through* the txn pooler — Supavisor silently ignores the
 // statement_timeout startup param (verified: SHOW statement_timeout stays at the


### PR DESCRIPTION
## The outage

Every Netlify deploy has failed with `exit code 2` since `a9b677ee` (#912) — `dev` branch deploys **and** all PR previews — blocking the entire merge train. Three increasingly-faithful local reproductions (`next build` with full prod env, GitHub CI, and `netlify build`) all passed, so it presented as hosted-only and resisted diagnosis.

## Root cause

`next build` **statically prerenders** DB-backed pages such as `/explore/programs`, which run Prisma queries **at build time**. #912 added `connectionTimeoutMillis: 3000` to `lib/prisma.ts` to make a saturated pooler fail fast *at runtime*. That same 3s budget also applies during the build, where a connect to the saturated Supabase Supavisor pooler (measured 5–9.6s in #912) now aborts:

```
prisma:error timeout exceeded when trying to connect
Error occurred prerendering page "/explore/programs"
Export encountered an error on /explore/programs/page, exiting the build.
```

Before #912 there was no connect timeout, so build-time connects waited and succeeded. It never reproduced locally because a developer machine connects to the pooler in well under 3s.

## The fix

One file. The connect budget becomes phase-aware:

```js
const IS_NEXT_BUILD = process.env.NEXT_PHASE === "phase-production-build";
const PG_CONNECT_TIMEOUT_MS = pgTimeoutMs("PG_CONNECT_TIMEOUT_MS", IS_NEXT_BUILD ? 30000 : 3000);
```

- **Build phase:** 30s — comfortable room for a cold/saturated pooler (3× the measured worst case), restoring pre-#912 robustness.
- **Runtime:** unchanged 3s fail-fast — #912's production fix is fully preserved (a slow connect must not pin a Netlify function toward its ~10s ceiling).
- `PG_CONNECT_TIMEOUT_MS` env override still wins in either phase. `NEXT_PHASE` is set by `next build` (`next/dist/build/index.js`).

## Verification (via Netlify CLI, locally)

- **Reproduced:** `PG_CONNECT_TIMEOUT_MS=2 netlify build` → the exact hosted prerender failure on `/explore/programs`.
- **Confirmed:** plain `netlify build` (build-phase 30s) → `Netlify Build Complete`.

## Merge order

This is the build unblocker — **it must merge first**, ahead of #917 → #911 → #914 → #915 → #898.

## Follow-ups (separate)

- De-bloat `lib/prisma.ts`: the ~190-line BigInt/Decimal money `$extends` map dominates the file; extract it + centralize the pg timeout knobs (zero behaviour change).
- Make the DB-backed `/explore/*` pages `force-dynamic` / add `revalidate` — the architecturally-correct fix that removes the build-time DB connect entirely and also fixes their current stale-at-build data (no `revalidate` today). That would let us delete the `IS_NEXT_BUILD` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted database connection timeout behavior to be more reliable during builds and runtime.
  * Uses a longer timeout while building the app and a shorter timeout during normal execution, with existing environment-based overrides still supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->