### PR TITLE
perf(explore): unblock soft-nav loading + harden against slow-query timeouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,4 +119,10 @@ jobs:
         run: npm run test
 
       - name: Build
+        # Raise the V8 heap so `next build` (+ Sentry source-map generation) does
+        # not flaky-OOM on the runner — mirrors netlify.toml's NODE_OPTIONS. The
+        # default heap sits right at the build's peak, so it intermittently exits
+        # 134 (heap out of memory) on otherwise-identical builds.
         run: npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,6 +21,9 @@ export default function GlobalError({
 }>) {
   useEffect(() => {
     console.error("[GlobalError]", error);
+    // Report client-boundary errors to Sentry — server render errors are already
+    // captured by onRequestError, but a client error caught here was silent.
+    Sentry.captureException(error);
   }, [error]);
 
   return (

--- a/app/explore/experts/page.tsx
+++ b/app/explore/experts/page.tsx
@@ -6,6 +6,7 @@ import {
   getExpertsMetadata,
   getCuratedExperts,
 } from "@/lib/data/explore-experts";
+import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 
 function HeroSection({
   totalConsultants,
@@ -79,9 +80,15 @@ export default async function ExploreExperts() {
   const [metadata, featuredExperts, trendingExperts, newestExperts] =
     await Promise.all([
       getExpertsMetadata(),
-      getCuratedExperts("rating", 5).catch(() => []),
-      getCuratedExperts("trending", 8).catch(() => []),
-      getCuratedExperts("newest", 8).catch(() => []),
+      getCuratedExperts("rating", 5).catch(
+        emptyOnTransientDbError("featured experts"),
+      ),
+      getCuratedExperts("trending", 8).catch(
+        emptyOnTransientDbError("trending experts"),
+      ),
+      getCuratedExperts("newest", 8).catch(
+        emptyOnTransientDbError("newest experts"),
+      ),
     ]);
 
   return (

--- a/app/explore/experts/page.tsx
+++ b/app/explore/experts/page.tsx
@@ -74,12 +74,14 @@ function HeroSection({
 }
 
 export default async function ExploreExperts() {
+  // Degrade gracefully: a heavy curated read that times out (cold query brushing
+  // the pg query budget) renders an empty row instead of erroring the whole page.
   const [metadata, featuredExperts, trendingExperts, newestExperts] =
     await Promise.all([
       getExpertsMetadata(),
-      getCuratedExperts("rating", 5),
-      getCuratedExperts("trending", 8),
-      getCuratedExperts("newest", 8),
+      getCuratedExperts("rating", 5).catch(() => []),
+      getCuratedExperts("trending", 8).catch(() => []),
+      getCuratedExperts("newest", 8).catch(() => []),
     ]);
 
   return (

--- a/app/explore/programs/page.tsx
+++ b/app/explore/programs/page.tsx
@@ -2,6 +2,7 @@ import {
   getCuratedPrograms,
   getTopicsWithCount,
 } from "@/lib/data/explore-programs";
+import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 import prisma from "@/lib/prisma";
 import ProgramsInteractiveContent from "./ProgramsInteractiveContent";
 
@@ -20,9 +21,13 @@ export default async function ExplorePrograms() {
   // the pg query budget) renders an empty row instead of erroring the whole page.
   const [trendingPrograms, newestPrograms, topicsWithCount, stats] =
     await Promise.all([
-      getCuratedPrograms("all", "trending", 8).catch(() => []),
-      getCuratedPrograms("all", "newest", 8).catch(() => []),
-      getTopicsWithCount("all").catch(() => []),
+      getCuratedPrograms("all", "trending", 8).catch(
+        emptyOnTransientDbError("trending programs"),
+      ),
+      getCuratedPrograms("all", "newest", 8).catch(
+        emptyOnTransientDbError("newest programs"),
+      ),
+      getTopicsWithCount("all").catch(emptyOnTransientDbError("topics")),
       fetchProgramStats(),
     ]);
 

--- a/app/explore/programs/page.tsx
+++ b/app/explore/programs/page.tsx
@@ -16,11 +16,13 @@ import ProgramsInteractiveContent from "./ProgramsInteractiveContent";
  * `useCuratedPrograms` / `useTopicsWithCount` hooks.
  */
 export default async function ExplorePrograms() {
+  // Degrade gracefully: a heavy curated read that times out (cold query brushing
+  // the pg query budget) renders an empty row instead of erroring the whole page.
   const [trendingPrograms, newestPrograms, topicsWithCount, stats] =
     await Promise.all([
-      getCuratedPrograms("all", "trending", 8),
-      getCuratedPrograms("all", "newest", 8),
-      getTopicsWithCount("all"),
+      getCuratedPrograms("all", "trending", 8).catch(() => []),
+      getCuratedPrograms("all", "newest", 8).catch(() => []),
+      getTopicsWithCount("all").catch(() => []),
       fetchProgramStats(),
     ]);
 

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -1,0 +1,25 @@
+/**
+ * Fail-open helper for read-only list queries on public surfaces (explore pages).
+ *
+ * Returns `[]` ONLY for the transient DB-read-timeout class — the cold-query case
+ * (pg connect/query budget, pool timeout) these pages must survive — and RETHROWS
+ * everything else (mapper/serialization regressions, logic bugs) so real defects
+ * still surface to the error boundary + Sentry rather than rendering an empty
+ * section. The transient case is logged for observability. (#925 review.)
+ */
+export function emptyOnTransientDbError(context: string) {
+  return (err: unknown): never[] => {
+    const code = (err as { code?: string } | null)?.code;
+    const msg = err instanceof Error ? err.message : String(err);
+    const isTransient =
+      code === "P2024" || // pool timeout
+      code === "P1008" || // operations timed out
+      /timeout|timed out|connection terminated|ETIMEDOUT/i.test(msg);
+    if (!isTransient) throw err;
+    console.error(
+      `[explore] ${context} read failed (transient DB timeout) — rendering empty:`,
+      msg,
+    );
+    return [];
+  };
+}

--- a/lib/maintenance-edge.ts
+++ b/lib/maintenance-edge.ts
@@ -55,12 +55,13 @@ let cachedState: MaintenanceState | null = null;
 let cacheTimestamp = 0;
 const CACHE_TTL_MS = 30_000; // 30 seconds
 
-// Per-request fail-open budget for the edge Upstash read. This runs in
-// middleware on (almost) every request and falls back to OFF on timeout, so a
-// slow Upstash should give up fast rather than add latency to live traffic.
+// Per-request fail-open budget for the edge Upstash read. Document loads + /api/*
+// pay this (RSC/prefetch sub-navigations use getMaintenanceStateCachedOnly and
+// never read live), and it falls back to OFF on timeout — so a slow Upstash gives
+// up fast rather than adding latency to live traffic. 200ms: well under a frame.
 const REDIS_FETCH_TIMEOUT_MS = (() => {
   const v = Number(process.env.REDIS_FETCH_TIMEOUT_MS);
-  return Number.isFinite(v) && v > 0 ? v : 700;
+  return Number.isFinite(v) && v > 0 ? v : 200;
 })();
 
 /**
@@ -128,6 +129,22 @@ export async function getMaintenanceState(): Promise<MaintenanceState> {
     cacheTimestamp = now;
     return OFF_STATE;
   }
+}
+
+/**
+ * Non-blocking maintenance read for the hot sub-navigation path (Next RSC +
+ * prefetch fetches). Returns the in-memory cached state if fresh, else OFF —
+ * NEVER a live Upstash round-trip. Without this, the blocking read in
+ * getMaintenanceState() runs before the RSC response can stream, so a soft
+ * navigation sits blank until it resolves (the gap before loading.tsx appears).
+ * A full document load still does the live read, so a maintenance window is
+ * always enforced within one document navigation / the 30s cache window.
+ */
+export function getMaintenanceStateCachedOnly(): MaintenanceState {
+  if (cachedState && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedState;
+  }
+  return OFF_STATE;
 }
 
 // Matches paths ending with a file extension (e.g. .js, .css, .png, .woff2).

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import {
   getMaintenanceState,
+  getMaintenanceStateCachedOnly,
   isMaintenanceExempt,
   validateBypass,
   isWriteBlockedInDegraded,
@@ -352,12 +353,18 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     return NextResponse.next();
   }
 
-  // 2. Maintenance gate (fail-open; 30s-cached read).
-  const maintenance = handleMaintenance(
-    req,
-    pathname,
-    await getMaintenanceState(),
-  );
+  // 2. Maintenance gate (fail-open; 30s-cached read). RSC/prefetch sub-navigation
+  // fetches use the cached value only — no blocking Upstash round-trip — so a soft
+  // navigation can't sit blank before its loading.tsx streams. A full document
+  // load still does the live read, so a maintenance window is enforced within one
+  // navigation / the 30s cache window.
+  const isSubNavigation =
+    req.headers.get("Next-Router-Prefetch") === "1" ||
+    req.headers.get("RSC") === "1";
+  const maintenanceState = isSubNavigation
+    ? getMaintenanceStateCachedOnly()
+    : await getMaintenanceState();
+  const maintenance = handleMaintenance(req, pathname, maintenanceState);
   if (maintenance) return maintenance;
 
   // 3. Edge rate limiting.


### PR DESCRIPTION
Fixes the two explore/details issues diagnosed from the production reports.

**1. Blank-before-skeleton (middleware).** The middleware did a blocking Upstash maintenance read on *every* RSC/prefetch fetch before the response could stream. Now RSC/prefetch sub-navigations use a non-blocking cached-only read (`getMaintenanceStateCachedOnly`); full document loads still do the live read, so a maintenance window is still enforced within one navigation. Edge Upstash budget tightened 700→200ms.

**2. Intermittent 'Something went wrong' (slow cold query vs 6s pg timeout).** Each heavy curated explore read now `.catch(() => [])` — a cold query that brushes the query budget renders an empty row instead of erroring the whole page.

**3. Silent client errors.** `app/error.tsx` now calls `Sentry.captureException` (server render errors were already covered by `onRequestError`; the client boundary was silent).

Deferred follow-up: cross-request caching of the explore reads (`unstable_cache`) to eliminate the cold-query cost entirely — needs care around Date serialization.

Verified: `tsc --noEmit` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app resilience when some explore-page data sources fail, so pages can still load with partial results instead of erroring.
  * Client-side errors are now reported more reliably, helping surface issues faster.
  * Maintenance checks now respond faster and are less likely to block navigation, especially during prefetching or quick page transitions.

* **Performance**
  * Reduced waiting on maintenance-related requests to make navigation feel snappier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->