### PR TITLE
release: dev → prod (2026-06-26) — explore resilience + schema sync + config de-bloat + Novu CSP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,9 +17,6 @@ GITHUB_CLIENT_SECRET=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
-# Secret key for JWT token generation and verification
-JWT_SECRET=""
-
 # BetterAuth credentials
 # 32+ character random secret for signing sessions (openssl rand -base64 32)
 BETTER_AUTH_SECRET=""
@@ -40,9 +37,6 @@ NEXT_PUBLIC_SUPABASE_URL=""
 # Test user ID for development/testing purposes
 NEXT_PUBLIC_TEST_USERID=""
 
-# Redis connection URL
-REDIS_URL=""
-
 # Resend API key for transactional email service. #474 — also drives the
 # email retry worker (jobs/email/retry-failed-emails.ts), which re-sends
 # rows the senders dead-lettered to FailedEmail on a transient Resend failure.
@@ -50,6 +44,8 @@ RESEND_API_KEY=""
 
 # Razorpay API credentials for payment processing
 RAZORPAY_KEY_ID=""
+# Client-safe Razorpay key id, inlined into the checkout bundle.
+NEXT_PUBLIC_RAZORPAY_KEY_ID=""
 RAZORPAY_SECRET=""
 # Webhook signing secret from the Razorpay dashboard (Settings > Webhooks)
 RAZORPAY_WEBHOOK_SECRET=""
@@ -70,16 +66,16 @@ RAZORPAY_ROUTE_KEY_ID=""
 RAZORPAY_ROUTE_KEY_SECRET=""
 RAZORPAY_ROUTE_ACCOUNT_NUMBER=""
 
-# Stripe API credentials and configuration
-STRIPE_API_KEY=""
-STRIPE_API_VERSION=""
+# Stripe API credentials. STRIPE_SECRET_KEY (server, sk_*) signs API calls;
+# NEXT_PUBLIC_STRIPE_KEY (publishable, pk_*) is inlined into the checkout bundle.
+STRIPE_SECRET_KEY=""
+NEXT_PUBLIC_STRIPE_KEY=""
 STRIPE_WEBHOOK_SECRET=""
 
 # Stream API keys for real-time features
 NEXT_PUBLIC_STREAM_API_KEY=""
 STREAM_API_KEY=""
 STREAM_API_SECRET=""
-STREAM_SYNC_SECRET=""
 
 # Upstash Redis credentials for caching/queue management
 UPSTASH_REDIS_REST_TOKEN=""

--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import prisma from "@/lib/prisma";
+import { fallbackOnTransientDbError } from "@/lib/data/fail-open";
 import type { Metadata } from "next";
 
 export const revalidate = 60;
