### PR TITLE
feat(consultee): refund visibility, feedback dedup, chat fallback, trials in resources (redesign 8/9)

### DIFF
--- a/app/api/dashboard/consultee/[consulteeId]/payments/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/payments/route.ts
@@ -75,7 +75,9 @@ export async function GET(
           ? { organizationId: scopeResolution.scope.orgId }
           : {};
 
-    const [payments, invoices, credits, creditUsages] = await Promise.all([
+    // Per-Payment invoices stay out of this response since the v0 lockdown
+    // (#768) — v1.1 re-introduces a per-Payment invoice flow.
+    const [payments, credits, creditUsages] = await Promise.all([
       // All payments for this user, scoped to the selected org context
       prisma.payment.findMany({
         where: { userId, ...orgFilter },
@@ -112,16 +114,22 @@ export async function GET(
               discountValue: true,
             },
           },
+          // #776 — refund visibility. Without this a cancelled-with-refund
+          // booking reads "SUCCEEDED" in the payment history forever.
+          refunds: {
+            where: { deletedAt: null },
+            select: {
+              id: true,
+              amountPaise: true,
+              status: true,
+              reason: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: "desc" },
+          },
         },
         orderBy: { createdAt: "desc" },
       }),
-
-      // Personal-consultee per-Payment invoice surface removed in v0
-      // lockdown (#768). UI now shows OrganizationInvoice rows for
-      // org-funded paths only; PERSONAL consultees can request a
-      // receipt from support until v1.1 re-introduces a per-Payment
-      // invoice flow. Empty array keeps the response shape stable.
-      Promise.resolve([] as const),
 
       // Referral credits
       prisma.referralCredit.findMany({
@@ -157,6 +165,29 @@ export async function GET(
         apt?.class?.classPlan?.title ??
         "Payment";
 
+      // BigInt → Number at the serialization boundary; refund amounts are
+      // paise like Payment.amount.
+      const refunds = p.refunds.map((r) => ({
+        id: r.id,
+        amountPaise: Number(r.amountPaise),
+        status: r.status,
+        reason: r.reason,
+        createdAt: r.createdAt,
+      }));
+      const refundedPaise = refunds
+        .filter((r) => r.status === "SUCCEEDED")
+        .reduce((sum, r) => sum + r.amountPaise, 0);
+      // Derived display status — the PaymentStatus enum has no REFUNDED
+      // value (refunds live on the relation), so the UI-facing status is
+      // computed here: full refund wins over partial, and only SUCCEEDED
+      // payments can read as refunded.
+      const displayStatus =
+        p.paymentStatus === "SUCCEEDED" && refundedPaise > 0
+          ? refundedPaise >= Number(p.amount)
+            ? "REFUNDED"
+            : "PARTIALLY_REFUNDED"
+          : p.paymentStatus;
+
       return {
         id: p.id,
         amount: p.amount,
@@ -179,6 +210,9 @@ export async function GET(
               value: p.discountCode.discountValue,
             }
           : null,
+        refunds,
+        refundedPaise,
+        displayStatus,
         receiptUrl: p.receiptUrl,
         expiresAt: p.expiresAt,
         createdAt: p.createdAt,
@@ -196,7 +230,6 @@ export async function GET(
     return NextResponse.json({
       data: {
         payments: transformedPayments,
-        invoices,
         credits,
         creditUsages,
         creditSummary: {

--- a/app/api/dashboard/consultee/[consulteeId]/resources/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/resources/route.ts
@@ -113,6 +113,25 @@ const classInclude = {
   },
 } satisfies Prisma.ClassInclude;
 
+// Trials ride the subscription plan's materials + the single trial
+// appointment's recordings — same shape as consultations.
+const trialInclude = {
+  subscriptionPlan: {
+    include: {
+      materials: {
+        select: planMaterialSelect,
+        orderBy: { order: "asc" as const },
+      },
+      consultantProfile: {
+        include: { user: { select: consultantUserSelect } },
+      },
+    },
+  },
+  appointment: {
+    include: slotsWithRecordings,
+  },
+} satisfies Prisma.TrialSessionInclude;
+
 // Derived via the extended client — raw GetPayload would re-introduce
 // bigint money/fileSize fields (#780).
 type ConsultationWithResources = Prisma.Result<
@@ -133,6 +152,11 @@ type WebinarWithResources = Prisma.Result<
 type ClassWithResources = Prisma.Result<
   typeof prisma.class,
   { include: typeof classInclude },
+  "findFirstOrThrow"
+>;
+type TrialWithResources = Prisma.Result<
+  typeof prisma.trialSession,
+  { include: typeof trialInclude },
   "findFirstOrThrow"
 >;
 
@@ -188,8 +212,8 @@ export async function GET(
       classPlanIds: paidClassPlanIds,
     } = await RecordingService.getPaidPlanIds(userId);
 
-    const [consultations, subscriptions, webinars, classes] = await Promise.all(
-      [
+    const [consultations, subscriptions, webinars, classes, trials] =
+      await Promise.all([
         prisma.consultation.findMany({
           where: { requestedById: consulteeId },
           include: consultationInclude,
@@ -291,8 +315,13 @@ export async function GET(
           include: classInclude,
           orderBy: { createdAt: "desc" },
         }),
-      ],
-    );
+
+        prisma.trialSession.findMany({
+          where: { consulteeProfileId: consulteeId },
+          include: trialInclude,
+          orderBy: { requestedAt: "desc" },
+        }),
+      ]);
 
     // Include if COMPLETED or has at least 1 material/recording
     type TransformedEvent = {
@@ -369,6 +398,25 @@ export async function GET(
               cl.createdAt,
             materials: cl.classPlan.materials,
             recordings: await extractRecordings(cl.appointments),
+          })),
+        )
+      ).filter(shouldInclude),
+      trials: (
+        await Promise.all(
+          trials.map(async (t: TrialWithResources) => ({
+            id: t.id,
+            planTitle: `Free Trial: ${t.subscriptionPlan.title}`,
+            consultantName:
+              t.subscriptionPlan.consultantProfile?.user.name ?? null,
+            consultantImage:
+              t.subscriptionPlan.consultantProfile?.user.image ?? null,
+            status: t.status,
+            date:
+              t.appointment?.slotsOfAppointment?.[0]?.startsAt || t.requestedAt,
+            materials: t.subscriptionPlan.materials,
+            recordings: await extractRecordings(
+              t.appointment ? [t.appointment] : [],
+            ),
           })),
         )
       ).filter(shouldInclude),

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/utils/status-guards.ts
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/utils/status-guards.ts
@@ -9,6 +9,14 @@
  * so guards normalize case rather than typing against one enum.
  */
 
+import {
+  APPOINTMENT_STATUS_BADGE,
+  EVENT_STATUS_BADGE,
+  TRIAL_STATUS_BADGE,
+  formatStatusLabel,
+  type StatusBadgeStyle,
+} from "@/lib/labels/session-labels";
+
 const TERMINAL_STATUSES = new Set([
   "CANCELLED",
   "REJECTED",
@@ -40,4 +48,30 @@ export function isApprovedStatus(status: string | null | undefined): boolean {
 /** Booking is locked in (approved/scheduled/live) — enables uploads, joining, etc. */
 export function isConfirmedStatus(status: string | null | undefined): boolean {
   return CONFIRMED_STATUSES.has(normalize(status));
+}
+
+/**
+ * Badge style for the consultee event UNION (consultations/subscriptions
+ * carry AppointmentStatus, webinars/classes carry Webinar/ClassStatus,
+ * trials carry TrialSessionStatus). Tries the maps in specificity order
+ * and falls back to a neutral title-cased pill for legacy values.
+ */
+export function eventUnionStatusBadge(
+  status: string | null | undefined,
+): StatusBadgeStyle {
+  const s = normalize(status);
+  if (s in APPOINTMENT_STATUS_BADGE) {
+    return APPOINTMENT_STATUS_BADGE[s as keyof typeof APPOINTMENT_STATUS_BADGE];
+  }
+  if (s in EVENT_STATUS_BADGE) {
+    return EVENT_STATUS_BADGE[s as keyof typeof EVENT_STATUS_BADGE];
+  }
+  if (s in TRIAL_STATUS_BADGE) {
+    return TRIAL_STATUS_BADGE[s as keyof typeof TRIAL_STATUS_BADGE];
+  }
+  return {
+    label: status ? formatStatusLabel(status) : "Unknown",
+    className: "bg-zinc-100 text-zinc-600 border-zinc-200",
+    dotClassName: "bg-zinc-400",
+  };
 }

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/FeedbackSupportTab.tsx
@@ -1,25 +1,26 @@
 "use client";
 
 import React from "react";
-import { Card, CardContent } from "components/ui/card";
-import { Button } from "components/ui/button";
-import { Input } from "components/ui/input";
-import { Label } from "components/ui/label";
-import { Textarea } from "components/ui/textarea";
-import { Badge } from "components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "components/ui/select";
+} from "@/components/ui/select";
 import {
   FeedbackStatus,
   SupportPriority,
   SupportTicketStatus,
   SupportIssueType,
 } from "@prisma/client";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { useFeedbackSupport, type SupportTicketWithResponses } from "./useFeedbackSupport";
 import {
   MessageSquare,
@@ -31,7 +32,6 @@ import {
   AlertCircle,
   Loader2,
   ChevronRight,
-  Sparkles,
   Link2,
 } from "lucide-react";
 import {
@@ -45,7 +45,7 @@ interface FeedbackSupportTabProps {
 }
 
 export default function FeedbackSupportTab({
-  consulteeId: _consulteeId,
+  consulteeId,
 }: FeedbackSupportTabProps) {
   const {
     isLoading,
@@ -64,7 +64,7 @@ export default function FeedbackSupportTab({
     handleFeedbackSubmit,
     handleTicketSubmit,
     handleResponseSubmit,
-  } = useFeedbackSupport();
+  } = useFeedbackSupport(consulteeId);
 
   // Semantic status colors kept (amber=in progress, green=resolved); the
   // off-brand blue OPEN/PENDING accent collapses to neutral monochrome.
@@ -122,24 +122,10 @@ export default function FeedbackSupportTab({
 
   return (
     <div className="space-y-8">
-      {/* Header */}
-      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-800 p-8">
-        <div className="absolute inset-0 bg-grid-white/5 [mask-image:linear-gradient(0deg,transparent,black)]" />
-        <div className="relative">
-          <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 rounded-lg bg-white/10">
-              <Sparkles className="h-5 w-5 text-white" />
-            </div>
-            <h2 className="text-fluid-2xl font-semibold tracking-tight text-white">
-              Feedback & Support
-            </h2>
-          </div>
-          <p className="text-zinc-400 max-w-lg">
-            Share your experience or get help with any issues. We&apos;re here
-            to assist you.
-          </p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Feedback & Support"
+        subtitle="Share your experience or get help with any issues. We're here to assist you."
+      />
 
       {/* Tab Navigation */}
       <div className="flex w-full gap-2 p-1 rounded-xl bg-muted dark:bg-zinc-800 sm:w-fit">

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/page.tsx
@@ -6,6 +6,9 @@ import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
 import { createConsulteeQueries } from "@/lib/dashboard-queries";
 import FeedbackSupportTab from "./FeedbackSupportTab";
+import { EmptyState } from "@/components/dashboard/DataCard";
+import { Button } from "@/components/ui/button";
+import { LifeBuoy } from "lucide-react";
 
 type PageProps = {
   params: Promise<{ consulteeId: string }>;
@@ -15,18 +18,19 @@ type PageProps = {
 export default function FeedbackPage({ params }: Readonly<PageProps>) {
   const { consulteeId } = use(params);
 
-  // Use the centralized query configurations
+  // These are the SAME query configs useFeedbackSupport consumes inside the
+  // tab — one fetch pair per page load, shared through the query cache.
   const consulteeQueries = createConsulteeQueries(consulteeId);
   const {
-    data: _feedbacks,
     isLoading: feedbackLoading,
     error: feedbackError,
+    refetch: refetchFeedback,
   } = useQuery(consulteeQueries.feedback);
 
   const {
-    data: _tickets,
     isLoading: ticketsLoading,
     error: ticketsError,
+    refetch: refetchTickets,
   } = useQuery(consulteeQueries.supportTickets);
 
   const isLoading = feedbackLoading || ticketsLoading;
@@ -38,23 +42,24 @@ export default function FeedbackPage({ params }: Readonly<PageProps>) {
 
   if (error) {
     return (
-      <DashboardErrorBoundary>
-        <div className="flex items-center justify-center min-h-[400px]">
-          <div className="p-4 bg-red-50 text-red-600 rounded-lg max-w-md text-center">
-            <h3 className="font-semibold mb-2">Error Loading Feedback</h3>
-            <p className="text-sm">
-              {error.message ||
-                "Failed to load feedback data. Please try again."}
-            </p>
-            <button
-              onClick={() => window.location.reload()}
-              className="mt-4 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-            >
-              Retry
-            </button>
-          </div>
-        </div>
-      </DashboardErrorBoundary>
+      <EmptyState
+        icon={LifeBuoy}
+        title="Couldn't load feedback & support"
+        description={
+          error.message || "Failed to load feedback data. Please try again."
+        }
+        action={
+          <Button
+            variant="outline"
+            onClick={() => {
+              void refetchFeedback();
+              void refetchTickets();
+            }}
+          >
+            Retry
+          </Button>
+        }
+      />
     );
   }
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/feedback/useFeedbackSupport.ts
+++ b/app/dashboard/consultee/[consulteeId]/(features)/feedback/useFeedbackSupport.ts
@@ -8,8 +8,10 @@ import {
   SupportResponse as PrismaSupportResponse,
   UserRole,
 } from "@prisma/client";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import React from "react";
+import { createConsulteeQueries } from "@/lib/dashboard-queries";
 
 interface FeedbackFormData {
   title: string;
@@ -41,19 +43,34 @@ export interface SupportTicketWithResponses extends SupportTicket {
   responses: EnrichedSupportTicketResponse[];
 }
 
-export function useFeedbackSupport() {
+export function useFeedbackSupport(consulteeId: string) {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = React.useState(false);
   const [activeTab, setActiveTab] = React.useState<"feedback" | "support">(
     "feedback",
   );
-  const [feedbacks, setFeedbacks] = React.useState<Feedback[]>([]);
-  const [tickets, setTickets] = React.useState<SupportTicketWithResponses[]>(
-    [],
-  );
   const [selectedTicket, setSelectedTicket] = React.useState<string | null>(
     null,
   );
+
+  // Same query configs the feedback page prefetches — the page's fetch IS
+  // this hook's data (previously the hook re-fetched both endpoints via
+  // useEffect, doubling every page load's network calls).
+  const consulteeQueries = createConsulteeQueries(consulteeId);
+  const { data: feedbacksData } = useQuery(consulteeQueries.feedback);
+  const { data: ticketsData } = useQuery(consulteeQueries.supportTickets);
+  const feedbacks = (feedbacksData ?? []) as unknown as Feedback[];
+  const tickets = (ticketsData ?? []) as unknown as SupportTicketWithResponses[];
+
+  const invalidateFeedbacks = () =>
+    queryClient.invalidateQueries({
+      queryKey: consulteeQueries.feedback.queryKey,
+    });
+  const invalidateTickets = () =>
+    queryClient.invalidateQueries({
+      queryKey: consulteeQueries.supportTickets.queryKey,
+    });
 
   const [feedbackForm, setFeedbackForm] = React.useState<FeedbackFormData>({
     title: "",
@@ -70,65 +87,6 @@ export function useFeedbackSupport() {
     React.useState<SupportResponseFormData>({
       message: "",
     });
-
-  const loadFeedbacks = React.useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const response = await fetch(`/api/user/feedbacks`);
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(
-          errorData.message || "Failed to fetch your feedback history",
-        );
-      }
-      const data = await response.json();
-      setFeedbacks(data);
-    } catch (error: unknown) {
-      console.error("Failed to load feedbacks:", error);
-      toast({
-        title: "Error",
-        description:
-          error instanceof Error
-            ? error.message
-            : "Unable to load your feedback history. Please try refreshing the page.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [toast]);
-
-  const loadTickets = React.useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const response = await fetch(`/api/user/support-tickets`);
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(
-          errorData.message || "Failed to fetch your support tickets",
-        );
-      }
-      const data = await response.json();
-      setTickets(data);
-    } catch (error: unknown) {
-      console.error("Failed to load support tickets:", error);
-      toast({
-        title: "Error",
-        description:
-          error instanceof Error
-            ? error.message
-            : "Unable to load your support tickets. Please try refreshing the page.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [toast]);
-
-  React.useEffect(() => {
-    loadFeedbacks();
-    loadTickets();
-  }, [loadFeedbacks, loadTickets]);
 
   const handleFeedbackSubmit = async () => {
     try {
@@ -151,7 +109,7 @@ export function useFeedbackSupport() {
       });
 
       setFeedbackForm({ title: "", description: "" });
-      loadFeedbacks();
+      void invalidateFeedbacks();
     } catch (error: unknown) {
       console.error("Failed to submit feedback:", error);
       toast({
@@ -197,7 +155,7 @@ export function useFeedbackSupport() {
         issueType: undefined,
       });
 
-      loadTickets();
+      void invalidateTickets();
     } catch (error: unknown) {
       console.error("Failed to create support ticket:", error);
       toast({
@@ -236,7 +194,7 @@ export function useFeedbackSupport() {
       });
 
       setResponseForm({ message: "" });
-      loadTickets(); // Reload tickets to show the new response
+      void invalidateTickets(); // Refresh tickets to show the new response
     } catch (error: unknown) {
       console.error("Failed to submit response:", error);
       toast({

--- a/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
@@ -1,14 +1,32 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import { ChatLayout } from "@/components/chat/ChatLayout";
+import { ChatUnavailable } from "@/components/chat/ChatUnavailable";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
+import { useStreamConnection } from "@/providers/StreamProvider";
 
 export default function MessagesTab() {
+  // Connection state from the Stream provider: render the chat UI only once
+  // the chat client is live; surface failures instead of a blank box (same
+  // contract as the consultant Chats tab).
+  const { chatConnected, error, retryConnection } = useStreamConnection();
+
   return (
-    <div
-      className="w-full bg-card rounded-xl border border-border shadow-sm overflow-hidden"
-      style={{ height: "calc(100vh - 100px)" }}
-    >
-      <ChatLayout />
-    </div>
+    <>
+      <DashboardHeader title="Messages" subtitle="Chat with your consultants" />
+      <div className="mt-4 w-full bg-card rounded-xl border border-border shadow-sm overflow-hidden h-[calc(100vh-15rem)] min-h-[400px]">
+        {error ? (
+          <ChatUnavailable description={error} onRetry={retryConnection} />
+        ) : chatConnected ? (
+          <ChatLayout />
+        ) : (
+          <div className="flex h-full items-center justify-center text-muted-foreground">
+            <Loader2 className="h-6 w-6 animate-spin mr-2" />
+            Connecting to chat…
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
@@ -213,15 +213,15 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
   // / home surfaces.
   const orgMemberships = session?.user?.organizationMemberships ?? [];
 
-  // Successful spend grouped per currency — a USD payment must never be
-  // summed into an INR total.
+  // Net successful spend grouped per currency — a USD payment must never be
+  // summed into an INR total, and refunded amounts don't count as spend.
   const totalsByCurrency = useMemo(() => {
     const map = new Map<string, { total: number; count: number }>();
     for (const p of data?.payments ?? []) {
       if (p.status !== "SUCCEEDED") continue;
       const currency = p.currency || "INR";
       const entry = map.get(currency) ?? { total: 0, count: 0 };
-      entry.total += p.amount;
+      entry.total += p.amount - (p.refundedPaise ?? 0);
       entry.count += 1;
       map.set(currency, entry);
     }
@@ -533,7 +533,7 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
               </TooltipTrigger>
               <TooltipContent>
                 <p>
-                  Only includes successful payments. Multi-currency spend is
+                  Successful payments net of refunds. Multi-currency spend is
                   totalled per currency, never converted.
                 </p>
               </TooltipContent>

--- a/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/payments/PaymentsTab.tsx
@@ -5,15 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { motion } from "framer-motion";
 import { useCurrency } from "@/hooks/useCurrency";
 import { cn } from "@/utils/tailwind";
-import {
-  CreditCard,
-  Gift,
-  Download,
-  FileText,
-  Tag,
-  ArrowUpDown,
-  Building2,
-} from "lucide-react";
+import { CreditCard, Gift, Tag, ArrowUpDown, Building2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useSession } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
@@ -34,7 +26,21 @@ import {
   ResponsiveTable,
   type ResponsiveColumn,
 } from "@/components/ui/responsive-table";
-import { PageHeader } from "@/components/ui/page-header";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import {
+  paymentStatusBadge,
+  refundStatusBadge,
+  resolveSponsoringOrgName,
+} from "@/lib/labels/session-labels";
+
+interface RefundItem {
+  id: string;
+  amountPaise: number;
+  status: string;
+  reason: string | null;
+  createdAt: string;
+}
 
 interface PaymentItem {
   id: string;
@@ -53,25 +59,13 @@ interface PaymentItem {
     type: string;
     value: number;
   } | null;
+  refunds: RefundItem[];
+  refundedPaise: number;
+  /** Server-derived: REFUNDED | PARTIALLY_REFUNDED | PaymentStatus. */
+  displayStatus: string;
   receiptUrl: string | null;
   expiresAt: string | null;
   createdAt: string;
-}
-
-interface InvoiceItem {
-  id: string;
-  paymentId: string | null;
-  invoiceNumber: string;
-  amount: number;
-  taxAmount: number | null;
-  status: string;
-  createdAt: string;
-  payment: {
-    id: string;
-    amount: number;
-    currency: string;
-    paymentStatus: string;
-  } | null;
 }
 
 interface CreditItem {
@@ -99,7 +93,6 @@ interface CreditUsageItem {
 
 interface PaymentsData {
   payments: PaymentItem[];
-  invoices: InvoiceItem[];
   credits: CreditItem[];
   creditUsages: CreditUsageItem[];
   creditSummary: {
@@ -160,18 +153,37 @@ function formatRelativeTime(date: Date): string {
 }
 
 /**
- * Derive UI display status: if PENDING but expiresAt is past, show EXPIRED
- * so the user doesn't see a misleading amber "PENDING" badge while the
- * cleanup cron hasn't run yet.
+ * Derive UI display status: start from the server's refund-aware
+ * `displayStatus` (REFUNDED / PARTIALLY_REFUNDED / PaymentStatus); if
+ * PENDING but expiresAt is past, show EXPIRED so the user doesn't see a
+ * misleading amber "PENDING" badge while the cleanup cron hasn't run yet.
  */
 function getDisplayStatus(payment: PaymentItem): string {
-  if (payment.status !== "PENDING") return payment.status;
+  const base = payment.displayStatus ?? payment.status;
+  if (base !== "PENDING") return base;
 
   const expiresAt = payment.expiresAt
     ? new Date(payment.expiresAt)
     : new Date(new Date(payment.createdAt).getTime() + 30 * 60 * 1000);
 
   return expiresAt <= new Date() ? "EXPIRED" : "PENDING";
+}
+
+/**
+ * Format an amount in ITS OWN currency (no cross-currency conversion) —
+ * used by the per-currency summary so a USD payment is never summed or
+ * displayed as INR.
+ */
+function formatAmountInCurrency(paise: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(currency === "INR" ? "en-IN" : "en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 2,
+    }).format(paise / 100);
+  } catch {
+    return `${currency} ${(paise / 100).toFixed(2)}`;
+  }
 }
 
 function getExpiryInfo(payment: PaymentItem): {
@@ -193,34 +205,6 @@ function getExpiryInfo(payment: PaymentItem): {
   };
 }
 
-// Semantic status colors kept (green=success, amber=pending, red=failed);
-// off-brand emerald collapses to green and the generic blue REFUNDED accent
-// goes monochrome neutral.
-const STATUS_STYLES: Record<string, string> = {
-  SUCCEEDED: "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-  COMPLETED: "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-  PENDING: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-  EXPIRED: "bg-muted text-muted-foreground",
-  FAILED: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300",
-  REFUNDED: "bg-muted text-foreground",
-  CANCELLED: "bg-muted text-muted-foreground",
-  PAID: "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300",
-  UNPAID: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
-};
-
-function StatusBadge({ status }: { status: string }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium",
-        STATUS_STYLES[status] || "bg-muted text-muted-foreground",
-      )}
-    >
-      {status}
-    </span>
-  );
-}
-
 export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
   const { formatPrice } = useCurrency();
   const { data: session } = useSession();
@@ -228,34 +212,20 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
   // the "Sponsored · <Org>" badge — same convention as the appointments
   // / home surfaces.
   const orgMemberships = session?.user?.organizationMemberships ?? [];
-  const resolveSponsoringOrgName = (
-    orgId: string | null | undefined,
-  ): string | null => {
-    if (!orgId) return null;
-    return (
-      orgMemberships.find((m) => m.organizationId === orgId)?.organizationName ??
-      "the organization"
-    );
-  };
 
-  // Build a map from paymentId → invoice for quick lookup
-  const invoiceByPaymentId = useMemo(() => {
-    if (!data) return new Map<string, InvoiceItem>();
-    const map = new Map<string, InvoiceItem>();
-    for (const inv of data.invoices) {
-      if (inv.paymentId) {
-        map.set(inv.paymentId, inv);
-      }
+  // Successful spend grouped per currency — a USD payment must never be
+  // summed into an INR total.
+  const totalsByCurrency = useMemo(() => {
+    const map = new Map<string, { total: number; count: number }>();
+    for (const p of data?.payments ?? []) {
+      if (p.status !== "SUCCEEDED") continue;
+      const currency = p.currency || "INR";
+      const entry = map.get(currency) ?? { total: 0, count: 0 };
+      entry.total += p.amount;
+      entry.count += 1;
+      map.set(currency, entry);
     }
     return map;
-  }, [data]);
-
-  // TODO: currently sums all currencies as INR — add multi-currency support later
-  const totalSpent = useMemo(() => {
-    if (!data) return 0;
-    return data.payments
-      .filter((p) => p.status === "SUCCEEDED")
-      .reduce((sum, p) => sum + p.amount, 0);
   }, [data]);
 
   const [statusFilter, setStatusFilter] = useState<string>("all");
@@ -293,6 +263,7 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
           {(() => {
             const sponsoringOrgName = resolveSponsoringOrgName(
               payment.organizationId,
+              orgMemberships,
             );
             return sponsoringOrgName ? (
               <Badge
@@ -315,20 +286,6 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
           {formatDate(payment.createdAt)}
         </span>
       ),
-    },
-    {
-      key: "invoiceNo",
-      header: "Invoice #",
-      cell: (payment) => {
-        const invoice = invoiceByPaymentId.get(payment.id);
-        return (
-          <span className="font-mono text-xs text-muted-foreground whitespace-nowrap">
-            {invoice?.invoiceNumber || (
-              <span className="text-muted-foreground/70">&mdash;</span>
-            )}
-          </span>
-        );
-      },
     },
     {
       key: "type",
@@ -389,7 +346,51 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
     {
       key: "status",
       header: "Status",
-      cell: (payment) => <StatusBadge status={getDisplayStatus(payment)} />,
+      cell: (payment) => {
+        const displayStatus = getDisplayStatus(payment);
+        return (
+          <div className="space-y-1">
+            <StatusBadge {...paymentStatusBadge(displayStatus)} size="sm" />
+            {payment.refundedPaise > 0 && (
+              <span className="block text-xs text-muted-foreground whitespace-nowrap">
+                {formatAmountInCurrency(payment.refundedPaise, payment.currency)}{" "}
+                refunded
+              </span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      key: "refunds",
+      header: "Refunds",
+      cell: (payment) => {
+        if (payment.refunds.length === 0) {
+          return <span className="text-muted-foreground/70">&mdash;</span>;
+        }
+        return (
+          <ul className="space-y-1.5">
+            {payment.refunds.map((refund) => (
+              <li key={refund.id} className="whitespace-nowrap">
+                <StatusBadge {...refundStatusBadge(refund.status)} size="sm" />
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  {formatAmountInCurrency(refund.amountPaise, payment.currency)}
+                  {" · "}
+                  {formatDate(refund.createdAt)}
+                </span>
+                {refund.reason && (
+                  <span
+                    className="block text-xs text-muted-foreground/70 max-w-[200px] truncate"
+                    title={refund.reason}
+                  >
+                    {refund.reason}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        );
+      },
     },
     {
       key: "expires",
@@ -415,54 +416,6 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
               {expiry.relative}
             </span>
           </div>
-        );
-      },
-    },
-    {
-      key: "invoice",
-      header: "Invoice",
-      headClassName: "text-center",
-      className: "text-center",
-      cell: (payment) => {
-        const invoice = invoiceByPaymentId.get(payment.id);
-        const displayStatus = getDisplayStatus(payment);
-        if (invoice) {
-          return (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={() => {
-                      window.open(`/api/invoices/${invoice.id}/pdf`, "_blank");
-                    }}
-                  >
-                    <Download className="w-4 h-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Download invoice PDF</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          );
-        }
-        if (displayStatus === "FAILED" || displayStatus === "EXPIRED") {
-          return <span className="text-xs text-muted-foreground/70">&mdash;</span>;
-        }
-        return (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <FileText className="w-4 h-4 text-muted-foreground/50 mx-auto" />
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Invoice pending</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
         );
       },
     },
@@ -560,11 +513,12 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
     >
-      <PageHeader
-        className="mb-6"
-        title="Payments"
-        description="Your payment history and credits"
-      />
+      <div className="mb-6">
+        <DashboardHeader
+          title="Payments"
+          subtitle="Your payment history and credits"
+        />
+      </div>
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
@@ -578,16 +532,34 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                 </p>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Only includes successful payments</p>
+                <p>
+                  Only includes successful payments. Multi-currency spend is
+                  totalled per currency, never converted.
+                </p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <p className="text-2xl font-bold text-foreground">
-            {formatPrice(totalSpent)}
-          </p>
+          {totalsByCurrency.size === 0 ? (
+            <p className="text-2xl font-bold text-foreground">
+              {formatPrice(0)}
+            </p>
+          ) : (
+            <div className="space-y-0.5">
+              {Array.from(totalsByCurrency.entries()).map(([currency, entry]) => (
+                <p
+                  key={currency}
+                  className="text-2xl font-bold text-foreground leading-tight"
+                >
+                  {formatAmountInCurrency(entry.total, currency)}
+                </p>
+              ))}
+            </div>
+          )}
           <p className="text-xs text-muted-foreground/70 mt-1">
             {(() => {
-              const count = data.payments.filter((p) => p.status === "SUCCEEDED").length;
+              const count = data.payments.filter(
+                (p) => p.status === "SUCCEEDED",
+              ).length;
               return `${count} successful ${count === 1 ? "transaction" : "transactions"} `;
             })()}
             &middot; {data.payments.length} total
@@ -638,6 +610,10 @@ export function PaymentsTab({ data }: { data: PaymentsData | undefined }) {
                   <SelectContent>
                     <SelectItem value="all">All statuses</SelectItem>
                     <SelectItem value="SUCCEEDED">Succeeded</SelectItem>
+                    <SelectItem value="REFUNDED">Refunded</SelectItem>
+                    <SelectItem value="PARTIALLY_REFUNDED">
+                      Partially refunded
+                    </SelectItem>
                     <SelectItem value="PENDING">Pending</SelectItem>
                     <SelectItem value="FAILED">Failed</SelectItem>
                     <SelectItem value="EXPIRED">Expired</SelectItem>

--- a/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
@@ -101,6 +101,7 @@ export default function ConsulteeReferralsPage({
   const {
     data: creditsData,
     isLoading: creditsLoading,
+    isError: creditsError,
     refetch: refetchCredits,
   } = useQuery<{ data: CreditData }>({
     queryKey: ["referral-credits"],
@@ -339,7 +340,7 @@ export default function ConsulteeReferralsPage({
             </h3>
           </div>
           <div className="p-2 sm:p-3">
-            {referralsError ? (
+            {referralsError || creditsError ? (
               <EmptyState
                 icon={Users}
                 title="Couldn't load referrals"

--- a/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/referrals/page.tsx
@@ -16,11 +16,12 @@ import {
 } from "@/components/ui/responsive-table";
 import { useToast } from "@/hooks/use-toast";
 import { WhatsAppIcon } from "@/components/icons/WhatsAppIcon";
-import {
-  QUALIFICATION_WINDOW_DAYS,
-  CREDIT_EXPIRY_DAYS,
-} from "@/lib/referrals/constants";
+import { QUALIFICATION_WINDOW_DAYS } from "@/lib/referrals/constants";
 import { useCurrency } from "@/hooks/useCurrency";
+import { StatCardSkeleton } from "@/components/dashboard/StatCard";
+import { EmptyState } from "@/components/dashboard/DataCard";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
+import { referralStatusBadge } from "@/lib/labels/session-labels";
 
 interface ReferralCode {
   id: string;
@@ -67,7 +68,12 @@ export default function ConsulteeReferralsPage({
   const { formatPrice } = useCurrency();
   const [copied, setCopied] = useState(false);
 
-  const { data: codeData } = useQuery<{ data: ReferralCode }>({
+  const {
+    data: codeData,
+    isLoading: codeLoading,
+    isError: codeError,
+    refetch: refetchCode,
+  } = useQuery<{ data: ReferralCode }>({
     queryKey: ["referral-code"],
     queryFn: async () => {
       const res = await fetch("/api/referrals/code", { method: "POST" });
@@ -77,7 +83,12 @@ export default function ConsulteeReferralsPage({
     staleTime: 60_000,
   });
 
-  const { data: referralsData } = useQuery<{ data: Referral[] }>({
+  const {
+    data: referralsData,
+    isLoading: referralsLoading,
+    isError: referralsError,
+    refetch: refetchReferrals,
+  } = useQuery<{ data: Referral[] }>({
     queryKey: ["referrals"],
     queryFn: async () => {
       const res = await fetch("/api/referrals");
@@ -87,7 +98,11 @@ export default function ConsulteeReferralsPage({
     staleTime: 30_000,
   });
 
-  const { data: creditsData } = useQuery<{ data: CreditData }>({
+  const {
+    data: creditsData,
+    isLoading: creditsLoading,
+    refetch: refetchCredits,
+  } = useQuery<{ data: CreditData }>({
     queryKey: ["referral-credits"],
     queryFn: async () => {
       const res = await fetch("/api/referrals/credits");
@@ -96,6 +111,8 @@ export default function ConsulteeReferralsPage({
     },
     staleTime: 30_000,
   });
+
+  const isLoading = codeLoading || referralsLoading || creditsLoading;
 
   const code = codeData?.data;
   const referrals = referralsData?.data ?? [];
@@ -137,19 +154,7 @@ export default function ConsulteeReferralsPage({
     {
       key: "status",
       header: "Status",
-      cell: (ref) => (
-        <span
-          className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
-            ref.status === "REWARDED"
-              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
-              : ref.status === "SIGNED_UP"
-                ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300"
-                : "bg-muted text-muted-foreground"
-          }`}
-        >
-          {ref.status}
-        </span>
-      ),
+      cell: (ref) => <StatusBadge {...referralStatusBadge(ref.status)} />,
     },
     {
       key: "signedUp",
@@ -207,6 +212,24 @@ export default function ConsulteeReferralsPage({
       },
     ];
 
+  if (isLoading) {
+    return (
+      <>
+        <DashboardHeader
+          title="Referrals"
+          subtitle="Invite friends and earn credits towards your next booking"
+        />
+        <DashboardContent>
+          <DashboardGrid columns={3}>
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+            <StatCardSkeleton />
+          </DashboardGrid>
+        </DashboardContent>
+      </>
+    );
+  }
+
   return (
     <>
       <DashboardHeader
@@ -248,11 +271,23 @@ export default function ConsulteeReferralsPage({
               their first booking!
             </div>
           )}
+          {codeError && (
+            <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+              <span>Couldn&apos;t generate your referral link.</span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => refetchCode()}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
           <div className="flex gap-2">
             <div className="min-w-0 flex-1 flex items-center rounded-md border border-border bg-muted px-3 py-2 font-mono text-sm text-foreground select-all truncate">
               {referralLink || (
                 <span className="text-muted-foreground/70 italic font-sans">
-                  Generating link...
+                  {codeError ? "Link unavailable" : "Generating link..."}
                 </span>
               )}
             </div>
@@ -296,30 +331,6 @@ export default function ConsulteeReferralsPage({
           </div>
         </div>
 
-        {/* TODO: Program Details - hidden for now
-        <div className="mt-6 bg-white rounded-xl border border-zinc-200 p-6">
-          <h3 className="text-sm font-medium text-zinc-900 mb-3">
-            Program Details
-          </h3>
-          <div className="grid grid-cols-3 gap-4 text-sm">
-            <div className="rounded-lg bg-zinc-50 px-4 py-3">
-              <p className="text-zinc-500">Qualification Window</p>
-              <p className="mt-1 font-medium text-zinc-900">{QUALIFICATION_WINDOW_DAYS} days</p>
-            </div>
-            <div className="rounded-lg bg-zinc-50 px-4 py-3">
-              <p className="text-zinc-500">Credit Expiry</p>
-              <p className="mt-1 font-medium text-zinc-900">{CREDIT_EXPIRY_DAYS} days</p>
-            </div>
-            <div className="rounded-lg bg-zinc-50 px-4 py-3">
-              <p className="text-zinc-500">Max Referrals</p>
-              <p className="mt-1 font-medium text-zinc-900">
-                {code?.maxReferrals ?? 25}
-              </p>
-            </div>
-          </div>
-        </div>
-        */}
-
         {/* Referrals List */}
         <div className="mt-6 bg-card rounded-xl border border-border overflow-hidden">
           <div className="px-6 py-4 border-b border-border">
@@ -328,16 +339,34 @@ export default function ConsulteeReferralsPage({
             </h3>
           </div>
           <div className="p-2 sm:p-3">
-            <ResponsiveTable<Referral>
-              columns={referralColumns}
-              rows={referrals}
-              getRowId={(r) => r.id}
-              empty={
-                <div className="px-6 py-12 text-center text-muted-foreground text-sm">
-                  No referrals yet. Share your link to get started!
-                </div>
-              }
-            />
+            {referralsError ? (
+              <EmptyState
+                icon={Users}
+                title="Couldn't load referrals"
+                action={
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      void refetchReferrals();
+                      void refetchCredits();
+                    }}
+                  >
+                    Retry
+                  </Button>
+                }
+              />
+            ) : (
+              <ResponsiveTable<Referral>
+                columns={referralColumns}
+                rows={referrals}
+                getRowId={(r) => r.id}
+                empty={
+                  <div className="px-6 py-12 text-center text-muted-foreground text-sm">
+                    No referrals yet. Share your link to get started!
+                  </div>
+                }
+              />
+            )}
           </div>
         </div>
 

--- a/app/dashboard/consultee/[consulteeId]/(features)/resources/EventResourceCard.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/resources/EventResourceCard.tsx
@@ -12,10 +12,8 @@ import {
   Video,
 } from "lucide-react";
 import { cn } from "@/utils/tailwind";
-import {
-  formatStatusLabel,
-  getStatusStyle,
-} from "@/app/dashboard/consultee/[consulteeId]/utils/statusConfig";
+import { eventUnionStatusBadge } from "../appointments/utils/status-guards";
+import { StatusBadge } from "@/components/dashboard/StatusBadge";
 
 export interface EventResource {
   id: string;
@@ -113,17 +111,7 @@ export function EventResourceCard({ event }: { event: EventResource }) {
         </div>
 
         <div className="flex items-center gap-3 shrink-0">
-          <span
-            className={cn(
-              "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium",
-              (() => {
-                const s = getStatusStyle(event.status);
-                return `${s.bg} ${s.text}`;
-              })(),
-            )}
-          >
-            {formatStatusLabel(event.status)}
-          </span>
+          <StatusBadge {...eventUnionStatusBadge(event.status)} size="sm" />
           {totalItems > 0 && (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               {event.materials.length > 0 && (

--- a/app/dashboard/consultee/[consulteeId]/(features)/resources/ResourcesTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/resources/ResourcesTab.tsx
@@ -20,7 +20,7 @@ import {
 import { motion } from "framer-motion";
 import { ArrowUpDown, FolderOpen, RefreshCw } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { PageHeader } from "@/components/ui/page-header";
+import { DashboardHeader } from "@/components/dashboard/DashboardShell";
 import { EventResourceCard, type EventResource } from "./EventResourceCard";
 
 interface ResourcesData {
@@ -28,6 +28,7 @@ interface ResourcesData {
   subscriptions: EventResource[];
   webinars: EventResource[];
   classes: EventResource[];
+  trials?: EventResource[];
 }
 
 interface ResourcesTabProps {
@@ -40,6 +41,7 @@ const EVENT_TYPES = [
   { key: "subscriptions", label: "Subscriptions" },
   { key: "webinars", label: "Webinars" },
   { key: "classes", label: "Classes" },
+  { key: "trials", label: "Trials" },
 ] as const;
 
 type FilterOption = "all" | "with_recordings" | "with_materials" | "completed";
@@ -126,6 +128,10 @@ export function ResourcesTab({ data, onRefresh }: ResourcesTabProps) {
         sortDir,
       ),
       classes: sortEvents(filterEvents(data.classes, resourceFilter), sortDir),
+      trials: sortEvents(
+        filterEvents(data.trials ?? [], resourceFilter),
+        sortDir,
+      ),
     };
   }, [data, resourceFilter, sortDir]);
 
@@ -135,7 +141,8 @@ export function ResourcesTab({ data, onRefresh }: ResourcesTabProps) {
     data.consultations.length +
     data.subscriptions.length +
     data.webinars.length +
-    data.classes.length;
+    data.classes.length +
+    (data.trials ?? []).length;
 
   if (totalResources === 0) {
     return (
@@ -162,7 +169,7 @@ export function ResourcesTab({ data, onRefresh }: ResourcesTabProps) {
 
   // Find the first tab that has events (based on unfiltered data)
   const defaultTab =
-    EVENT_TYPES.find((t) => data[t.key as keyof ResourcesData].length > 0)
+    EVENT_TYPES.find((t) => (data[t.key as keyof ResourcesData] ?? []).length > 0)
       ?.key || "consultations";
 
   return (
@@ -171,10 +178,9 @@ export function ResourcesTab({ data, onRefresh }: ResourcesTabProps) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
     >
-      <PageHeader
-        className="mb-6"
+      <DashboardHeader
         title="Resources"
-        description="Materials and recordings from your enrolled events"
+        subtitle="Materials and recordings from your enrolled events"
         actions={
           <TooltipProvider>
             <Tooltip>
@@ -229,8 +235,8 @@ export function ResourcesTab({ data, onRefresh }: ResourcesTabProps) {
       <Tabs defaultValue={defaultTab} className="space-y-6">
         <TabsList>
           {EVENT_TYPES.map(({ key, label }) => {
-            const total = data[key as keyof ResourcesData].length;
-            const filtered = filteredData[key as keyof ResourcesData].length;
+            const total = (data[key as keyof ResourcesData] ?? []).length;
+            const filtered = (filteredData[key as keyof ResourcesData] ?? []).length;
             return (
               <TabsTrigger key={key} value={key} disabled={total === 0}>
                 {label}
@@ -245,8 +251,8 @@ export function ResourcesTab({ data, onRefresh }: ResourcesTabProps) {
         </TabsList>
 
         {EVENT_TYPES.map(({ key }) => {
-          const total = data[key as keyof ResourcesData].length;
-          const items = filteredData[key as keyof ResourcesData];
+          const total = (data[key as keyof ResourcesData] ?? []).length;
+          const items = filteredData[key as keyof ResourcesData] ?? [];
           return (
             <TabsContent key={key} value={key}>
               <div className="space-y-4">

--- a/app/dashboard/consultee/[consulteeId]/(features)/settings/SettingsTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/settings/SettingsTab.tsx
@@ -1,20 +1,22 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import { Button } from "components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "components/ui/card";
-import { Input } from "components/ui/input";
-import { Label } from "components/ui/label";
-import { Textarea } from "components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "components/ui/select";
+} from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import { NotificationPreferencesPanel } from "@/components/notifications";
+import { EmptyState } from "@/components/dashboard/DataCard";
+import { Settings as SettingsIcon } from "lucide-react";
 import React, { useEffect, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { createConsulteeQueries } from "@/lib/dashboard-queries";
@@ -198,7 +200,15 @@ export default function SettingsTab({ consulteeId }: SettingsTabProps) {
           }),
         });
         if (!bgResponse.ok) {
-          console.error("Failed to update education/work experience");
+          // Profile saved but background details didn't — say so instead of
+          // reporting blanket success; the form stays dirty for a retry.
+          toast({
+            title: "Partially saved",
+            description:
+              "Your profile was saved, but education/work experience failed to update. Please try saving again.",
+            variant: "destructive",
+          });
+          return;
         }
       }
 
@@ -247,6 +257,23 @@ export default function SettingsTab({ consulteeId }: SettingsTabProps) {
           </CardContent>
         </Card>
       </div>
+    );
+  }
+
+  // In-page error state — the old toast-only path left a form rendering
+  // nulls after a failed load, which read like empty settings.
+  if (error && !consulteeData) {
+    return (
+      <EmptyState
+        icon={SettingsIcon}
+        title="Couldn't load your settings"
+        description="Something went wrong while fetching your profile."
+        action={
+          <Button variant="outline" onClick={() => refetch()}>
+            Retry
+          </Button>
+        }
+      />
     );
   }
 


### PR DESCRIPTION
P0: payments API includes refunds + derived displayStatus (REFUNDED/PARTIALLY_REFUNDED) — refunded bookings no longer read 'SUCCEEDED' forever; refund rows in PaymentsTab; unreachable invoice-PDF column removed; per-currency totals (no more INR-summing). Feedback fetched once (hook consumes the page's query configs). Messages gets ChatUnavailable fallback. Resources gains Trials end-to-end. Settings load/save failures surfaced. utils/statusConfig.ts deleted (zero consumers). NOTE: parallel sibling of 07 — this PR's unique commit is ef365535.

---
Part of the consultant/consultee dashboard redesign chain (9 PRs -> mega branch `feat/dashboard-redesign` -> `dev`). Review this PR's own commit(s); the mega PR follows after chain review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)