### PR TITLE
feat(consultant): appointments resilience, honest org filter, analytics page (redesign 4/9)

### DIFF
--- a/app/api/bookings/consultations/route.ts
+++ b/app/api/bookings/consultations/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { transitionConsultationRequest } from "@/lib/booking/transitions";
 import { IllegalTransitionError } from "@/lib/enterprise/transitions";
 import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
+import { resolveOrgScope } from "@/lib/api/scope/parse";
 import {
   requireApiAuth,
   isPrivileged,
@@ -64,6 +65,44 @@ export async function GET(request: NextRequest) {
 
     if (status) {
       whereClause.status = status;
+    }
+
+    // Personal-vs-org scope filter (same mechanism as /api/slots/appointments:
+    // the denormalized Appointment.organizationId). ADDITIVE: when the param
+    // is absent, behavior is unchanged (unfiltered union) so existing callers
+    // keep seeing everything. A consultation with no Appointment row is
+    // definitionally not org-funded, so it counts as personal.
+    const rawOrgScope = searchParams.get("orgScope");
+    if (rawOrgScope) {
+      const memberships = await prisma.membership.findMany({
+        where: { userId: session.user.id, status: "ACTIVE" },
+        select: { organizationId: true, status: true },
+      });
+      const scopeResolution = resolveOrgScope({
+        raw: rawOrgScope,
+        memberships,
+        userRole: session.user.role,
+        // Self-scoped: the ownership filter above already locks non-admin
+        // callers to their own rows, so "all" just means "all of MY data".
+        allowAllForOwner: true,
+      });
+      if (!scopeResolution.ok) {
+        return NextResponse.json(
+          { error: scopeResolution.message, code: scopeResolution.code },
+          { status: scopeResolution.status },
+        );
+      }
+      if (scopeResolution.scope.kind === "personal") {
+        whereClause.OR = [
+          { appointment: null },
+          { appointment: { organizationId: null } },
+        ];
+      } else if (scopeResolution.scope.kind === "org") {
+        whereClause.appointment = {
+          organizationId: scopeResolution.scope.orgId,
+        };
+      }
+      // kind === "all": no additional filter
     }
 
     const [consultations, total] = await Promise.all([

--- a/app/api/bookings/subscriptions/route.ts
+++ b/app/api/bookings/subscriptions/route.ts
@@ -17,6 +17,7 @@ import {
 import { transitionSubscriptionRequest } from "@/lib/booking/transitions";
 import { IllegalTransitionError } from "@/lib/enterprise/transitions";
 import { applyRateLimit, eventMutationLimiter } from "@/lib/rate-limit";
+import { resolveOrgScope } from "@/lib/api/scope/parse";
 
 export async function GET(request: NextRequest) {
   // Require authentication
@@ -69,6 +70,44 @@ export async function GET(request: NextRequest) {
 
     if (status) {
       whereClause.status = status;
+    }
+
+    // Personal-vs-org scope filter (same mechanism as /api/slots/appointments:
+    // the denormalized Appointment.organizationId, here through the
+    // subscription's to-many `appointments`). ADDITIVE: when the param is
+    // absent, behavior is unchanged (unfiltered union). A subscription whose
+    // appointments carry no org stamp — including one with zero appointment
+    // rows — is definitionally personal.
+    const rawOrgScope = searchParams.get("orgScope");
+    if (rawOrgScope) {
+      const memberships = await prisma.membership.findMany({
+        where: { userId: session.user.id, status: "ACTIVE" },
+        select: { organizationId: true, status: true },
+      });
+      const scopeResolution = resolveOrgScope({
+        raw: rawOrgScope,
+        memberships,
+        userRole: session.user.role,
+        // Self-scoped: the ownership filter above already locks non-admin
+        // callers to their own rows, so "all" just means "all of MY data".
+        allowAllForOwner: true,
+      });
+      if (!scopeResolution.ok) {
+        return NextResponse.json(
+          { error: scopeResolution.message, code: scopeResolution.code },
+          { status: scopeResolution.status },
+        );
+      }
+      if (scopeResolution.scope.kind === "personal") {
+        whereClause.appointments = {
+          none: { organizationId: { not: null } },
+        };
+      } else if (scopeResolution.scope.kind === "org") {
+        whereClause.appointments = {
+          some: { organizationId: scopeResolution.scope.orgId },
+        };
+      }
+      // kind === "all": no additional filter
     }
 
     const [subscriptions, total] = await Promise.all([

--- a/app/api/consultant/earnings/route.ts
+++ b/app/api/consultant/earnings/route.ts
@@ -8,11 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { EarningStatus } from "@prisma/client";
 import { getSession } from "@/lib/auth-server";
-import {
-  getConsultantEarningsSummary,
-  getConsultantEarnings,
-  checkPayoutEligibility,
-} from "@/lib/payments/payouts";
+import { buildConsultantEarningsPayload } from "@/lib/data/consultant-earnings-analytics";
 
 /**
  * GET /api/consultant/earnings
@@ -42,34 +38,18 @@ export async function GET(req: NextRequest) {
     const status = searchParams.get("status") as EarningStatus | null;
     const limit = parseInt(searchParams.get("limit") || "20");
     const offset = parseInt(searchParams.get("offset") || "0");
+    // Additive: ?includeMonthly=1 appends trailing-6-month buckets for the
+    // analytics page. Absent param = response unchanged.
+    const includeMonthly = searchParams.get("includeMonthly") === "1";
 
-    // Get earnings summary
-    const summary = await getConsultantEarningsSummary(consultantProfile.id);
-
-    // Get payout eligibility
-    const eligibility = await checkPayoutEligibility(consultantProfile.id);
-
-    // Get earnings history
-    const { earnings, total, hasMore } = await getConsultantEarnings(
-      consultantProfile.id,
-      {
-        status: status || undefined,
-        limit,
-        offset,
-      },
-    );
-
-    return NextResponse.json({
-      summary,
-      eligibility,
-      earnings,
-      pagination: {
-        total,
-        limit,
-        offset,
-        hasMore,
-      },
+    const payload = await buildConsultantEarningsPayload(consultantProfile.id, {
+      status: status || undefined,
+      limit,
+      offset,
+      includeMonthly,
     });
+
+    return NextResponse.json(payload);
   } catch (error) {
     Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "consultant" } });
     console.error("Error fetching earnings:", error);

--- a/app/dashboard/consultant/[consultantId]/(features)/analytics/AnalyticsPageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/analytics/AnalyticsPageClient.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { format, parse } from "date-fns";
+import {
+  BarChart3,
+  CalendarCheck,
+  CalendarClock,
+  CheckCircle2,
+  IndianRupee,
+  Wallet,
+} from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
+import {
+  DashboardContent,
+  DashboardGrid,
+  DashboardHeader,
+} from "@/components/dashboard/DashboardShell";
+import { StatCard, StatCardSkeleton } from "@/components/dashboard/StatCard";
+import { DataCard, EmptyState } from "@/components/dashboard/DataCard";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { createConsultantQueries } from "@/lib/dashboard-queries";
+import { getAppointmentStatus } from "../../utils/appointmentHelpers";
+import { formatCurrencyAmount } from "@/utils/formatting";
+import type { MonthlyEarning } from "@/lib/data/consultant-earnings-analytics";
+
+interface EarningsAnalyticsResponse {
+  summary: {
+    totalEarnings: number;
+    pendingEarnings: number;
+    readyEarnings: number;
+    paidEarnings: number;
+    heldEarnings: number;
+    pendingTrustEarnings: number;
+  };
+  monthlyEarnings?: MonthlyEarning[];
+}
+
+const formatInr = (paise: number) => formatCurrencyAmount(paise, "INR");
+
+const monthLabel = (month: string) =>
+  format(parse(month, "yyyy-MM", new Date()), "MMM");
+
+export default function AnalyticsPageClient({
+  consultantId,
+}: Readonly<{ consultantId: string }>) {
+  // queryKey MUST match the server prefetch in ./page.tsx.
+  const {
+    data: earningsData,
+    isLoading: earningsLoading,
+    isError: earningsError,
+    refetch: refetchEarnings,
+  } = useQuery<EarningsAnalyticsResponse>({
+    queryKey: ["consultant-earnings-analytics", consultantId],
+    queryFn: async () => {
+      const res = await fetch(
+        "/api/consultant/earnings?includeMonthly=1&limit=1",
+      );
+      if (!res.ok) throw new Error("Failed to fetch earnings analytics");
+      return res.json();
+    },
+    staleTime: 60_000,
+    retry: 2,
+  });
+
+  // Personal-scope appointments — same key + payload as the appointments
+  // page's #890 SSR prefetch, so the two pages share one cache entry.
+  const appointmentsQuery = createConsultantQueries(
+    consultantId,
+    "personal",
+  ).appointments;
+  const {
+    data: appointments,
+    isLoading: appointmentsLoading,
+    isError: appointmentsError,
+    refetch: refetchAppointments,
+  } = useQuery(appointmentsQuery);
+
+  const sessionStats = useMemo(() => {
+    const all = appointments ?? [];
+    let completed = 0;
+    let cancelled = 0;
+    let upcoming = 0;
+    for (const appointment of all) {
+      const status = getAppointmentStatus(appointment);
+      if (status === "Completed") completed += 1;
+      else if (status === "Cancelled") cancelled += 1;
+      else if (status !== "Not Scheduled") upcoming += 1;
+    }
+    const settled = completed + cancelled;
+    return {
+      completed,
+      upcoming,
+      completionRate:
+        settled > 0 ? Math.round((completed / settled) * 100) : null,
+    };
+  }, [appointments]);
+
+  const monthly = earningsData?.monthlyEarnings ?? [];
+  const chartData = monthly.map((m) => ({
+    label: monthLabel(m.month),
+    totalInr: m.totalPaise / 100,
+    count: m.count,
+  }));
+  const thisMonth = monthly.at(-1);
+  const hasAnyEarnings =
+    (earningsData?.summary.totalEarnings ?? 0) > 0 ||
+    monthly.some((m) => m.count > 0);
+
+  const summary = earningsData?.summary;
+
+  return (
+    <DashboardErrorBoundary>
+      <DashboardHeader
+        title="Analytics"
+        subtitle="Earnings and session performance across your practice"
+      />
+      <DashboardContent className="px-0 lg:px-0">
+        {/* KPI grid */}
+        {earningsLoading || appointmentsLoading ? (
+          <DashboardGrid columns={3}>
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <StatCardSkeleton key={i} />
+            ))}
+          </DashboardGrid>
+        ) : earningsError && appointmentsError ? (
+          <EmptyState
+            icon={BarChart3}
+            title="Couldn't load analytics"
+            description="Both the earnings and session reads failed. Please retry."
+            action={
+              <Button
+                variant="outline"
+                onClick={() => {
+                  void refetchEarnings();
+                  void refetchAppointments();
+                }}
+              >
+                Retry
+              </Button>
+            }
+          />
+        ) : (
+          <DashboardGrid columns={3}>
+            <StatCard
+              title="Total Earnings"
+              value={formatInr(summary?.totalEarnings ?? 0)}
+              icon={IndianRupee}
+              tooltip="All cleared earnings (pending + ready + paid + held). Excludes refunds and org-trust holds."
+            />
+            <StatCard
+              title="This Month"
+              value={formatInr(thisMonth?.totalPaise ?? 0)}
+              icon={CalendarCheck}
+              subtitle={
+                thisMonth ? `${thisMonth.count} earning sessions` : undefined
+              }
+            />
+            <StatCard
+              title="Ready for Payout"
+              value={formatInr(summary?.readyEarnings ?? 0)}
+              icon={Wallet}
+              variant="success"
+            />
+            <StatCard
+              title="Sessions Completed"
+              value={appointmentsError ? "—" : sessionStats.completed}
+              icon={CheckCircle2}
+              tooltip="Completed appointments in your personal practice."
+            />
+            <StatCard
+              title="Upcoming Sessions"
+              value={appointmentsError ? "—" : sessionStats.upcoming}
+              icon={CalendarClock}
+            />
+            <StatCard
+              title="Completion Rate"
+              value={
+                appointmentsError || sessionStats.completionRate === null
+                  ? "—"
+                  : `${sessionStats.completionRate}%`
+              }
+              icon={BarChart3}
+              tooltip="Completed sessions as a share of all settled (completed + cancelled) sessions."
+            />
+          </DashboardGrid>
+        )}
+
+        {/* Charts */}
+        <div className="mt-6 grid gap-4 lg:gap-6 grid-cols-1 lg:grid-cols-2">
+          <DataCard title="Earnings — last 6 months">
+            {earningsLoading ? (
+              <Skeleton className="h-[220px] w-full rounded-lg" />
+            ) : earningsError ? (
+              <EmptyState
+                icon={BarChart3}
+                title="Couldn't load earnings trend"
+                action={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void refetchEarnings()}
+                  >
+                    Retry
+                  </Button>
+                }
+              />
+            ) : !hasAnyEarnings ? (
+              <EmptyState
+                icon={IndianRupee}
+                title="No earnings yet"
+                description="Once you complete paid sessions, your monthly earnings trend shows up here."
+              />
+            ) : (
+              <div style={{ width: "100%", height: 220 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={chartData}
+                    margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+                    <XAxis
+                      dataKey="label"
+                      stroke="#71717a"
+                      fontSize={12}
+                      tickLine={false}
+                      axisLine={false}
+                    />
+                    <YAxis
+                      stroke="#71717a"
+                      fontSize={12}
+                      tickLine={false}
+                      axisLine={false}
+                      tickFormatter={(value: number) =>
+                        value >= 1000
+                          ? `${(value / 1000).toFixed(1)}k`
+                          : String(value)
+                      }
+                    />
+                    <Tooltip
+                      formatter={(value: number) =>
+                        value.toLocaleString(undefined, {
+                          style: "currency",
+                          currency: "INR",
+                          maximumFractionDigits: 0,
+                        })
+                      }
+                    />
+                    <Bar
+                      dataKey="totalInr"
+                      name="Earnings"
+                      fill="#71717a"
+                      radius={[4, 4, 0, 0]}
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </DataCard>
+
+          <DataCard title="Earning sessions — last 6 months">
+            {earningsLoading ? (
+              <Skeleton className="h-[220px] w-full rounded-lg" />
+            ) : earningsError ? (
+              <EmptyState
+                icon={BarChart3}
+                title="Couldn't load session trend"
+                action={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void refetchEarnings()}
+                  >
+                    Retry
+                  </Button>
+                }
+              />
+            ) : !hasAnyEarnings ? (
+              <EmptyState
+                icon={CalendarCheck}
+                title="No sessions yet"
+                description="Session volume per month appears here once earnings start flowing."
+              />
+            ) : (
+              <div style={{ width: "100%", height: 220 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart
+                    data={chartData}
+                    margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#f4f4f5" />
+                    <XAxis
+                      dataKey="label"
+                      stroke="#71717a"
+                      fontSize={12}
+                      tickLine={false}
+                      axisLine={false}
+                    />
+                    <YAxis
+                      stroke="#71717a"
+                      fontSize={12}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip />
+                    <Line
+                      type="monotone"
+                      dataKey="count"
+                      name="Sessions"
+                      stroke="#18181b"
+                      strokeWidth={2}
+                      dot={{ r: 3 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </DataCard>
+        </div>
+      </DashboardContent>
+    </DashboardErrorBoundary>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/analytics/AnalyticsPageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/analytics/AnalyticsPageClient.tsx
@@ -34,6 +34,7 @@ import { DataCard, EmptyState } from "@/components/dashboard/DataCard";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { createConsultantQueries } from "@/lib/dashboard-queries";
+import { useSession } from "@/lib/auth-client";
 import { getAppointmentStatus } from "../../utils/appointmentHelpers";
 import { formatCurrencyAmount } from "@/utils/formatting";
 import type { MonthlyEarning } from "@/lib/data/consultant-earnings-analytics";
@@ -58,6 +59,17 @@ const monthLabel = (month: string) =>
 export default function AnalyticsPageClient({
   consultantId,
 }: Readonly<{ consultantId: string }>) {
+  const { data: session } = useSession();
+  // GET /api/consultant/earnings is strictly session-scoped (it resolves
+  // the profile from the signed-in user), while the SSR prefetch keys this
+  // cache entry by the URL's consultantId. For a privileged viewer
+  // (ADMIN/STAFF on someone else's dashboard) a client refetch would fetch
+  // the WRONG record — so refetching is gated to the profile owner and
+  // non-owners render the server-prefetched data only.
+  const isOwnDashboard =
+    (session?.user as { consultantProfileId?: string } | undefined)
+      ?.consultantProfileId === consultantId;
+
   // queryKey MUST match the server prefetch in ./page.tsx.
   const {
     data: earningsData,
@@ -75,7 +87,15 @@ export default function AnalyticsPageClient({
     },
     staleTime: 60_000,
     retry: 2,
+    enabled: isOwnDashboard,
   });
+
+  // react-query's refetch() bypasses `enabled`, so the Retry buttons must
+  // re-apply the owner gate — otherwise a privileged viewer's retry would
+  // fetch THEIR session-scoped earnings under this consultant's cache key.
+  const retryEarnings = () => {
+    if (isOwnDashboard) void refetchEarnings();
+  };
 
   // Personal-scope appointments — same key + payload as the appointments
   // page's #890 SSR prefetch, so the two pages share one cache entry.
@@ -146,7 +166,7 @@ export default function AnalyticsPageClient({
               <Button
                 variant="outline"
                 onClick={() => {
-                  void refetchEarnings();
+                  retryEarnings();
                   void refetchAppointments();
                 }}
               >
@@ -210,11 +230,7 @@ export default function AnalyticsPageClient({
                 icon={BarChart3}
                 title="Couldn't load earnings trend"
                 action={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void refetchEarnings()}
-                  >
+                  <Button variant="outline" size="sm" onClick={retryEarnings}>
                     Retry
                   </Button>
                 }
@@ -252,12 +268,17 @@ export default function AnalyticsPageClient({
                       }
                     />
                     <Tooltip
-                      formatter={(value: number) =>
-                        value.toLocaleString(undefined, {
-                          style: "currency",
-                          currency: "INR",
-                          maximumFractionDigits: 0,
-                        })
+                      formatter={(value) =>
+                        // Recharts can hand the formatter undefined/arrays
+                        // on empty data points — never call toLocaleString
+                        // on a non-number.
+                        typeof value === "number"
+                          ? value.toLocaleString(undefined, {
+                              style: "currency",
+                              currency: "INR",
+                              maximumFractionDigits: 0,
+                            })
+                          : ""
                       }
                     />
                     <Bar
@@ -283,7 +304,9 @@ export default function AnalyticsPageClient({
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => void refetchEarnings()}
+                    // Session trend derives from the appointments query —
+                    // the earnings refetch was the wrong retry target.
+                    onClick={() => void refetchAppointments()}
                   >
                     Retry
                   </Button>

--- a/app/dashboard/consultant/[consultantId]/(features)/analytics/loading.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/analytics/loading.tsx
@@ -1,5 +1,5 @@
-import { TableSkeleton } from "@/components/dashboard/DashboardSkeletons";
+import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
 
 export default function Loading() {
-  return <TableSkeleton />;
+  return <PageSkeleton />;
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/analytics/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/analytics/page.tsx
@@ -1,27 +1,49 @@
-"use client";
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from "@tanstack/react-query";
+import AnalyticsPageClient from "./AnalyticsPageClient";
+import { getConsultantAppointments } from "@/lib/data/consultant-appointments";
+import { buildConsultantEarningsPayload } from "@/lib/data/consultant-earnings-analytics";
 
-import { BarChart3 } from "lucide-react";
+type PageProps = {
+  params: Promise<{ consultantId: string }>;
+};
 
-export default function AnalyticsPage() {
+export default async function AnalyticsPage({ params }: Readonly<PageProps>) {
+  const { consultantId } = await params;
+  const queryClient = new QueryClient();
+
+  // SSR prefetch both analytics reads (org home-page pattern). Keys MUST
+  // match AnalyticsPageClient's useQuery keys exactly or hydration won't
+  // apply. Payload parity is guaranteed structurally: the earnings payload
+  // comes from the same buildConsultantEarningsPayload assembler the API
+  // route serves, and the appointments read reuses the #890 prefetch
+  // (personal scope — deterministic, session-independent). allSettled so a
+  // failed read degrades to a client-side fetch rather than crashing.
+  await Promise.allSettled([
+    queryClient.prefetchQuery({
+      queryKey: ["consultant-earnings-analytics", consultantId],
+      queryFn: () =>
+        buildConsultantEarningsPayload(consultantId, {
+          limit: 1,
+          includeMonthly: true,
+        }),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["consultant-appointments", consultantId, "personal"],
+      queryFn: () =>
+        getConsultantAppointments({
+          consultantProfileId: consultantId,
+          orgScopeFilter: { organizationId: null },
+        }),
+    }),
+  ]);
+
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-zinc-900">Analytics</h1>
-        <p className="text-sm text-zinc-500 mt-1">
-          Track your performance and insights.
-        </p>
-      </div>
-
-      <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-white p-16 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-zinc-100 mb-4">
-          <BarChart3 className="h-7 w-7 text-zinc-400" />
-        </div>
-        <h2 className="text-lg font-semibold text-zinc-900">Coming Soon</h2>
-        <p className="mt-2 max-w-sm text-sm text-zinc-500">
-          Analytics and insights for your consultations, earnings, and audience
-          engagement will be available here.
-        </p>
-      </div>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <AnalyticsPageClient consultantId={consultantId} />
+    </HydrationBoundary>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsPageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsPageClient.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { CalendarX } from "lucide-react";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
-import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
+import { EmptyState } from "@/components/dashboard/DataCard";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { createConsultantQueries } from "@/lib/dashboard-queries";
 import { useOrgScope } from "@/hooks/useOrgScope";
 import {
@@ -11,8 +15,21 @@ import {
   ORG_FILTER_PERSONAL,
   type OrgContextFilterValue,
 } from "@/components/dashboard/OrgContextFilter";
-import { BADGE_STYLES } from "../../types";
 import { AppointmentsTab } from "./AppointmentsTab";
+
+function AppointmentsListSkeleton() {
+  return (
+    <div className="rounded-xl border border-zinc-200/80 bg-white shadow-sm p-4 sm:p-6 space-y-4">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-10 w-full" />
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function AppointmentsPageClient({
   consultantId,
@@ -53,13 +70,25 @@ export default function AppointmentsPageClient({
     consultantId,
     orgScopeParam,
   ).appointments;
-  const { data: appointments, isLoading, error } = useQuery({
+  const {
+    data: appointments,
+    isLoading,
+    error,
+    refetch: refetchAppointments,
+  } = useQuery({
     ...appointmentsQuery,
     placeholderData: keepPreviousData,
   });
 
-  // Fetch scheduled trials for this consultant
-  const { data: trialsData, isLoading: trialsLoading } = useQuery({
+  // Auxiliary sections each carry their own query state into the tab so a
+  // slow or failed trials/classes/webinars read can't blank the main list
+  // (previously ONE loading flag gated the entire page).
+  const {
+    data: trialsData,
+    isLoading: trialsLoading,
+    isError: trialsError,
+    refetch: refetchTrials,
+  } = useQuery({
     placeholderData: keepPreviousData,
     queryKey: ["trials", consultantId, "SCHEDULED", orgScopeParam] as const,
     queryFn: async () => {
@@ -75,8 +104,12 @@ export default function AppointmentsPageClient({
     },
   });
 
-  // Fetch class events for this consultant (to show unscheduled classes in appointments page)
-  const { data: classEventsData, isLoading: classesLoading } = useQuery({
+  const {
+    data: classEventsData,
+    isLoading: classesLoading,
+    isError: classesError,
+    refetch: refetchClasses,
+  } = useQuery({
     placeholderData: keepPreviousData,
     queryKey: ["consultant-classes", consultantId, orgScopeParam] as const,
     queryFn: async () => {
@@ -94,8 +127,12 @@ export default function AppointmentsPageClient({
     },
   });
 
-  // Fetch webinar events for this consultant; filter to those with no appointment yet
-  const { data: webinarEventsData, isLoading: webinarsLoading } = useQuery({
+  const {
+    data: webinarEventsData,
+    isLoading: webinarsLoading,
+    isError: webinarsError,
+    refetch: refetchWebinars,
+  } = useQuery({
     placeholderData: keepPreviousData,
     queryKey: [
       "consultant-webinars-unscheduled",
@@ -117,48 +154,64 @@ export default function AppointmentsPageClient({
     },
   });
 
-  if (isLoading || trialsLoading || classesLoading || webinarsLoading) {
-    return <PageSkeleton />;
-  }
-
-  if (error) {
-    return (
-      <DashboardErrorBoundary>
-        <div className="flex items-center justify-center min-h-[400px]">
-          <div className="p-4 bg-red-50 text-red-600 rounded-lg max-w-md text-center">
-            <h3 className="font-semibold mb-2">Error Loading Appointments</h3>
-            <p className="text-sm">
-              {error.message ||
-                "Failed to load appointments. Please try again."}
-            </p>
-            <button
-              onClick={() => window.location.reload()}
-              className="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
-      </DashboardErrorBoundary>
-    );
-  }
-
   return (
     <DashboardErrorBoundary>
-      <AppointmentsTab
-        appointments={appointments || []}
-        badgeStyles={BADGE_STYLES}
-        scheduledTrials={trialsData || []}
-        consultantId={consultantId}
-        unscheduledClasses={classEventsData || []}
-        unscheduledWebinars={webinarEventsData || []}
-        headerSlot={
-          <OrgContextFilter
-            value={filterValue}
-            onChange={handleFilterChange}
-          />
-        }
+      <DashboardHeader
+        title="Appointments"
+        subtitle="Your consultations, subscriptions, webinars, and classes"
       />
+      <div className="pt-6">
+        {isLoading ? (
+          <AppointmentsListSkeleton />
+        ) : error ? (
+          <EmptyState
+            icon={CalendarX}
+            title="Couldn't load appointments"
+            description={
+              error instanceof Error
+                ? error.message
+                : "Failed to load appointments. Please try again."
+            }
+            action={
+              <Button
+                variant="outline"
+                onClick={() => void refetchAppointments()}
+              >
+                Retry
+              </Button>
+            }
+          />
+        ) : (
+          <AppointmentsTab
+            appointments={appointments || []}
+            scheduledTrials={trialsData || []}
+            trialsState={{
+              isLoading: trialsLoading,
+              isError: trialsError,
+              onRetry: () => void refetchTrials(),
+            }}
+            consultantId={consultantId}
+            unscheduledClasses={classEventsData || []}
+            unscheduledClassesState={{
+              isLoading: classesLoading,
+              isError: classesError,
+              onRetry: () => void refetchClasses(),
+            }}
+            unscheduledWebinars={webinarEventsData || []}
+            unscheduledWebinarsState={{
+              isLoading: webinarsLoading,
+              isError: webinarsError,
+              onRetry: () => void refetchWebinars(),
+            }}
+            headerSlot={
+              <OrgContextFilter
+                value={filterValue}
+                onChange={handleFilterChange}
+              />
+            }
+          />
+        )}
+      </div>
     </DashboardErrorBoundary>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/AppointmentsTab.tsx
@@ -1,100 +1,61 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { useToast } from "@/hooks/use-toast";
-import {
-  getOrCreateAppointmentMeeting,
-  MeetingAppointment,
-  MeetingSlot,
-} from "@/lib/meeting";
-import { useStreamVideoClient } from "@stream-io/video-react-sdk";
-import { useRouter } from "next/navigation";
-import {
-  ChevronLeft,
-  ChevronRight,
-  Clock,
-  Users,
-  Gift,
-  Video,
-  Loader2,
-  Search,
-  Building2,
-} from "lucide-react";
+import { CalendarX } from "lucide-react";
 import { useSession } from "@/lib/auth-client";
+import { resolveSponsoringOrgName as resolveSponsoringOrgNameShared } from "@/lib/labels/session-labels";
 import {
   AppointmentsTabProps,
   ScheduledTrial,
-  getBadgeStyle,
 } from "../../types";
 import {
   buildUnscheduledClassAppointment,
   buildUnscheduledWebinarAppointment,
   UnscheduledAppointment,
 } from "./utils/unscheduledAppointments";
-import { UnscheduledEventCard } from "./components/UnscheduledEventCard";
 import { TAppointment } from "@/types/appointment";
 import {
-  calculateSessionProgress,
-  formatAppointmentTime,
   getAppointmentStatus,
   getAppointmentTypeAndPlan,
-  getConsumeeImage,
   getConsumeeName,
-  getGroupStatus,
-  getGroupTitle,
   getNextUpcomingSlotTime,
-  getStartTime,
   groupRecurringAppointments,
   groupAppointmentsByType,
   getAppointmentTypeDisplayName,
-  getCollaboratorRole,
-  formatCollaboratorRole,
-  getRoleBadgeStyle,
 } from "../../utils/appointmentHelpers";
 import { EventTimingsCalendar } from "./components/EventTimingsCalendar";
+import { useLazyJoinMeeting } from "../shared/hooks/useLazyJoinMeeting";
 import {
-  canManageAppointmentTimings,
-  canManageGroupTimings,
-} from "./utils/appointmentTimingHelpers";
+  AppointmentFilters,
+  type AppointmentStatusFilter,
+} from "./components/AppointmentFilters";
+import { TrialsSubsection } from "./components/TrialsSubsection";
+import { UnscheduledEventsSection } from "./components/UnscheduledEventsSection";
 import {
-  getParticipantManagementUrl,
-  supportsParticipantManagement,
-} from "./utils/participantHelpers";
-import { getJoinableSlot } from "../../utils/joinState";
+  AppointmentGroupCard,
+  type GroupPaginationState,
+} from "./components/AppointmentGroupCard";
 
 export function AppointmentsTab({
   appointments,
-  badgeStyles: _badgeStyles,
   scheduledTrials = [],
+  trialsState,
   consultantId,
   unscheduledClasses = [],
+  unscheduledClassesState,
   unscheduledWebinars = [],
+  unscheduledWebinarsState,
   headerSlot,
 }: Readonly<AppointmentsTabProps>) {
-  const router = useRouter();
-  const client = useStreamVideoClient();
-  const { toast } = useToast();
   const { data: session } = useSession();
+  const joinMeeting = useLazyJoinMeeting();
   // Memberships used to resolve an appointment's `organizationId` to a
-  // displayable org name for the "Sponsored · <Org>" badge. Mirrors the
-  // consultee dashboard convention so a panel expert can tell at a
-  // glance which sessions came through which org.
+  // displayable org name for the "Sponsored · <Org>" badge.
   const orgMemberships = session?.user?.organizationMemberships ?? [];
-  const resolveSponsoringOrgName = (
-    orgId: string | null | undefined,
-  ): string | null => {
-    if (!orgId) return null;
-    return (
-      orgMemberships.find((m) => m.organizationId === orgId)?.organizationName ??
-      "the organization"
-    );
-  };
+  const resolveSponsoringOrgName = (orgId: string | null | undefined) =>
+    resolveSponsoringOrgNameShared(orgId, orgMemberships);
+
   const [joiningTrialId, setJoiningTrialId] = useState<string | null>(null);
   const searchParams = useSearchParams();
   const [selectedAppointment, setSelectedAppointment] =
@@ -104,16 +65,13 @@ export function AppointmentsTab({
     totalSessions: number;
   } | null>(null);
   const [groupPagination, setGroupPagination] = useState<
-    Map<string, { currentPage: number; showAll: boolean }>
+    Map<string, GroupPaginationState>
   >(new Map());
   const [highlightedGroup, setHighlightedGroup] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<
-    "ALL" | "UPCOMING" | "PAST"
-  >("ALL");
+  const [statusFilter, setStatusFilter] =
+    useState<AppointmentStatusFilter>("ALL");
   const groupRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-
-  const PAGE_SIZE = 5; // Show 5 items per page
 
   // Handle highlight from URL parameter
   useEffect(() => {
@@ -121,7 +79,6 @@ export function AppointmentsTab({
     if (highlight) {
       setHighlightedGroup(highlight);
 
-      // Scroll to highlighted group
       setTimeout(() => {
         const element = groupRefs.current.get(highlight);
         if (element) {
@@ -129,16 +86,14 @@ export function AppointmentsTab({
         }
       }, 100);
 
-      // Remove highlight after 3 seconds
       setTimeout(() => {
         setHighlightedGroup(null);
       }, 3000);
     }
   }, [searchParams]);
 
-  const getPaginationState = (groupKey: string) => {
-    return groupPagination.get(groupKey) || { currentPage: 1, showAll: false };
-  };
+  const getPaginationState = (groupKey: string): GroupPaginationState =>
+    groupPagination.get(groupKey) || { currentPage: 1, showAll: false };
 
   const setPage = (groupKey: string, page: number) => {
     setGroupPagination((prev) => {
@@ -157,175 +112,43 @@ export function AppointmentsTab({
     });
   };
 
-  // Helper to get consultant ID from appointment
-  const getConsultantIdFromAppointment = (
-    appointment: TAppointment,
-  ): string => {
-    switch (appointment.appointmentType) {
-      case "CONSULTATION":
-        return (
-          appointment.consultation?.consultationPlan?.consultantProfileId || ""
-        );
-      case "SUBSCRIPTION":
-        return (
-          appointment.subscription?.subscriptionPlan?.consultantProfileId || ""
-        );
-      case "WEBINAR":
-        return appointment.webinar?.webinarPlan?.consultantProfileId || "";
-      case "CLASS":
-        return appointment.class?.classPlan?.consultantProfileId || "";
-      default:
-        return "";
-    }
-  };
-
-  const getStyleFromBadgeData = (status: string): string => {
-    return getBadgeStyle(status);
-  };
-
-  const handleJoinMeeting = async (
-    appointment: TAppointment,
-    joinableSlot?: TAppointment["slotsOfAppointment"][number],
-  ) => {
-    if (!client) {
-      console.warn("Stream client not ready");
-      toast({
-        title: "Not signed in",
-        description:
-          "Video client not initialized. You have to sign in to join a meeting.",
-        variant: "warning",
-      });
-      return;
-    }
-    const relevantSlot =
-      joinableSlot ?? appointment.slotsOfAppointment?.[0];
-    if (!relevantSlot) {
-      toast({
-        title: "Error",
-        description: "Slot information missing for this appointment item.",
-        variant: "error",
-      });
-      return;
-    }
-
-    try {
-      const meetingId = await getOrCreateAppointmentMeeting(
-        client,
-        appointment,
-        relevantSlot,
-      );
-      router.push(`/meetings/${meetingId}`);
-      toast({
-        title: "Joining meeting",
-        description: "You will now be redirected to the meeting",
-        variant: "success",
-      });
-    } catch (error) {
-      Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "client" } });
-      console.error("Error joining meeting:", error);
-      toast({
-        title: "Error joining meeting",
-        description: error instanceof Error ? error.message : "Unknown error",
-        variant: "destructive",
-      });
-    }
-  };
-
-  // Helper to check if a trial is joinable (within 10 mins before start and before end)
-  const isTrialJoinable = (trial: ScheduledTrial): boolean => {
-    if (!trial.appointment?.slotsOfAppointment?.[0]) return false;
-    const slot = trial.appointment.slotsOfAppointment[0];
-    const now = new Date();
-    const startTime = new Date(slot.startsAt);
-    const endTime = slot.endsAt
-      ? new Date(slot.endsAt)
-      : new Date(startTime.getTime() + 60 * 60 * 1000);
-    if (isNaN(startTime.getTime()) || isNaN(endTime.getTime())) return false;
-    const joinWindowStart = new Date(startTime.getTime() - 10 * 60 * 1000);
-    return now >= joinWindowStart && now <= endTime;
-  };
-
-  // Handle joining a trial meeting
+  // Handle joining a trial meeting — builds the minimal meeting shape from
+  // the trial's appointment, then defers to the shared lazy join hook.
   const handleJoinTrialMeeting = async (trial: ScheduledTrial) => {
-    if (!client) {
-      toast({
-        title: "Not signed in",
-        description: "Video client not initialized. Please sign in to join.",
-        variant: "warning",
-      });
-      return;
-    }
-    if (!trial.appointment?.slotsOfAppointment?.[0]) {
-      toast({
-        title: "Error",
-        description: "Meeting information is not available.",
-        variant: "destructive",
-      });
-      return;
-    }
+    if (!trial.appointment?.slotsOfAppointment?.[0]) return;
     setJoiningTrialId(trial.id);
-    try {
-      const trialSlot = trial.appointment.slotsOfAppointment[0];
-      const slot: MeetingSlot = {
-        id: trialSlot.id,
-        startsAt: trialSlot.startsAt,
-        endsAt: trialSlot.endsAt,
-        appointmentId: trial.appointment.id,
-      };
-      const appointmentForMeeting: MeetingAppointment = {
+    const trialSlot = trial.appointment.slotsOfAppointment[0];
+    const navigating = await joinMeeting(
+      {
         id: trial.appointment.id,
         appointmentType: "TRIAL",
-        slotsOfAppointment: [slot],
-      };
-      const meetingId = await getOrCreateAppointmentMeeting(
-        client,
-        appointmentForMeeting,
-        slot,
-      );
-      toast({
-        title: "Joining meeting",
-        description: "You will now be redirected to the meeting room.",
-      });
-      router.push(`/meetings/${meetingId}`);
-    } catch (error) {
-      Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "client" } });
-      console.error("Error joining trial meeting:", error);
-      toast({
-        title: "Error joining meeting",
-        description: error instanceof Error ? error.message : "Unknown error",
-        variant: "destructive",
-      });
-      setJoiningTrialId(null);
-    }
-  };
-
-  const formatTrialTime = (dateString: string) => {
-    return new Date(dateString).toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+        slotsOfAppointment: [
+          {
+            id: trialSlot.id,
+            startsAt: trialSlot.startsAt,
+            endsAt: trialSlot.endsAt,
+            appointmentId: trial.appointment.id,
+          },
+        ],
+      },
+      undefined,
+    );
+    if (!navigating) setJoiningTrialId(null);
   };
 
   // Apply search and status filters
   const filteredAppointments = useMemo(() => {
     return (appointments || []).filter((apt) => {
-      // Status filter
       if (statusFilter !== "ALL") {
         const s = getAppointmentStatus(apt);
         if (statusFilter === "UPCOMING") {
-          // Upcoming = has future sessions (exclude completed, cancelled, not scheduled)
           if (s === "Completed" || s === "Cancelled" || s === "Not Scheduled")
             return false;
         }
         if (statusFilter === "PAST") {
-          // Past = all sessions are done (completed or cancelled)
           if (s !== "Completed" && s !== "Cancelled") return false;
         }
       }
-      // Name/plan search
       if (searchQuery.trim()) {
         const q = searchQuery.toLowerCase();
         if (
@@ -344,20 +167,17 @@ export function AppointmentsTab({
   // Further group recurring appointments (subscriptions/classes) within each type
   const groupedAppointments = Object.entries(appointmentsByType).reduce(
     (acc, [type, typeAppointments]) => {
-      // If this type has no appointments, create an empty group to show the section
       if (typeAppointments.length === 0) {
         acc[`${type}-empty`] = [];
         return acc;
       }
 
-      // For SUBSCRIPTION and CLASS types, further group by recurring sessions
       if (type === "SUBSCRIPTION" || type === "CLASS") {
         const recurringGroups = groupRecurringAppointments(typeAppointments);
         Object.entries(recurringGroups).forEach(([key, appointments]) => {
           acc[`${type}-${key}`] = appointments;
         });
       } else {
-        // For CONSULTATION and WEBINAR, each appointment is its own group
         typeAppointments.forEach((appointment) => {
           acc[`${type}-${appointment.id}`] = [appointment];
         });
@@ -374,12 +194,10 @@ export function AppointmentsTab({
 
   const getGroupSortTime = (groupAppts: TAppointment[]): Date | null => {
     if (groupAppts.length === 0) return null;
-    // For recurring groups, use the next upcoming slot across all appointments
     const times = groupAppts
       .map((apt) => getNextUpcomingSlotTime(apt))
       .filter((t): t is Date => t !== null);
     if (times.length === 0) return null;
-    // Return the earliest time in the group
     return times.reduce((a, b) => (a < b ? a : b));
   };
 
@@ -387,12 +205,9 @@ export function AppointmentsTab({
     ([keyA, apptsA], [keyB, apptsB]) => {
       const typeA = keyA.split("-")[0];
       const typeB = keyB.split("-")[0];
-      // First sort by type
-      const typeCompare =
-        typeOrder.indexOf(typeA) - typeOrder.indexOf(typeB);
+      const typeCompare = typeOrder.indexOf(typeA) - typeOrder.indexOf(typeB);
       if (typeCompare !== 0) return typeCompare;
 
-      // Within same type: upcoming before past, empty groups last
       const timeA = getGroupSortTime(apptsA);
       const timeB = getGroupSortTime(apptsB);
       if (!timeA && !timeB) return 0;
@@ -402,60 +217,31 @@ export function AppointmentsTab({
       const aIsUpcoming = timeA >= now;
       const bIsUpcoming = timeB >= now;
 
-      // Upcoming groups come before past groups
       if (aIsUpcoming && !bIsUpcoming) return -1;
       if (!aIsUpcoming && bIsUpcoming) return 1;
 
-      // Both upcoming: nearest future first (ascending)
       if (aIsUpcoming && bIsUpcoming) {
         return timeA.getTime() - timeB.getTime();
       }
 
-      // Both past: most recent first (descending)
       return timeB.getTime() - timeA.getTime();
     },
   );
 
   return (
-    <div className="bg-white p-4 sm:p-6 rounded-lg shadow">
+    <div className="rounded-xl border border-zinc-200/80 bg-white shadow-sm p-4 sm:p-6">
       <div className="flex items-center justify-between gap-3 flex-wrap mb-4">
-        <h2 className="text-xl font-semibold text-gray-800">
+        <h2 className="text-xl font-semibold text-zinc-800">
           All Appointments
         </h2>
         {headerSlot}
       </div>
-      <div className="space-y-3 mb-4">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <Input
-            placeholder="Search by name or plan..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-10 h-10"
-          />
-        </div>
-        <div className="flex items-center gap-2 border-b border-zinc-200 overflow-x-auto">
-          {(
-            [
-              { label: "All", value: "ALL" },
-              { label: "Upcoming", value: "UPCOMING" },
-              { label: "Past", value: "PAST" },
-            ] as const
-          ).map((tab) => (
-            <button
-              key={tab.value}
-              onClick={() => setStatusFilter(tab.value)}
-              className={`px-4 py-2.5 text-sm font-medium whitespace-nowrap border-b-2 transition-colors ${
-                statusFilter === tab.value
-                  ? "border-zinc-900 text-zinc-900"
-                  : "border-transparent text-zinc-500 hover:text-zinc-700 hover:border-zinc-300"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <AppointmentFilters
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+      />
       <div className="space-y-6">
         {(() => {
           let currentType: string | null = null;
@@ -472,26 +258,28 @@ export function AppointmentsTab({
               const isRecurring =
                 groupKey.startsWith("SUBSCRIPTION-subscription-") ||
                 groupKey.startsWith("CLASS-class-");
-              const groupTitle = getGroupTitle(groupAppointments);
-              const groupStatus = getGroupStatus(groupAppointments);
-              const firstAppointment = groupAppointments[0];
 
-              // Calculate session progress for recurring appointments
-              const {
-                totalSessions,
-                completedSessions,
-                remainingSessions,
-                progressPercentage,
-              } = calculateSessionProgress(groupAppointments);
+              const showTrialsBlock =
+                isNewTypeSection &&
+                statusFilter === "ALL" &&
+                groupType === "SUBSCRIPTION";
+              const showUnscheduledClasses =
+                isNewTypeSection &&
+                statusFilter === "ALL" &&
+                groupType === "CLASS";
+              const showUnscheduledWebinars =
+                isNewTypeSection &&
+                statusFilter === "ALL" &&
+                groupType === "WEBINAR";
 
               return (
                 <div key={groupKey}>
                   {/* Type Section Header */}
                   {isNewTypeSection && (
                     <div className="mb-4 pt-6 first:pt-0">
-                      <h3 className="text-lg font-semibold text-gray-900 border-b-2 border-gray-300 pb-2">
+                      <h3 className="text-lg font-semibold text-zinc-900 border-b-2 border-zinc-200 pb-2">
                         {getAppointmentTypeDisplayName(groupType)}
-                        <span className="text-sm font-normal text-gray-500 ml-2">
+                        <span className="text-sm font-normal text-zinc-500 ml-2">
                           ({(appointmentsByType[groupType]?.length ?? 0) +
                             (statusFilter === "ALL"
                               ? (groupType === "CLASS"
@@ -506,165 +294,62 @@ export function AppointmentsTab({
                     </div>
                   )}
 
-                  {/* Free Trials Sub-section (only for SUBSCRIPTION type, only in "All" view) */}
-                  {isNewTypeSection &&
-                    statusFilter === "ALL" &&
-                    groupType === "SUBSCRIPTION" &&
-                    scheduledTrials.length > 0 && (
-                      <div className="mb-6 bg-purple-50/50 border border-purple-200 rounded-lg p-4">
-                        <h4 className="text-sm font-semibold text-purple-700 mb-3 flex items-center gap-2">
-                          <Gift className="h-4 w-4" />
-                          Free Trial Sessions ({scheduledTrials.length})
-                        </h4>
-                        <div className="space-y-3">
-                          {scheduledTrials.map((trial) => (
-                            <div
-                              key={trial.id}
-                              className="border border-purple-200 rounded-lg p-4 bg-purple-50/50"
-                            >
-                              <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-3">
-                                  <Avatar className="h-10 w-10">
-                                    <AvatarImage
-                                      src={
-                                        trial.consulteeProfile.user.image || ""
-                                      }
-                                      alt={trial.consulteeProfile.user.name}
-                                    />
-                                    <AvatarFallback>
-                                      {trial.consulteeProfile.user.name
-                                        .split(" ")
-                                        .map((n) => n[0])
-                                        .join("")}
-                                    </AvatarFallback>
-                                  </Avatar>
-                                  <div>
-                                    <p className="font-medium text-gray-900">
-                                      {trial.consulteeProfile.user.name}
-                                    </p>
-                                    <p className="text-sm text-gray-600">
-                                      {trial.subscriptionPlan.title} •{" "}
-                                      {
-                                        trial.subscriptionPlan
-                                          .freeTrialDurationMinutes
-                                      }{" "}
-                                      min trial
-                                    </p>
-                                  </div>
-                                </div>
-                                <div className="flex items-center gap-3">
-                                  <div className="text-right">
-                                    <Badge className="bg-purple-100 text-purple-800">
-                                      Trial
-                                    </Badge>
-                                    {trial.appointment
-                                      ?.slotsOfAppointment?.[0] && (
-                                      <p className="text-xs text-gray-500 mt-1">
-                                        {formatTrialTime(
-                                          trial.appointment
-                                            .slotsOfAppointment[0].startsAt,
-                                        )}
-                                      </p>
-                                    )}
-                                  </div>
-                                  <Button
-                                    size="sm"
-                                    onClick={() =>
-                                      handleJoinTrialMeeting(trial)
-                                    }
-                                    disabled={
-                                      joiningTrialId === trial.id ||
-                                      !isTrialJoinable(trial)
-                                    }
-                                    className={
-                                      isTrialJoinable(trial)
-                                        ? "bg-purple-600 hover:bg-purple-700"
-                                        : ""
-                                    }
-                                  >
-                                    {joiningTrialId === trial.id ? (
-                                      <>
-                                        <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                                        Joining...
-                                      </>
-                                    ) : (
-                                      <>
-                                        <Video className="h-4 w-4 mr-1" />
-                                        Join
-                                      </>
-                                    )}
-                                  </Button>
-                                </div>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                  {/* Free Trials sub-section (SUBSCRIPTION type, "All" view) */}
+                  {showTrialsBlock && (
+                    <TrialsSubsection
+                      trials={scheduledTrials}
+                      joiningTrialId={joiningTrialId}
+                      onJoin={handleJoinTrialMeeting}
+                      state={trialsState}
+                    />
+                  )}
 
-                  {/* Unscheduled events — only in "All" view (they're neither upcoming nor past) */}
-                  {isNewTypeSection &&
-                    statusFilter === "ALL" &&
-                    groupType === "CLASS" &&
-                    unscheduledClasses.length > 0 && (
-                      <div className="mb-4">
-                        <h4 className="text-sm font-semibold text-orange-700 mb-3 flex items-center gap-2">
-                          <Clock className="h-4 w-4" />
-                          Unscheduled Classes ({unscheduledClasses.length})
-                        </h4>
-                        <div className="space-y-3">
-                          {unscheduledClasses.map((classEvent) => (
-                            <UnscheduledEventCard
-                              key={classEvent.id}
-                              title={classEvent.classPlan.title}
-                              subtitle={`${classEvent.classPlan.meetingsPerWeek} meeting${classEvent.classPlan.meetingsPerWeek !== 1 ? "s" : ""}/week · ${classEvent.classPlan.totalSessions} sessions · ${classEvent.classPlan.sessionDurationInHours}h each`}
-                              onSetSchedule={() => {
-                                setSelectedAppointment(
-                                  buildUnscheduledClassAppointment(classEvent),
-                                );
-                                setSelectedGroupProgress(null);
-                              }}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  {isNewTypeSection &&
-                    statusFilter === "ALL" &&
-                    groupType === "WEBINAR" &&
-                    unscheduledWebinars.length > 0 && (
-                      <div className="mb-4">
-                        <h4 className="text-sm font-semibold text-orange-700 mb-3 flex items-center gap-2">
-                          <Clock className="h-4 w-4" />
-                          Unscheduled Webinars ({unscheduledWebinars.length})
-                        </h4>
-                        <div className="space-y-3">
-                          {unscheduledWebinars.map((webinarEvent) => (
-                            <UnscheduledEventCard
-                              key={webinarEvent.id}
-                              title={webinarEvent.webinarPlan.title}
-                              subtitle={`Single session · ${webinarEvent.webinarPlan.durationInHours}h`}
-                              onSetSchedule={() => {
-                                setSelectedAppointment(
-                                  buildUnscheduledWebinarAppointment(webinarEvent),
-                                );
-                                setSelectedGroupProgress(null);
-                              }}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                  {/* Unscheduled events — only in "All" view */}
+                  {showUnscheduledClasses && (
+                    <UnscheduledEventsSection
+                      title="Unscheduled Classes"
+                      state={unscheduledClassesState}
+                      items={unscheduledClasses.map((classEvent) => ({
+                        id: classEvent.id,
+                        title: classEvent.classPlan.title,
+                        subtitle: `${classEvent.classPlan.meetingsPerWeek} meeting${classEvent.classPlan.meetingsPerWeek !== 1 ? "s" : ""}/week · ${classEvent.classPlan.totalSessions} sessions · ${classEvent.classPlan.sessionDurationInHours}h each`,
+                        onSetSchedule: () => {
+                          setSelectedAppointment(
+                            buildUnscheduledClassAppointment(classEvent),
+                          );
+                          setSelectedGroupProgress(null);
+                        },
+                      }))}
+                    />
+                  )}
+                  {showUnscheduledWebinars && (
+                    <UnscheduledEventsSection
+                      title="Unscheduled Webinars"
+                      state={unscheduledWebinarsState}
+                      items={unscheduledWebinars.map((webinarEvent) => ({
+                        id: webinarEvent.id,
+                        title: webinarEvent.webinarPlan.title,
+                        subtitle: `Single session · ${webinarEvent.webinarPlan.durationInHours}h`,
+                        onSetSchedule: () => {
+                          setSelectedAppointment(
+                            buildUnscheduledWebinarAppointment(webinarEvent),
+                          );
+                          setSelectedGroupProgress(null);
+                        },
+                      }))}
+                    />
+                  )}
 
-                  {/* Empty state — only shown when section has no scheduled appointments
-                      AND no unscheduled items were already rendered above */}
+                  {/* Empty state — only when the section has no scheduled
+                      appointments AND no unscheduled items rendered above */}
                   {groupAppointments.length === 0 ? (
                     (statusFilter === "ALL" &&
-                      ((groupType === "CLASS" && unscheduledClasses.length > 0) ||
+                      ((groupType === "CLASS" &&
+                        unscheduledClasses.length > 0) ||
                         (groupType === "WEBINAR" &&
                           unscheduledWebinars.length > 0))) ? null : (
-                      <div className="border rounded-lg p-8 bg-gray-50 text-center">
-                        <p className="text-gray-500 text-sm">
+                      <div className="border border-zinc-200 rounded-lg p-8 bg-zinc-50 text-center">
+                        <p className="text-zinc-500 text-sm">
                           {statusFilter === "UPCOMING"
                             ? `No upcoming ${getAppointmentTypeDisplayName(groupType).toLowerCase()}`
                             : statusFilter === "PAST"
@@ -674,443 +359,26 @@ export function AppointmentsTab({
                       </div>
                     )
                   ) : (
-                    /* Existing appointment group card */
-                    <div
-                      ref={(el) => {
+                    <AppointmentGroupCard
+                      appointments={groupAppointments}
+                      isRecurring={isRecurring}
+                      consultantId={consultantId}
+                      highlighted={highlightedGroup === groupKey}
+                      registerRef={(el) => {
                         if (el) groupRefs.current.set(groupKey, el);
                       }}
-                      className={`border rounded-lg overflow-hidden shadow-sm transition-all duration-300 ${
-                        highlightedGroup === groupKey
-                          ? "ring-4 ring-yellow-400 shadow-xl"
-                          : ""
-                      }`}
-                    >
-                      {/* Group Header */}
-                      {isRecurring && (
-                        <div className="bg-gray-50 p-4 border-b border-gray-200">
-                          <div className="flex items-center justify-between mb-3">
-                            <div className="flex items-center space-x-3 sm:space-x-4 min-w-0">
-                              <Avatar className="w-10 h-10">
-                                <AvatarImage
-                                  alt={getConsumeeName(firstAppointment)}
-                                  src={getConsumeeImage(firstAppointment)}
-                                />
-                                <AvatarFallback>
-                                  {getConsumeeName(firstAppointment)
-                                    .split(" ")
-                                    .map((n: string) => n[0])
-                                    .join("")}
-                                </AvatarFallback>
-                              </Avatar>
-                              <div>
-                                <div className="flex items-center gap-2">
-                                  <h3 className="font-semibold text-gray-800 text-sm">
-                                    {getConsumeeName(firstAppointment)}
-                                  </h3>
-                                  {consultantId &&
-                                    (() => {
-                                      const role = getCollaboratorRole(
-                                        firstAppointment,
-                                        consultantId,
-                                      );
-                                      return role ? (
-                                        <Badge
-                                          variant="secondary"
-                                          className={`text-[10px] px-1.5 py-0 h-5 ${getRoleBadgeStyle(role)}`}
-                                        >
-                                          {formatCollaboratorRole(role)}
-                                        </Badge>
-                                      ) : null;
-                                    })()}
-                                </div>
-                                <p className="text-xs text-gray-600">
-                                  {groupTitle.split("(")[0].trim()}
-                                </p>
-                              </div>
-
-                              {/* Management buttons inline with user name */}
-                              <div className="flex items-center gap-2 ml-4">
-                                {groupStatus !== "Completed" &&
-                                  groupStatus !== "Cancelled" &&
-                                  canManageGroupTimings(groupAppointments) && (
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      className="h-8 text-xs px-3"
-                                      onClick={() => {
-                                        setSelectedAppointment(
-                                          firstAppointment,
-                                        );
-                                        setSelectedGroupProgress(
-                                          completedSessions > 0
-                                            ? {
-                                                completedSessions,
-                                                totalSessions,
-                                              }
-                                            : null,
-                                        );
-                                      }}
-                                    >
-                                      <Clock className="w-3 h-3 mr-1" />
-                                      Timings
-                                    </Button>
-                                  )}
-                                {supportsParticipantManagement(
-                                  firstAppointment,
-                                ) && (
-                                  <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="h-8 text-xs px-3"
-                                    onClick={() =>
-                                      router.push(
-                                        getParticipantManagementUrl(
-                                          firstAppointment,
-                                          getConsultantIdFromAppointment(
-                                            firstAppointment,
-                                          ),
-                                        ),
-                                      )
-                                    }
-                                  >
-                                    <Users className="w-3 h-3 mr-1" />
-                                    Participants
-                                  </Button>
-                                )}
-                              </div>
-                            </div>
-
-                            <Badge
-                              variant="secondary"
-                              className={`${getStyleFromBadgeData(groupStatus)} flex-shrink-0`}
-                            >
-                              {groupStatus}
-                            </Badge>
-                          </div>
-
-                          {/* Progress Section */}
-                          <div className="space-y-2">
-                            <div className="flex items-center justify-between text-xs">
-                              <span className="text-gray-600">
-                                <span className="font-semibold text-green-600">
-                                  {completedSessions}
-                                </span>{" "}
-                                completed
-                              </span>
-                              <span className="text-gray-600">
-                                <span className="font-semibold text-blue-600">
-                                  {remainingSessions}
-                                </span>{" "}
-                                remaining
-                              </span>
-                            </div>
-
-                            {/* Progress Bar */}
-                            <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
-                              <div
-                                className="bg-gradient-to-r from-green-500 to-blue-500 h-2 rounded-full transition-all duration-500"
-                                style={{ width: `${progressPercentage}%` }}
-                              />
-                            </div>
-
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Appointments List */}
-                      <ul className="divide-y">
-                        {(() => {
-                          const paginationState = getPaginationState(groupKey);
-                          const shouldPaginate =
-                            groupAppointments.length > PAGE_SIZE;
-                          const totalPages = Math.ceil(
-                            groupAppointments.length / PAGE_SIZE,
-                          );
-
-                          let visibleAppointments = groupAppointments;
-                          if (shouldPaginate && !paginationState.showAll) {
-                            const startIndex =
-                              (paginationState.currentPage - 1) * PAGE_SIZE;
-                            const endIndex = startIndex + PAGE_SIZE;
-                            visibleAppointments = groupAppointments.slice(
-                              startIndex,
-                              endIndex,
-                            );
-                          }
-
-                          return (
-                            <>
-                              {visibleAppointments.map((appointment) => {
-                                const status =
-                                  getAppointmentStatus(appointment);
-                                const joinableSlot = getJoinableSlot(
-                                  appointment.slotsOfAppointment ?? [],
-                                );
-                                const isJoinable = joinableSlot !== null;
-                                const isDev =
-                                  process.env.NODE_ENV !== "production";
-                                const joinButtonStyle =
-                                  isDev || isJoinable
-                                    ? "bg-black text-white hover:bg-gray-800"
-                                    : "bg-gray-400 text-white cursor-not-allowed";
-
-                                // Check if this is a one-off event (consultation or webinar)
-                                const isOneOffEvent =
-                                  !isRecurring &&
-                                  (appointment.appointmentType ===
-                                    "CONSULTATION" ||
-                                    appointment.appointmentType === "WEBINAR");
-
-                                const containerClasses = isOneOffEvent
-                                  ? "flex items-center justify-between p-4 bg-gray-200 hover:bg-gray-250 border border-gray-300"
-                                  : "flex items-center justify-between p-4 hover:bg-gray-100";
-
-                                return (
-                                  <li
-                                    key={appointment.id}
-                                    className={containerClasses}
-                                  >
-                                    <div className="flex items-center justify-between w-full">
-                                      {/* Left: Avatar and User info */}
-                                      <div className="flex items-center space-x-3 min-w-0">
-                                        {!isRecurring && (
-                                          <Avatar className="flex-shrink-0">
-                                            <AvatarImage
-                                              alt={getConsumeeName(appointment)}
-                                              src={getConsumeeImage(
-                                                appointment,
-                                              )}
-                                            />
-                                            <AvatarFallback>
-                                              {getConsumeeName(appointment)
-                                                .split(" ")
-                                                .map((n: string) => n[0])
-                                                .join("")}
-                                            </AvatarFallback>
-                                          </Avatar>
-                                        )}
-                                        <div className="min-w-0">
-                                          {!isRecurring && (
-                                            <>
-                                              <div className="flex items-center gap-2 flex-wrap">
-                                                <h3 className="font-semibold text-gray-800">
-                                                  {getConsumeeName(appointment)}
-                                                </h3>
-                                                {(() => {
-                                                  const sponsoringOrgName =
-                                                    resolveSponsoringOrgName(
-                                                      appointment.organizationId,
-                                                    );
-                                                  return sponsoringOrgName ? (
-                                                    <Badge
-                                                      className="text-[10px] font-semibold px-2 py-0.5 bg-indigo-50 text-indigo-700 border-0 rounded-md inline-flex items-center gap-1 max-w-[200px]"
-                                                      title={`Sponsored by ${sponsoringOrgName}`}
-                                                    >
-                                                      <Building2 className="h-3 w-3 shrink-0" />
-                                                      <span className="truncate">
-                                                        Sponsored ·{" "}
-                                                        {sponsoringOrgName}
-                                                      </span>
-                                                    </Badge>
-                                                  ) : null;
-                                                })()}
-                                                {consultantId &&
-                                                  (() => {
-                                                    const role =
-                                                      getCollaboratorRole(
-                                                        appointment,
-                                                        consultantId,
-                                                      );
-                                                    return role ? (
-                                                      <Badge
-                                                        variant="secondary"
-                                                        className={`text-[10px] px-1.5 py-0 h-5 ${getRoleBadgeStyle(role)}`}
-                                                      >
-                                                        {formatCollaboratorRole(
-                                                          role,
-                                                        )}
-                                                      </Badge>
-                                                    ) : null;
-                                                  })()}
-                                              </div>
-                                              <p className="text-sm text-gray-600">
-                                                {getAppointmentTypeAndPlan(
-                                                  appointment,
-                                                )}
-                                              </p>
-                                            </>
-                                          )}
-                                          <div className="text-sm text-gray-500">
-                                            Starts:{" "}
-                                            {(() => {
-                                              const startTime =
-                                                getStartTime(appointment);
-                                              return startTime ? (
-                                                formatAppointmentTime(
-                                                  startTime.toISOString(),
-                                                )
-                                              ) : (
-                                                <span className="text-orange-600 font-medium">
-                                                  Not Scheduled
-                                                </span>
-                                              );
-                                            })()}
-                                          </div>
-                                        </div>
-
-                                        {/* Management buttons right after user info */}
-                                        <div className="flex items-center gap-2 ml-4">
-                                          {!isRecurring &&
-                                            status !== "Completed" &&
-                                            status !== "Cancelled" &&
-                                            canManageAppointmentTimings(
-                                              appointment,
-                                            ) && (
-                                              <Button
-                                                variant="outline"
-                                                size="sm"
-                                                className="h-8 text-xs px-3"
-                                                onClick={() => {
-                                                  setSelectedAppointment(
-                                                    appointment,
-                                                  );
-                                                  setSelectedGroupProgress(
-                                                    null,
-                                                  );
-                                                }}
-                                              >
-                                                <Clock className="w-3 h-3 mr-1" />
-                                                Timings
-                                              </Button>
-                                            )}
-                                          {!isRecurring &&
-                                            supportsParticipantManagement(
-                                              appointment,
-                                            ) && (
-                                              <Button
-                                                variant="outline"
-                                                size="sm"
-                                                className="h-8 text-xs px-3"
-                                                onClick={() =>
-                                                  router.push(
-                                                    getParticipantManagementUrl(
-                                                      appointment,
-                                                      getConsultantIdFromAppointment(
-                                                        appointment,
-                                                      ),
-                                                    ),
-                                                  )
-                                                }
-                                              >
-                                                <Users className="w-3 h-3 mr-1" />
-                                                Participants
-                                              </Button>
-                                            )}
-                                        </div>
-                                      </div>
-
-                                      {/* Right side: Status and Join button */}
-                                      <div className="flex items-center gap-3 flex-shrink-0">
-                                        {status !== "Not Scheduled" && (
-                                          <Badge
-                                            variant="secondary"
-                                            className={getStyleFromBadgeData(
-                                              status,
-                                            )}
-                                          >
-                                            {status}
-                                          </Badge>
-                                        )}
-                                        {status !== "Completed" &&
-                                          status !== "Not Scheduled" && (
-                                            <Button
-                                              variant="default"
-                                              size="sm"
-                                              className={`${joinButtonStyle} h-8 px-4 text-xs`}
-                                              disabled={
-                                                isDev ? false : !isJoinable
-                                              }
-                                              onClick={() =>
-                                                handleJoinMeeting(
-                                                  appointment,
-                                                  joinableSlot ?? undefined,
-                                                )
-                                              }
-                                            >
-                                              {isDev
-                                                ? "Join (Dev)"
-                                                : isJoinable
-                                                  ? "Join Meeting"
-                                                  : "Not available"}
-                                            </Button>
-                                          )}
-                                      </div>
-                                    </div>
-                                  </li>
-                                );
-                              })}
-
-                              {/* Pagination Controls */}
-                              {shouldPaginate && (
-                                <li className="p-3 bg-gray-200 border-t border-gray-300">
-                                  <div className="flex justify-end gap-2">
-                                    {!paginationState.showAll && (
-                                      <>
-                                        <Button
-                                          variant="ghost"
-                                          size="sm"
-                                          className="text-xs"
-                                          onClick={() =>
-                                            setPage(
-                                              groupKey,
-                                              paginationState.currentPage - 1,
-                                            )
-                                          }
-                                          disabled={
-                                            paginationState.currentPage === 1
-                                          }
-                                        >
-                                          <ChevronLeft className="w-4 h-4 mr-1" />
-                                          Previous
-                                        </Button>
-                                        <Button
-                                          variant="ghost"
-                                          size="sm"
-                                          className="text-xs"
-                                          onClick={() =>
-                                            setPage(
-                                              groupKey,
-                                              paginationState.currentPage + 1,
-                                            )
-                                          }
-                                          disabled={
-                                            paginationState.currentPage ===
-                                            totalPages
-                                          }
-                                        >
-                                          Next
-                                          <ChevronRight className="w-4 h-4 ml-1" />
-                                        </Button>
-                                      </>
-                                    )}
-                                    <Button
-                                      variant="ghost"
-                                      size="sm"
-                                      className="text-xs"
-                                      onClick={() => toggleShowAll(groupKey)}
-                                    >
-                                      {paginationState.showAll
-                                        ? "Show Less"
-                                        : "Show All"}
-                                    </Button>
-                                  </div>
-                                </li>
-                              )}
-                            </>
-                          );
-                        })()}
-                      </ul>
-                    </div>
+                      pagination={getPaginationState(groupKey)}
+                      onSetPage={(page) => setPage(groupKey, page)}
+                      onToggleShowAll={() => toggleShowAll(groupKey)}
+                      onJoinMeeting={(appointment, joinableSlot) =>
+                        void joinMeeting(appointment, joinableSlot)
+                      }
+                      onOpenTimings={(appointment, groupProgress) => {
+                        setSelectedAppointment(appointment);
+                        setSelectedGroupProgress(groupProgress);
+                      }}
+                      resolveSponsoringOrgName={resolveSponsoringOrgName}
+                    />
                   )}
                 </div>
               );
@@ -1118,30 +386,16 @@ export function AppointmentsTab({
           );
         })()}
         {!Object.keys(groupedAppointments).length && (
-          <div className="flex flex-col items-center justify-center min-h-[400px] p-8 bg-gray-50 rounded-lg">
-            <div className="w-16 h-16 mb-4 text-gray-400">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">
+          <div className="flex flex-col items-center justify-center min-h-[400px] p-8 bg-zinc-50 rounded-lg">
+            <CalendarX className="w-16 h-16 mb-4 text-zinc-400" strokeWidth={1.5} />
+            <h3 className="text-xl font-semibold text-zinc-900 mb-2">
               {statusFilter === "UPCOMING"
                 ? "No Upcoming Appointments"
                 : statusFilter === "PAST"
                   ? "No Past Appointments"
                   : "No Appointments Found"}
             </h3>
-            <p className="text-gray-500 text-center">
+            <p className="text-zinc-500 text-center">
               {statusFilter === "UPCOMING"
                 ? "You don't have any upcoming appointments."
                 : statusFilter === "PAST"

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/AppointmentFilters.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/AppointmentFilters.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+export type AppointmentStatusFilter = "ALL" | "UPCOMING" | "PAST";
+
+interface AppointmentFiltersProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  statusFilter: AppointmentStatusFilter;
+  onStatusChange: (value: AppointmentStatusFilter) => void;
+}
+
+const STATUS_TABS: { label: string; value: AppointmentStatusFilter }[] = [
+  { label: "All", value: "ALL" },
+  { label: "Upcoming", value: "UPCOMING" },
+  { label: "Past", value: "PAST" },
+];
+
+/** Search box + All/Upcoming/Past tab strip for the appointments list. */
+export function AppointmentFilters({
+  searchQuery,
+  onSearchChange,
+  statusFilter,
+  onStatusChange,
+}: AppointmentFiltersProps) {
+  return (
+    <div className="space-y-3 mb-4">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-zinc-400" />
+        <Input
+          placeholder="Search by name or plan..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="pl-10 h-10"
+        />
+      </div>
+      <div className="flex items-center gap-2 border-b border-zinc-200 overflow-x-auto">
+        {STATUS_TABS.map((tab) => (
+          <button
+            key={tab.value}
+            onClick={() => onStatusChange(tab.value)}
+            className={`px-4 py-2.5 text-sm font-medium whitespace-nowrap border-b-2 transition-colors ${
+              statusFilter === tab.value
+                ? "border-zinc-900 text-zinc-900"
+                : "border-transparent text-zinc-500 hover:text-zinc-700 hover:border-zinc-300"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/AppointmentGroupCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/AppointmentGroupCard.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Building2, ChevronLeft, ChevronRight, Clock, Users } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TAppointment } from "@/types/appointment";
+import { getBadgeStyle } from "../../../types";
+import {
+  calculateSessionProgress,
+  formatAppointmentTime,
+  getAppointmentStatus,
+  getAppointmentTypeAndPlan,
+  getConsumeeImage,
+  getConsumeeName,
+  getGroupStatus,
+  getGroupTitle,
+  getStartTime,
+  getCollaboratorRole,
+  formatCollaboratorRole,
+  getRoleBadgeStyle,
+} from "../../../utils/appointmentHelpers";
+import {
+  canManageAppointmentTimings,
+  canManageGroupTimings,
+} from "../utils/appointmentTimingHelpers";
+import {
+  getParticipantManagementUrl,
+  supportsParticipantManagement,
+} from "../utils/participantHelpers";
+import { getJoinableSlot } from "../../../utils/joinState";
+
+const PAGE_SIZE = 5;
+
+export interface GroupPaginationState {
+  currentPage: number;
+  showAll: boolean;
+}
+
+interface AppointmentGroupCardProps {
+  appointments: TAppointment[];
+  isRecurring: boolean;
+  consultantId?: string;
+  highlighted: boolean;
+  registerRef: (el: HTMLDivElement | null) => void;
+  pagination: GroupPaginationState;
+  onSetPage: (page: number) => void;
+  onToggleShowAll: () => void;
+  onJoinMeeting: (
+    appointment: TAppointment,
+    joinableSlot?: TAppointment["slotsOfAppointment"][number],
+  ) => void;
+  onOpenTimings: (
+    appointment: TAppointment,
+    groupProgress: { completedSessions: number; totalSessions: number } | null,
+  ) => void;
+  resolveSponsoringOrgName: (
+    orgId: string | null | undefined,
+  ) => string | null;
+}
+
+// Helper to get consultant ID from appointment (for the participants URL)
+function getConsultantIdFromAppointment(appointment: TAppointment): string {
+  switch (appointment.appointmentType) {
+    case "CONSULTATION":
+      return (
+        appointment.consultation?.consultationPlan?.consultantProfileId || ""
+      );
+    case "SUBSCRIPTION":
+      return (
+        appointment.subscription?.subscriptionPlan?.consultantProfileId || ""
+      );
+    case "WEBINAR":
+      return appointment.webinar?.webinarPlan?.consultantProfileId || "";
+    case "CLASS":
+      return appointment.class?.classPlan?.consultantProfileId || "";
+    default:
+      return "";
+  }
+}
+
+/**
+ * One appointment group: a recurring subscription/class (progress header +
+ * paginated session list) or a single consultation/webinar row. Extracted
+ * mechanically from the 1,100-line AppointmentsTab — behavior unchanged;
+ * pagination state stays parent-owned (keyed by groupKey) so it survives
+ * re-groupings exactly as before.
+ */
+export function AppointmentGroupCard({
+  appointments: groupAppointments,
+  isRecurring,
+  consultantId,
+  highlighted,
+  registerRef,
+  pagination,
+  onSetPage,
+  onToggleShowAll,
+  onJoinMeeting,
+  onOpenTimings,
+  resolveSponsoringOrgName,
+}: AppointmentGroupCardProps) {
+  const router = useRouter();
+  const firstAppointment = groupAppointments[0];
+  const groupTitle = getGroupTitle(groupAppointments);
+  const groupStatus = getGroupStatus(groupAppointments);
+  const {
+    totalSessions,
+    completedSessions,
+    remainingSessions,
+    progressPercentage,
+  } = calculateSessionProgress(groupAppointments);
+
+  const shouldPaginate = groupAppointments.length > PAGE_SIZE;
+  const totalPages = Math.ceil(groupAppointments.length / PAGE_SIZE);
+
+  let visibleAppointments = groupAppointments;
+  if (shouldPaginate && !pagination.showAll) {
+    const startIndex = (pagination.currentPage - 1) * PAGE_SIZE;
+    visibleAppointments = groupAppointments.slice(
+      startIndex,
+      startIndex + PAGE_SIZE,
+    );
+  }
+
+  return (
+    <div
+      ref={registerRef}
+      className={`border border-zinc-200 rounded-xl overflow-hidden shadow-sm bg-white transition-all duration-300 ${
+        highlighted ? "ring-4 ring-yellow-400 shadow-xl" : ""
+      }`}
+    >
+      {/* Group Header */}
+      {isRecurring && (
+        <div className="bg-zinc-50 p-4 border-b border-zinc-200">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-3 sm:space-x-4 min-w-0">
+              <Avatar className="w-10 h-10">
+                <AvatarImage
+                  alt={getConsumeeName(firstAppointment)}
+                  src={getConsumeeImage(firstAppointment)}
+                />
+                <AvatarFallback>
+                  {getConsumeeName(firstAppointment)
+                    .split(" ")
+                    .map((n: string) => n[0])
+                    .join("")}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <div className="flex items-center gap-2">
+                  <h3 className="font-semibold text-zinc-800 text-sm">
+                    {getConsumeeName(firstAppointment)}
+                  </h3>
+                  {consultantId &&
+                    (() => {
+                      const role = getCollaboratorRole(
+                        firstAppointment,
+                        consultantId,
+                      );
+                      return role ? (
+                        <Badge
+                          variant="secondary"
+                          className={`text-[10px] px-1.5 py-0 h-5 ${getRoleBadgeStyle(role)}`}
+                        >
+                          {formatCollaboratorRole(role)}
+                        </Badge>
+                      ) : null;
+                    })()}
+                </div>
+                <p className="text-xs text-zinc-600">
+                  {groupTitle.split("(")[0].trim()}
+                </p>
+              </div>
+
+              {/* Management buttons inline with user name */}
+              <div className="flex items-center gap-2 ml-4">
+                {groupStatus !== "Completed" &&
+                  groupStatus !== "Cancelled" &&
+                  canManageGroupTimings(groupAppointments) && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 text-xs px-3"
+                      onClick={() =>
+                        onOpenTimings(
+                          firstAppointment,
+                          completedSessions > 0
+                            ? { completedSessions, totalSessions }
+                            : null,
+                        )
+                      }
+                    >
+                      <Clock className="w-3 h-3 mr-1" />
+                      Timings
+                    </Button>
+                  )}
+                {supportsParticipantManagement(firstAppointment) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 text-xs px-3"
+                    onClick={() =>
+                      router.push(
+                        getParticipantManagementUrl(
+                          firstAppointment,
+                          getConsultantIdFromAppointment(firstAppointment),
+                        ),
+                      )
+                    }
+                  >
+                    <Users className="w-3 h-3 mr-1" />
+                    Participants
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className={`${getBadgeStyle(groupStatus)} flex-shrink-0`}
+            >
+              {groupStatus}
+            </Badge>
+          </div>
+
+          {/* Progress Section */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-zinc-600">
+                <span className="font-semibold text-green-600">
+                  {completedSessions}
+                </span>{" "}
+                completed
+              </span>
+              <span className="text-zinc-600">
+                <span className="font-semibold text-blue-600">
+                  {remainingSessions}
+                </span>{" "}
+                remaining
+              </span>
+            </div>
+
+            <div className="w-full bg-zinc-200 rounded-full h-2 overflow-hidden">
+              <div
+                className="bg-emerald-500 h-2 rounded-full transition-all duration-500"
+                style={{ width: `${progressPercentage}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Appointments List */}
+      <ul className="divide-y divide-zinc-100">
+        {visibleAppointments.map((appointment) => {
+          const status = getAppointmentStatus(appointment);
+          const joinableSlot = getJoinableSlot(
+            appointment.slotsOfAppointment ?? [],
+          );
+          const isJoinable = joinableSlot !== null;
+          const isDev = process.env.NODE_ENV !== "production";
+          const joinButtonStyle =
+            isDev || isJoinable
+              ? "bg-zinc-900 text-white hover:bg-zinc-800"
+              : "bg-zinc-300 text-zinc-500 cursor-not-allowed";
+
+          const isOneOffEvent =
+            !isRecurring &&
+            (appointment.appointmentType === "CONSULTATION" ||
+              appointment.appointmentType === "WEBINAR");
+
+          const containerClasses = isOneOffEvent
+            ? "flex items-center justify-between p-4 bg-zinc-50 hover:bg-zinc-100"
+            : "flex items-center justify-between p-4 hover:bg-zinc-50";
+
+          return (
+            <li key={appointment.id} className={containerClasses}>
+              <div className="flex items-center justify-between w-full">
+                {/* Left: Avatar and User info */}
+                <div className="flex items-center space-x-3 min-w-0">
+                  {!isRecurring && (
+                    <Avatar className="flex-shrink-0">
+                      <AvatarImage
+                        alt={getConsumeeName(appointment)}
+                        src={getConsumeeImage(appointment)}
+                      />
+                      <AvatarFallback>
+                        {getConsumeeName(appointment)
+                          .split(" ")
+                          .map((n: string) => n[0])
+                          .join("")}
+                      </AvatarFallback>
+                    </Avatar>
+                  )}
+                  <div className="min-w-0">
+                    {!isRecurring && (
+                      <>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <h3 className="font-semibold text-zinc-800">
+                            {getConsumeeName(appointment)}
+                          </h3>
+                          {(() => {
+                            const sponsoringOrgName = resolveSponsoringOrgName(
+                              appointment.organizationId,
+                            );
+                            return sponsoringOrgName ? (
+                              <Badge
+                                className="text-[10px] font-semibold px-2 py-0.5 bg-indigo-50 text-indigo-700 border-0 rounded-md inline-flex items-center gap-1 max-w-[200px]"
+                                title={`Sponsored by ${sponsoringOrgName}`}
+                              >
+                                <Building2 className="h-3 w-3 shrink-0" />
+                                <span className="truncate">
+                                  Sponsored · {sponsoringOrgName}
+                                </span>
+                              </Badge>
+                            ) : null;
+                          })()}
+                          {consultantId &&
+                            (() => {
+                              const role = getCollaboratorRole(
+                                appointment,
+                                consultantId,
+                              );
+                              return role ? (
+                                <Badge
+                                  variant="secondary"
+                                  className={`text-[10px] px-1.5 py-0 h-5 ${getRoleBadgeStyle(role)}`}
+                                >
+                                  {formatCollaboratorRole(role)}
+                                </Badge>
+                              ) : null;
+                            })()}
+                        </div>
+                        <p className="text-sm text-zinc-600">
+                          {getAppointmentTypeAndPlan(appointment)}
+                        </p>
+                      </>
+                    )}
+                    <div className="text-sm text-zinc-500">
+                      Starts:{" "}
+                      {(() => {
+                        const startTime = getStartTime(appointment);
+                        return startTime ? (
+                          formatAppointmentTime(startTime.toISOString())
+                        ) : (
+                          <span className="text-orange-600 font-medium">
+                            Not Scheduled
+                          </span>
+                        );
+                      })()}
+                    </div>
+                  </div>
+
+                  {/* Management buttons right after user info */}
+                  <div className="flex items-center gap-2 ml-4">
+                    {!isRecurring &&
+                      status !== "Completed" &&
+                      status !== "Cancelled" &&
+                      canManageAppointmentTimings(appointment) && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-8 text-xs px-3"
+                          onClick={() => onOpenTimings(appointment, null)}
+                        >
+                          <Clock className="w-3 h-3 mr-1" />
+                          Timings
+                        </Button>
+                      )}
+                    {!isRecurring &&
+                      supportsParticipantManagement(appointment) && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-8 text-xs px-3"
+                          onClick={() =>
+                            router.push(
+                              getParticipantManagementUrl(
+                                appointment,
+                                getConsultantIdFromAppointment(appointment),
+                              ),
+                            )
+                          }
+                        >
+                          <Users className="w-3 h-3 mr-1" />
+                          Participants
+                        </Button>
+                      )}
+                  </div>
+                </div>
+
+                {/* Right side: Status and Join button */}
+                <div className="flex items-center gap-3 flex-shrink-0">
+                  {status !== "Not Scheduled" && (
+                    <Badge
+                      variant="secondary"
+                      className={getBadgeStyle(status)}
+                    >
+                      {status}
+                    </Badge>
+                  )}
+                  {status !== "Completed" && status !== "Not Scheduled" && (
+                    <Button
+                      variant="default"
+                      size="sm"
+                      className={`${joinButtonStyle} h-8 px-4 text-xs`}
+                      disabled={isDev ? false : !isJoinable}
+                      onClick={() =>
+                        onJoinMeeting(appointment, joinableSlot ?? undefined)
+                      }
+                    >
+                      {isDev
+                        ? "Join (Dev)"
+                        : isJoinable
+                          ? "Join Meeting"
+                          : "Not available"}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+
+        {/* Pagination Controls */}
+        {shouldPaginate && (
+          <li className="p-3 bg-zinc-50 border-t border-zinc-200">
+            <div className="flex justify-end gap-2">
+              {!pagination.showAll && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs"
+                    onClick={() => onSetPage(pagination.currentPage - 1)}
+                    disabled={pagination.currentPage === 1}
+                  >
+                    <ChevronLeft className="w-4 h-4 mr-1" />
+                    Previous
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs"
+                    onClick={() => onSetPage(pagination.currentPage + 1)}
+                    disabled={pagination.currentPage === totalPages}
+                  >
+                    Next
+                    <ChevronRight className="w-4 h-4 ml-1" />
+                  </Button>
+                </>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs"
+                onClick={onToggleShowAll}
+              >
+                {pagination.showAll ? "Show Less" : "Show All"}
+              </Button>
+            </div>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/TrialsSubsection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/TrialsSubsection.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Gift, Loader2, Video } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type {
+  ScheduledTrial,
+  SectionQueryState,
+} from "../../../types";
+
+interface TrialsSubsectionProps {
+  trials: ScheduledTrial[];
+  joiningTrialId: string | null;
+  onJoin: (trial: ScheduledTrial) => void;
+  /** Query state for this section — renders its own skeleton/error inline. */
+  state?: SectionQueryState;
+}
+
+// Joinable within 10 mins before start and until the slot ends.
+function isTrialJoinable(trial: ScheduledTrial): boolean {
+  if (!trial.appointment?.slotsOfAppointment?.[0]) return false;
+  const slot = trial.appointment.slotsOfAppointment[0];
+  const now = new Date();
+  const startTime = new Date(slot.startsAt);
+  const endTime = slot.endsAt
+    ? new Date(slot.endsAt)
+    : new Date(startTime.getTime() + 60 * 60 * 1000);
+  if (isNaN(startTime.getTime()) || isNaN(endTime.getTime())) return false;
+  const joinWindowStart = new Date(startTime.getTime() - 10 * 60 * 1000);
+  return now >= joinWindowStart && now <= endTime;
+}
+
+function formatTrialTime(dateString: string) {
+  return new Date(dateString).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+/**
+ * "Free Trial Sessions" block embedded at the top of the SUBSCRIPTION
+ * section of the appointments list. Owns its own loading/error rendering
+ * so a slow trials query can't blank the rest of the page.
+ */
+export function TrialsSubsection({
+  trials,
+  joiningTrialId,
+  onJoin,
+  state,
+}: TrialsSubsectionProps) {
+  if (state?.isLoading) {
+    return (
+      <div className="mb-6 rounded-lg border border-purple-200 bg-purple-50/50 p-4">
+        <Skeleton className="h-4 w-44 mb-3" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (state?.isError) {
+    return (
+      <div className="mb-6 rounded-lg border border-purple-200 bg-purple-50/50 p-4 flex items-center justify-between gap-3">
+        <p className="text-sm text-purple-800">
+          Couldn&apos;t load your trial sessions.
+        </p>
+        <Button variant="outline" size="sm" onClick={state.onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (trials.length === 0) return null;
+
+  return (
+    <div className="mb-6 bg-purple-50/50 border border-purple-200 rounded-lg p-4">
+      <h4 className="text-sm font-semibold text-purple-700 mb-3 flex items-center gap-2">
+        <Gift className="h-4 w-4" />
+        Free Trial Sessions ({trials.length})
+      </h4>
+      <div className="space-y-3">
+        {trials.map((trial) => (
+          <div
+            key={trial.id}
+            className="border border-purple-200 rounded-lg p-4 bg-purple-50/50"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Avatar className="h-10 w-10">
+                  <AvatarImage
+                    src={trial.consulteeProfile.user.image || ""}
+                    alt={trial.consulteeProfile.user.name}
+                  />
+                  <AvatarFallback>
+                    {trial.consulteeProfile.user.name
+                      .split(" ")
+                      .map((n) => n[0])
+                      .join("")}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="font-medium text-zinc-900">
+                    {trial.consulteeProfile.user.name}
+                  </p>
+                  <p className="text-sm text-zinc-600">
+                    {trial.subscriptionPlan.title} •{" "}
+                    {trial.subscriptionPlan.freeTrialDurationMinutes} min trial
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className="text-right">
+                  <Badge className="bg-purple-100 text-purple-900 border-purple-200">
+                    Trial
+                  </Badge>
+                  {trial.appointment?.slotsOfAppointment?.[0] && (
+                    <p className="text-xs text-zinc-500 mt-1">
+                      {formatTrialTime(
+                        trial.appointment.slotsOfAppointment[0].startsAt,
+                      )}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => onJoin(trial)}
+                  disabled={
+                    joiningTrialId === trial.id || !isTrialJoinable(trial)
+                  }
+                  className={
+                    isTrialJoinable(trial)
+                      ? "bg-purple-600 hover:bg-purple-700"
+                      : ""
+                  }
+                >
+                  {joiningTrialId === trial.id ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                      Joining...
+                    </>
+                  ) : (
+                    <>
+                      <Video className="h-4 w-4 mr-1" />
+                      Join
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/UnscheduledEventsSection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/UnscheduledEventsSection.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { UnscheduledEventCard } from "./UnscheduledEventCard";
+import type { SectionQueryState } from "../../../types";
+
+export interface UnscheduledEventItem {
+  id: string;
+  title: string;
+  subtitle: string;
+  onSetSchedule: () => void;
+}
+
+interface UnscheduledEventsSectionProps {
+  title: string;
+  items: UnscheduledEventItem[];
+  /** Query state for this section — renders its own skeleton/error inline. */
+  state?: SectionQueryState;
+}
+
+/**
+ * "Unscheduled Classes/Webinars" block embedded at the top of the matching
+ * type section of the appointments list. Owns its own loading/error
+ * rendering so a slow events query can't blank the rest of the page.
+ */
+export function UnscheduledEventsSection({
+  title,
+  items,
+  state,
+}: UnscheduledEventsSectionProps) {
+  if (state?.isLoading) {
+    return (
+      <div className="mb-4">
+        <Skeleton className="h-4 w-48 mb-3" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (state?.isError) {
+    return (
+      <div className="mb-4 rounded-lg border border-orange-200 bg-orange-50 p-4 flex items-center justify-between gap-3">
+        <p className="text-sm text-orange-800">
+          Couldn&apos;t load {title.toLowerCase()}.
+        </p>
+        <Button variant="outline" size="sm" onClick={state.onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="mb-4">
+      <h4 className="text-sm font-semibold text-orange-700 mb-3 flex items-center gap-2">
+        <Clock className="h-4 w-4" />
+        {title} ({items.length})
+      </h4>
+      <div className="space-y-3">
+        {items.map((item) => (
+          <UnscheduledEventCard
+            key={item.id}
+            title={item.title}
+            subtitle={item.subtitle}
+            onSetSchedule={item.onSetSchedule}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/classes/[classId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/classes/[classId]/page.tsx
@@ -4,13 +4,13 @@ import * as Sentry from "@sentry/nextjs";
 import React from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   ResponsiveTable,
   type ResponsiveColumn,
 } from "@/components/ui/responsive-table";
-import { PageHeader } from "@/components/ui/page-header";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { ClassEvent } from "../../../types/event";
 import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -215,34 +215,23 @@ export default function ClassParticipantsPage() {
   );
 
   return (
-    <div className="container mx-auto py-8">
-      <Card>
-        <CardHeader>
+    <>
+      <DashboardHeader
+        title={`${classEvent.classPlan.title} — Participants`}
+        subtitle={`${participants.length}/${classEvent.classPlan.maxParticipants} participants · ${waitlist.length} on waitlist`}
+        actions={
           <Link
             href={`/dashboard/consultant/${params.consultantId}/appointments`}
             passHref
-            className="mb-4"
           >
             <Button variant="outline" size="sm">
               <ArrowLeft className="mr-2 h-4 w-4" /> Back to Appointments
             </Button>
           </Link>
-          <PageHeader
-            headingAs="h1"
-            title={`${classEvent.classPlan.title} - Participants`}
-            description={
-              <span className="flex gap-4">
-                <span>
-                  {participants.length}/{classEvent.classPlan.maxParticipants}{" "}
-                  participants
-                </span>
-                <span>•</span>
-                <span>{waitlist.length} on waitlist</span>
-              </span>
-            }
-          />
-        </CardHeader>
-        <CardContent>
+        }
+      />
+      <Card className="mt-6">
+        <CardContent className="pt-6">
           <Tabs defaultValue="registered" className="w-full">
             <TabsList className="mb-4">
               <TabsTrigger value="registered">Registered</TabsTrigger>
@@ -280,6 +269,6 @@ export default function ClassParticipantsPage() {
           </Tabs>
         </CardContent>
       </Card>
-    </div>
+    </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/consultations/[consultationId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/consultations/[consultationId]/page.tsx
@@ -4,13 +4,13 @@ import * as Sentry from "@sentry/nextjs";
 import React from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   ResponsiveTable,
   type ResponsiveColumn,
 } from "@/components/ui/responsive-table";
-import { PageHeader } from "@/components/ui/page-header";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ParticipantUser } from "@/types/participants";
@@ -142,25 +142,23 @@ export default function ConsultationParticipantsPage() {
   );
 
   return (
-    <div className="container mx-auto py-8">
-      <Card>
-        <CardHeader>
+    <>
+      <DashboardHeader
+        title={`${consultation.consultationPlan.title} — Participants`}
+        subtitle={`${participants.length}/2 participants (1-on-1 consultation)`}
+        actions={
           <Link
             href={`/dashboard/consultant/${params.consultantId}/appointments`}
             passHref
-            className="mb-4"
           >
             <Button variant="outline" size="sm">
               <ArrowLeft className="mr-2 h-4 w-4" /> Back to Appointments
             </Button>
           </Link>
-          <PageHeader
-            headingAs="h1"
-            title={`${consultation.consultationPlan.title} - Participants`}
-            description={`${participants.length}/2 participants (1-on-1 consultation)`}
-          />
-        </CardHeader>
-        <CardContent>
+        }
+      />
+      <Card className="mt-6">
+        <CardContent className="pt-6">
           <ResponsiveTable<ParticipantUser>
             columns={columns}
             rows={participants}
@@ -170,6 +168,6 @@ export default function ConsultationParticipantsPage() {
           />
         </CardContent>
       </Card>
-    </div>
+    </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/subscriptions/[subscriptionId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/subscriptions/[subscriptionId]/page.tsx
@@ -4,13 +4,13 @@ import * as Sentry from "@sentry/nextjs";
 import React from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   ResponsiveTable,
   type ResponsiveColumn,
 } from "@/components/ui/responsive-table";
-import { PageHeader } from "@/components/ui/page-header";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ParticipantUser } from "@/types/participants";
@@ -142,25 +142,23 @@ export default function SubscriptionParticipantsPage() {
   );
 
   return (
-    <div className="container mx-auto py-8">
-      <Card>
-        <CardHeader>
+    <>
+      <DashboardHeader
+        title={`${subscription.subscriptionPlan.title} — Participants`}
+        subtitle={`${participants.length}/2 participants (1-on-1 subscription)`}
+        actions={
           <Link
             href={`/dashboard/consultant/${params.consultantId}/appointments`}
             passHref
-            className="mb-4"
           >
             <Button variant="outline" size="sm">
               <ArrowLeft className="mr-2 h-4 w-4" /> Back to Appointments
             </Button>
           </Link>
-          <PageHeader
-            headingAs="h1"
-            title={`${subscription.subscriptionPlan.title} - Participants`}
-            description={`${participants.length}/2 participants (1-on-1 subscription)`}
-          />
-        </CardHeader>
-        <CardContent>
+        }
+      />
+      <Card className="mt-6">
+        <CardContent className="pt-6">
           <ResponsiveTable<ParticipantUser>
             columns={columns}
             rows={participants}
@@ -170,6 +168,6 @@ export default function SubscriptionParticipantsPage() {
           />
         </CardContent>
       </Card>
-    </div>
+    </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/webinars/[webinarId]/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/participants/webinars/[webinarId]/page.tsx
@@ -4,13 +4,13 @@ import * as Sentry from "@sentry/nextjs";
 import React from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   ResponsiveTable,
   type ResponsiveColumn,
 } from "@/components/ui/responsive-table";
-import { PageHeader } from "@/components/ui/page-header";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { WebinarEvent } from "../../../types/event";
 import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -210,34 +210,23 @@ export default function WebinarParticipantsPage() {
   );
 
   return (
-    <div className="container mx-auto py-8">
-      <Card>
-        <CardHeader>
+    <>
+      <DashboardHeader
+        title={`${webinar.webinarPlan.title} — Participants`}
+        subtitle={`${participants.length}/${webinar.webinarPlan.maxParticipants} registered · ${waitlist.length} on waitlist`}
+        actions={
           <Link
             href={`/dashboard/consultant/${params.consultantId}/appointments`}
             passHref
-            className="mb-4"
           >
             <Button variant="outline" size="sm">
               <ArrowLeft className="mr-2 h-4 w-4" /> Back to Appointments
             </Button>
           </Link>
-          <PageHeader
-            headingAs="h1"
-            title={`${webinar.webinarPlan.title} - Participants`}
-            description={
-              <span className="flex gap-4">
-                <span>
-                  {participants.length}/{webinar.webinarPlan.maxParticipants}{" "}
-                  registered
-                </span>
-                <span>•</span>
-                <span>{waitlist.length} on waitlist</span>
-              </span>
-            }
-          />
-        </CardHeader>
-        <CardContent>
+        }
+      />
+      <Card className="mt-6">
+        <CardContent className="pt-6">
           <Tabs defaultValue="registered" className="w-full">
             <TabsList className="mb-4">
               <TabsTrigger value="registered">Registered</TabsTrigger>
@@ -275,6 +264,6 @@ export default function WebinarParticipantsPage() {
           </Tabs>
         </CardContent>
       </Card>
-    </div>
+    </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import { useMemo } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useToast } from "@/components/ui/use-toast";
 // #248: do NOT statically import the Stream SDK (useStreamVideoClient) or
 // lib/meeting (which imports the SDK) here — that would pull the heavy SDK into
 // the dashboard-HOME bundle / critical path. The video client + meeting helper
 // are acquired lazily inside the Join handler (only when a user clicks Join).
-import { waitForGlobalVideoClient } from "@/lib/stream/disconnect";
+import { useLazyJoinMeeting } from "../shared/hooks/useLazyJoinMeeting";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
@@ -96,7 +94,7 @@ export function HomeTab({
   financialSummary,
 }: Readonly<HomeTabProps>) {
   const router = useRouter();
-  const { toast } = useToast();
+  const joinMeeting = useLazyJoinMeeting();
   const { data: session } = useSession();
   // Sponsoring-org lookup for the indigo "Sponsored · <Org>" badge —
   // shows on org-funded appointments only, mirroring the consultee
@@ -106,51 +104,13 @@ export function HomeTab({
   const resolveSponsoringOrgName = (orgId: string | null | undefined) =>
     resolveSponsoringOrgNameShared(orgId, orgMemberships);
 
-  const handleJoinMeeting = async (
+  // #248: the shared hook reads the connected client singleton at click
+  // time and lazy-imports lib/meeting, keeping the Stream SDK off the home
+  // bundle. This used to be a private copy of that pattern.
+  const handleJoinMeeting = (
     appointment: TAppointment,
     joinableSlot?: TAppointment["slotsOfAppointment"][number],
-  ) => {
-    // #248: read the already-connected video client singleton at click time
-    // (same instance <StreamVideo> uses) instead of via useStreamVideoClient,
-    // so the SDK stays off the home bundle. The video connect is now deferred
-    // to requestIdleCallback, so a fast Join click can land before the client
-    // exists — briefly wait for it instead of immediately erroring.
-    const client = await waitForGlobalVideoClient();
-    if (!client) {
-      toast({
-        title: "Connecting…",
-        description: "Setting up your meeting client. Please try Join again.",
-      });
-      return;
-    }
-    const relevantSlot =
-      joinableSlot ?? appointment.slotsOfAppointment?.[0];
-    if (!relevantSlot) {
-      toast({
-        title: "Error",
-        description: "Slot information missing.",
-      });
-      return;
-    }
-
-    try {
-      // #248: lazy-import the meeting helper (it imports the SDK) on demand.
-      const { getOrCreateAppointmentMeeting } = await import("@/lib/meeting");
-      const meetingId = await getOrCreateAppointmentMeeting(
-        client,
-        appointment,
-        relevantSlot,
-      );
-      router.push(`/meetings/${meetingId}`);
-    } catch (_error) {
-      Sentry.captureException(_error instanceof Error ? _error : new Error(String(_error)), { tags: { subsystem: "client" } });
-      toast({
-        title: "Error",
-        description: "Failed to join meeting.",
-        variant: "destructive",
-      });
-    }
-  };
+  ) => void joinMeeting(appointment, joinableSlot);
 
   const expandedAppointments = useMemo(() => appointments || [], [appointments]);
 

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -84,6 +84,12 @@ type RequestType = "all" | "consultation" | "subscription";
 interface RequestSlotAllocationTabProps {
   type: RequestType;
   onUpdate: () => void;
+  /**
+   * Personal-vs-org scope ("personal" | "all" | orgId) threaded into the
+   * /api/bookings/* fetches as ?orgScope=. Provided by the page's
+   * OrgContextFilter; omitted = server returns the unfiltered union.
+   */
+  orgScope?: string;
 }
 
 // Helper function to fetch and process data
@@ -135,6 +141,7 @@ async function fetchDataFromApi<T>(
 export function RequestSlotAllocationTab({
   type,
   onUpdate,
+  orgScope,
 }: RequestSlotAllocationTabProps) {
   const params = useParams();
   const consultantId = params.consultantId as string;
@@ -154,13 +161,17 @@ export function RequestSlotAllocationTab({
     setError(null);
 
     try {
-      // Fetch data in parallel (only PENDING requests)
+      // Fetch data in parallel (only PENDING requests). orgScope filters
+      // server-side via the denormalized Appointment.organizationId.
+      const orgScopeQs = orgScope
+        ? `&orgScope=${encodeURIComponent(orgScope)}`
+        : "";
       const [consultationsResult, subscriptionsResult] = await Promise.all([
         fetchDataFromApi<ConsultationApiResponse[]>(
-          `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING`,
+          `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING${orgScopeQs}`,
         ),
         fetchDataFromApi<SubscriptionApiResponse[]>(
-          `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING`,
+          `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING${orgScopeQs}`,
         ),
       ]);
 
@@ -324,7 +335,7 @@ export function RequestSlotAllocationTab({
         setLoading(false);
       }
     }
-  }, [consultantId, type, error]);
+  }, [consultantId, type, error, orgScope]);
 
   useEffect(() => {
     fetchData();

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { useOrgScope } from "@/hooks/useOrgScope";
 import {
   OrgContextFilter,
@@ -24,15 +25,20 @@ import { RequestSlotAllocationTab } from "./RequestSlotAllocationTab";
  * removing the double loading phase.
  */
 export default function RequestsPage() {
-  // S1 (B1-personal-retrofit): the OrgContextFilter dropdown lets a
-  // consultant who works for multiple orgs toggle between "Personal" /
-  // "<org>" / "All" (drives the ?orgScope= URL param via useOrgScope).
-  // Self-hides for consultants with zero org memberships. Note: the tab's
-  // /api/bookings/* fetches don't consume orgScope yet — wiring the scope
-  // into those endpoints is tracked follow-up work, not a regression of
-  // this page (the deleted query was the only thing that ever read it,
-  // and its data went nowhere).
-  const { scope, setScope } = useOrgScope();
+  // The OrgContextFilter dropdown lets a consultant who works for multiple
+  // orgs toggle between "Personal" / "<org>" / "All". The resolved scope is
+  // threaded into the tab's /api/bookings/* fetches as ?orgScope= (filtered
+  // server-side via the denormalized Appointment.organizationId) — the
+  // dropdown used to be a documented no-op here. Org members default to
+  // "All activity" so panel experts land on the union view, matching the
+  // appointments page.
+  const { scope, setScope } = useOrgScope({ defaultForOrgMember: "all" });
+  const orgScopeParam =
+    scope.kind === "personal"
+      ? "personal"
+      : scope.kind === "all"
+        ? "all"
+        : scope.orgId;
 
   const filterValue: OrgContextFilterValue =
     scope.kind === "personal"
@@ -52,10 +58,20 @@ export default function RequestsPage() {
 
   return (
     <DashboardErrorBoundary>
-      <div className="mb-4 flex justify-end">
-        <OrgContextFilter value={filterValue} onChange={handleFilterChange} />
+      <DashboardHeader
+        title="Requests"
+        subtitle="Pending booking requests awaiting slot allocation"
+        actions={
+          <OrgContextFilter value={filterValue} onChange={handleFilterChange} />
+        }
+      />
+      <div className="pt-6">
+        <RequestSlotAllocationTab
+          type="all"
+          onUpdate={handleUpdate}
+          orgScope={orgScopeParam}
+        />
       </div>
-      <RequestSlotAllocationTab type="all" onUpdate={handleUpdate} />
     </DashboardErrorBoundary>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useLazyJoinMeeting.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useLazyJoinMeeting.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/hooks/use-toast";
+// #248: type-only imports are erased at compile time, so referencing
+// lib/meeting's types here does NOT pull the Stream SDK into the bundle.
+// MeetingAppointment/MeetingSlot are structural subsets that TAppointment
+// and its slots satisfy, so callers pass their richer types directly.
+import type { MeetingAppointment, MeetingSlot } from "@/lib/meeting";
+import { waitForGlobalVideoClient } from "@/lib/stream/disconnect";
+
+/**
+ * Join-meeting handler that keeps the Stream video SDK off the tab
+ * bundles (#248): the already-connected video client singleton is read at
+ * click time (same instance <StreamVideo> uses) instead of via
+ * useStreamVideoClient, and lib/meeting — which statically imports the
+ * SDK — is dynamic-imported on demand.
+ *
+ * Previously HomeTab had this pattern privately while AppointmentsTab,
+ * TrialsTab, and the planner each statically imported the SDK, dragging
+ * it into every consultant page. One hook, one bundle boundary.
+ *
+ * Returns true when navigation to the meeting was initiated — callers
+ * tracking per-row "joining" state can reset it on false.
+ */
+export function useLazyJoinMeeting() {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  return useCallback(
+    async (
+      appointment: MeetingAppointment,
+      joinableSlot?: MeetingSlot,
+    ): Promise<boolean> => {
+      // The video connect is deferred to requestIdleCallback, so a fast
+      // Join click can land before the client exists — briefly wait for
+      // it instead of immediately erroring.
+      const client = await waitForGlobalVideoClient();
+      if (!client) {
+        toast({
+          title: "Connecting…",
+          description:
+            "Setting up your meeting client. Please try Join again.",
+        });
+        return false;
+      }
+
+      const relevantSlot = joinableSlot ?? appointment.slotsOfAppointment?.[0];
+      if (!relevantSlot) {
+        toast({
+          title: "Error",
+          description: "Slot information missing for this appointment.",
+          variant: "destructive",
+        });
+        return false;
+      }
+
+      try {
+        const { getOrCreateAppointmentMeeting } = await import(
+          "@/lib/meeting"
+        );
+        const meetingId = await getOrCreateAppointmentMeeting(
+          client,
+          appointment,
+          relevantSlot,
+        );
+        router.push(`/meetings/${meetingId}`);
+        toast({
+          title: "Joining meeting",
+          description: "You will now be redirected to the meeting room.",
+        });
+        return true;
+      } catch (error) {
+        Sentry.captureException(
+          error instanceof Error ? error : new Error(String(error)),
+          { tags: { subsystem: "client" } },
+        );
+        console.error("Error joining meeting:", error);
+        toast({
+          title: "Error joining meeting",
+          description:
+            error instanceof Error ? error.message : "Unknown error",
+          variant: "destructive",
+        });
+        return false;
+      }
+    },
+    [router, toast],
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/trials/TrialsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/trials/TrialsTab.tsx
@@ -46,13 +46,10 @@ import {
 } from "@/components/ui/tooltip";
 import Link from "next/link";
 import { cn } from "@/utils/tailwind";
-import { useRouter } from "next/navigation";
-import { useStreamVideoClient } from "@stream-io/video-react-sdk";
-import {
-  getOrCreateAppointmentMeeting,
-  type MeetingAppointment,
-  type MeetingSlot,
-} from "@/lib/meeting";
+// #248: no static Stream SDK / lib/meeting import — the shared hook
+// lazy-loads both at click time. Type-only imports are erased.
+import type { MeetingSlot } from "@/lib/meeting";
+import { useLazyJoinMeeting } from "../shared/hooks/useLazyJoinMeeting";
 import {
   TrialScheduleCalendar,
   SelectedSlot,
@@ -135,8 +132,7 @@ export function TrialsTab() {
   const params = useParams();
   const consultantId = params.consultantId as string;
   const { toast } = useToast();
-  const router = useRouter();
-  const client = useStreamVideoClient();
+  const joinMeeting = useLazyJoinMeeting();
 
   const [trials, setTrials] = useState<TrialSession[]>([]);
   const [loading, setLoading] = useState(true);
@@ -420,16 +416,6 @@ export function TrialsTab() {
   };
 
   const handleJoinMeeting = async (trial: TrialSession) => {
-    if (!client) {
-      toast({
-        title: "Not signed in",
-        description:
-          "Video client not initialized. Please sign in to join the meeting.",
-        variant: "destructive",
-      });
-      return;
-    }
-
     if (!trial.appointment?.slotsOfAppointment?.[0]) {
       toast({
         title: "Unable to join",
@@ -440,37 +426,18 @@ export function TrialsTab() {
     }
 
     setIsJoining(trial.id);
-    try {
-      const slot = trial.appointment.slotsOfAppointment[0];
-      // Create a minimal appointment object for the meeting helper
-      const appointmentForMeeting: MeetingAppointment = {
+    const slot = trial.appointment.slotsOfAppointment[0];
+    // Minimal appointment shape for the meeting helper; the shared hook
+    // lazy-loads the Stream SDK at click time (#248).
+    const navigating = await joinMeeting(
+      {
         id: trial.appointment.id,
         appointmentType: "TRIAL",
         slotsOfAppointment: trial.appointment.slotsOfAppointment,
-      };
-
-      const meetingId = await getOrCreateAppointmentMeeting(
-        client,
-        appointmentForMeeting,
-        slot as MeetingSlot,
-      );
-
-      toast({
-        title: "Joining meeting",
-        description: "You will now be redirected to the meeting room.",
-      });
-
-      router.push(`/meetings/${meetingId}`);
-    } catch (error) {
-      console.error("Error joining meeting:", error);
-      toast({
-        title: "Error joining meeting",
-        description:
-          error instanceof Error ? error.message : "Unknown error occurred",
-        variant: "destructive",
-      });
-      setIsJoining(null);
-    }
+      },
+      slot as MeetingSlot,
+    );
+    if (!navigating) setIsJoining(null);
   };
 
   const handleRefresh = async () => {

--- a/app/dashboard/consultant/[consultantId]/types.ts
+++ b/app/dashboard/consultant/[consultantId]/types.ts
@@ -163,14 +163,28 @@ export interface UnscheduledWebinar {
   appointment: null | undefined;
 }
 
+/**
+ * Loading/error state for an auxiliary section fed by its own query
+ * (trials / unscheduled classes / unscheduled webinars). Each section
+ * renders its own skeleton and inline retry so one slow or failed query
+ * can't blank the whole appointments page.
+ */
+export interface SectionQueryState {
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+}
+
 export interface AppointmentsTabProps {
   appointments: TAppointment[];
-  badgeStyles: BadgeStyleMap;
   scheduledTrials?: ScheduledTrial[];
+  trialsState?: SectionQueryState;
   consultantId?: string;
   onUpdate?: () => void;
   unscheduledClasses?: UnscheduledClass[];
+  unscheduledClassesState?: SectionQueryState;
   unscheduledWebinars?: UnscheduledWebinar[];
+  unscheduledWebinarsState?: SectionQueryState;
   /** Optional right-aligned element rendered next to the "All Appointments"
    *  header — used by the page wrapper to mount the OrgContextFilter
    *  dropdown inline instead of stacking it above the card. */
@@ -246,20 +260,27 @@ export interface ClientActivityProps {
 // Utility type for badge styles
 export type BadgeStyleMap = { [key: string]: string };
 
-// Constants for badge styles
+// Badge styles for the DERIVED timing statuses produced by
+// getAppointmentStatus() ("Today", "Starting soon", "In 3 days", …).
+// These are relative-proximity labels, not AppointmentStatus enum values,
+// so they can't live in lib/labels/session-labels.ts — but they wear the
+// same pill conventions (bg-*-100 text-*-900 border-*-200) so every badge
+// across the dashboard reads as one system. Proximity ladder: red (now) →
+// orange (imminent / needs action) → amber (today-ish) → emerald (soon) →
+// zinc (far / terminal).
 export const BADGE_STYLES: BadgeStyleMap = {
-  Completed: "bg-gray-400 text-white",
-  Cancelled: "bg-stone-400 text-white",
-  "In Progress": "bg-emerald-600 text-white",
-  "Starting soon": "bg-amber-500 text-white",
-  "Meeting in 5 min": "bg-red-500 text-white",
-  Today: "bg-blue-600 text-white",
-  Tomorrow: "bg-purple-500 text-white",
-  "In week": "bg-green-500 text-white",
-  "In month": "bg-yellow-500 text-white",
-  "In year": "bg-orange-500 text-white",
-  "Not Scheduled": "bg-orange-600 text-white",
-  default: "bg-gray-500 text-white",
+  Completed: "bg-green-100 text-green-900 border-green-200",
+  Cancelled: "bg-zinc-100 text-zinc-600 border-zinc-200",
+  "In Progress": "bg-blue-100 text-blue-900 border-blue-200",
+  "Starting soon": "bg-orange-100 text-orange-900 border-orange-200",
+  "Meeting in 5 min": "bg-red-100 text-red-900 border-red-200",
+  Today: "bg-amber-100 text-amber-900 border-amber-200",
+  Tomorrow: "bg-emerald-100 text-emerald-900 border-emerald-200",
+  "In week": "bg-emerald-100 text-emerald-900 border-emerald-200",
+  "In month": "bg-zinc-100 text-zinc-700 border-zinc-200",
+  "In year": "bg-zinc-100 text-zinc-700 border-zinc-200",
+  "Not Scheduled": "bg-orange-100 text-orange-900 border-orange-200",
+  default: "bg-zinc-100 text-zinc-600 border-zinc-200",
 };
 
 /**
@@ -270,9 +291,9 @@ export const BADGE_STYLES: BadgeStyleMap = {
 export const getBadgeStyle = (status: string): string => {
   if (BADGE_STYLES[status]) return BADGE_STYLES[status];
   if (status.startsWith("In ") && status.includes("day"))
-    return "bg-green-500 text-white";
+    return "bg-emerald-100 text-emerald-900 border-emerald-200";
   if (status.startsWith("In ") && status.includes("week"))
-    return "bg-green-500 text-white";
+    return "bg-emerald-100 text-emerald-900 border-emerald-200";
   return BADGE_STYLES.default;
 };
 

--- a/lib/data/consultant-earnings-analytics.ts
+++ b/lib/data/consultant-earnings-analytics.ts
@@ -1,0 +1,94 @@
+import "server-only";
+
+import { format, startOfMonth, subMonths } from "date-fns";
+import type { EarningStatus } from "@prisma/client";
+import prisma from "@/lib/prisma";
+import {
+  getConsultantEarningsSummary,
+  getConsultantEarnings,
+  checkPayoutEligibility,
+} from "@/lib/payments/payouts";
+
+export interface MonthlyEarning {
+  /** Calendar month bucket, "YYYY-MM". */
+  month: string;
+  /** Sum of consultantSharePaise accrued in the month. */
+  totalPaise: number;
+  /** Number of earning records (≈ paid sessions) in the month. */
+  count: number;
+}
+
+/**
+ * Trailing per-month earnings buckets for the consultant analytics chart.
+ * Aggregates ALL rows in the window (not the paginated history slice —
+ * a `limit`-truncated reduce would undercount every month but the newest).
+ * Empty months are zero-filled so the chart never has gaps.
+ */
+export async function getConsultantMonthlyEarnings(
+  consultantProfileId: string,
+  months = 6,
+): Promise<MonthlyEarning[]> {
+  const since = startOfMonth(subMonths(new Date(), months - 1));
+  const rows = await prisma.consultantEarnings.findMany({
+    where: { consultantProfileId, createdAt: { gte: since } },
+    select: { createdAt: true, consultantSharePaise: true },
+  });
+
+  const buckets = new Map<string, { totalPaise: number; count: number }>();
+  for (let i = months - 1; i >= 0; i--) {
+    buckets.set(format(subMonths(new Date(), i), "yyyy-MM"), {
+      totalPaise: 0,
+      count: 0,
+    });
+  }
+  for (const row of rows) {
+    const bucket = buckets.get(format(row.createdAt, "yyyy-MM"));
+    if (!bucket) continue;
+    // consultantSharePaise is BigInt — convert before JSON serialization.
+    bucket.totalPaise += Number(row.consultantSharePaise ?? 0);
+    bucket.count += 1;
+  }
+
+  return Array.from(buckets, ([month, v]) => ({ month, ...v }));
+}
+
+export interface ConsultantEarningsPayloadOptions {
+  status?: EarningStatus;
+  limit?: number;
+  offset?: number;
+  includeMonthly?: boolean;
+}
+
+/**
+ * Single assembler for the GET /api/consultant/earnings response body,
+ * shared by the route handler and the analytics page's SSR prefetch so the
+ * dehydrated cache and the client refetch can never drift apart.
+ */
+export async function buildConsultantEarningsPayload(
+  consultantProfileId: string,
+  options: ConsultantEarningsPayloadOptions = {},
+) {
+  const { status, limit = 20, offset = 0, includeMonthly = false } = options;
+
+  const [summary, eligibility, history, monthlyEarnings] = await Promise.all([
+    getConsultantEarningsSummary(consultantProfileId),
+    checkPayoutEligibility(consultantProfileId),
+    getConsultantEarnings(consultantProfileId, { status, limit, offset }),
+    includeMonthly
+      ? getConsultantMonthlyEarnings(consultantProfileId)
+      : Promise.resolve(undefined),
+  ]);
+
+  return {
+    summary,
+    eligibility,
+    earnings: history.earnings,
+    pagination: {
+      total: history.total,
+      limit,
+      offset,
+      hasMore: history.hasMore,
+    },
+    ...(monthlyEarnings ? { monthlyEarnings } : {}),
+  };
+}

--- a/lib/data/consultant-earnings-analytics.ts
+++ b/lib/data/consultant-earnings-analytics.ts
@@ -28,7 +28,11 @@ export async function getConsultantMonthlyEarnings(
   consultantProfileId: string,
   months = 6,
 ): Promise<MonthlyEarning[]> {
-  const since = startOfMonth(subMonths(new Date(), months - 1));
+  // One clock read for the whole computation — repeated new Date() calls
+  // could straddle a month rollover and misalign the buckets vs the query
+  // window.
+  const now = new Date();
+  const since = startOfMonth(subMonths(now, months - 1));
   const rows = await prisma.consultantEarnings.findMany({
     where: { consultantProfileId, createdAt: { gte: since } },
     select: { createdAt: true, consultantSharePaise: true },
@@ -36,7 +40,7 @@ export async function getConsultantMonthlyEarnings(
 
   const buckets = new Map<string, { totalPaise: number; count: number }>();
   for (let i = months - 1; i >= 0; i--) {
-    buckets.set(format(subMonths(new Date(), i), "yyyy-MM"), {
+    buckets.set(format(subMonths(now, i), "yyyy-MM"), {
       totalPaise: 0,
       count: 0,
     });
@@ -45,7 +49,9 @@ export async function getConsultantMonthlyEarnings(
     const bucket = buckets.get(format(row.createdAt, "yyyy-MM"));
     if (!bucket) continue;
     // consultantSharePaise is BigInt — convert before JSON serialization.
-    bucket.totalPaise += Number(row.consultantSharePaise ?? 0);
+    // BigInt fallback keeps the ?? branch type-consistent (0n literal needs
+    // ES2020 target, which this tsconfig doesn't set).
+    bucket.totalPaise += Number(row.consultantSharePaise ?? BigInt(0));
     bucket.count += 1;
   }
 


### PR DESCRIPTION
Appointments sections load/err independently (one slow query no longer blanks the page); AppointmentsTab decomposed. Requests org filter is honest: additive ?orgScope= on /api/bookings/{consultations,subscriptions} + threaded into fetches. New Analytics page (StatCard grid + recharts trends; additive ?includeMonthly=1 on /api/consultant/earnings). Stream SDK lazy via shared useLazyJoinMeeting (no static @stream-io imports in tabs).

---
Part of the consultant/consultee dashboard redesign chain (9 PRs -> mega branch `feat/dashboard-redesign` -> `dev`). Review this PR's own commit(s); the mega PR follows after chain review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)