@@ -126,7 +127,15 @@ export async function generateMetadata({
   params: Promise<{ orgSlug: string }>;
 }): Promise<Metadata> {
   const { orgSlug } = await params;
-  const org = await fetchOrgBySlug(orgSlug);
+  // Metadata runs before render with no error boundary — a transient timeout
+  // would 500. Fall back to null (generic title); the page body re-reads and
+  // surfaces any real error. (#925)
+  const org = await fetchOrgBySlug(orgSlug).catch(
+    fallbackOnTransientDbError<Awaited<ReturnType<typeof fetchOrgBySlug>>>(
+      "org metadata",
+      null,
+    ),
+  );
   if (!org) return { title: "Organisation not found" };
   return {
     title: `${org.name} — Familiarise`,

--- a/app/explore/enterprise/organisations/page.tsx
+++ b/app/explore/enterprise/organisations/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import Link from "next/link";
 import prisma from "@/lib/prisma";
+import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 
 export const revalidate = 60;
 
@@ -211,7 +212,11 @@ export default async function ExploreOrganisationsPage({
   searchParams: Promise<{ industry?: string }>;
 }) {
   const { industry } = await searchParams;
-  const industries = await fetchIndustryList();
+  // Outside the orgs Suspense boundary — a transient timeout here would crash the
+  // whole page, so degrade to no industry filters rather than erroring (#925).
+  const industries = await fetchIndustryList().catch(
+    emptyOnTransientDbError("org industries"),
+  );
 
   return (
     <main className="min-h-screen bg-background">

--- a/app/explore/experts/page.tsx
+++ b/app/explore/experts/page.tsx
@@ -5,8 +5,12 @@ import ExpertsInteractiveContent from "./ExpertsInteractiveContent";
 import {
   getExpertsMetadata,
   getCuratedExperts,
+  EMPTY_EXPERTS_METADATA,
 } from "@/lib/data/explore-experts";
-import { emptyOnTransientDbError } from "@/lib/data/fail-open";
+import {
+  emptyOnTransientDbError,
+  fallbackOnTransientDbError,
+} from "@/lib/data/fail-open";
 
 function HeroSection({
   totalConsultants,
@@ -79,7 +83,9 @@ export default async function ExploreExperts() {
   // the pg query budget) renders an empty row instead of erroring the whole page.
   const [metadata, featuredExperts, trendingExperts, newestExperts] =
     await Promise.all([
-      getExpertsMetadata(),
+      getExpertsMetadata().catch(
+        fallbackOnTransientDbError("experts metadata", EMPTY_EXPERTS_METADATA),
+      ),
       getCuratedExperts("rating", 5).catch(
         emptyOnTransientDbError("featured experts"),
       ),

--- a/docs/maintenance/01-architecture.md
+++ b/docs/maintenance/01-architecture.md
@@ -103,6 +103,22 @@ model MaintenanceWindow {
 
 `betterstackIncidentId` is set when entering OFFLINE mode (incident creation succeeds) and read when ending maintenance (to auto-resolve the incident). It is `null` if DEGRADED was used or if incident creation failed.
 
+## Edge Read Strategy
+
+The middleware reads the maintenance state on every non-static request, so the read must never become a per-request Upstash round-trip. `lib/maintenance-edge.ts` keeps a 30-second in-memory cache (edge isolates share module scope within an instance lifetime) and exposes two readers:
+
+| Reader                            | Used by                        | Behaviour                                                                                                |
+| --------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `getMaintenanceState()`           | Full document loads + `/api/*` | Returns the cached value if fresh, otherwise does the live Upstash read (200 ms budget; fails open OFF). |
+| `getMaintenanceStateCachedOnly()` | RSC / prefetch sub-navigations | Never blocks on Upstash. Returns the last-known state and triggers a background refresh when stale.      |
+
+A soft (RSC) navigation must not block on a Redis round-trip, or it sits blank before its `loading.tsx` can stream. So sub-navigations take the cached-only path. Two edge-runtime details make that path correct rather than a maintenance-bypass hole (#927, #929):
+
+- **`event.waitUntil`** — an unawaited promise is not guaranteed to run after the middleware response is sent, so `middleware()` passes `event.waitUntil` into `getMaintenanceStateCachedOnly()` to keep the background refresh alive. Without it the cache would never repopulate and a session that only soft-navigates would serve stale state indefinitely.
+- **`isRefreshing` guard** — a single module-level flag collapses concurrent stale sub-navigations into one Upstash read instead of a thundering herd.
+
+When the cache is stale the cached-only reader returns the **last-known** state (not OFF), so an active window is still enforced while the refresh is in flight. A full document load always does the live read, so any window is enforced within one document navigation or the 30-second cache window.
+
 ## Bypass Mechanism
 
 Each maintenance window generates a UUID bypass secret (`crypto.randomUUID()`).

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,27 +1,12 @@
 // This file configures the initialization of Sentry on the client.
 // The added config here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+//
+// Init config lives in sentry.shared.config.ts (shared across runtimes — #913).
 
 import * as Sentry from "@sentry/nextjs";
-import { isNotDevelopmentEnvironment, isProductionEnvironment } from "@/utils/env";
+import { initSentry } from "./sentry.shared.config";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
-
-Sentry.init({
-  dsn,
-  // No DSN => Sentry fully disabled. Also gated off in local `next dev` so a
-  // developer's .env DSN doesn't flood the shared prod project with dev noise.
-  enabled: Boolean(dsn) && isNotDevelopmentEnvironment(),
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: isProductionEnvironment() ? 0.1 : 1,
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: false,
-});
+initSentry();
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -190,6 +190,23 @@ export async function fetchExpertsMetadata() {
 /** Cached wrapper for Server Components. */
 export const getExpertsMetadata = cache(fetchExpertsMetadata);
 
+export type ExpertsMetadata = Awaited<ReturnType<typeof fetchExpertsMetadata>>;
+
+// Safe empty shape so a transient metadata-read timeout degrades to empty
+// filters + the hero's marketing defaults instead of crashing the page (#925).
+export const EMPTY_EXPERTS_METADATA: ExpertsMetadata = {
+  domains: [],
+  subdomains: [],
+  tags: [],
+  consultantMetadata: {
+    totalConsultants: 0,
+    consultantsByDomain: [],
+    averageRating: 0,
+  },
+  availableLanguages: [],
+  availableCompanies: [],
+};
+
 // ---------------------------------------------------------------------------
 // Curated experts (Featured / Trending / Newest rows)
 // ---------------------------------------------------------------------------

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -5,21 +5,57 @@
  * (pg connect/query budget, pool timeout) these pages must survive — and RETHROWS
  * everything else (mapper/serialization regressions, logic bugs) so real defects
  * still surface to the error boundary + Sentry rather than rendering an empty
- * section. The transient case is logged for observability. (#925 review.)
+ * section. The transient case is reported to Sentry (warning) so a recurrence of
+ * the cold-query / schema-drift condition stays alertable. (#925, #929 review.)
  */
+import * as Sentry from "@sentry/nextjs";
+
+function isTransientDbError(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code;
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    code === "P2024" || // pool timeout
+    code === "P1008" || // operations timed out
+    /timeout|timed out|connection terminated|ETIMEDOUT/i.test(msg)
+  );
+}
+
+// Report a degraded read without re-raising it. console for local visibility +
+// a Sentry warning so the fail-open path is observable rather than silent (#929).
+function reportTransient(context: string, err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(
+    `[explore] ${context} read failed (transient DB timeout) — degrading:`,
+    msg,
+  );
+  Sentry.captureMessage(
+    `explore fail-open: ${context} (transient DB timeout)`,
+    {
+      level: "warning",
+      extra: { context, message: msg },
+    },
+  );
+}
+
 export function emptyOnTransientDbError(context: string) {
   return (err: unknown): never[] => {
-    const code = (err as { code?: string } | null)?.code;
-    const msg = err instanceof Error ? err.message : String(err);
-    const isTransient =
-      code === "P2024" || // pool timeout
-      code === "P1008" || // operations timed out
-      /timeout|timed out|connection terminated|ETIMEDOUT/i.test(msg);
-    if (!isTransient) throw err;
-    console.error(
-      `[explore] ${context} read failed (transient DB timeout) — rendering empty:`,
-      msg,
-    );
+    if (!isTransientDbError(err)) throw err;
+    reportTransient(context, err);
     return [];
+  };
+}
+
+/**
+ * Object-shaped sibling of {@link emptyOnTransientDbError}: returns `fallback`
+ * for the transient-timeout class and RETHROWS everything else. For non-list
+ * reads whose page can still render with a degraded value — the experts-page
+ * metadata bundle (empty filters + marketing hero defaults) or a detail page's
+ * `generateMetadata` (a generic title beats a 500 with no error boundary).
+ */
+export function fallbackOnTransientDbError<T>(context: string, fallback: T) {
+  return (err: unknown): T => {
+    if (!isTransientDbError(err)) throw err;
+    reportTransient(context, err);
+    return fallback;
   };
 }

--- a/lib/maintenance-edge.ts
+++ b/lib/maintenance-edge.ts
@@ -10,19 +10,13 @@
 
 import { NextRequest } from "next/server";
 
-// Redis key constants. Platform-scoped: the middleware reads the single
-// platform maintenance phase/config on every request (30s-cached below).
-//
-// NOTE for future devs: per-org maintenance windows
-// ("maintenance:phase:org:<orgId>") are NOT implemented. There was previously
-// `orgMaintenanceKeys()` / `platformMaintenanceKeys()` scaffolding here with no
-// consumers — it was removed (#776) as dead code. If/when per-org windows ship,
-// add the org-scoped read here (org key first, fall back to platform) and a
-// matching writer in the admin maintenance route.
-const REDIS_KEYS = {
-  PHASE: "maintenance:phase",
-  CONFIG: "maintenance:config",
-} as const;
+import { REDIS_KEYS } from "./maintenance-keys";
+
+// REDIS_KEYS is platform-scoped (single phase/config read per request, 30s-cached
+// below). Per-org windows ("maintenance:phase:org:<orgId>") are NOT implemented —
+// prior orgMaintenanceKeys()/platformMaintenanceKeys() scaffolding was removed
+// (#776) as dead code. If they ship, add the org-scoped read here (org key first,
+// fall back to platform) and a matching writer in the admin maintenance route.
 
 // Routes exempt from maintenance mode
 const EXEMPT_PREFIXES = [
@@ -139,12 +133,34 @@ export async function getMaintenanceState(): Promise<MaintenanceState> {
  * navigation sits blank until it resolves (the gap before loading.tsx appears).
  * A full document load still does the live read, so a maintenance window is
  * always enforced within one document navigation / the 30s cache window.
+ *
+ * When the cache is stale we kick off a refresh (so the NEXT sub-navigation sees
+ * fresh state) and return the last-known state rather than OFF — otherwise a
+ * session that only soft-navigates would bypass an active window indefinitely
+ * once the TTL lapses (#927). Two edge-runtime caveats (#929 review):
+ *  - an unawaited promise is not guaranteed to run after the response is sent, so
+ *    the caller passes `event.waitUntil` to keep the refresh alive;
+ *  - a single `isRefreshing` guard collapses concurrent stale sub-navigations into
+ *    one Upstash read instead of a thundering herd.
  */
-export function getMaintenanceStateCachedOnly(): MaintenanceState {
+let isRefreshing = false;
+
+export function getMaintenanceStateCachedOnly(
+  waitUntil?: (promise: Promise<unknown>) => void,
+): MaintenanceState {
   if (cachedState && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
     return cachedState;
   }
-  return OFF_STATE;
+  if (!isRefreshing) {
+    isRefreshing = true;
+    const refresh = getMaintenanceState()
+      .catch(() => {})
+      .finally(() => {
+        isRefreshing = false;
+      });
+    waitUntil?.(refresh);
+  }
+  return cachedState ?? OFF_STATE;
 }
 
 // Matches paths ending with a file extension (e.g. .js, .css, .png, .woff2).
@@ -185,7 +201,6 @@ const WRITE_BLOCKED_IN_DEGRADED = [
   "/api/waitlist", // Block waitlist mutations
   "/api/referrals", // Block referral code creation
   "/api/collaborators", // Block collaborator management
-  "/api/payments/refunds", // Block refund mutations
   "/api/payments/disputes", // Block dispute handling mutations
   "/api/admin/payouts", // Block admin payout mutations
 ];

--- a/lib/maintenance-keys.ts
+++ b/lib/maintenance-keys.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the maintenance Redis keys, shared by the edge
+// reader (lib/maintenance-edge.ts) and the Node writer (lib/maintenance.ts) so
+// the schema can't drift between them. Platform-scoped; no per-org keys (#776).
+// Plain constants only — kept edge-safe (no Node/Prisma imports).
+export const REDIS_KEYS = {
+  PHASE: "maintenance:phase",
+  CONFIG: "maintenance:config",
+} as const;

--- a/lib/maintenance.ts
+++ b/lib/maintenance.ts
@@ -12,12 +12,7 @@ import { MaintenancePhase } from "@prisma/client";
 
 import prisma from "@/lib/prisma";
 import redis, { withCircuitBreaker } from "@/lib/redis";
-
-// Redis key constants
-const REDIS_KEYS = {
-  PHASE: "maintenance:phase",
-  CONFIG: "maintenance:config",
-} as const;
+import { REDIS_KEYS } from "@/lib/maintenance-keys";
 
 export interface MaintenanceState {
   phase: MaintenancePhase;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -60,11 +60,7 @@ const adapter = new PrismaPg({
 
 // Slow-query threshold (ms). A query exceeding this is logged via the
 // query-event hook below so hot-path regressions surface in any environment.
-const PARSED_SLOW_QUERY_MS = Number(process.env.PRISMA_SLOW_QUERY_MS);
-const SLOW_QUERY_MS =
-  Number.isFinite(PARSED_SLOW_QUERY_MS) && PARSED_SLOW_QUERY_MS > 0
-    ? PARSED_SLOW_QUERY_MS
-    : 500;
+const SLOW_QUERY_MS = pgTimeoutMs("PRISMA_SLOW_QUERY_MS", 500);
 
 function makeClient() {
   // Emit the `query` event everywhere so the slow-query hook fires in prod too;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 import { getSessionCookie } from "better-auth/cookies";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, NextFetchEvent } from "next/server";
 
 import {
   getMaintenanceState,
@@ -42,7 +42,6 @@ import { Ratelimit } from "@upstash/ratelimit";
 
 const URLS = {
   SIGNIN: "/auth/signin",
-  ONBOARDING: "/form/onboarding",
 };
 
 // Route-prefix groups. Prefix matching (startsWith) is used instead of globs for
@@ -121,7 +120,9 @@ function maintenanceRetryAfterHeaders(
   estimatedEnd: string | null,
 ): Record<string, string> {
   if (!estimatedEnd) return {};
-  const secs = Math.ceil((new Date(estimatedEnd).getTime() - Date.now()) / 1000);
+  const secs = Math.ceil(
+    (new Date(estimatedEnd).getTime() - Date.now()) / 1000,
+  );
   return secs > 0 ? { "Retry-After": String(secs) } : {};
 }
 
@@ -331,7 +332,10 @@ async function applyEdgeRateLimits(
  * Cookie-based middleware — no DB hit, no JWT parsing. See the header block above
  * for the auth model and the per-stage rationale.
  */
-export async function middleware(req: NextRequest): Promise<NextResponse> {
+export async function middleware(
+  req: NextRequest,
+  event: NextFetchEvent,
+): Promise<NextResponse> {
   const { pathname } = req.nextUrl;
 
   // 1a. Static assets / Next internals — nothing to gate. (Mostly excluded by
@@ -362,7 +366,7 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     req.headers.get("Next-Router-Prefetch") === "1" ||
     req.headers.get("RSC") === "1";
   const maintenanceState = isSubNavigation
-    ? getMaintenanceStateCachedOnly()
+    ? getMaintenanceStateCachedOnly(event.waitUntil.bind(event))
     : await getMaintenanceState();
   const maintenance = handleMaintenance(req, pathname, maintenanceState);
   if (maintenance) return maintenance;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,7 +36,7 @@ const withBundleAnalyzer =
 const CSP_DIRECTIVES = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com https://*.sentry.io https://*.getstream.io https://*.supabase.co",
-  "connect-src 'self' https://*.getstream.io wss://*.getstream.io https://*.supabase.co https://*.upstash.io https://api.razorpay.com https://*.sentry.io https://api.resend.com",
+  "connect-src 'self' https://*.getstream.io wss://*.getstream.io https://*.supabase.co https://*.upstash.io https://api.razorpay.com https://*.sentry.io https://api.resend.com https://*.novu.co wss://*.novu.co",
   "img-src 'self' data: https: blob:",
   "media-src 'self' blob: https://*.getstream.io",
   "style-src 'self' 'unsafe-inline'",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -121,22 +121,13 @@ const nextConfig = {
         hostname: "lh3.googleusercontent.com",
       },
       {
-        hostname: "firebasestorage.googleapis.com",
-      },
-      {
         hostname: "*.supabase.co",
       },
       {
         hostname: "avatars.githubusercontent.com",
       },
       {
-        hostname: "cloudflare-ipfs.com",
-      },
-      {
         hostname: "picsum.photos",
-      },
-      {
-        hostname: "source.unsplash.com",
       },
       {
         hostname: "cdn.jsdelivr.net",
@@ -166,52 +157,52 @@ const nextConfig = {
 };
 
 export default withSentryConfig(withBundleAnalyzer(nextConfig), {
- // For all available options, see:
- // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+  // For all available options, see:
+  // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
- org: "practitionist",
+  org: "practitionist",
 
- project: "familiarise_web",
+  project: "familiarise_web",
 
- // Only print logs for uploading source maps in CI
- silent: !process.env.CI,
+  // Only print logs for uploading source maps in CI
+  silent: !process.env.CI,
 
- // #900 — the build/deploy must NOT fail because the Sentry source-map upload
- // failed (e.g. an expired/invalid SENTRY_AUTH_TOKEN on Netlify). With an
- // errorHandler the Sentry plugin logs and CONTINUES instead of exiting
- // non-zero; source maps just won't upload until the token is rotated, but the
- // build always succeeds. (next build succeeds locally — the upload only runs
- // where the token is set, so this surfaced as a Netlify-only build failure.)
- errorHandler: (err) => {
-   console.warn(
-     "[sentry] source-map upload step failed (non-fatal):",
-     err?.message ?? err,
-   );
- },
+  // #900 — the build/deploy must NOT fail because the Sentry source-map upload
+  // failed (e.g. an expired/invalid SENTRY_AUTH_TOKEN on Netlify). With an
+  // errorHandler the Sentry plugin logs and CONTINUES instead of exiting
+  // non-zero; source maps just won't upload until the token is rotated, but the
+  // build always succeeds. (next build succeeds locally — the upload only runs
+  // where the token is set, so this surfaced as a Netlify-only build failure.)
+  errorHandler: (err) => {
+    console.warn(
+      "[sentry] source-map upload step failed (non-fatal):",
+      err?.message ?? err,
+    );
+  },
 
- // For all available options, see:
- // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+  // For all available options, see:
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
- // Upload a larger set of source maps for prettier stack traces (increases build time)
- widenClientFileUpload: true,
+  // Upload a larger set of source maps for prettier stack traces (increases build time)
+  widenClientFileUpload: true,
 
- // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
- // This can increase your server load as well as your hosting bill.
- // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
- // side errors will fail.
- // tunnelRoute: "/monitoring",
+  // Uncomment to route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+  // This can increase your server load as well as your hosting bill.
+  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+  // side errors will fail.
+  // tunnelRoute: "/monitoring",
 
- webpack: {
-   // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-   // See the following for more information:
-   // https://docs.sentry.io/product/crons/
-   // https://vercel.com/docs/cron-jobs
-   automaticVercelMonitors: true,
+  webpack: {
+    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
 
-   // Tree-shaking options for reducing bundle size
-   treeshake: {
-     // Automatically tree-shake Sentry logger statements to reduce bundle size
-     removeDebugLogging: true,
-   },
- },
+    // Tree-shaking options for reducing bundle size
+    treeshake: {
+      // Automatically tree-shake Sentry logger statements to reduce bundle size
+      removeDebugLogging: true,
+    },
+  },
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -2,26 +2,9 @@
 // The config you add here will be used whenever one of the edge features is loaded.
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+//
+// Init config lives in sentry.shared.config.ts (shared across runtimes — #913).
 
-import * as Sentry from "@sentry/nextjs";
-import { isNotDevelopmentEnvironment, isProductionEnvironment } from "@/utils/env";
+import { initSentry } from "./sentry.shared.config";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
-
-Sentry.init({
-  dsn,
-  // No DSN => Sentry fully disabled. Also gated off in local `next dev` so a
-  // developer's .env DSN doesn't flood the shared prod project with dev noise.
-  enabled: Boolean(dsn) && isNotDevelopmentEnvironment(),
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: isProductionEnvironment() ? 0.1 : 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: false,
-});
+initSentry();

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,26 +1,9 @@
 // This file configures the initialization of Sentry on the server.
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+//
+// Init config lives in sentry.shared.config.ts (shared across runtimes — #913).
 
-import * as Sentry from "@sentry/nextjs";
-import { isNotDevelopmentEnvironment, isProductionEnvironment } from "@/utils/env";
+import { initSentry } from "./sentry.shared.config";
 
-const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
-
-Sentry.init({
-  dsn,
-  // No DSN => Sentry fully disabled. Also gated off in local `next dev` so a
-  // developer's .env DSN doesn't flood the shared prod project with dev noise.
-  enabled: Boolean(dsn) && isNotDevelopmentEnvironment(),
-  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: isProductionEnvironment() ? 0.1 : 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: false,
-});
+initSentry();

--- a/sentry.shared.config.ts
+++ b/sentry.shared.config.ts
@@ -1,0 +1,32 @@
+// Shared Sentry.init() for all three runtimes (server / edge / client).
+//
+// The three Sentry entrypoints used to carry byte-identical init config; they
+// differ only in that the client also exports onRouterTransitionStart. This
+// centralizes the one config so a sampling/PII/env tweak lands in one place. (#913)
+
+import * as Sentry from "@sentry/nextjs";
+import {
+  isNotDevelopmentEnvironment,
+  isProductionEnvironment,
+} from "@/utils/env";
+
+export function initSentry(): void {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+  Sentry.init({
+    dsn,
+    // No DSN => Sentry fully disabled. Also gated off in local `next dev` so a
+    // developer's .env DSN doesn't flood the shared prod project with dev noise.
+    enabled: Boolean(dsn) && isNotDevelopmentEnvironment(),
+    environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+
+    // Sample 10% of traces in production; everything outside production.
+    tracesSampleRate: isProductionEnvironment() ? 0.1 : 1,
+
+    // Send structured logs to Sentry.
+    enableLogs: true,
+
+    // Never attach PII to events.
+    sendDefaultPii: false,
+  });
+}


### PR DESCRIPTION
Promotes `dev` → `prod`. Two changes since the last promotion:

- **#929** — `/explore/experts` resilience + schema↔DB sync (FK indexes already `db push`ed; this activates the code resilience layer, the corrected maintenance gate with `event.waitUntil`, and the config de-bloat incl. Sentry shared config). Closes #913.
- **#926** — CSP `connect-src` for Novu WebSocket endpoints.

Activates on prod: the explore graceful-degradation, the maintenance soft-nav bypass fix, and the corrected Sentry DSN/observability path.

Validated on dev: tsc + eslint + build green, dev-server smoke (explore routes 200), CI green on #929.