### PR TITLE
release: dev → prod — Netlify build-OOM fix (#942)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,8 @@
 [build.environment]
   # Node version
   NODE_VERSION = "22"
-  # Increase heap size to prevent OOM during lint/type-check step
+  # Heap headroom for the webpack build. Lint + tsc are now skipped in `next build`
+  # (next.config.mjs) since CI gates them, so this no longer has to cover that step. #932
   NODE_OPTIONS = "--max-old-space-size=4096"
 
 # Skip builds for Dependabot PRs

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,6 +79,13 @@ const securityHeaders = [
 ];
 
 const nextConfig = {
+  // Only the Netlify deploy build OOM'd at the 4GB heap re-running ESLint + tsc.
+  // Skip them THERE (NETLIFY=true is set in Netlify's build env) to drop that memory
+  // hog — CI gates both independently anyway (ci.yaml runs `npx tsc --noEmit` +
+  // `npx eslint .` as their own steps). Local `npm run build` and CI's own build keep
+  // the checks on, so nothing loses its safety net off-Netlify. (#932)
+  eslint: { ignoreDuringBuilds: !!process.env.NETLIFY },
+  typescript: { ignoreBuildErrors: !!process.env.NETLIFY },
   // Reduce Webpack memory usage during builds (Next.js 15+, low-risk experimental)
   experimental: {
     webpackMemoryOptimizations: true,


### PR DESCRIPTION
Promotes `dev` → `prod`. One change since the last promotion:

- **#942** — fix the Netlify build OOM-ing at the 4 GB heap by skipping the redundant ESLint + tsc inside `next build`, gated on `process.env.NETLIFY` (only the Netlify deploy build skips them; local + CI keep the checks, and CI gates both as standalone steps). Build-config only — no runtime/app behavior change. Part of #932.

Stops the next prod deploy from hitting the flaky 4 GB OOM (which broke the #940 deploy and needed a manual clean-cache retry).