### PR TITLE
fix(home): fail open on transient DB timeout + quiet fail-open Sentry noise (FAMILIARISE_WEB-A/B/C/D)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,6 +37,10 @@ async function FeaturedExpertsLoader() {
   const experts = await getHomeExperts().catch(
     emptyOnTransientDbError("home experts"),
   );
+  // Hide the section rather than render an empty marquee under its headers when
+  // there's nothing to show — whether a transient timeout degraded it or the
+  // platform genuinely has no featured experts yet. (#934 review.)
+  if (experts.length === 0) return null;
   return <FeaturedExpertsSection experts={experts} isLoading={false} />;
 }
 
@@ -44,6 +48,7 @@ async function ReviewsLoader() {
   const reviews = await getHomeReviews().catch(
     emptyOnTransientDbError("home reviews"),
   );
+  if (reviews.length === 0) return null;
   return (
     <>
       <TestimonialsSection reviews={reviews} isLoading={false} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,24 +16,34 @@ import { BecomeExpertSection } from "@/components/home/BecomeExpertSection";
 import { FAQSection } from "@/components/home/FAQSection";
 import { SatisfiedTestimonial } from "@/app/explore/experts/components/SatisfiedTestimonial";
 import { getHomeExperts, getHomeReviews, getHomeImages } from "@/lib/data/home";
+import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 import {
   BenefitsSkeleton,
   FeaturedExpertsSkeleton,
   TestimonialsSkeleton,
 } from "@/components/home/HomeSectionSkeletons";
 
+// Each section reads independently; a transient pooler timeout (cross-region cold
+// connect, #932) in any one degrades that section to empty rather than throwing
+// past its Suspense boundary and crashing the whole landing page. (FAMILIARISE_WEB-A)
 async function BenefitsLoader() {
-  const images = await getHomeImages();
+  const images = await getHomeImages().catch(
+    emptyOnTransientDbError("home images"),
+  );
   return <BenefitsSection images={images} />;
 }
 
 async function FeaturedExpertsLoader() {
-  const experts = await getHomeExperts();
+  const experts = await getHomeExperts().catch(
+    emptyOnTransientDbError("home experts"),
+  );
   return <FeaturedExpertsSection experts={experts} isLoading={false} />;
 }
 
 async function ReviewsLoader() {
-  const reviews = await getHomeReviews();
+  const reviews = await getHomeReviews().catch(
+    emptyOnTransientDbError("home reviews"),
+  );
   return (
     <>
       <TestimonialsSection reviews={reviews} isLoading={false} />

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -22,24 +22,27 @@ export function isTransientDbError(err: unknown): boolean {
   );
 }
 
-// Report a degraded read without re-raising it: a console line for local/server
-// log visibility + a structured Sentry warning carrying the underlying error
-// message, so the fail-open path stays observable rather than silent. Shared by
-// the explore reads and other public read paths (e.g. announcements). (#929, #931.)
+// Report a degraded read without re-raising it: a server-log line plus a Sentry
+// breadcrumb — NOT a captured event. The transient pooler-timeout class is a
+// known, tracked condition (cross-region latency, #932), so firing a Sentry
+// warning *issue* per degradation only floods the dashboard (and multiplies as
+// more read paths adopt fail-open). The breadcrumb keeps the context attached to
+// any *real* error captured later in the same request. (#929, #931, #934.)
 export function reportTransient(
   context: string,
   err: unknown,
   tags?: Record<string, string>,
 ): void {
-  const msg = err instanceof Error ? err.message : String(err);
+  const message = err instanceof Error ? err.message : String(err);
   console.warn(
     `[fail-open] ${context} (transient DB timeout) — degrading:`,
-    msg,
+    message,
   );
-  Sentry.captureMessage(`fail-open: ${context} (transient DB timeout)`, {
+  Sentry.addBreadcrumb({
+    category: "fail-open",
     level: "warning",
-    extra: { context, message: msg },
-    ...(tags ? { tags } : {}),
+    message: `${context} (transient DB timeout)`,
+    data: { context, message, ...tags },
   });
 }
 


### PR DESCRIPTION
## More Sentry issues — diagnosed and fixed

Searched the project's unresolved issues. They split into a real crash and self-inflicted noise:

| Sentry | What | Verdict |
|---|---|---|
| **FAMILIARISE_WEB-A** | `timeout exceeded when trying to connect`, `handled: no`, transaction `GET /`, **latest release** | Real crash — homepage was unwrapped |
| **FAMILIARISE_WEB-9** | `Connection terminated…`, now also `GET /` | Homepage (already wrapped on `/api/announcements` in #931) |
| **FAMILIARISE_WEB-B/C/D** | `fail-open: experts metadata/trending/newest (transient DB timeout)`, `level: warning` | The warning events **I added** in #929/#931 — one issue per context |

`search_events` over 14d confirmed the blast radius: **`GET /` = 26 of 30** connect-timeout errors; the rest (`/api/announcements`, `/explore/experts`) are already handled, plus one stray detail-page event.

## Fix

**1. Wrap the homepage (`FAMILIARISE_WEB-A`).** `app/page.tsx` reads three sections (`getHomeImages`, `getHomeExperts`, `getHomeReviews`) in Suspense loaders; a transient timeout in any threw past Suspense and crashed the landing page. Each now degrades to an empty section via `emptyOnTransientDbError` — the established pattern from #929/#931.

**2. Quiet the fail-open noise (`FAMILIARISE_WEB-B/C/D`).** `reportTransient` no longer captures a Sentry **event** per degradation; it adds a **breadcrumb + console warning** instead. The transient class is a *known, tracked* condition (**#932** cross-region latency), so a warning issue per context just floods the dashboard and multiplies as more reads adopt fail-open. The breadcrumb still attaches context to any real error captured later in the same request.

## Not in scope (tracked in #932)
ISR-caching the landing page (it *is* cacheable — no `force-dynamic`/`headers()`) would remove the DB from its hot path entirely. That's the durable fix and belongs with the #932 region/caching work.

Validated: `tsc` clean (cold), `eslint`/`prettier` clean.

After this reaches prod I'll resolve FAMILIARISE_WEB-A/9/B/C/D on Sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the landing page’s resilience when temporary data service issues occur.
  * Sections for Benefits, Featured Experts, and Reviews now show empty states instead of failing the whole page when data can’t be loaded.
  * Reduced noisy warning events during transient outages while still keeping degradation visible in monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->