### PR TITLE
release: dev → prod — announcements fail-open on transient DB timeout (FAMILIARISE_WEB-9)

### DIFF
--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { notifyGeneralAnnouncement } from "@/lib/novu";
 import { CreateAnnouncementSchema } from "@/schemas/announcements";
+import { isTransientDbError, reportTransient } from "@/lib/data/fail-open";
 
 import { getSession } from "@/lib/auth-server";
 import { assertBodySize } from "@/lib/validation/limits";
@@ -33,7 +34,20 @@ export async function GET() {
       data: announcements,
     });
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "notifications" } });
+    // The announcements banner is non-critical and polled often. A transient
+    // pooler connect/read timeout (cross-region cold connect) should degrade to
+    // an empty banner, not a 500 + error-noise — report it as a warning and
+    // fail open. Real defects still surface as exceptions + 500. (FAMILIARISE_WEB-9)
+    if (isTransientDbError(error)) {
+      reportTransient("announcements read", error, {
+        subsystem: "notifications",
+      });
+      return NextResponse.json({ success: true, data: [] });
+    }
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "notifications" } },
+    );
     console.error("Get announcements error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to fetch announcements" },
@@ -112,7 +126,10 @@ export async function POST(request: NextRequest) {
       data: announcement,
     });
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "notifications" } });
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "notifications" } },
+    );
     console.error("Create announcement error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to create announcement" },

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -10,7 +10,9 @@
  */
 import * as Sentry from "@sentry/nextjs";
 
-function isTransientDbError(err: unknown): boolean {
+// Exported so non-explore read paths (e.g. the public announcements banner) can
+// share the same transient-class detection and degrade rather than 500 (#929).
+export function isTransientDbError(err: unknown): boolean {
   const code = (err as { code?: string } | null)?.code;
   const msg = err instanceof Error ? err.message : String(err);
   return (
@@ -20,21 +22,25 @@ function isTransientDbError(err: unknown): boolean {
   );
 }
 
-// Report a degraded read without re-raising it. console for local visibility +
-// a Sentry warning so the fail-open path is observable rather than silent (#929).
-function reportTransient(context: string, err: unknown): void {
+// Report a degraded read without re-raising it: a console line for local/server
+// log visibility + a structured Sentry warning carrying the underlying error
+// message, so the fail-open path stays observable rather than silent. Shared by
+// the explore reads and other public read paths (e.g. announcements). (#929, #931.)
+export function reportTransient(
+  context: string,
+  err: unknown,
+  tags?: Record<string, string>,
+): void {
   const msg = err instanceof Error ? err.message : String(err);
-  console.error(
-    `[explore] ${context} read failed (transient DB timeout) — degrading:`,
+  console.warn(
+    `[fail-open] ${context} (transient DB timeout) — degrading:`,
     msg,
   );
-  Sentry.captureMessage(
-    `explore fail-open: ${context} (transient DB timeout)`,
-    {
-      level: "warning",
-      extra: { context, message: msg },
-    },
-  );
+  Sentry.captureMessage(`fail-open: ${context} (transient DB timeout)`, {
+    level: "warning",
+    extra: { context, message: msg },
+    ...(tags ? { tags } : {}),
+  });
 }
 
 export function emptyOnTransientDbError(context: string) {


### PR DESCRIPTION
Promotes `dev` → `prod`. One change since the last promotion (#930):

- **#931** — `GET /api/announcements` now fails open (empty banner + Sentry warning) on the transient Supavisor pooler connect/read-timeout class instead of 500 + exception, via the shared `reportTransient` helper (console.warn + structured Sentry event). Resolves Sentry **FAMILIARISE_WEB-9**.

Root-cause context tracked in #932 (cross-region us-east-2 ↔ ap-south-1 latency).

Validated on dev: GitHub CI green (Lint + TypeScript/Tests/Build), dev branch deploy succeeded (401s, no error).