### PR TITLE
release: dev → prod — homepage fail-open + public-read caching (FAMILIARISE_WEB-A/9/B/C/D; #932)

### DIFF
--- a/app/api/announcements/[id]/route.ts
+++ b/app/api/announcements/[id]/route.ts
@@ -1,8 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import prisma from "@/lib/prisma";
 
 import { getSession } from "@/lib/auth-server";
+import { ANNOUNCEMENTS_TAG } from "@/lib/cache-tags";
 interface RouteParams {
   params: Promise<{ id: string }>;
 }
@@ -80,12 +82,18 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       },
     });
 
+    // Invalidate the cached banner read so the edit shows immediately.
+    revalidateTag(ANNOUNCEMENTS_TAG);
+
     return NextResponse.json({
       success: true,
       data: announcement,
     });
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "notifications" } });
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "notifications" } },
+    );
     console.error("Update announcement error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to update announcement" },
@@ -133,12 +141,18 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       where: { id },
     });
 
+    // Invalidate the cached banner read so the removal shows immediately.
+    revalidateTag(ANNOUNCEMENTS_TAG);
+
     return NextResponse.json({
       success: true,
       message: "Announcement deleted successfully",
     });
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "notifications" } });
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "notifications" } },
+    );
     console.error("Delete announcement error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to delete announcement" },

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -1,21 +1,24 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
+import { unstable_cache, revalidateTag } from "next/cache";
 import prisma from "@/lib/prisma";
 import { notifyGeneralAnnouncement } from "@/lib/novu";
 import { CreateAnnouncementSchema } from "@/schemas/announcements";
+import { ANNOUNCEMENTS_TAG } from "@/lib/cache-tags";
 import { isTransientDbError, reportTransient } from "@/lib/data/fail-open";
 
 import { getSession } from "@/lib/auth-server";
 import { assertBodySize } from "@/lib/validation/limits";
