### PR TITLE
fix(announcements): fail open on transient DB timeout (FAMILIARISE_WEB-9)

### DIFF
--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { notifyGeneralAnnouncement } from "@/lib/novu";
 import { CreateAnnouncementSchema } from "@/schemas/announcements";
+import { isTransientDbError } from "@/lib/data/fail-open";
 
 import { getSession } from "@/lib/auth-server";
 import { assertBodySize } from "@/lib/validation/limits";
@@ -33,7 +34,21 @@ export async function GET() {
       data: announcements,
     });
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "notifications" } });
+    // The announcements banner is non-critical and polled often. A transient
+    // pooler connect/read timeout (cross-region cold connect) should degrade to
+    // an empty banner, not a 500 + error-noise — report it as a warning and
+    // fail open. Real defects still surface as exceptions + 500. (FAMILIARISE_WEB-9)
+    if (isTransientDbError(error)) {
+      Sentry.captureMessage(
+        "announcements read failed (transient DB timeout) — empty",
+        { level: "warning", tags: { subsystem: "notifications" } },
+      );
+      return NextResponse.json({ success: true, data: [] });
+    }
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "notifications" } },
+    );
     console.error("Get announcements error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to fetch announcements" },
@@ -112,7 +127,10 @@ export async function POST(request: NextRequest) {
       data: announcement,
     });
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "notifications" } });
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "notifications" } },
+    );
     console.error("Create announcement error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to create announcement" },

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { notifyGeneralAnnouncement } from "@/lib/novu";
 import { CreateAnnouncementSchema } from "@/schemas/announcements";
-import { isTransientDbError } from "@/lib/data/fail-open";
+import { isTransientDbError, reportTransient } from "@/lib/data/fail-open";
 
 import { getSession } from "@/lib/auth-server";
 import { assertBodySize } from "@/lib/validation/limits";
@@ -39,10 +39,9 @@ export async function GET() {
     // an empty banner, not a 500 + error-noise — report it as a warning and
     // fail open. Real defects still surface as exceptions + 500. (FAMILIARISE_WEB-9)
     if (isTransientDbError(error)) {
-      Sentry.captureMessage(
-        "announcements read failed (transient DB timeout) — empty",
-        { level: "warning", tags: { subsystem: "notifications" } },
-      );
+      reportTransient("announcements read", error, {
+        subsystem: "notifications",
+      });
       return NextResponse.json({ success: true, data: [] });
     }
     Sentry.captureException(

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -22,21 +22,25 @@ export function isTransientDbError(err: unknown): boolean {
   );
 }
 
-// Report a degraded read without re-raising it. console for local visibility +
-// a Sentry warning so the fail-open path is observable rather than silent (#929).
-function reportTransient(context: string, err: unknown): void {
+// Report a degraded read without re-raising it: a console line for local/server
+// log visibility + a structured Sentry warning carrying the underlying error
+// message, so the fail-open path stays observable rather than silent. Shared by
+// the explore reads and other public read paths (e.g. announcements). (#929, #931.)
+export function reportTransient(
+  context: string,
+  err: unknown,
+  tags?: Record<string, string>,
+): void {
   const msg = err instanceof Error ? err.message : String(err);
-  console.error(
-    `[explore] ${context} read failed (transient DB timeout) — degrading:`,
+  console.warn(
+    `[fail-open] ${context} (transient DB timeout) — degrading:`,
     msg,
   );
-  Sentry.captureMessage(
-    `explore fail-open: ${context} (transient DB timeout)`,
-    {
-      level: "warning",
-      extra: { context, message: msg },
-    },
-  );
+  Sentry.captureMessage(`fail-open: ${context} (transient DB timeout)`, {
+    level: "warning",
+    extra: { context, message: msg },
+    ...(tags ? { tags } : {}),
+  });
 }
 
 export function emptyOnTransientDbError(context: string) {

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -10,7 +10,9 @@
  */
 import * as Sentry from "@sentry/nextjs";
 
-function isTransientDbError(err: unknown): boolean {
+// Exported so non-explore read paths (e.g. the public announcements banner) can
+// share the same transient-class detection and degrade rather than 500 (#929).
+export function isTransientDbError(err: unknown): boolean {
   const code = (err as { code?: string } | null)?.code;
   const msg = err instanceof Error ? err.message : String(err);
   return (


### PR DESCRIPTION
## Sentry: FAMILIARISE_WEB-9 — `Connection terminated due to connection timeout` on `GET /api/announcements`

A new production Sentry error: the public announcements banner (polled often) hit a transient Supavisor pooler connect/read timeout, which the route caught, reported as a **Sentry exception**, and returned **500**.

**Root-cause context:** `PG_POOL_MAX=1` is already correct on prod; the structural factor is **cross-region latency** — Netlify functions run in `us-east-2` while the Supabase pooler is in `ap-south-1`, so cold connects occasionally brush the 3s `PG_CONNECT_TIMEOUT_MS`. Not something to fix by loosening the (deliberately tight, sub-ceiling) timeout.

**Fix:** the transient-timeout class now degrades to an **empty banner (200)** + a Sentry **warning**, instead of a 500 + exception. Real defects still surface as exceptions + 500. Reuses `isTransientDbError` (now exported from `lib/data/fail-open.ts`) — same resilience pattern as #929's explore pages.

The sibling issue **FAMILIARISE_WEB-A** (`/explore/experts` connect timeout) is already handled by #929's fail-open wraps (now on prod via `ff695c5a`).

Validated: `tsc` clean, `eslint`/`prettier` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved announcement loading so temporary database issues now return an empty list instead of an error, helping the app stay available during brief outages.
  * Kept non-temporary failures reported and surfaced as server errors as before.
  * Refined error reporting for failed announcement submissions while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->