### PR TITLE
perf: drop framer-motion from the landing bundle via CSS scroll-reveal (Part of #932)

### DIFF
--- a/app/explore/experts/components/SatisfiedTestimonial.tsx
+++ b/app/explore/experts/components/SatisfiedTestimonial.tsx
@@ -1,9 +1,7 @@
-"use client";
-
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { motion } from "framer-motion";
 import { Quote, Star } from "lucide-react";
 import Image from "next/image";
+import { Reveal } from "@/components/ui/reveal";
 
 const TESTIMONIALS = [
   {
@@ -50,13 +48,7 @@ export function SatisfiedTestimonial() {
 
       <div className="max-w-[1600px] mx-auto px-4 md:px-8 lg:px-12 relative z-10">
         {/* Section Header */}
-        <motion.div
-          className="text-center mb-16"
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
-        >
+        <Reveal className="text-center mb-16">
           <div className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800/50 backdrop-blur-sm border border-zinc-700/50 rounded-full mb-6">
             <Quote className="w-4 h-4 text-white" />
             <span className="text-sm font-medium text-zinc-300">
@@ -70,18 +62,15 @@ export function SatisfiedTestimonial() {
             Hear from professionals who&apos;ve transformed their careers with
             expert mentors on Familiarise
           </p>
-        </motion.div>
+        </Reveal>
 
         {/* Testimonials Grid */}
         <div className="grid md:grid-cols-3 gap-6 max-w-6xl mx-auto">
           {TESTIMONIALS.map((testimonial, index) => (
-            <motion.div
+            <Reveal
               key={testimonial.id}
               className="relative"
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
+              delay={index * 0.1}
             >
               <div className="h-full bg-zinc-900/50 backdrop-blur-sm border border-zinc-800 rounded-2xl p-6 hover:border-zinc-700 transition-colors">
                 {/* Quote Icon */}
@@ -138,7 +127,7 @@ export function SatisfiedTestimonial() {
                   </span>
                 </div>
               </div>
-            </motion.div>
+            </Reveal>
           ))}
         </div>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -295,6 +295,49 @@
   }
 }
 
+/* On-load entrance (above-the-fold, e.g. hero) — pure CSS, no JS/observer. The
+   `both` fill-mode shows the start frame during a staggered animation-delay so a
+   delayed element doesn't flash visible→hidden before it animates. (#932) */
+.animate-rise {
+  animation: slideUp 0.5s ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-rise {
+    animation: none;
+  }
+}
+
+/* Scroll-in reveal driven by <Reveal> (components/ui/reveal.tsx) — the CSS
+   replacement for framer-motion's whileInView fade+slide. (#932) */
+[data-reveal="hidden"] {
+  opacity: 0;
+}
+
+[data-reveal="visible"] {
+  animation: revealUp 0.5s ease-out forwards;
+}
+
+@keyframes revealUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    opacity: 1 !important;
+    transform: none !important;
+    animation: none !important;
+  }
+}
+
 /* Scrollbar customization for WebKit browsers */
 .custom-scrollbar::-webkit-scrollbar {
   width: 4px;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
 import {
   ChevronDown,
   Menu,
@@ -193,13 +192,7 @@ function DesktopDropdownPanel({
   onClose: () => void;
 }) {
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 8 }}
-      transition={{ duration: 0.15 }}
-      className="absolute top-full left-1/2 -translate-x-1/2 mt-2 w-80 bg-popover rounded-xl shadow-xl border border-border overflow-hidden z-[1100]"
-    >
+    <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 w-80 bg-popover rounded-xl shadow-xl border border-border overflow-hidden z-[1100] animate-fade-in">
       <div className="p-2">
         {group.items.map((item) => {
           const Icon = item.icon;
@@ -253,7 +246,7 @@ function DesktopDropdownPanel({
           </div>
         </div>
       )}
-    </motion.div>
+    </div>
   );
 }
 
@@ -306,11 +299,9 @@ function DesktopNavItem({
           className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
         />
       </button>
-      <AnimatePresence>
-        {open && (
-          <DesktopDropdownPanel group={group} onClose={() => setOpen(false)} />
-        )}
-      </AnimatePresence>
+      {open && (
+        <DesktopDropdownPanel group={group} onClose={() => setOpen(false)} />
+      )}
     </div>
   );
 }
@@ -554,206 +545,198 @@ const Navbar = () => {
         </div>
       </nav>
 
-      {/* Mobile Drawer */}
-      <AnimatePresence>
-        {isOpen && (
-          <>
-            {/* Backdrop */}
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[1001] lg:hidden"
-              onClick={closeMenu}
+      {/* Mobile Drawer — always mounted; CSS transitions animate open AND close,
+          replacing framer-motion's AnimatePresence so framer-motion stays out of
+          the shared (every-route) bundle. (#932) */}
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 bg-black/60 backdrop-blur-sm z-[1001] lg:hidden transition-opacity duration-300 ${
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={closeMenu}
+        aria-hidden={!isOpen}
+      />
+
+      {/* Drawer */}
+      <div
+        className={`lg:hidden fixed top-0 left-0 h-full w-[85%] max-w-sm bg-zinc-950 z-[1002] shadow-2xl safe-top safe-bottom safe-left transition-transform duration-300 ease-out ${
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+        aria-hidden={!isOpen}
+      >
+        {/* Drawer Header */}
+        <div className="flex justify-between items-center p-5 border-b border-zinc-800">
+          <div className="relative h-8 w-28">
+            <Image
+              src={familiariseLogoWhite}
+              alt="Familiarise Logo"
+              fill
+              className="object-contain object-left"
+              sizes="112px"
             />
+          </div>
+          <button
+            onClick={closeMenu}
+            className="w-9 h-9 flex items-center justify-center rounded-full bg-zinc-800 hover:bg-zinc-700 transition-colors text-white"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
 
-            {/* Drawer */}
-            <motion.div
-              initial={{ x: "-100%" }}
-              animate={{ x: 0 }}
-              exit={{ x: "-100%" }}
-              transition={{ type: "spring", damping: 25, stiffness: 200 }}
-              className="lg:hidden fixed top-0 left-0 h-full w-[85%] max-w-sm bg-zinc-950 z-[1002] shadow-2xl safe-top safe-bottom safe-left"
+        {/* Navigation — Accordion Sections */}
+        <div
+          className="flex flex-col p-5 overflow-y-auto"
+          style={{ maxHeight: "calc(100% - 10rem)" }}
+        >
+          {session?.user && (
+            <Link
+              href="/dashboard"
+              className="flex items-center gap-3 px-4 py-3 rounded-xl text-white hover:bg-zinc-800 transition-colors mb-1"
+              onClick={closeMenu}
             >
-              {/* Drawer Header */}
-              <div className="flex justify-between items-center p-5 border-b border-zinc-800">
-                <div className="relative h-8 w-28">
-                  <Image
-                    src={familiariseLogoWhite}
-                    alt="Familiarise Logo"
-                    fill
-                    className="object-contain object-left"
-                    sizes="112px"
-                  />
-                </div>
-                <button
-                  onClick={closeMenu}
-                  className="w-9 h-9 flex items-center justify-center rounded-full bg-zinc-800 hover:bg-zinc-700 transition-colors text-white"
-                >
-                  <X className="w-5 h-5" />
-                </button>
-              </div>
+              <span className="font-medium">Dashboard</span>
+            </Link>
+          )}
 
-              {/* Navigation — Accordion Sections */}
-              <div
-                className="flex flex-col p-5 overflow-y-auto"
-                style={{ maxHeight: "calc(100% - 10rem)" }}
+          <Accordion type="multiple" className="w-full">
+            {NAV_GROUPS.map((group) => (
+              <AccordionItem
+                key={group.label}
+                value={group.label}
+                className="border-b border-zinc-800"
               >
-                {session?.user && (
-                  <Link
-                    href="/dashboard"
-                    className="flex items-center gap-3 px-4 py-3 rounded-xl text-white hover:bg-zinc-800 transition-colors mb-1"
-                    onClick={closeMenu}
-                  >
-                    <span className="font-medium">Dashboard</span>
-                  </Link>
-                )}
-
-                <Accordion type="multiple" className="w-full">
-                  {NAV_GROUPS.map((group) => (
-                    <AccordionItem
-                      key={group.label}
-                      value={group.label}
-                      className="border-b border-zinc-800"
-                    >
-                      <AccordionTrigger className="text-white hover:no-underline px-4 py-3">
-                        {group.label}
-                      </AccordionTrigger>
-                      <AccordionContent className="px-2 pb-2">
-                        <div className="space-y-1">
-                          {group.items.map((item) => (
-                            <Link
-                              key={item.href + item.label}
-                              href={item.disabled ? "/contactus" : item.href}
-                              onClick={closeMenu}
-                              className={`block px-4 py-2.5 rounded-lg transition-colors ${
-                                item.disabled
-                                  ? "opacity-50"
-                                  : "hover:bg-zinc-800"
-                              }`}
-                            >
-                              <span className="text-sm font-medium text-white flex items-center gap-2">
-                                {item.label}
-                                {(item.disabled || item.comingSoon) && (
-                                  <span className="text-[10px] uppercase tracking-wider text-zinc-500 bg-zinc-800 px-1.5 py-0.5 rounded">
-                                    Soon
-                                  </span>
-                                )}
-                              </span>
-                              <span className="text-xs text-zinc-500 mt-0.5 block">
-                                {item.description}
-                              </span>
-                            </Link>
-                          ))}
-
-                          {/* Category chips on mobile */}
-                          {group.categoryChips &&
-                            group.categoryChips.length > 0 && (
-                              <div className="px-4 pt-2">
-                                <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500 mb-2">
-                                  By Category
-                                </p>
-                                <div className="flex flex-wrap gap-1.5">
-                                  {group.categoryChips.map((chip) => (
-                                    <Link
-                                      key={chip.href}
-                                      href={chip.href}
-                                      onClick={closeMenu}
-                                      className="text-xs px-2.5 py-1 rounded-full bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-white transition-colors"
-                                    >
-                                      {chip.label}
-                                    </Link>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                        </div>
-                      </AccordionContent>
-                    </AccordionItem>
-                  ))}
-                </Accordion>
-
-                {/* Pricing — flat link */}
-                <Link
-                  href="/pricing"
-                  className="flex items-center gap-3 px-4 py-3 rounded-xl text-white hover:bg-zinc-800 transition-colors mt-1"
-                  onClick={closeMenu}
-                >
-                  <span className="font-medium">Pricing</span>
-                </Link>
-
-                {/* Mobile Currency Selector */}
-                <div className="px-4 pt-4 mt-2 border-t border-zinc-800">
-                  <span className="text-xs text-zinc-500 uppercase tracking-wide">
-                    Currency
-                  </span>
-                  <div className="flex flex-wrap gap-2 mt-2">
-                    {SUPPORTED_CURRENCIES.map((c) => (
-                      <button
-                        key={c.code}
-                        onClick={() => setCurrency(c.code)}
-                        className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
-                          currency === c.code
-                            ? "bg-white text-zinc-900 font-medium"
-                            : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700"
+                <AccordionTrigger className="text-white hover:no-underline px-4 py-3">
+                  {group.label}
+                </AccordionTrigger>
+                <AccordionContent className="px-2 pb-2">
+                  <div className="space-y-1">
+                    {group.items.map((item) => (
+                      <Link
+                        key={item.href + item.label}
+                        href={item.disabled ? "/contactus" : item.href}
+                        onClick={closeMenu}
+                        className={`block px-4 py-2.5 rounded-lg transition-colors ${
+                          item.disabled ? "opacity-50" : "hover:bg-zinc-800"
                         }`}
                       >
-                        {c.symbol} {c.code}
-                      </button>
+                        <span className="text-sm font-medium text-white flex items-center gap-2">
+                          {item.label}
+                          {(item.disabled || item.comingSoon) && (
+                            <span className="text-[10px] uppercase tracking-wider text-zinc-500 bg-zinc-800 px-1.5 py-0.5 rounded">
+                              Soon
+                            </span>
+                          )}
+                        </span>
+                        <span className="text-xs text-zinc-500 mt-0.5 block">
+                          {item.description}
+                        </span>
+                      </Link>
                     ))}
-                  </div>
-                </div>
-              </div>
 
-              {/* User Section */}
-              <div className="absolute bottom-0 left-0 right-0 p-5 border-t border-zinc-800 bg-zinc-900 safe-bottom">
-                {isPending ? (
-                  <div className="flex items-center gap-3">
-                    <Skeleton className="h-10 w-10 rounded-full" />
-                    <Skeleton className="h-4 w-32 rounded" />
+                    {/* Category chips on mobile */}
+                    {group.categoryChips && group.categoryChips.length > 0 && (
+                      <div className="px-4 pt-2">
+                        <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500 mb-2">
+                          By Category
+                        </p>
+                        <div className="flex flex-wrap gap-1.5">
+                          {group.categoryChips.map((chip) => (
+                            <Link
+                              key={chip.href}
+                              href={chip.href}
+                              onClick={closeMenu}
+                              className="text-xs px-2.5 py-1 rounded-full bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-white transition-colors"
+                            >
+                              {chip.label}
+                            </Link>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
-                ) : session?.user ? (
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <Avatar className="h-10 w-10 border border-zinc-700">
-                        <AvatarImage src={getUserImage()} alt="Profile" />
-                        <AvatarFallback className="bg-zinc-800 text-white">
-                          {session.user.name?.charAt(0) ?? "U"}
-                        </AvatarFallback>
-                      </Avatar>
-                      <span className="text-white font-medium text-sm truncate max-w-[140px]">
-                        {session.user.name}
-                      </span>
-                    </div>
-                    <Button
-                      variant="ghost"
-                      onClick={handleSignOut}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
-                    >
-                      Sign out
-                    </Button>
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-3">
-                    <Button
-                      onClick={() => handleNavigation("/form/onboarding")}
-                      className="w-full bg-white text-zinc-900 hover:bg-zinc-200"
-                    >
-                      Become an Expert
-                    </Button>
-                    <Button
-                      onClick={() => handleNavigation("/auth/signin")}
-                      className="w-full bg-transparent border border-zinc-700 text-white hover:bg-zinc-800"
-                    >
-                      Sign in
-                    </Button>
-                  </div>
-                )}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+
+          {/* Pricing — flat link */}
+          <Link
+            href="/pricing"
+            className="flex items-center gap-3 px-4 py-3 rounded-xl text-white hover:bg-zinc-800 transition-colors mt-1"
+            onClick={closeMenu}
+          >
+            <span className="font-medium">Pricing</span>
+          </Link>
+
+          {/* Mobile Currency Selector */}
+          <div className="px-4 pt-4 mt-2 border-t border-zinc-800">
+            <span className="text-xs text-zinc-500 uppercase tracking-wide">
+              Currency
+            </span>
+            <div className="flex flex-wrap gap-2 mt-2">
+              {SUPPORTED_CURRENCIES.map((c) => (
+                <button
+                  key={c.code}
+                  onClick={() => setCurrency(c.code)}
+                  className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                    currency === c.code
+                      ? "bg-white text-zinc-900 font-medium"
+                      : "bg-zinc-800 text-zinc-300 hover:bg-zinc-700"
+                  }`}
+                >
+                  {c.symbol} {c.code}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* User Section */}
+        <div className="absolute bottom-0 left-0 right-0 p-5 border-t border-zinc-800 bg-zinc-900 safe-bottom">
+          {isPending ? (
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <Skeleton className="h-4 w-32 rounded" />
+            </div>
+          ) : session?.user ? (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Avatar className="h-10 w-10 border border-zinc-700">
+                  <AvatarImage src={getUserImage()} alt="Profile" />
+                  <AvatarFallback className="bg-zinc-800 text-white">
+                    {session.user.name?.charAt(0) ?? "U"}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-white font-medium text-sm truncate max-w-[140px]">
+                  {session.user.name}
+                </span>
               </div>
-            </motion.div>
-          </>
-        )}
-      </AnimatePresence>
+              <Button
+                variant="ghost"
+                onClick={handleSignOut}
+                className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
+              >
+                Sign out
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <Button
+                onClick={() => handleNavigation("/form/onboarding")}
+                className="w-full bg-white text-zinc-900 hover:bg-zinc-200"
+              >
+                Become an Expert
+              </Button>
+              <Button
+                onClick={() => handleNavigation("/auth/signin")}
+                className="w-full bg-transparent border border-zinc-700 text-white hover:bg-zinc-800"
+              >
+                Sign in
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
     </>
   );
 };

--- a/components/home/BecomeExpertSection.tsx
+++ b/components/home/BecomeExpertSection.tsx
@@ -1,11 +1,9 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ArrowRight, Clock, Mic, Target } from "lucide-react";
 import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Reveal } from "@/components/ui/reveal";
 
 const EXPERT_BENEFITS = [
   { icon: Target, label: "Set Your Rates" },
@@ -23,13 +21,7 @@ export function BecomeExpertSection() {
       <div className="absolute inset-0 dot-pattern-light opacity-40" />
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="max-w-3xl mx-auto text-center"
-        >
+        <Reveal className="max-w-3xl mx-auto text-center">
           <Badge
             variant="secondary"
             className="mb-4 bg-primary text-primary-foreground hover:bg-primary"
@@ -48,17 +40,14 @@ export function BecomeExpertSection() {
           {/* Expert benefits */}
           <div className="grid sm:grid-cols-3 gap-6 mb-10">
             {EXPERT_BENEFITS.map((item, i) => (
-              <motion.div
+              <Reveal
                 key={item.label}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: i * 0.1 }}
-                viewport={{ once: true }}
                 className="flex items-center justify-center gap-2 text-foreground"
+                delay={i * 0.1}
               >
                 <item.icon className="w-5 h-5" />
                 <span className="font-medium">{item.label}</span>
-              </motion.div>
+              </Reveal>
             ))}
           </div>
 
@@ -80,7 +69,7 @@ export function BecomeExpertSection() {
               Learn More
             </Button>
           </div>
-        </motion.div>
+        </Reveal>
       </div>
     </section>
   );

--- a/components/home/BenefitsSection.tsx
+++ b/components/home/BenefitsSection.tsx
@@ -1,9 +1,7 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { CheckCircle2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Reveal } from "@/components/ui/reveal";
 import { renderLCPImage } from "@/utils/image";
 import type { SupabaseImageFile } from "@/lib/supabase";
 import { BENEFITS } from "./data";
@@ -23,12 +21,7 @@ export function BenefitsSection({ images }: BenefitsSectionProps) {
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
         <div className="grid lg:grid-cols-2 gap-16 items-center">
-          <motion.div
-            initial={{ opacity: 0, x: -30 }}
-            whileInView={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
+          <Reveal>
             <Badge
               variant="secondary"
               className="mb-4 bg-secondary text-secondary-foreground hover:bg-secondary border-0"
@@ -46,12 +39,9 @@ export function BenefitsSection({ images }: BenefitsSectionProps) {
 
             <div className="space-y-6">
               {BENEFITS.map((benefit, index) => (
-                <motion.div
+                <Reveal
                   key={benefit.title}
-                  initial={{ opacity: 0, x: -20 }}
-                  whileInView={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.5, delay: index * 0.1 }}
-                  viewport={{ once: true }}
+                  delay={index * 0.1}
                   className="flex gap-4 group"
                 >
                   <div className="w-12 h-12 rounded-xl bg-primary flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform shadow-elevation-2">
@@ -65,18 +55,12 @@ export function BenefitsSection({ images }: BenefitsSectionProps) {
                       {benefit.description}
                     </p>
                   </div>
-                </motion.div>
+                </Reveal>
               ))}
             </div>
-          </motion.div>
+          </Reveal>
 
-          <motion.div
-            initial={{ opacity: 0, x: 30 }}
-            whileInView={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-            className="relative"
-          >
+          <Reveal className="relative">
             <div className="relative rounded-2xl overflow-hidden shadow-elevation-3 border border-border">
               {renderLCPImage(images, 0, "/placeholder.svg", 600, 400)}
             </div>
@@ -96,7 +80,7 @@ export function BenefitsSection({ images }: BenefitsSectionProps) {
                 </div>
               </div>
             </div>
-          </motion.div>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/components/home/CategoriesSection.tsx
+++ b/components/home/CategoriesSection.tsx
@@ -1,12 +1,10 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ChevronRight, LucideIcon } from "lucide-react";
 import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Reveal } from "@/components/ui/reveal";
 import { CATEGORIES } from "./data";
 
 function CategoryCard({
@@ -19,12 +17,7 @@ function CategoryCard({
   const Icon = category.icon;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, scale: 0.9 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.4, delay: index * 0.05 }}
-      viewport={{ once: true }}
-    >
+    <Reveal delay={index * 0.05}>
       <Link href={`/explore/experts?category=${category.name.toLowerCase()}`}>
         <Card className="group cursor-pointer border border-border bg-card hover:border-foreground/40 transition-all duration-300 hover:-translate-y-1 hover:shadow-elevation-2">
           <CardContent className="p-6 flex items-center gap-4">
@@ -45,7 +38,7 @@ function CategoryCard({
           </CardContent>
         </Card>
       </Link>
-    </motion.div>
+    </Reveal>
   );
 }
 
@@ -55,13 +48,7 @@ export function CategoriesSection() {
       <div className="absolute inset-0 grid-pattern-dark opacity-30" />
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center mb-12"
-        >
+        <Reveal className="text-center mb-12">
           <Badge
             variant="secondary"
             className="mb-4 bg-secondary text-secondary-foreground hover:bg-secondary border-0"
@@ -74,7 +61,7 @@ export function CategoriesSection() {
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
             Find experts in your field and start learning from the best
           </p>
-        </motion.div>
+        </Reveal>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {CATEGORIES.map((category, index) => (
@@ -86,13 +73,7 @@ export function CategoriesSection() {
           ))}
         </div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.3 }}
-          viewport={{ once: true }}
-          className="text-center mt-10"
-        >
+        <Reveal className="text-center mt-10" delay={0.3}>
           <Link href="/explore/experts">
             <Button
               variant="outline"
@@ -103,7 +84,7 @@ export function CategoriesSection() {
               <ChevronRight className="ml-2 w-4 h-4" />
             </Button>
           </Link>
-        </motion.div>
+        </Reveal>
       </div>
     </section>
   );

--- a/components/home/FAQSection.tsx
+++ b/components/home/FAQSection.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
-
 import {
   Accordion,
   AccordionContent,
@@ -9,19 +5,14 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
+import { Reveal } from "@/components/ui/reveal";
 import { FAQ_ITEMS } from "./data";
 
 export function FAQSection() {
   return (
     <section className="py-20 md:py-32 bg-background relative">
       <div className="container mx-auto px-4 md:px-6">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center mb-12"
-        >
+        <Reveal className="text-center mb-12">
           <Badge
             variant="secondary"
             className="mb-4 bg-secondary text-secondary-foreground hover:bg-secondary border-0"
@@ -34,15 +25,9 @@ export function FAQSection() {
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
             Everything you need to know about getting started
           </p>
-        </motion.div>
+        </Reveal>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.1 }}
-          viewport={{ once: true }}
-          className="max-w-3xl mx-auto"
-        >
+        <Reveal className="max-w-3xl mx-auto" delay={0.1}>
           <Accordion type="single" collapsible className="space-y-4">
             {FAQ_ITEMS.map((item, index) => (
               <AccordionItem
@@ -61,7 +46,7 @@ export function FAQSection() {
               </AccordionItem>
             ))}
           </Accordion>
-        </motion.div>
+        </Reveal>
       </div>
     </section>
   );

--- a/components/home/FeaturedExpertsSection.tsx
+++ b/components/home/FeaturedExpertsSection.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ChevronRight, Star } from "lucide-react";
 import Link from "next/link";
 
@@ -8,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Reveal } from "@/components/ui/reveal";
 import type { IConsultantCardData } from "@/types/consultant";
 
 function ExpertCard({ expert }: { expert: IConsultantCardData }) {
@@ -90,13 +88,7 @@ export function FeaturedExpertsSection({
       <div className="absolute inset-0 dot-pattern-light opacity-60" />
 
       <div className="container mx-auto px-4 md:px-6 mb-12 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="flex flex-col md:flex-row md:items-end md:justify-between gap-6"
-        >
+        <Reveal className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
           <div>
             <Badge
               variant="secondary"
@@ -121,7 +113,7 @@ export function FeaturedExpertsSection({
               <ChevronRight className="ml-1 w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Button>
           </Link>
-        </motion.div>
+        </Reveal>
       </div>
 
       {/* Marquee */}

--- a/components/home/FeaturesSection.tsx
+++ b/components/home/FeaturesSection.tsx
@@ -1,10 +1,8 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { LucideIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { Reveal } from "@/components/ui/reveal";
 import { FEATURES } from "./data";
 
 function FeatureCard({
@@ -22,12 +20,7 @@ function FeatureCard({
   const Icon = feature.icon;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 30 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, delay: index * 0.1 }}
-      viewport={{ once: true }}
-    >
+    <Reveal delay={index * 0.1}>
       <Card className="feature-card-dark h-full border-0 bg-zinc-900/80 backdrop-blur-sm overflow-hidden group relative">
         <div className="absolute inset-0 bg-gradient-to-br from-white/[0.02] to-transparent" />
         <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-white/[0.05] to-transparent" />
@@ -43,7 +36,7 @@ function FeatureCard({
           <p className="text-zinc-400 leading-relaxed">{feature.description}</p>
         </CardContent>
       </Card>
-    </motion.div>
+    </Reveal>
   );
 }
 
@@ -56,13 +49,7 @@ export function FeaturesSection() {
       <div className="absolute top-0 right-0 w-1/2 h-1/2 bg-gradient-to-bl from-zinc-800/30 to-transparent blur-[100px]" />
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center mb-16"
-        >
+        <Reveal className="text-center mb-16">
           <Badge
             variant="secondary"
             className="mb-4 bg-zinc-800 text-zinc-300 hover:bg-zinc-800 border-zinc-700"
@@ -76,7 +63,7 @@ export function FeaturesSection() {
             Choose the format that works best for your learning style and
             schedule
           </p>
-        </motion.div>
+        </Reveal>
 
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
           {FEATURES.map((feature, index) => (

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useCallback } from "react";
-import { motion, useInView } from "framer-motion";
+import { useCallback, useState, useEffect } from "react";
 import { ArrowRight, Play, Sparkles } from "lucide-react";
 import Link from "next/link";
-import { useRef, useState, useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
+import { useInViewOnce } from "@/components/ui/reveal";
 import { STATS } from "./data";
 
 function AnimatedNumber({
@@ -16,8 +15,7 @@ function AnimatedNumber({
   value: number;
   suffix: string;
 }) {
-  const ref = useRef(null);
-  const isInView = useInView(ref, { once: true });
+  const [ref, isInView] = useInViewOnce<HTMLSpanElement>();
   const [displayValue, setDisplayValue] = useState(0);
 
   const animate = useCallback(() => {
@@ -44,7 +42,7 @@ function AnimatedNumber({
   }, [isInView, animate]);
 
   return (
-    <motion.span
+    <span
       ref={ref}
       className="text-4xl md:text-5xl font-bold text-white tabular-nums"
     >
@@ -52,7 +50,7 @@ function AnimatedNumber({
         ? displayValue.toFixed(1)
         : displayValue.toLocaleString()}
       {suffix}
-    </motion.span>
+    </span>
   );
 }
 
@@ -75,22 +73,15 @@ export function HeroSection() {
       <div className="container mx-auto px-4 md:px-6 relative z-10 py-20 md:py-32">
         <div className="max-w-4xl mx-auto text-center">
           {/* Badge */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-zinc-400 text-sm mb-8"
-          >
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-zinc-400 text-sm mb-8 animate-rise">
             <Sparkles className="w-4 h-4 text-zinc-300" />
             <span>Trusted by 10,000+ professionals worldwide</span>
-          </motion.div>
+          </div>
 
           {/* Main headline */}
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.1 }}
-            className="text-fluid-5xl font-bold text-white mb-6 leading-tight tracking-tight"
+          <h1
+            className="text-fluid-5xl font-bold text-white mb-6 leading-tight tracking-tight animate-rise"
+            style={{ animationDelay: "0.1s" }}
           >
             Learn from the{" "}
             <span className="relative inline-block">
@@ -98,26 +89,22 @@ export function HeroSection() {
             </span>
             <br />
             <span className="text-zinc-400">in your industry</span>
-          </motion.h1>
+          </h1>
 
           {/* Subheadline */}
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-            className="text-lg md:text-xl text-zinc-500 mb-10 max-w-2xl mx-auto leading-relaxed"
+          <p
+            className="text-lg md:text-xl text-zinc-500 mb-10 max-w-2xl mx-auto leading-relaxed animate-rise"
+            style={{ animationDelay: "0.2s" }}
           >
             Connect with world-class experts for personalized 1-on-1 sessions,
             interactive classes, and live webinars. Your career transformation
             starts here.
-          </motion.p>
+          </p>
 
           {/* CTAs */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.3 }}
-            className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16"
+          <div
+            className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16 animate-rise"
+            style={{ animationDelay: "0.3s" }}
           >
             <Link href="/explore/experts">
               <Button
@@ -136,14 +123,12 @@ export function HeroSection() {
               <Play className="mr-2 w-5 h-5" />
               Watch Demo
             </Button>
-          </motion.div>
+          </div>
 
           {/* Stats with animated counters */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.4 }}
-            className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12 pt-8 border-t border-zinc-800"
+          <div
+            className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12 pt-8 border-t border-zinc-800 animate-rise"
+            style={{ animationDelay: "0.4s" }}
           >
             {STATS.map((stat, i) => (
               <div key={i} className="text-center">
@@ -151,7 +136,7 @@ export function HeroSection() {
                 <div className="text-zinc-600 text-sm mt-1">{stat.label}</div>
               </div>
             ))}
-          </motion.div>
+          </div>
         </div>
       </div>
 

--- a/components/home/HowItWorksSection.tsx
+++ b/components/home/HowItWorksSection.tsx
@@ -1,11 +1,9 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Reveal } from "@/components/ui/reveal";
 import { HOW_IT_WORKS } from "./data";
 
 function HowItWorksStep({
@@ -18,13 +16,7 @@ function HowItWorksStep({
   isLast: boolean;
 }) {
   return (
-    <motion.div
-      initial={{ opacity: 0, x: -20 }}
-      whileInView={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.5, delay: index * 0.15 }}
-      viewport={{ once: true }}
-      className="relative"
-    >
+    <Reveal className="relative" delay={index * 0.15}>
       <div className="flex gap-6">
         <div className="flex flex-col items-center">
           <div className="w-12 h-12 rounded-full bg-gradient-to-br from-zinc-100 to-zinc-300 flex items-center justify-center text-zinc-900 font-bold text-lg shadow-elevation-2 border border-border">
@@ -43,7 +35,7 @@ function HowItWorksStep({
           </p>
         </div>
       </div>
-    </motion.div>
+    </Reveal>
   );
 }
 
@@ -61,13 +53,7 @@ export function HowItWorksSection() {
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
         <div className="grid lg:grid-cols-2 gap-16 items-start">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-            viewport={{ once: true }}
-            className="lg:sticky lg:top-32"
-          >
+          <Reveal className="lg:sticky lg:top-32">
             <Badge
               variant="secondary"
               className="mb-4 bg-secondary text-secondary-foreground hover:bg-secondary border-0"
@@ -90,7 +76,7 @@ export function HowItWorksSection() {
                 <ArrowRight className="ml-2 w-5 h-5" />
               </Button>
             </Link>
-          </motion.div>
+          </Reveal>
 
           <div>
             {HOW_IT_WORKS.map((step, index) => (

--- a/components/home/PlatformFeaturesSection.tsx
+++ b/components/home/PlatformFeaturesSection.tsx
@@ -1,9 +1,7 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { LucideIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Reveal } from "@/components/ui/reveal";
 import { PLATFORM_FEATURES } from "./data";
 
 function PlatformFeatureCard({
@@ -16,19 +14,13 @@ function PlatformFeatureCard({
   const Icon = feature.icon;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, delay: index * 0.1 }}
-      viewport={{ once: true }}
-      className="text-center group"
-    >
+    <Reveal className="text-center group" delay={index * 0.1}>
       <div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center mx-auto mb-4 group-hover:bg-secondary transition-colors group-hover:scale-110 duration-300">
         <Icon className="w-8 h-8 text-foreground" />
       </div>
       <h4 className="font-semibold text-foreground mb-2">{feature.title}</h4>
       <p className="text-sm text-muted-foreground">{feature.description}</p>
-    </motion.div>
+    </Reveal>
   );
 }
 
@@ -38,13 +30,7 @@ export function PlatformFeaturesSection() {
       <div className="absolute inset-0 diagonal-stripes" />
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center mb-16"
-        >
+        <Reveal className="text-center mb-16">
           <Badge
             variant="secondary"
             className="mb-4 bg-secondary text-secondary-foreground hover:bg-secondary border-0"
@@ -58,7 +44,7 @@ export function PlatformFeaturesSection() {
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
             A seamless experience built for learning and growth
           </p>
-        </motion.div>
+        </Reveal>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-10 md:gap-12">
           {PLATFORM_FEATURES.map((feature, index) => (

--- a/components/home/SuccessStoriesSection.tsx
+++ b/components/home/SuccessStoriesSection.tsx
@@ -1,11 +1,9 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { Rocket } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { Reveal } from "@/components/ui/reveal";
 import { SUCCESS_STORIES } from "./data";
 
 function SuccessStoryCard({
@@ -16,12 +14,7 @@ function SuccessStoryCard({
   index: number;
 }) {
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 30 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, delay: index * 0.1 }}
-      viewport={{ once: true }}
-    >
+    <Reveal delay={index * 0.1}>
       <Card className="h-full border border-zinc-800 bg-gradient-to-br from-zinc-900 to-zinc-950 overflow-hidden group">
         <CardContent className="p-6 md:p-8">
           <div className="flex items-center gap-4 mb-6">
@@ -46,7 +39,7 @@ function SuccessStoryCard({
           </div>
         </CardContent>
       </Card>
-    </motion.div>
+    </Reveal>
   );
 }
 
@@ -59,13 +52,7 @@ export function SuccessStoriesSection() {
       <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-zinc-600/15 rounded-full blur-[150px]" />
 
       <div className="container mx-auto px-4 md:px-6 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center mb-16"
-        >
+        <Reveal className="text-center mb-16">
           <Badge
             variant="secondary"
             className="mb-4 bg-zinc-800 text-zinc-300 hover:bg-zinc-800 border-zinc-700"
@@ -79,7 +66,7 @@ export function SuccessStoriesSection() {
           <p className="text-lg text-zinc-500 max-w-2xl mx-auto">
             See how our mentees have achieved their career goals
           </p>
-        </motion.div>
+        </Reveal>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {SUCCESS_STORIES.map((story, index) => (

--- a/components/home/TestimonialsSection.tsx
+++ b/components/home/TestimonialsSection.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useMemo } from "react";
-import { motion } from "framer-motion";
 import { Star } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { Reveal } from "@/components/ui/reveal";
 import type { ReviewWithProfiles } from "@/types/review";
 
 function TestimonialCard({ review }: { review: ReviewWithProfiles }) {
@@ -81,13 +81,7 @@ export function TestimonialsSection({
       <div className="absolute top-1/2 right-0 w-96 h-96 bg-zinc-600/15 rounded-full blur-[150px] -translate-y-1/2" />
 
       <div className="container mx-auto px-4 md:px-6 mb-12 relative z-10">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center"
-        >
+        <Reveal className="text-center">
           <Badge
             variant="secondary"
             className="mb-4 bg-zinc-800 text-zinc-300 hover:bg-zinc-800 border-zinc-700"
@@ -100,7 +94,7 @@ export function TestimonialsSection({
           <p className="text-lg text-zinc-500 max-w-2xl mx-auto">
             See what our community has to say about their experience
           </p>
-        </motion.div>
+        </Reveal>
       </div>
 
       {/* First marquee row - left to right */}

--- a/components/home/TrustBadgesSection.tsx
+++ b/components/home/TrustBadgesSection.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { motion } from "framer-motion";
+import { Reveal } from "@/components/ui/reveal";
 import { TRUST_BADGES } from "./data";
 
 export function TrustBadgesSection() {
@@ -9,12 +7,9 @@ export function TrustBadgesSection() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
           {TRUST_BADGES.map((badge, index) => (
-            <motion.div
+            <Reveal
               key={badge.label}
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: index * 0.1 }}
-              viewport={{ once: true }}
+              delay={index * 0.1}
               className="text-center"
             >
               <div className="w-12 h-12 rounded-full bg-zinc-800 flex items-center justify-center mx-auto mb-3">
@@ -22,7 +17,7 @@ export function TrustBadgesSection() {
               </div>
               <h4 className="font-semibold text-white mb-1">{badge.label}</h4>
               <p className="text-sm text-zinc-500">{badge.description}</p>
-            </motion.div>
+            </Reveal>
           ))}
         </div>
       </div>

--- a/components/home/TrustedBySection.tsx
+++ b/components/home/TrustedBySection.tsx
@@ -1,33 +1,22 @@
-"use client";
-
-import { motion } from "framer-motion";
+import { Reveal } from "@/components/ui/reveal";
 import { COMPANY_LOGOS } from "./data";
 
 export function TrustedBySection() {
   return (
     <section className="py-16 bg-zinc-950 border-b border-zinc-900">
       <div className="container mx-auto px-4 md:px-6">
-        <motion.p
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          transition={{ duration: 0.5 }}
-          viewport={{ once: true }}
-          className="text-center text-zinc-500 text-sm mb-8"
-        >
+        <Reveal className="text-center text-zinc-500 text-sm mb-8">
           Our experts have worked at leading companies
-        </motion.p>
+        </Reveal>
         <div className="flex flex-wrap items-center justify-center gap-8 md:gap-16">
           {COMPANY_LOGOS.map((company, i) => (
-            <motion.div
+            <Reveal
               key={company}
-              initial={{ opacity: 0, y: 10 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: i * 0.05 }}
-              viewport={{ once: true }}
               className="text-zinc-600 font-semibold text-lg md:text-xl hover:text-zinc-400 transition-colors cursor-default"
+              delay={i * 0.05}
             >
               {company}
-            </motion.div>
+            </Reveal>
           ))}
         </div>
       </div>

--- a/components/home/UpcomingEventsSection.tsx
+++ b/components/home/UpcomingEventsSection.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { motion } from "framer-motion";
 import { Calendar, ChevronRight, Clock, Star } from "lucide-react";
 import Link from "next/link";
 
@@ -8,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Reveal } from "@/components/ui/reveal";
 import type { ReviewWithProfiles } from "@/types/review";
 import { UPCOMING_EVENTS } from "./data";
 
@@ -19,12 +17,7 @@ function EventCard({
   index: number;
 }) {
   return (
-    <motion.div
-      initial={{ opacity: 0, x: 20 }}
-      whileInView={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.4, delay: index * 0.1 }}
-      viewport={{ once: true }}
-    >
+    <Reveal delay={index * 0.1}>
       <Card className="border border-zinc-800 bg-zinc-900/50 hover:bg-zinc-900 transition-colors group">
         <CardContent className="p-5">
           <div className="flex items-start justify-between mb-3">
@@ -54,7 +47,7 @@ function EventCard({
           </div>
         </CardContent>
       </Card>
-    </motion.div>
+    </Reveal>
   );
 }
 
@@ -77,13 +70,7 @@ export function UpcomingEventsSection({ reviews }: UpcomingEventsSectionProps) {
         <div className="grid lg:grid-cols-2 gap-16">
           {/* Testimonials Column */}
           <div>
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5 }}
-              viewport={{ once: true }}
-              className="mb-8"
-            >
+            <Reveal className="mb-8">
               <Badge
                 variant="secondary"
                 className="mb-4 bg-zinc-800 text-zinc-300 hover:bg-zinc-800 border-zinc-700"
@@ -93,17 +80,11 @@ export function UpcomingEventsSection({ reviews }: UpcomingEventsSectionProps) {
               <h2 className="text-fluid-3xl font-bold text-white mb-4 tracking-tight">
                 What our users say
               </h2>
-            </motion.div>
+            </Reveal>
 
             <div className="space-y-4">
               {slicedReviews.map((review, i) => (
-                <motion.div
-                  key={review.id}
-                  initial={{ opacity: 0, x: -20 }}
-                  whileInView={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.4, delay: i * 0.1 }}
-                  viewport={{ once: true }}
-                >
+                <Reveal key={review.id} delay={i * 0.1}>
                   <Card className="border border-zinc-800 bg-zinc-900/50 backdrop-blur-sm">
                     <CardContent className="p-5">
                       <div className="flex items-center gap-1 mb-3">
@@ -134,20 +115,14 @@ export function UpcomingEventsSection({ reviews }: UpcomingEventsSectionProps) {
                       </div>
                     </CardContent>
                   </Card>
-                </motion.div>
+                </Reveal>
               ))}
             </div>
           </div>
 
           {/* Upcoming Events Column */}
           <div>
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5 }}
-              viewport={{ once: true }}
-              className="mb-8"
-            >
+            <Reveal className="mb-8">
               <Badge
                 variant="secondary"
                 className="mb-4 bg-zinc-800 text-zinc-300 hover:bg-zinc-800 border-zinc-700"
@@ -157,7 +132,7 @@ export function UpcomingEventsSection({ reviews }: UpcomingEventsSectionProps) {
               <h2 className="text-fluid-3xl font-bold text-white mb-4 tracking-tight">
                 Upcoming events
               </h2>
-            </motion.div>
+            </Reveal>
 
             <div className="space-y-4">
               {UPCOMING_EVENTS.map((event, index) => (
@@ -165,20 +140,14 @@ export function UpcomingEventsSection({ reviews }: UpcomingEventsSectionProps) {
               ))}
             </div>
 
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.3 }}
-              viewport={{ once: true }}
-              className="mt-6"
-            >
+            <Reveal className="mt-6" delay={0.3}>
               <Link href="/explore/programs">
                 <Button className="w-full bg-white text-zinc-900 hover:bg-zinc-200 font-medium">
                   View All Events
                   <ChevronRight className="ml-2 w-4 h-4" />
                 </Button>
               </Link>
-            </motion.div>
+            </Reveal>
           </div>
         </div>
       </div>

--- a/components/ui/reveal.tsx
+++ b/components/ui/reveal.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+// Lightweight scroll-in reveal — replaces framer-motion's `whileInView` across the
+// landing sections so framer-motion stays out of the `/` route bundle (#932). An
+// IntersectionObserver toggles a data attribute that drives the `revealUp` CSS
+// keyframe (app/globals.css); reduced-motion users get the content immediately.
+interface RevealProps {
+  children: ReactNode;
+  className?: string;
+  /** Stagger, in seconds — mirrors framer's `transition.delay`. */
+  delay?: number;
+  style?: CSSProperties;
+}
+
+export function Reveal({ children, className, delay = 0, style }: RevealProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -10% 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      data-reveal={visible ? "visible" : "hidden"}
+      style={delay ? { animationDelay: `${delay}s`, ...style } : style}
+      className={className}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Ref + once-only in-view flag — for components that need the boolean to drive
+// their own logic (e.g. the hero stat counters) rather than a wrapper animation.
+export function useInViewOnce<T extends HTMLElement = HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting) {
+        setInView(true);
+        observer.disconnect();
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, inView] as const;
+}


### PR DESCRIPTION
## What
framer-motion shipped in the **`/` route's first-load bundle** purely to drive entrance/scroll animations across the landing sections and the shared Navbar — the single largest item there. This replaces all of it with CSS so framer-motion leaves the `/` bundle entirely.

## How the feel is preserved
- **Scroll-in sections** → a new shared `<Reveal>` (components/ui/reveal.tsx) — an IntersectionObserver client island driving a `revealUp` CSS keyframe (fade + slide-up), the drop-in for framer's `whileInView`. Respects `prefers-reduced-motion`.
- **Hero** (on-load entrances) → pure CSS `.animate-rise` with staggered `animation-delay` (`both` fill-mode so a delayed element doesn't flash). The stat counters keep their JS count-up via a tiny `useInViewOnce` hook — no framer.
- **Navbar drawer** → always-mounted with `translate-x` + `transition-transform`, so it animates **open AND close** (replacing AnimatePresence). **Desktop dropdown** → `animate-fade-in`.

## Bundle / rendering win
- framer-motion removed from **every landing-path component** → out of the `/` bundle.
- **11 of the 14 sections + `SatisfiedTestimonial` are now Server Components** (only the small `<Reveal>` islands ship JS). `TestimonialsSection` keeps `"use client"` (useMemo).

## Validated
- eslint clean; a scan confirms no de-`"use client"` section uses a client-only API; warm TypeScript server reports **zero diagnostics** across all 16 changed files. (Cold local tsc OOMs on this machine — CI runs the authoritative cold tsc + build.)
- **Please verify the animation feel on the deploy preview** — that's the human check this PR is built around.

## Scope notes (deliberate)
- **Explore-page cards were not converted** — `ExpertsInteractiveContent` on that route keeps framer-motion, so converting the cards alone sheds nothing from that bundle; it's a separate route-scoped effort.
- **Over-fetch trims** from the audit were **dropped as unsafe** — the consultant/plan detail pages legitimately render the full plan lists (trimming would hide bookable plans).
- A few sections that previously slid in horizontally / scaled now use the unified vertical rise — consistent, minor feel change worth a look.

Part of #932.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new reveal animation style across key homepage and explore sections for smoother on-scroll content entry.
  * Introduced staggered loading/reveal timing for cards, badges, testimonials, and event items.
* **Bug Fixes**
  * Improved reduced-motion support so content stays visible without animation for users who prefer minimal motion.
  * Updated navigation and content panels to behave more consistently with CSS-driven transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->