-/**
- * GET /api/announcements
- * Public endpoint to get active announcements
- */
-export async function GET() {
-  try {
-    const now = new Date();
 
-    const announcements = await prisma.announcement.findMany({
+// Cache the active-announcements read. The banner is polled frequently and the
+// data only changes on the admin writes below (which revalidate the tag), so this
+// keeps the high-frequency GET off the cross-region pooler hot path (#932). `now`
+// is computed inside the cached fn — not in the key — so the active-window filter
+// is re-evaluated on each revalidation rather than frozen at first call.
+const getActiveAnnouncements = unstable_cache(
+  async () => {
+    const now = new Date();
+    return prisma.announcement.findMany({
       where: {
         isActive: true,
         OR: [
@@ -28,6 +31,18 @@ export async function GET() {
       orderBy: { createdAt: "desc" },
       take: 5,
     });
+  },
+  ["active-announcements"],
+  { revalidate: 60, tags: [ANNOUNCEMENTS_TAG] },
+);
+
+/**
+ * GET /api/announcements
+ * Public endpoint to get active announcements
+ */
+export async function GET() {
+  try {
+    const announcements = await getActiveAnnouncements();
 
     return NextResponse.json({
       success: true,
@@ -112,6 +127,9 @@ export async function POST(request: NextRequest) {
         createdBy: session.user.id,
       },
     });
+
+    // Invalidate the cached banner read so the new announcement shows immediately.
+    revalidateTag(ANNOUNCEMENTS_TAG);
 
     // Fire-and-forget: broadcast announcement to all subscribers via Novu
     void notifyGeneralAnnouncement({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,24 +16,39 @@ import { BecomeExpertSection } from "@/components/home/BecomeExpertSection";
 import { FAQSection } from "@/components/home/FAQSection";
 import { SatisfiedTestimonial } from "@/app/explore/experts/components/SatisfiedTestimonial";
 import { getHomeExperts, getHomeReviews, getHomeImages } from "@/lib/data/home";
+import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 import {
   BenefitsSkeleton,
   FeaturedExpertsSkeleton,
   TestimonialsSkeleton,
 } from "@/components/home/HomeSectionSkeletons";
 
+// Each section reads independently; a transient pooler timeout (cross-region cold
+// connect, #932) in any one degrades that section to empty rather than throwing
+// past its Suspense boundary and crashing the whole landing page. (FAMILIARISE_WEB-A)
 async function BenefitsLoader() {
-  const images = await getHomeImages();
+  const images = await getHomeImages().catch(
+    emptyOnTransientDbError("home images"),
+  );
   return <BenefitsSection images={images} />;
 }
 
 async function FeaturedExpertsLoader() {
-  const experts = await getHomeExperts();
+  const experts = await getHomeExperts().catch(
+    emptyOnTransientDbError("home experts"),
+  );
+  // Hide the section rather than render an empty marquee under its headers when
+  // there's nothing to show — whether a transient timeout degraded it or the
+  // platform genuinely has no featured experts yet. (#934 review.)
+  if (experts.length === 0) return null;
   return <FeaturedExpertsSection experts={experts} isLoading={false} />;
 }
 
 async function ReviewsLoader() {
-  const reviews = await getHomeReviews();
+  const reviews = await getHomeReviews().catch(
+    emptyOnTransientDbError("home reviews"),
+  );
+  if (reviews.length === 0) return null;
   return (
     <>
       <TestimonialsSection reviews={reviews} isLoading={false} />

--- a/lib/cache-tags.ts
+++ b/lib/cache-tags.ts
@@ -1,0 +1,3 @@
+// Single source of truth for Next data-cache tags, so a cached read and the
+// write paths that must invalidate it can't drift apart. (#932)
+export const ANNOUNCEMENTS_TAG = "announcements";

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 
@@ -7,7 +8,8 @@ import { Prisma } from "@prisma/client";
  *
  * Exports two flavors of each function:
  *  - Raw (e.g. fetchExpertsMetadata) — pure Prisma, no cache. Used by API routes.
- *  - Cached (e.g. getExpertsMetadata)  — React.cache() wrapper. Used by Server Components.
+ *  - Cached (e.g. getExpertsMetadata) — unstable_cache wrapper (cross-request Next
+ *    data cache, #932). Used by Server Components.
  */
 
 /**
@@ -158,17 +160,22 @@ export async function fetchExpertsMetadata() {
         Array.from(new Set(rows.flatMap((r) => r.languages))).sort(),
       ),
     // Available companies (from verified consultants' work experiences)
-    prisma.workExperience.findMany({
-      where: {
-        company: { not: "" },
-        user: {
-          consultantProfile: { verificationStatus: "VERIFIED", deletedAt: null },
+    prisma.workExperience
+      .findMany({
+        where: {
+          company: { not: "" },
+          user: {
+            consultantProfile: {
+              verificationStatus: "VERIFIED",
+              deletedAt: null,
+            },
+          },
         },
-      },
-      select: { company: true },
-      distinct: ["company"],
-      orderBy: { company: "asc" },
-    }).then((result) => result.map((r) => r.company)),
+        select: { company: true },
+        distinct: ["company"],
+        orderBy: { company: "asc" },
+      })
+      .then((result) => result.map((r) => r.company)),
   ]);
 
   return {
@@ -187,8 +194,14 @@ export async function fetchExpertsMetadata() {
   };
 }
 
-/** Cached wrapper for Server Components. */
-export const getExpertsMetadata = cache(fetchExpertsMetadata);
+// Cross-request cached wrapper for Server Components: the filter metadata
+// (domains, tags, counts) changes slowly, so serve it from the Next data cache
+// rather than opening a cross-region pooled connection per request (#932).
+export const getExpertsMetadata = unstable_cache(
+  fetchExpertsMetadata,
+  ["experts-metadata"],
+  { revalidate: 300, tags: ["experts"] },
+);
 
 export type ExpertsMetadata = Awaited<ReturnType<typeof fetchExpertsMetadata>>;
 
@@ -241,8 +254,10 @@ export const getRecentReviews = cache(async (limit: number = 6) => {
 // Curated experts (Featured / Trending / Newest rows)
 // ---------------------------------------------------------------------------
 
-/** Cached wrapper for Server Components. */
-export const getCuratedExperts = cache(
+// Cross-request cached: each (sort, limit) pair is keyed separately by
+// unstable_cache, so the three curated rows share one short-lived cache entry
+// apiece instead of re-querying the pooler on every explore load (#932).
+export const getCuratedExperts = unstable_cache(
   async (sort: "rating" | "trending" | "newest", limit: number = 8) => {
     let orderBy: Record<string, unknown>;
     switch (sort) {
@@ -307,4 +322,6 @@ export const getCuratedExperts = cache(
       };
     });
   },
+  ["curated-experts"],
+  { revalidate: 120, tags: ["experts"] },
 );

--- a/lib/data/explore-programs.ts
+++ b/lib/data/explore-programs.ts
@@ -1,4 +1,3 @@
-import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import { toPlain } from "@/lib/data/serialize";
@@ -158,7 +157,7 @@ const getTrendingWebinarPlanIds = unstable_cache(
  * Fetch curated programs for server-rendered sections.
  * Combines class plans + webinar plans, normalizes into Program[].
  */
-export const getCuratedPrograms = cache(
+export const getCuratedPrograms = unstable_cache(
   async (
     programType: ProgramType,
     sort: "trending" | "newest",
@@ -221,12 +220,7 @@ export const getCuratedPrograms = cache(
             ...plan,
             classes: plan.classes || [],
             type: "class",
-            imageUrl: generateProgramImageUrl(
-              plan.id,
-              600,
-              400,
-              plan.imageUrl,
-            ),
+            imageUrl: generateProgramImageUrl(plan.id, 600, 400, plan.imageUrl),
           }),
         ),
       );
@@ -275,12 +269,7 @@ export const getCuratedPrograms = cache(
             ...plan,
             webinars: [],
             type: "webinar",
-            imageUrl: generateProgramImageUrl(
-              plan.id,
-              600,
-              400,
-              plan.imageUrl,
-            ),
+            imageUrl: generateProgramImageUrl(plan.id, 600, 400, plan.imageUrl),
           }),
         ),
       );
@@ -297,13 +286,15 @@ export const getCuratedPrograms = cache(
     // toPlain — extended plan rows carry an inspect symbol (see serialize.ts)
     return toPlain(programs.slice(0, limit));
   },
+  ["curated-programs"],
+  { revalidate: 120, tags: ["programs"] },
 );
 
 // ---------------------------------------------------------------------------
 // Topics with program counts (for category grid)
 // ---------------------------------------------------------------------------
 
-export const getTopicsWithCount = cache(
+export const getTopicsWithCount = unstable_cache(
   async (planType: ProgramType = "all"): Promise<TopicWithCount[]> => {
     const topics = await prisma.topic.findMany({
       include: {
@@ -353,4 +344,6 @@ export const getTopicsWithCount = cache(
       .filter((t) => t.programCount > 0)
       .sort((a, b) => b.programCount - a.programCount);
   },
+  ["topics-with-count"],
+  { revalidate: 300, tags: ["programs"] },
 );

--- a/lib/data/fail-open.ts
+++ b/lib/data/fail-open.ts
@@ -22,24 +22,27 @@ export function isTransientDbError(err: unknown): boolean {
   );
 }
 
-// Report a degraded read without re-raising it: a console line for local/server
-// log visibility + a structured Sentry warning carrying the underlying error
-// message, so the fail-open path stays observable rather than silent. Shared by
-// the explore reads and other public read paths (e.g. announcements). (#929, #931.)
+// Report a degraded read without re-raising it: a server-log line plus a Sentry
+// breadcrumb — NOT a captured event. The transient pooler-timeout class is a
+// known, tracked condition (cross-region latency, #932), so firing a Sentry
+// warning *issue* per degradation only floods the dashboard (and multiplies as
+// more read paths adopt fail-open). The breadcrumb keeps the context attached to
+// any *real* error captured later in the same request. (#929, #931, #934.)
 export function reportTransient(
   context: string,
   err: unknown,
   tags?: Record<string, string>,
 ): void {
-  const msg = err instanceof Error ? err.message : String(err);
+  const message = err instanceof Error ? err.message : String(err);
   console.warn(
     `[fail-open] ${context} (transient DB timeout) — degrading:`,
-    msg,
+    message,
   );
-  Sentry.captureMessage(`fail-open: ${context} (transient DB timeout)`, {
+  Sentry.addBreadcrumb({
+    category: "fail-open",
     level: "warning",
-    extra: { context, message: msg },
-    ...(tags ? { tags } : {}),
+    message: `${context} (transient DB timeout)`,
+    data: { context, message, ...tags },
   });
 }
 

--- a/lib/data/home.ts
+++ b/lib/data/home.ts
@@ -1,82 +1,100 @@
-import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import { toPlain } from "@/lib/data/serialize";
 import { fetchImagesFromSupabaseStorage } from "@/lib/supabase";
 
 /**
  * Server-side data access for the landing page.
- * Uses React cache() for per-request deduplication.
+ *
+ * Wrapped in unstable_cache so the curated landing-page reads are served from the
+ * Next data cache (cross-request, cross-instance on Netlify) instead of opening a
+ * cross-region pooled connection on every request — the root layout's session read
+ * forces these pages dynamic, so page-level ISR can't apply and the cache has to
+ * live at the data layer. Bounded staleness is fine for a marketing surface; the
+ * consumers don't read the rows' Date fields, so cache serialization is safe (#932).
  */
 
-export const getHomeExperts = cache(async () => {
-  const consultants = await prisma.consultantProfile.findMany({
-    // #781 §B — soft-deleted profiles leave public surfaces
-    where: { verificationStatus: "VERIFIED", deletedAt: null },
-    orderBy: { rating: "desc" },
-    take: 10,
-    include: {
-      user: {
-        select: {
-          id: true,
-          name: true,
-          image: true,
-          profileDisplayImage: true,
+export const getHomeExperts = unstable_cache(
+  async () => {
+    const consultants = await prisma.consultantProfile.findMany({
+      // #781 §B — soft-deleted profiles leave public surfaces
+      where: { verificationStatus: "VERIFIED", deletedAt: null },
+      orderBy: { rating: "desc" },
+      take: 10,
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            profileDisplayImage: true,
+          },
+        },
+        domain: { select: { id: true, name: true } },
+        subDomains: { select: { id: true, name: true } },
+        tags: { select: { id: true, name: true } },
+        reviews: {
+          select: { rating: true },
+          take: 10,
+        },
+        subscriptionPlans: {
+          select: {
+            id: true,
+            title: true,
+            price: true,
+            priceCurrency: true,
+            durationInMonths: true,
+            callsPerWeek: true,
+            emailSupport: true,
+            totalSessions: true,
+          },
+          take: 5,
         },
       },
-      domain: { select: { id: true, name: true } },
-      subDomains: { select: { id: true, name: true } },
-      tags: { select: { id: true, name: true } },
-      reviews: {
-        select: { rating: true },
-        take: 10,
-      },
-      subscriptionPlans: {
-        select: {
-          id: true,
-          title: true,
-          price: true,
-          priceCurrency: true,
-          durationInMonths: true,
-          callsPerWeek: true,
-          emailSupport: true,
-          totalSessions: true,
-        },
-        take: 5,
-      },
-    },
-  });
-  // price is already number at the JS boundary (#780 result extension);
-  // toPlain strips the extension's inspect symbol so the rows can cross
-  // the RSC boundary.
-  return toPlain(consultants);
-});
+    });
+    // price is already number at the JS boundary (#780 result extension);
+    // toPlain strips the extension's inspect symbol so the rows can cross
+    // the RSC boundary.
+    return toPlain(consultants);
+  },
+  ["home-experts"],
+  { revalidate: 120, tags: ["experts", "home"] },
+);
 
-export const getHomeReviews = cache(async () => {
-  const reviews = await prisma.consultantReview.findMany({
-    // #781 §B — soft-deleted profiles leave public surfaces
-    where: { rating: { gte: 4 }, consultantProfile: { deletedAt: null } },
-    take: 20,
-    include: {
-      consultantProfile: {
-        include: {
-          user: { select: { name: true } },
+export const getHomeReviews = unstable_cache(
+  async () => {
+    const reviews = await prisma.consultantReview.findMany({
+      // #781 §B — soft-deleted profiles leave public surfaces
+      where: { rating: { gte: 4 }, consultantProfile: { deletedAt: null } },
+      take: 20,
+      include: {
+        consultantProfile: {
+          include: {
+            user: { select: { name: true } },
+          },
+        },
+        consulteeProfile: {
+          include: {
+            user: { select: { name: true, image: true } },
+          },
         },
       },
-      consulteeProfile: {
-        include: {
-          user: { select: { name: true, image: true } },
-        },
-      },
-    },
-    orderBy: { rating: "desc" },
-  });
-  return toPlain(reviews);
-});
+      orderBy: { rating: "desc" },
+    });
+    return toPlain(reviews);
+  },
+  ["home-reviews"],
+  { revalidate: 120, tags: ["reviews", "home"] },
+);
 
-export const getHomeImages = cache(async () => {
-  const images = await fetchImagesFromSupabaseStorage(
-    "assets",
-    "images/landing-page",
-  );
-  return images || [];
-});
+export const getHomeImages = unstable_cache(
+  async () => {
+    const images = await fetchImagesFromSupabaseStorage(
+      "assets",
+      "images/landing-page",
+    );
+    return images || [];
+  },
+  ["home-images"],
+  { revalidate: 600, tags: ["home-images"] },
+);


### PR DESCRIPTION
Promotes `dev` → `prod`. Two changes since the last promotion (#933):

- **#934** — the landing page `/` now fails open per-section on a transient pooler timeout (was the dominant crash, `FAMILIARISE_WEB-A`), and `reportTransient` is downgraded to a breadcrumb + console warning so the fail-open path stops spawning Sentry warning issues (`FAMILIARISE_WEB-B/C/D`).
- **#935** — public read surfaces (home, explore experts/programs, announcements) are served from the Next data cache via `unstable_cache`, taking them off the cross-region pooler hot path (#932 Phase 2); announcements invalidates via `revalidateTag` on writes.

Together these resolve the reported Sentry issues on prod and sharply cut DB exposure for the read-heavy public pages.

Validated on dev: CI green on both PRs, dev branch deploy succeeded, dev-server cache-hit reads 12-18x faster.