### PR TITLE
fix(build): skip redundant ESLint + tsc in next build — Netlify 4GB OOM fix (Part of #932)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,8 @@
 [build.environment]
   # Node version
   NODE_VERSION = "22"
-  # Increase heap size to prevent OOM during lint/type-check step
+  # Heap headroom for the webpack build. Lint + tsc are now skipped in `next build`
+  # (next.config.mjs) since CI gates them, so this no longer has to cover that step. #932
   NODE_OPTIONS = "--max-old-space-size=4096"
 
 # Skip builds for Dependabot PRs

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,12 +79,13 @@ const securityHeaders = [
 ];
 
 const nextConfig = {
-  // The Netlify build OOM'd at the 4GB heap re-running ESLint + tsc — which CI
-  // already gates on every PR (the "TypeScript, Tests & Build" job) before anything
-  // merges to dev/prod. Skip them in `next build` to drop that memory hog and speed
-  // deploys; correctness is enforced upstream in CI, not at deploy time. (#932)
-  eslint: { ignoreDuringBuilds: true },
-  typescript: { ignoreBuildErrors: true },
+  // Only the Netlify deploy build OOM'd at the 4GB heap re-running ESLint + tsc.
+  // Skip them THERE (NETLIFY=true is set in Netlify's build env) to drop that memory
+  // hog — CI gates both independently anyway (ci.yaml runs `npx tsc --noEmit` +
+  // `npx eslint .` as their own steps). Local `npm run build` and CI's own build keep
+  // the checks on, so nothing loses its safety net off-Netlify. (#932)
+  eslint: { ignoreDuringBuilds: !!process.env.NETLIFY },
+  typescript: { ignoreBuildErrors: !!process.env.NETLIFY },
   // Reduce Webpack memory usage during builds (Next.js 15+, low-risk experimental)
   experimental: {
     webpackMemoryOptimizations: true,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,6 +79,12 @@ const securityHeaders = [
 ];
 
 const nextConfig = {
+  // The Netlify build OOM'd at the 4GB heap re-running ESLint + tsc — which CI
+  // already gates on every PR (the "TypeScript, Tests & Build" job) before anything
+  // merges to dev/prod. Skip them in `next build` to drop that memory hog and speed
+  // deploys; correctness is enforced upstream in CI, not at deploy time. (#932)
+  eslint: { ignoreDuringBuilds: true },
+  typescript: { ignoreBuildErrors: true },
   // Reduce Webpack memory usage during builds (Next.js 15+, low-risk experimental)
   experimental: {
     webpackMemoryOptimizations: true,


### PR DESCRIPTION
## Problem
The prod deploy of #940 (`c08165e6`) **failed**, OOM-ing at the **4 GB build heap** (`NODE_OPTIONS=--max-old-space-size=4096`). It's flaky, not deterministic — the same commit built green in the deploy-preview and dev contexts — i.e. the build peaks right at the 4 GB ceiling and occasionally gets OOM-killed. (Netlify kept the previous deploy live; recovered separately via a clean-cache rebuild, so prod is current.)

## Root cause
`next build` re-runs **ESLint + tsc** — exactly the step the `netlify.toml` heap comment named (*"prevent OOM during lint/type-check step"*). But CI already gates both on **every PR** to dev and prod (the "TypeScript, Tests & Build" job), so the deploy build is OOM-ing on redundant work.

## Fix
- `next.config.mjs`: `eslint.ignoreDuringBuilds: true` + `typescript.ignoreBuildErrors: true` — `next build` no longer re-lints/re-typechecks. Removes the memory hog and speeds deploys. **Correctness is still enforced upstream in CI**, which must pass before anything merges.
- `netlify.toml`: refreshed the `NODE_OPTIONS` comment (the 4 GB heap is now plain webpack headroom; left at 4096).

Part of #932.