### PR TITLE
fix(calendar): default eventTentativeSlots to [] (#923 review)

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -395,7 +395,7 @@ export function UnifiedCalendar({
     availableSlots,
     existingAppointments,
     eventSlots,
-    eventTentativeSlots,
+    eventTentativeSlots = [],
     loading,
     error,
     refetch,


### PR DESCRIPTION
Addresses the one valid Gemini comment from the #923 release PR: UnifiedCalendar maps over `eventTentativeSlots` (spread via SafeUnifiedCalendar), so a default of `[]` prevents a TypeError if any render path omits it. The other Gemini comment (createAppointments returning a non-array) was a **false positive** — the reuse arm sits inside `Promise.all(calls.map(...))` which collects each return into the array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar reliability by handling missing tentative event slots gracefully, preventing empty or undefined values from affecting scheduling views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->