### PR TITLE
perf: instant navigation (static shell) + force-dynamic + read caching (Part of #932)

### DIFF
--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -17,7 +17,9 @@ import prisma from "@/lib/prisma";
 import { fallbackOnTransientDbError } from "@/lib/data/fail-open";
 import type { Metadata } from "next";
 
-export const revalidate = 60;
+// Stream behind the static layout's instant skeleton; don't prerender at build (#932).
+// (Replaces the prior `revalidate = 60`, inert while the layout forced dynamic.)
+export const dynamic = "force-dynamic";
 
 async function fetchOrgBySlug(slug: string) {
   const row = await prisma.organization.findFirst({
@@ -42,22 +44,46 @@ async function fetchOrgBySlug(slug: string) {
       // OrganizationPlan model was collapsed into these (one bookable shape).
       consultationPlans: {
         where: { visibility: { in: ["PUBLIC", "ORG_AND_PUBLIC"] } },
-        select: { id: true, title: true, description: true, price: true, priceCurrency: true },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          priceCurrency: true,
+        },
         take: 6,
       },
       subscriptionPlans: {
         where: { visibility: { in: ["PUBLIC", "ORG_AND_PUBLIC"] } },
-        select: { id: true, title: true, description: true, price: true, priceCurrency: true },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          priceCurrency: true,
+        },
         take: 6,
       },
       webinarPlans: {
         where: { visibility: { in: ["PUBLIC", "ORG_AND_PUBLIC"] } },
-        select: { id: true, title: true, description: true, price: true, priceCurrency: true },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          priceCurrency: true,
+        },
         take: 6,
       },
       classPlans: {
         where: { visibility: { in: ["PUBLIC", "ORG_AND_PUBLIC"] } },
-        select: { id: true, title: true, description: true, price: true, priceCurrency: true },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          priceCurrency: true,
+        },
         take: 6,
       },
       memberships: {
@@ -92,8 +118,14 @@ async function fetchOrgBySlug(slug: string) {
   // Normalize the four org-owned per-type plan lists into one catalog array,
   // tagged with planType, so the sidebar render is unchanged.
   const organizationPlans = [
-    ...row.consultationPlans.map((p) => ({ ...p, planType: "CONSULTATION" as const })),
-    ...row.subscriptionPlans.map((p) => ({ ...p, planType: "SUBSCRIPTION" as const })),
+    ...row.consultationPlans.map((p) => ({
+      ...p,
+      planType: "CONSULTATION" as const,
+    })),
+    ...row.subscriptionPlans.map((p) => ({
+      ...p,
+      planType: "SUBSCRIPTION" as const,
+    })),
     ...row.webinarPlans.map((p) => ({ ...p, planType: "WEBINAR" as const })),
     ...row.classPlans.map((p) => ({ ...p, planType: "CLASS" as const })),
   ].slice(0, 6);
@@ -114,7 +146,10 @@ type OrgData = NonNullable<Awaited<ReturnType<typeof fetchOrgBySlug>>>;
 
 // #777 §E — plan family → checkout route segment (lowercase). Booking a plan
 // from the public org page deep-links into the shared checkout flow.
-const CHECKOUT_FAMILY: Record<OrgData["organizationPlans"][number]["planType"], string> = {
+const CHECKOUT_FAMILY: Record<
+  OrgData["organizationPlans"][number]["planType"],
+  string
+> = {
   CONSULTATION: "consultation",
   SUBSCRIPTION: "subscription",
   WEBINAR: "webinar",
@@ -155,7 +190,11 @@ function ExpertMiniCard({
     >
       <div className="relative w-12 h-12 flex-shrink-0">
         <Image
-          src={expert.user.profileDisplayImage ?? expert.user.image ?? "/placeholder-user.jpg"}
+          src={
+            expert.user.profileDisplayImage ??
+            expert.user.image ??
+            "/placeholder-user.jpg"
+          }
           alt={expert.user.name}
           fill
           className="rounded-xl object-cover"
@@ -171,7 +210,9 @@ function ExpertMiniCard({
           )}
         </div>
         {expert.headline && (
-          <p className="text-xs text-muted-foreground truncate">{expert.headline}</p>
+          <p className="text-xs text-muted-foreground truncate">
+            {expert.headline}
+          </p>
         )}
         <div className="flex items-center gap-2 mt-0.5">
           <div className="flex items-center gap-0.5">
@@ -181,7 +222,9 @@ function ExpertMiniCard({
             </span>
           </div>
           {expert.domain && (
-            <span className="text-xs text-muted-foreground/70">{expert.domain.name}</span>
+            <span className="text-xs text-muted-foreground/70">
+              {expert.domain.name}
+            </span>
           )}
         </div>
       </div>
@@ -199,7 +242,8 @@ export default async function OrgProfilePage({
 
   if (!org) notFound();
 
-  const capabilityLabel = org.canSponsor && org.canHost ? "Hybrid" : "Host Agency";
+  const capabilityLabel =
+    org.canSponsor && org.canHost ? "Hybrid" : "Host Agency";
   // Binary categorical badge, no dark: variants — monochrome (filled vs muted).
   const capabilityClass =
     org.canSponsor && org.canHost
@@ -208,7 +252,9 @@ export default async function OrgProfilePage({
 
   const exclusiveExperts = org.memberships
     .map((m) => m.consultantProfile)
-    .filter(Boolean) as NonNullable<OrgData["memberships"][number]["consultantProfile"]>[];
+    .filter(Boolean) as NonNullable<
+    OrgData["memberships"][number]["consultantProfile"]
+  >[];
 
   return (
     <main className="min-h-screen bg-muted">
@@ -270,7 +316,9 @@ export default async function OrgProfilePage({
               </div>
 
               {org.industry && (
-                <p className="text-muted-foreground text-sm mb-3">{org.industry}</p>
+                <p className="text-muted-foreground text-sm mb-3">
+                  {org.industry}
+                </p>
               )}
 
               {org.description && (
@@ -321,7 +369,9 @@ export default async function OrgProfilePage({
             ) : (
               <div className="flex flex-col items-center justify-center py-16 text-center bg-card rounded-2xl border border-border">
                 <Users className="w-10 h-10 text-muted-foreground/70 mb-3" />
-                <p className="text-muted-foreground">No exclusive experts listed yet</p>
+                <p className="text-muted-foreground">
+                  No exclusive experts listed yet
+                </p>
               </div>
             )}
           </div>
@@ -384,7 +434,9 @@ export default async function OrgProfilePage({
                 asChild
                 className="w-full bg-card text-foreground hover:bg-muted font-medium rounded-xl"
               >
-                <Link href={`/explore/enterprise/organisations/${org.slug}#experts`}>
+                <Link
+                  href={`/explore/enterprise/organisations/${org.slug}#experts`}
+                >
                   Browse Experts
                 </Link>
               </Button>

--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -15,13 +15,16 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import prisma from "@/lib/prisma";
 import { fallbackOnTransientDbError } from "@/lib/data/fail-open";
+import { cache } from "react";
 import type { Metadata } from "next";
 
 // Stream behind the static layout's instant skeleton; don't prerender at build (#932).
 // (Replaces the prior `revalidate = 60`, inert while the layout forced dynamic.)
 export const dynamic = "force-dynamic";
 
-async function fetchOrgBySlug(slug: string) {
+// React.cache so generateMetadata() and the page body share one query per request
+// instead of running this heavy org read twice (more visible now it's per-request).
+const fetchOrgBySlug = cache(async (slug: string) => {
   const row = await prisma.organization.findFirst({
     where: { slug, isPublic: true, canHost: true, status: "ACTIVE" },
     select: {
@@ -140,7 +143,7 @@ async function fetchOrgBySlug(slug: string) {
     industry: row.brandingProfile?.industry ?? null,
     website: row.brandingProfile?.website ?? null,
   };
-}
+});
 
 type OrgData = NonNullable<Awaited<ReturnType<typeof fetchOrgBySlug>>>;
 

--- a/app/explore/enterprise/organisations/page.tsx
+++ b/app/explore/enterprise/organisations/page.tsx
@@ -6,7 +6,9 @@ import Link from "next/link";
 import prisma from "@/lib/prisma";
 import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 
-export const revalidate = 60;
+// Stream behind the static layout's instant skeleton; don't prerender at build (#932).
+// (Replaces the prior `revalidate = 60`, which was inert while the layout forced dynamic.)
+export const dynamic = "force-dynamic";
 
 async function fetchPublicOrgs(industry?: string) {
   const rows = await prisma.organization.findMany({
@@ -15,7 +17,11 @@ async function fetchPublicOrgs(industry?: string) {
       canHost: true,
       status: "ACTIVE",
       ...(industry
-        ? { brandingProfile: { industry: { equals: industry, mode: "insensitive" } } }
+        ? {
+            brandingProfile: {
+              industry: { equals: industry, mode: "insensitive" },
+            },
+          }
         : {}),
     },
     select: {
@@ -119,7 +125,9 @@ function OrgCard({
               {org.name}
             </h3>
             {org.industry && (
-              <p className="text-xs text-muted-foreground truncate">{org.industry}</p>
+              <p className="text-xs text-muted-foreground truncate">
+                {org.industry}
+              </p>
             )}
           </div>
         </div>
@@ -143,7 +151,10 @@ function OrgCard({
           </div>
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
             <Users className="w-3.5 h-3.5" />
-            <span>{org._count.memberships} expert{org._count.memberships !== 1 ? "s" : ""}</span>
+            <span>
+              {org._count.memberships} expert
+              {org._count.memberships !== 1 ? "s" : ""}
+            </span>
           </div>
         </div>
       </div>
@@ -182,11 +193,16 @@ async function OrgsGrid({ industry }: { industry?: string }) {
       <div className="flex flex-col items-center justify-center py-24 text-center">
         <Building2 className="w-12 h-12 text-muted-foreground/70 mb-4" />
         <p className="text-muted-foreground text-lg font-medium">
-          {industry ? `No agencies in ${industry} yet` : "No agencies listed yet"}
+          {industry
+            ? `No agencies in ${industry} yet`
+            : "No agencies listed yet"}
         </p>
         <p className="text-muted-foreground/70 text-sm mt-1">
           {industry ? (
-            <Link href="/explore/enterprise/organisations" className="underline hover:text-foreground">
+            <Link
+              href="/explore/enterprise/organisations"
+              className="underline hover:text-foreground"
+            >
               View all industries
             </Link>
           ) : (
@@ -240,8 +256,8 @@ export default async function ExploreOrganisationsPage({
               Explore <span className="silver-text">Organisations</span>
             </h1>
             <p className="text-lg text-zinc-300 max-w-xl mx-auto">
-              Discover expert networks, consulting agencies, and learning institutions
-              on Familiarise. Book their curated experts directly.
+              Discover expert networks, consulting agencies, and learning
+              institutions on Familiarise. Book their curated experts directly.
             </p>
           </div>
         </div>

--- a/app/explore/experts/[consultantId]/page.tsx
+++ b/app/explore/experts/[consultantId]/page.tsx
@@ -8,6 +8,10 @@ import { TUserWithProfessionalBackground } from "@/types/user";
 import { ExpertProfileClient } from "./ExpertProfileClient";
 import { ConsultantSkeletonLoader } from "./components/ConsultantSkeletonLoader";
 
+// Per-visitor detail page: stream behind the static layout's instant skeleton,
+// never prerender at build (#932).
+export const dynamic = "force-dynamic";
+
 type Params = Promise<{ consultantId: string }>;
 
 export default async function ExpertProfile({

--- a/app/explore/experts/components/ConsultantCard.tsx
+++ b/app/explore/experts/components/ConsultantCard.tsx
@@ -105,13 +105,14 @@ const SubscriptionPlanCard = ({
         {plan.callsPerWeek !== null &&
           plan.callsPerWeek !== undefined &&
           plan.callsPerWeek > 0 && (
-          <div className="flex items-center gap-2 text-sm">
-            <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-            <span className="text-muted-foreground">
-              {plan.callsPerWeek} {plan.callsPerWeek === 1 ? "call" : "calls"}/week
-            </span>
-          </div>
-        )}
+            <div className="flex items-center gap-2 text-sm">
+              <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+              <span className="text-muted-foreground">
+                {plan.callsPerWeek} {plan.callsPerWeek === 1 ? "call" : "calls"}
+                /week
+              </span>
+            </div>
+          )}
         {plan.emailSupport && (
           <div className="flex items-center gap-2 text-sm">
             <CheckCircle2 className="w-4 h-4 text-emerald-500" />
@@ -123,14 +124,14 @@ const SubscriptionPlanCard = ({
         {plan.totalSessions !== null &&
           plan.totalSessions !== undefined &&
           plan.totalSessions > 0 && (
-          <div className="flex items-center gap-2 text-sm">
-            <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-            <span className="text-muted-foreground">
-              {plan.totalSessions}{" "}
-              {plan.totalSessions === 1 ? "session" : "sessions"} total
-            </span>
-          </div>
-        )}
+            <div className="flex items-center gap-2 text-sm">
+              <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+              <span className="text-muted-foreground">
+                {plan.totalSessions}{" "}
+                {plan.totalSessions === 1 ? "session" : "sessions"} total
+              </span>
+            </div>
+          )}
       </div>
     </div>
   );
@@ -189,6 +190,8 @@ export const ConsultantCard = memo(function ConsultantCard({
                 className="rounded-2xl object-cover ring-2 ring-muted"
                 src={consultant.user.image || "/placeholder-user.jpg"}
                 fill
+                // 80×80 slot — without sizes, `fill` fetches a 100vw image (#932 perf).
+                sizes="80px"
               />
               {/* TODO: Add real presence indicator when online tracking is implemented */}
             </div>

--- a/app/explore/experts/page.tsx
+++ b/app/explore/experts/page.tsx
@@ -12,6 +12,9 @@ import {
   fallbackOnTransientDbError,
 } from "@/lib/data/fail-open";
 
+// Stream behind the static layout's instant skeleton; don't prerender at build (#932).
+export const dynamic = "force-dynamic";
+
 function HeroSection({
   totalConsultants,
   averageRating,

--- a/app/explore/programs/page.tsx
+++ b/app/explore/programs/page.tsx
@@ -3,8 +3,12 @@ import {
   getTopicsWithCount,
 } from "@/lib/data/explore-programs";
 import { emptyOnTransientDbError } from "@/lib/data/fail-open";
+import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import ProgramsInteractiveContent from "./ProgramsInteractiveContent";
+
+// Stream behind the static layout's instant skeleton; don't prerender at build (#932).
+export const dynamic = "force-dynamic";
 
 /**
  * Server-fetch the trending / newest curated rows, the topic list, and the
@@ -41,6 +45,20 @@ export default async function ExplorePrograms() {
   );
 }
 
+// Marketing counts change slowly (a few plans/day) — cache cross-request for an
+// hour rather than re-running two aggregates on every explore visit (#932 perf).
+const getCachedProgramCounts = unstable_cache(
+  async () => {
+    const [classCount, webinarCount] = await Promise.all([
+      prisma.classPlan.count(),
+      prisma.webinarPlan.count(),
+    ]);
+    return { classCount, webinarCount };
+  },
+  ["program-stats"],
+  { revalidate: 3600, tags: ["programs"] },
+);
+
 /** Counts of class plans + webinar plans for the hero stats strip.
  *  Returns null on failure so the client falls back to the marketing
  *  numbers — same fail-open behavior the old client `useEffect` had. */
@@ -49,11 +67,7 @@ async function fetchProgramStats(): Promise<{
   webinarCount: number;
 } | null> {
   try {
-    const [classCount, webinarCount] = await Promise.all([
-      prisma.classPlan.count(),
-      prisma.webinarPlan.count(),
-    ]);
-    return { classCount, webinarCount };
+    return await getCachedProgramCounts();
   } catch {
     return null;
   }

--- a/app/explore/programs/plans/classes/[classPlanId]/page.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/page.tsx
@@ -3,6 +3,9 @@ import { getClassPlanDetail } from "@/lib/data/plan-details";
 import { ClassDetails } from "./components/ClassDetails";
 import { generateProgramImageUrl } from "@/app/explore/programs/utils";
 
+// Stream behind the static layout's instant skeleton; don't prerender at build (#932).
+export const dynamic = "force-dynamic";
+
 export default async function ClassDetailsPage({
   params,
 }: Readonly<{

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/page.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/page.tsx
@@ -2,6 +2,9 @@ import { notFound } from "next/navigation";
 import { getWebinarPlanDetail } from "@/lib/data/plan-details";
 import { WebinarDetails } from "./components/WebinarDetails";
 
+// Stream behind the static layout's instant skeleton; don't prerender at build (#932).
+export const dynamic = "force-dynamic";
+
 export default async function WebinarDetailsPage({
   params,
 }: Readonly<{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,6 @@ import { AnnouncementBarProvider } from "@/providers/AnnouncementBarProvider";
 import AuthSyncProvider from "@/providers/AuthSyncProvider";
 import { MaintenanceProvider } from "@/providers/MaintenanceProvider";
 import ReactQueryProvider from "@/providers/ReactQueryProvider";
-import { getSession } from "@/lib/auth-server";
 import type { Metadata, Viewport } from "next";
 import { Sora } from "next/font/google";
 
@@ -65,22 +64,19 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function RootLayout({
+// Intentionally NO server-side session read here. Calling getSession() invokes
+// headers(), which forces the ENTIRE app to render dynamically — so even the
+// loading.tsx skeletons had to wait on a (cold) server render, which is why a
+// soft navigation sat blank for ~20-30s before the skeleton appeared. Keeping
+// the root layout static lets the shell + loading skeletons prefetch and paint
+// instantly; the Navbar hydrates the session client-side via useSession(), and
+// AuthSyncProvider keeps it live. The brief first-paint unknown state is shown
+// as a neutral placeholder in the Navbar rather than a signed-out flash. (#932)
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Resolve the session on the server so the Navbar renders the correct auth
-  // state on first paint (no signed-out flash). Cheap via the 5-min cookie
-  // cache; useSession() takes over client-side for live updates. Fail open: a
-  // transient auth/DB error must not 500 the whole app, including public pages.
-  let initialSession: Awaited<ReturnType<typeof getSession>> = null;
-  try {
-    initialSession = await getSession();
-  } catch {
-    initialSession = null;
-  }
-
   return (
     <html lang="en" className={sora.variable} suppressHydrationWarning>
       <body
@@ -95,7 +91,7 @@ export default async function RootLayout({
               <Toaster />
               <MaintenanceBanner />
               <AnnouncementBar />
-              <Navbar initialSession={initialSession} />
+              <Navbar />
               <HeaderSpacer />
               <div className="flex-1 w-full">{children}</div>
               <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,11 @@ import {
   TestimonialsSkeleton,
 } from "@/components/home/HomeSectionSkeletons";
 
+// Stream behind the (now static) layout's instant skeleton instead of prerendering
+// at build — the static layout makes loading.tsx prefetchable, and force-dynamic
+// keeps the curated data fresh + off the build-time cross-region DB connect. (#932)
+export const dynamic = "force-dynamic";
+
 // Each section reads independently; a transient pooler timeout (cross-region cold
 // connect, #932) in any one degrades that section to empty rather than throwing
 // past its Suspense boundary and crashing the whole landing page. (FAMILIARISE_WEB-A)

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -22,6 +22,7 @@ import { signOut, useSession } from "@/lib/auth-client";
 // Import the logout helper from the SDK-free module (not @/providers/StreamProvider)
 // so the root navbar no longer statically links the Stream video/chat SDK. #248
 import { disconnectStreamClients } from "@/lib/stream/disconnect";
+import { Skeleton } from "@/components/ui/skeleton";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -316,16 +317,13 @@ function DesktopNavItem({
 
 // ─── Main Navbar ─────────────────────────────────────────────────────────────
 
-type NavbarSession = ReturnType<typeof useSession>["data"];
-
-const Navbar = ({ initialSession }: { initialSession?: NavbarSession }) => {
+const Navbar = () => {
   const router = useRouter();
   const pathname = usePathname();
-  const { data, isPending } = useSession();
-  // Seed from the server-fetched session so the first paint shows the correct
-  // auth state instead of flashing the signed-out CTA until the client-side
-  // /get-session resolves. useSession takes over once it loads.
-  const session = isPending ? (data ?? initialSession ?? null) : data;
+  // The root layout is static (#932), so the session hydrates client-side here.
+  // While it resolves, `isPending` drives a neutral auth-area placeholder so a
+  // logged-in user doesn't flash the signed-out CTA on first paint.
+  const { data: session, isPending } = useSession();
   const [isOpen, setIsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const { currency, symbol, setCurrency } = useCurrency();
@@ -490,7 +488,12 @@ const Navbar = ({ initialSession }: { initialSession?: NavbarSession }) => {
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              {session?.user ? (
+              {isPending ? (
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-9 w-9 rounded-full" />
+                  <Skeleton className="h-9 w-28 rounded-md" />
+                </div>
+              ) : session?.user ? (
                 <div className="flex items-center gap-3">
                   <Link href="/profile">
                     <Avatar className="h-9 w-9 border-2 border-zinc-200 hover:border-zinc-400 transition-colors cursor-pointer">
@@ -704,7 +707,12 @@ const Navbar = ({ initialSession }: { initialSession?: NavbarSession }) => {
 
               {/* User Section */}
               <div className="absolute bottom-0 left-0 right-0 p-5 border-t border-zinc-800 bg-zinc-900 safe-bottom">
-                {session?.user ? (
+                {isPending ? (
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-10 w-10 rounded-full" />
+                    <Skeleton className="h-4 w-32 rounded" />
+                  </div>
+                ) : session?.user ? (
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                       <Avatar className="h-10 w-10 border border-zinc-700">

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -1,4 +1,3 @@
-import { cache } from "react";
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
@@ -228,27 +227,32 @@ export const EMPTY_EXPERTS_METADATA: ExpertsMetadata = {
 // Recent reviews (for testimonial sections)
 // ---------------------------------------------------------------------------
 
-/** Fetch recent high-quality reviews for social proof sections. */
-export const getRecentReviews = cache(async (limit: number = 6) => {
-  return prisma.consultantReview.findMany({
-    // #781 §B — soft-deleted profiles leave public surfaces
-    where: { rating: { gte: 4 }, consultantProfile: { deletedAt: null } },
-    orderBy: { createdAt: "desc" },
-    take: limit,
-    include: {
-      consultantProfile: {
-        include: {
-          user: { select: { name: true } },
+/** Recent high-quality reviews for social-proof sections (public landing). Cached
+ *  cross-request — testimonials change slowly and staleness is invisible. (#932) */
+export const getRecentReviews = unstable_cache(
+  async (limit: number = 6) => {
+    return prisma.consultantReview.findMany({
+      // #781 §B — soft-deleted profiles leave public surfaces
+      where: { rating: { gte: 4 }, consultantProfile: { deletedAt: null } },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      include: {
+        consultantProfile: {
+          include: {
+            user: { select: { name: true } },
+          },
+        },
+        consulteeProfile: {
+          include: {
+            user: { select: { name: true, image: true } },
+          },
         },
       },
-      consulteeProfile: {
-        include: {
-          user: { select: { name: true, image: true } },
-        },
-      },
-    },
-  });
-});
+    });
+  },
+  ["recent-reviews"],
+  { revalidate: 120, tags: ["reviews"] },
+);
 
 // ---------------------------------------------------------------------------
 // Curated experts (Featured / Trending / Newest rows)

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -227,10 +227,11 @@ export const EMPTY_EXPERTS_METADATA: ExpertsMetadata = {
 // Recent reviews (for testimonial sections)
 // ---------------------------------------------------------------------------
 
-/** Recent high-quality reviews for social-proof sections (public landing). Cached
- *  cross-request — testimonials change slowly and staleness is invisible. (#932) */
-export const getRecentReviews = unstable_cache(
-  async (limit: number = 6) => {
+// `limit` must be an explicit arg of the cached fn (not a default) — unstable_cache
+// keys on the args passed, so getRecentReviews() and getRecentReviews(6) would
+// otherwise create two entries for the same data. The default lives on the wrapper.
+const getCachedRecentReviews = unstable_cache(
+  async (limit: number) => {
     return prisma.consultantReview.findMany({
       // #781 §B — soft-deleted profiles leave public surfaces
       where: { rating: { gte: 4 }, consultantProfile: { deletedAt: null } },
@@ -253,6 +254,11 @@ export const getRecentReviews = unstable_cache(
   ["recent-reviews"],
   { revalidate: 120, tags: ["reviews"] },
 );
+
+/** Recent high-quality reviews for social-proof sections (public landing). Cached
+ *  cross-request — testimonials change slowly and staleness is invisible. (#932) */
+export const getRecentReviews = (limit: number = 6) =>
+  getCachedRecentReviews(limit);
 
 // ---------------------------------------------------------------------------
 // Curated experts (Featured / Trending / Newest rows)


### PR DESCRIPTION
## The problem
Soft-navigating landing → `/explore/*` (e.g. via the Navbar dropdown) showed a **20–30s blank before the loading skeleton**. Root cause: `app/layout.tsx` called `getSession()` → `headers()`, forcing the **entire app dynamic**, so even `loading.tsx` skeletons had to wait on a cold server render.

## The fix (centerpiece): static shell, dynamic pages
- **`app/layout.tsx`** — removed the server `getSession()`/`headers()`. The root layout is now **static**, so the shell + `loading.tsx` skeletons **prefetch and paint instantly** on navigation.
- **`components/Navbar.tsx`** — `useSession()` is now the source of truth (it already hydrated client-side via `AuthSyncProvider`), with a neutral **`Skeleton` placeholder** during `isPending` so logged-in users don't flash the signed-out CTA.
- **`force-dynamic` on the 8 public DB-reading pages** (home, explore experts/programs, org listing + the four detail pages). They stream behind the instant skeleton and **no longer prerender at build** — which removes the build-time cross-region DB connect (the local build OOM) while staying always-fresh. (Putting `force-dynamic` on the *layout* would re-break the skeleton, so it's per-page.)

## Supporting perf wins
- **Caching:** program-stats counts → `unstable_cache` (1h); `getRecentReviews` → `unstable_cache` (120s). Public reads off the pooler hot path.
- **Image:** `ConsultantCard` `fill` image got `sizes="80px"` (was fetching a full-viewport image for an 80px avatar).

## Validated
`tsc --noEmit` (cold) + `eslint` + `prettier` clean. The authoritative build is CI (the local build OOM'd doing the prerender this PR removes — CI has the headroom and will confirm the route table: layout static, pages `ƒ`).

## Deferred to a focused follow-up (per review decision — needs per-item visual/UI verification)
The **framer-motion → CSS animation conversion** (14 home sections + explore cards — the largest bundle win, but real visual-regression risk), **detail-page over-fetch trims** (verify each detail UI renders fully), **plan-listing API `Cache-Control`** (verify the routes don't vary by auth first), and the **`AnnouncementBar` CLS** fix.

Part of #932.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Explore and home pages now refresh dynamically, so listings and featured content stay up to date.
  * The navbar now shows loading placeholders while sign-in status is being resolved, reducing visual flicker.

* **Bug Fixes**
  * Improved page rendering behavior for expert, organization, and program pages to better support streaming and faster first paint.
  * Updated image sizing and display handling on expert cards for more consistent loading and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->