### PR TITLE
fix: preserve first-timer booking destination through onboarding + URL-encoding hardening

### DIFF
--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -26,7 +26,9 @@ export async function GET(request: NextRequest) {
     const subdomain = searchParams.get("subdomain");
     // Repeated params (?tags=a&tags=b), matching the client writers, so a literal
     // comma in a tag/company name can't split one value into two filter terms.
-    const tags = searchParams.getAll("tags");
+    // filter(Boolean) drops an empty ?tags= (mirrors companies) so it reads as
+    // "no filter" rather than name IN [""] → zero results.
+    const tags = searchParams.getAll("tags").filter(Boolean);
     const experience = parseInt(searchParams.get("experience") || "0");
     const search = searchParams.get("search");
     const language = searchParams.get("language");

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -24,11 +24,13 @@ export async function GET(request: NextRequest) {
   try {
     const domain = searchParams.get("domain");
     const subdomain = searchParams.get("subdomain");
-    const tags = searchParams.get("tags")?.split(",");
+    // Repeated params (?tags=a&tags=b), matching the client writers, so a literal
+    // comma in a tag/company name can't split one value into two filter terms.
+    const tags = searchParams.getAll("tags");
     const experience = parseInt(searchParams.get("experience") || "0");
     const search = searchParams.get("search");
     const language = searchParams.get("language");
-    const companies = searchParams.get("companies")?.split(",").filter(Boolean);
+    const companies = searchParams.getAll("companies").filter(Boolean);
     const affiliationType = searchParams.get("affiliationType");
 
     const rawMinPrice = searchParams.get("minPrice");
@@ -51,12 +53,12 @@ export async function GET(request: NextRequest) {
       !includeUnverified &&
       !domain &&
       !subdomain &&
-      !(tags && tags.length > 0) &&
+      tags.length === 0 &&
       experience <= 0 &&
       minPrice === undefined &&
       maxPrice === undefined &&
       minRating === undefined &&
-      !(companies && companies.length > 0) &&
+      companies.length === 0 &&
       !language &&
       !affiliationType &&
       !search;
@@ -84,7 +86,7 @@ export async function GET(request: NextRequest) {
     if (subdomain) {
       conditions.push({ subDomains: { some: { id: subdomain } } });
     }
-    if (tags && tags.length > 0) {
+    if (tags.length > 0) {
       conditions.push({ tags: { some: { name: { in: tags } } } });
     }
     if (experience > 0) {
@@ -103,7 +105,7 @@ export async function GET(request: NextRequest) {
     if (minRating !== undefined && !isNaN(minRating)) {
       conditions.push({ rating: { gte: minRating } });
     }
-    if (companies && companies.length > 0) {
+    if (companies.length > 0) {
       conditions.push({
         user: { workExperiences: { some: { company: { in: companies } } } },
       });

--- a/app/api/waitlist/[id]/respond/route.ts
+++ b/app/api/waitlist/[id]/respond/route.ts
@@ -85,9 +85,12 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
     const action = searchParams.get("action")?.toUpperCase();
 
-    // If not logged in, redirect to login with callback
+    // If not logged in, redirect to login with callback. Use a RELATIVE path —
+    // the sign-in page only honours relative callbackUrls, so the absolute
+    // request.url would be dropped and the accept/decline deep-link lost.
     if (!session?.user?.id) {
-      const loginUrl = `/auth/signin?callbackUrl=${encodeURIComponent(request.url)}`;
+      const returnTo = new URL(request.url);
+      const loginUrl = `/auth/signin?callbackUrl=${encodeURIComponent(returnTo.pathname + returnTo.search)}`;
       return NextResponse.redirect(new URL(loginUrl, request.url));
     }
 

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -292,7 +292,9 @@ function SignInContent() {
             ? "Redirecting to your destination..."
             : "Redirecting to dashboard...",
         });
-        router.push(callbackUrl || "/dashboard");
+        // Defer the redirect to the useSession-driven effect above so it honours
+        // onboarding status — a non-onboarded user signing in from a booking/trial
+        // callback must go through onboarding first, not straight to callbackUrl.
       }
     } catch (error) {
       Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "auth" } });

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -53,16 +53,27 @@ function SignInContent() {
     }
   }, [searchParams]);
 
+  // Thread the validated callbackUrl through the onboarding + sign-up hand-offs
+  // so a first-timer who came here to book/buy returns to their destination
+  // after finishing onboarding, instead of being dropped on the dashboard
+  // (mirrors the sign-up page, which already does this).
+  const onboardingUrl = callbackUrl
+    ? `/form/onboarding?callbackUrl=${encodeURIComponent(callbackUrl)}`
+    : "/form/onboarding";
+  const signUpUrl = callbackUrl
+    ? `/auth/signup?callbackUrl=${encodeURIComponent(callbackUrl)}`
+    : "/auth/signup";
+
   // Redirect authenticated users based on onboarding status
   useEffect(() => {
     if (!isPending && session?.user) {
       if (session.user.onboardingCompleted) {
         router.push(callbackUrl || "/dashboard");
       } else {
-        router.push("/form/onboarding");
+        router.push(onboardingUrl);
       }
     }
-  }, [session, isPending, router, callbackUrl]);
+  }, [session, isPending, router, callbackUrl, onboardingUrl]);
 
   // Show loading while checking session status (fallback for when middleware doesn't catch)
   if (isPending) {
@@ -424,7 +435,7 @@ function SignInContent() {
               </div>
               <SocialLoginButtons
                 callbackURL={callbackUrl || "/dashboard"}
-                newUserCallbackURL="/form/onboarding"
+                newUserCallbackURL={onboardingUrl}
                 isLoading={isLoading}
                 ssoEnforced={false}
                 onSSOClick={handleManualSSOClick}
@@ -435,7 +446,7 @@ function SignInContent() {
           <p className="mt-6 text-xs text-zinc-400">
             Don't have an account?{" "}
             <Link
-              href="/auth/signup"
+              href={signUpUrl}
               className="font-medium text-white underline-offset-4 hover:underline"
             >
               Sign up

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -68,6 +68,12 @@ function SignUpContent() {
     ? `/auth/verify-email?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`
     : "/auth/verify-email";
 
+  // Thread it back to sign-in too, so toggling sign-up ↔ sign-in preserves the
+  // destination in both directions (only the org-invite deep-link set it before).
+  const signInUrl = safeCallbackUrl
+    ? `/auth/signin?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`
+    : "/auth/signin";
+
   // Redirect authenticated users based on onboarding status
   useEffect(() => {
     if (!isPending && session?.user) {
@@ -151,7 +157,7 @@ function SignUpContent() {
           <p className="mt-4 text-xs text-zinc-400">
             Already verified?{" "}
             <Link
-              href="/auth/signin"
+              href={signInUrl}
               className="font-medium text-zinc-300 underline-offset-4 hover:text-white hover:underline"
             >
               Sign in
@@ -444,7 +450,7 @@ function SignUpContent() {
           <p className="mt-6 text-xs text-zinc-400">
             Already have an account?{" "}
             <Link
-              href="/auth/signin"
+              href={signInUrl}
               className="font-medium text-white underline-offset-4 hover:underline"
             >
               Sign in

--- a/app/explore/experts/[consultantId]/ExpertProfileClient.tsx
+++ b/app/explore/experts/[consultantId]/ExpertProfileClient.tsx
@@ -74,7 +74,7 @@ export function ExpertProfileClient({
         const response = await fetch(
           `/api/slots/availability-with-allocation/${
             consultantDetails.id
-          }?startDateInUtc=${startDateInUtc.toISOString()}&endDateInUtc=${endDateInUtc.toISOString()}&timezone=${timezone}`,
+          }?startDateInUtc=${startDateInUtc.toISOString()}&endDateInUtc=${endDateInUtc.toISOString()}&timezone=${encodeURIComponent(timezone)}`,
         );
 
         if (!response.ok) {

--- a/app/explore/experts/[consultantId]/components/ConsultantAvailability.tsx
+++ b/app/explore/experts/[consultantId]/components/ConsultantAvailability.tsx
@@ -57,7 +57,7 @@ export function ConsultantAvailability({
         const endDateInUtc = endOfDay(addDays(windowStart, 6));
 
         const response = await fetch(
-          `/api/slots/availability-with-allocation/${consultantDetails.id}?startDateInUtc=${startDateInUtc.toISOString()}&endDateInUtc=${endDateInUtc.toISOString()}&timezone=${timezone}`,
+          `/api/slots/availability-with-allocation/${consultantDetails.id}?startDateInUtc=${startDateInUtc.toISOString()}&endDateInUtc=${endDateInUtc.toISOString()}&timezone=${encodeURIComponent(timezone)}`,
         );
 
         if (!response.ok) {

--- a/app/explore/experts/[consultantId]/components/TrialBookingModal.tsx
+++ b/app/explore/experts/[consultantId]/components/TrialBookingModal.tsx
@@ -44,9 +44,17 @@ export function TrialBookingModal({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
 
+  // Send an unauthenticated visitor to sign-in, preserving the trial intent so
+  // that after auth + onboarding they land back on this expert with the trial
+  // modal auto-opened (the expert page honours ?action=trial).
+  const redirectToSignIn = () => {
+    const returnTo = `${window.location.pathname}?action=trial`;
+    router.push(`/auth/signin?callbackUrl=${encodeURIComponent(returnTo)}`);
+  };
+
   const handleSubmit = async () => {
     if (!session?.user?.id) {
-      router.push("/auth/signin");
+      redirectToSignIn();
       return;
     }
 
@@ -148,7 +156,7 @@ export function TrialBookingModal({
             <p className="text-muted-foreground mb-4">
               Please sign in to request a free trial with {consultantName}
             </p>
-            <Button onClick={() => router.push("/auth/signin")}>
+            <Button onClick={redirectToSignIn}>
               Sign In to Continue
             </Button>
           </div>

--- a/app/explore/experts/hooks/useConsultants.ts
+++ b/app/explore/experts/hooks/useConsultants.ts
@@ -47,17 +47,19 @@ export function useConsultants(filters: IExpertFilters) {
         limit: CONSULTANTS_PER_PAGE.toString(),
         ...(selectedDomain && { domain: selectedDomain }),
         ...(selectedSubdomain && { subdomain: selectedSubdomain }),
-        ...(selectedTags.length && { tags: selectedTags.join(",") }),
         ...(experienceYears > 0 && { experience: experienceYears.toString() }),
         ...(searchTerm && { search: searchTerm }),
         sort: sortBy,
         ...(minPrice !== undefined && { minPrice: String(minPrice) }),
         ...(maxPrice !== undefined && { maxPrice: String(maxPrice) }),
         ...(minRating !== undefined && { minRating: String(minRating) }),
-        ...(companies.length > 0 && { companies: companies.join(",") }),
         ...(language && { language }),
         ...(affiliationType && { affiliationType }),
       });
+      // Repeated params (not comma-joined) so a literal comma in a tag/company
+      // name can't corrupt the filter — must match the API's getAll() read.
+      for (const tag of selectedTags) params.append("tags", tag);
+      for (const company of companies) params.append("companies", company);
 
       return `/api/user/consultants?${params}`;
     },

--- a/app/explore/experts/utils.ts
+++ b/app/explore/experts/utils.ts
@@ -116,7 +116,9 @@ export function filtersFromSearchParams(
   return {
     domain: params.get("domain"),
     subdomain: params.get("subdomain"),
-    tags: params.get("tags")?.split(",").filter(Boolean) || [],
+    // Repeated params (?tags=a&tags=b), not comma-joined, so a literal comma in
+    // a tag/company name can't split one value into two bogus filter terms.
+    tags: params.getAll("tags").filter(Boolean),
     // API uses parseInt — keep both sides aligned so a hand-edited
     // ?experience=1.5 doesn't make the UI show 1.5 while the API filters at 1.
     experience: parseIntegerParam(params.get("experience")) ?? 0,
@@ -130,7 +132,7 @@ export function filtersFromSearchParams(
     minPrice: parseNumberParam(params.get("minPrice")),
     maxPrice: parseNumberParam(params.get("maxPrice")),
     minRating: parseNumberParam(params.get("minRating")),
-    companies: params.get("companies")?.split(",").filter(Boolean) || [],
+    companies: params.getAll("companies").filter(Boolean),
     language: params.get("language") || undefined,
     affiliationType: (params.get("affiliationType") as AffiliationType) || null,
   };
@@ -141,7 +143,7 @@ export function filtersToSearchParams(filters: IExpertFilters): string {
   const params = new URLSearchParams();
   if (filters.domain) params.set("domain", filters.domain);
   if (filters.subdomain) params.set("subdomain", filters.subdomain);
-  if (filters.tags.length > 0) params.set("tags", filters.tags.join(","));
+  for (const tag of filters.tags) params.append("tags", tag);
   if (filters.experience > 0)
     params.set("experience", String(filters.experience));
   if (filters.search) params.set("search", filters.search);
@@ -152,7 +154,7 @@ export function filtersToSearchParams(filters: IExpertFilters): string {
     params.set("maxPrice", String(filters.maxPrice));
   if (filters.minRating !== undefined)
     params.set("minRating", String(filters.minRating));
-  if (filters.companies.length > 0) params.set("companies", filters.companies.join(","));
+  for (const company of filters.companies) params.append("companies", company);
   if (filters.language) params.set("language", filters.language);
   if (filters.affiliationType) params.set("affiliationType", filters.affiliationType);
   return params.toString();

--- a/app/explore/programs/plans/classes/[classPlanId]/components/ClientClassRegistration.tsx
+++ b/app/explore/programs/plans/classes/[classPlanId]/components/ClientClassRegistration.tsx
@@ -73,11 +73,15 @@ export function ClientClassRegistration({
   const isOnWaitlist = !!userWaitlistEntry;
 
   const handleRegistration = () => {
+    const checkoutUrl = `/checkout/plans/class/${classId}`;
     if (!isLoggedIn) {
-      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.href)}`;
+      // Preserve the checkout destination as a RELATIVE callbackUrl (the sign-in
+      // page drops absolute URLs) so a first-timer lands on checkout after auth +
+      // onboarding.
+      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(checkoutUrl)}`;
       return;
     }
-    window.location.href = `/checkout/plans/class/${classId}`;
+    window.location.href = checkoutUrl;
   };
 
   if (!isLoggedIn) {

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
@@ -81,9 +81,11 @@ export function ClientWebinarRegistration({
   const isOnWaitlist = !!userWaitlistEntry;
 
   const handleRegistration = () => {
-    // Only checkout-able when the session is upcoming AND a webinar instance exists.
+    // Only checkout-able when the session is upcoming, a webinar instance exists,
+    // and there's still room — a full webinar must fall back to the page so the
+    // signed-in user lands on the waitlist UI, not checkout.
     const checkoutUrl =
-      sessionStatus === "Upcoming" && webinarId
+      sessionStatus === "Upcoming" && webinarId && !isFull
         ? `/checkout/plans/webinar/${webinarPlanId}?eventId=${webinarId}`
         : null;
     if (!isLoggedIn) {

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/components/ClientWebinarRegistration.tsx
@@ -81,13 +81,22 @@ export function ClientWebinarRegistration({
   const isOnWaitlist = !!userWaitlistEntry;
 
   const handleRegistration = () => {
+    // Only checkout-able when the session is upcoming AND a webinar instance exists.
+    const checkoutUrl =
+      sessionStatus === "Upcoming" && webinarId
+        ? `/checkout/plans/webinar/${webinarPlanId}?eventId=${webinarId}`
+        : null;
     if (!isLoggedIn) {
-      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.href)}`;
+      // Preserve the next step as a RELATIVE callbackUrl (the sign-in page drops
+      // absolute URLs) — checkout when registerable, else this page — so a
+      // first-timer lands there after auth + onboarding.
+      const returnTo =
+        checkoutUrl ?? window.location.pathname + window.location.search;
+      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(returnTo)}`;
       return;
     }
-    // Ensure we only redirect to checkout if the session is upcoming AND we have a webinar instance ID
-    if (sessionStatus === "Upcoming" && webinarId) {
-      window.location.href = `/checkout/plans/webinar/${webinarPlanId}?eventId=${webinarId}`;
+    if (checkoutUrl) {
+      window.location.href = checkoutUrl;
     }
   };
 

--- a/components/waitlist/JoinWaitlistButton.tsx
+++ b/components/waitlist/JoinWaitlistButton.tsx
@@ -40,8 +40,9 @@ export function JoinWaitlistButton({
 
   const handleJoinWaitlist = async () => {
     if (!session?.user) {
-      // Redirect to login with callback
-      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.href)}`;
+      // Redirect to login with a RELATIVE callback (the sign-in page drops
+      // absolute URLs) so the user returns to this event page after signing in.
+      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname + window.location.search)}`;
       return;
     }
 

--- a/lib/auth-guard.ts
+++ b/lib/auth-guard.ts
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
 import type { UserRole } from "@prisma/client";
 import { getSession } from "@/lib/auth-server";
 
@@ -50,6 +51,29 @@ export async function requireAuth() {
 }
 
 /**
+ * Build the onboarding redirect target, preserving the intended destination
+ * (the path middleware stashed in `x-pathname`) as `?callbackUrl=` so that
+ * finishing onboarding returns the user to where they were headed rather than
+ * the dashboard. Never loops back to onboarding itself.
+ */
+async function onboardingRedirectTarget(
+  extraParams?: Record<string, string>,
+): Promise<string> {
+  const params = new URLSearchParams(extraParams);
+  const current = (await headers()).get("x-pathname");
+  if (
+    current &&
+    current.startsWith("/") &&
+    !current.startsWith("//") &&
+    !current.startsWith("/form/onboarding")
+  ) {
+    params.set("callbackUrl", current);
+  }
+  const query = params.toString();
+  return query ? `/form/onboarding?${query}` : "/form/onboarding";
+}
+
+/**
  * Require an authenticated AND fully onboarded user.
  * Redirects to sign-in if no session, to onboarding if not completed or
  * profile is missing. Uses disableCookieCache to avoid stale values.
@@ -60,10 +84,10 @@ export async function requireOnboarded() {
     redirectWithCookieCleanup();
   }
   if (!session.user.onboardingCompleted) {
-    redirect("/form/onboarding");
+    redirect(await onboardingRedirectTarget());
   }
   if (!hasRequiredProfile(session.user)) {
-    redirect("/form/onboarding?error=missing_profile");
+    redirect(await onboardingRedirectTarget({ error: "missing_profile" }));
   }
   return session;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -413,7 +413,12 @@ export async function middleware(
       signInUrl.searchParams.set("callbackUrl", pathname + req.nextUrl.search);
       return NextResponse.redirect(signInUrl);
     }
-    return NextResponse.next();
+    // Expose the resolved path so server guards (requireOnboarded) can send an
+    // authenticated-but-not-onboarded user back to their intended destination
+    // after onboarding, instead of dropping them on the dashboard.
+    const requestHeaders = new Headers(req.headers);
+    requestHeaders.set("x-pathname", pathname + req.nextUrl.search);
+    return NextResponse.next({ request: { headers: requestHeaders } });
   }
 
   // Everything else (public pages) — allow.


### PR DESCRIPTION
## Context

An audit of the first-time-user journey found that a consultee who clicks **Book / Buy / Register** loses their intended destination. The consumer entry points funnel a first-timer through the **sign-in** page, which dropped the `callbackUrl` at the "Sign up" hand-off (and on social new-user sign-up), and `requireOnboarded()` bounced an authenticated-but-not-onboarded user to a bare `/form/onboarding`. The result was that a brand-new buyer finished onboarding on their dashboard rather than the checkout they set out for. The machinery to preserve the destination already existed end-to-end (it works for organization invites) — it simply was never wired into any of the booking entry points.

A parallel URL-encoding audit found the app is broadly correct: it standardises on `URLSearchParams` + `encodeURIComponent`, so complex strings round-trip cleanly and there is no open-redirect exposure. That audit surfaced three low-severity items worth hardening, which are bundled here.

## A — Preserve the first-timer's booking destination

The callback now survives the entire sign-in → sign-up → email-verify → onboarding journey. Every place that previously dropped it is fixed:

- **Sign-in ↔ sign-up hand-off** (`app/auth/signin/page.tsx`, `app/auth/signup/page.tsx`): the "Sign up" and "Sign in" links, the social `newUserCallbackURL`, and the not-onboarded redirect all thread the validated `callbackUrl`, in both directions.
- **`requireOnboarded()` black hole** (`middleware.ts`, `lib/auth-guard.ts`): middleware now exposes the resolved path as an `x-pathname` request header on protected, authenticated requests, and the guard carries it into `/form/onboarding?callbackUrl=…` so an authenticated-but-not-onboarded user returns to their destination rather than the dashboard.
- **Trial booking** (`TrialBookingModal.tsx`): previously set no callback at all; it now signs the user in with `callbackUrl=<expert>?action=trial`, so the trial modal auto-reopens after authentication.
- **Webinar / class registration** (`ClientWebinarRegistration.tsx`, `ClientClassRegistration.tsx`): the callback now points straight at checkout as a **relative** path. The previous absolute `window.location.href` was silently discarded by the relative-only open-redirect guard, so the destination was lost even for returning users.

Concretely, a new consultee who clicks **Book** now flows `signin?callbackUrl=/checkout` → `signup?callbackUrl=/checkout` → `verify-email?callbackUrl=/checkout` → `onboarding?callbackUrl=/checkout` and lands on checkout, instead of being dropped on the dashboard.

Onboarding remains a hard gate (no deferral or guest checkout); the consultee form is already minimal, and this change is purely about not losing the user's place.

## B — URL-encoding hardening

- **Experts filters** (`app/explore/experts/utils.ts`, `hooks/useConsultants.ts`, `app/api/user/consultants/route.ts`): the `companies` and `tags` filters move from a comma-joined single parameter to repeated parameters (`?tags=a&tags=b`) with `getAll()` on read, applied consistently to the browser URL, the API request, and the API parser. A literal comma inside a company name (for example "Booz, Allen & Hamilton") can no longer be split into two bogus filter terms.
- **Availability timezone** (`ExpertProfileClient.tsx`, `ConsultantAvailability.tsx`): the `timezone` query value is now `encodeURIComponent`-wrapped, so a POSIX-style zone such as `Etc/GMT+5` cannot have its `+` decoded to a space on the server.
- **Waitlist deep-link** (`app/api/waitlist/[id]/respond/route.ts`): the sign-in `callbackUrl` is now a relative path, so the accept/decline email link survives login; the previous absolute `request.url` was dropped by the relative-only guard, landing the user on the dashboard.

## Verification

- Cold `tsc --noEmit` (raised heap) — exit 0 across all 13 files.
- ESLint on the changed files — 0 errors (the one `eqeqeq` warning is pre-existing in untouched middleware code).
- No existing tests assert any of the changed behaviour.
- Dev-server smoke against the public read endpoints: repeated `companies`/`tags` parameters filter correctly (20 and 3 matches respectively), a comma-bearing company name is treated as a single value, and an encoded `Asia/Kolkata` timezone returns HTTP 200.

The full sign-up → email-verification → onboarding chain is best confirmed on the deploy preview, since email verification cannot be fully automated locally; the added flow mirrors the already-working organization-invite path.

## Out of scope

Slot expiry during a long first-time onboarding (a slot-TTL concern, not callback plumbing) is noted but not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in and sign-up flows more reliably preserve your original destination, including onboarding and checkout hand-offs.
  * Expert search filters now support multi-select tags and companies in the URL for easier sharing and restored filtered views.
* **Bug Fixes**
  * Improved login-required redirect behavior to return you to the intended page after authentication.
  * Fixed availability requests to handle timezone values more safely.
* **Other**
  * Waitlist and other gated actions now use consistent relative redirect targets to avoid dropping deep links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->