### PR TITLE
fix(dashboard): instant nav feedback on cold routes + availability editor height

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
@@ -38,6 +38,29 @@ interface AvailabilitySectionProps {
 }
 
 /**
+ * Compact stand-in for the schedule type that is NOT selected. Editing is
+ * per-type; rendering the inactive editor in full (even faded) doubled the
+ * page height — with 40+ custom dates it produced screens of washed-out
+ * rows that read as endless empty space.
+ */
+function InactiveScheduleNote({
+  label,
+  summary,
+}: {
+  label: string;
+  summary: string;
+}) {
+  return (
+    <div className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
+      <p className="font-medium text-zinc-600">{label} is inactive</p>
+      <p className="mt-1">
+        {summary}. Select this schedule type above to view and edit.
+      </p>
+    </div>
+  );
+}
+
+/**
  * Availability tab of the consultant settings form. Presentational only —
  * all slot state, validation, and the WEEKLY↔CUSTOM switch lock live in
  * SettingsTab so the combined settings PUT payload stays exactly as it was
@@ -141,21 +164,33 @@ export function AvailabilitySection({
             </Label>
             <RadioGroupItem id="WEEKLY" value={ScheduleType.WEEKLY} />
           </div>
-          <div
-            className={`space-y-4 transition-opacity ${scheduleType !== ScheduleType.WEEKLY ? "opacity-40 pointer-events-none" : ""}`}
-          >
-            {DAYS_OF_WEEK.map((day) => (
-              <AvailabilityGrid
-                key={day}
-                dayKey={day.toLowerCase()}
-                label={formatDayDisplay(day)}
-                slots={weeklySlots[day.toLowerCase()]}
-                onAddSlot={onAddSlot}
-                onUpdateSlot={onUpdateSlot}
-                onDeleteSlot={onDeleteSlot}
-              />
-            ))}
-          </div>
+          {/* Only the ACTIVE schedule type renders its full editor. The old
+              opacity-40 treatment still rendered the inactive editor at full
+              height — with a season of custom dates that meant screens of
+              washed-out rows that read as endless empty space. */}
+          {scheduleType === ScheduleType.WEEKLY ? (
+            <div className="space-y-4">
+              {DAYS_OF_WEEK.map((day) => (
+                <AvailabilityGrid
+                  key={day}
+                  dayKey={day.toLowerCase()}
+                  label={formatDayDisplay(day)}
+                  slots={weeklySlots[day.toLowerCase()]}
+                  onAddSlot={onAddSlot}
+                  onUpdateSlot={onUpdateSlot}
+                  onDeleteSlot={onDeleteSlot}
+                />
+              ))}
+            </div>
+          ) : (
+            <InactiveScheduleNote
+              label="Weekly Recurring"
+              summary={`${Object.values(weeklySlots).reduce(
+                (n, s) => n + (s?.length ?? 0),
+                0,
+              )} recurring slot(s) configured`}
+            />
+          )}
         </div>
 
         {/* Custom Schedule */}
@@ -170,9 +205,13 @@ export function AvailabilitySection({
             </Label>
             <RadioGroupItem id="CUSTOM" value={ScheduleType.CUSTOM} />
           </div>
-          <div
-            className={`space-y-4 transition-opacity ${scheduleType !== ScheduleType.CUSTOM ? "opacity-40 pointer-events-none" : ""}`}
-          >
+          {scheduleType !== ScheduleType.CUSTOM ? (
+            <InactiveScheduleNote
+              label="Custom Schedule"
+              summary={`${Object.keys(customSlots).length} date(s) configured`}
+            />
+          ) : (
+          <div className="space-y-4">
             <div className="calendar-container bg-card border p-4 rounded-lg">
               <div className="flex justify-between items-center mb-4">
                 <button
@@ -205,31 +244,41 @@ export function AvailabilitySection({
               </div>
             </div>
 
-            {Object.keys(customSlots)
-              .sort((a, b) => a.localeCompare(b))
-              .map((dateString) => {
-                // Parse YYYY-MM-DD as a LOCAL date — new Date("YYYY-MM-DD")
-                // is UTC midnight, which renders as the PREVIOUS day for
-                // users in timezones behind UTC.
-                const [year, month, day] = dateString.split("-").map(Number);
-                const date = new Date(year, month - 1, day);
-                return (
-                  <AvailabilityGrid
-                    key={dateString}
-                    dayKey={dateString}
-                    label={date.toLocaleDateString("en-US", {
-                      weekday: "long",
-                      month: "long",
-                      day: "numeric",
-                    })}
-                    slots={customSlots[dateString]}
-                    onAddSlot={onAddSlot}
-                    onUpdateSlot={onUpdateSlot}
-                    onDeleteSlot={onDeleteSlot}
-                  />
-                );
-              })}
+            {/* A season of custom dates can run 40+ entries — contain them in
+                their own scroll region instead of stretching the page. */}
+            {Object.keys(customSlots).length > 0 && (
+              <p className="text-xs text-zinc-500">
+                {Object.keys(customSlots).length} date(s) configured
+              </p>
+            )}
+            <div className="max-h-[560px] overflow-y-auto pr-2 space-y-4">
+              {Object.keys(customSlots)
+                .sort((a, b) => a.localeCompare(b))
+                .map((dateString) => {
+                  // Parse YYYY-MM-DD as a LOCAL date — new Date("YYYY-MM-DD")
+                  // is UTC midnight, which renders as the PREVIOUS day for
+                  // users in timezones behind UTC.
+                  const [year, month, day] = dateString.split("-").map(Number);
+                  const date = new Date(year, month - 1, day);
+                  return (
+                    <AvailabilityGrid
+                      key={dateString}
+                      dayKey={dateString}
+                      label={date.toLocaleDateString("en-US", {
+                        weekday: "long",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                      slots={customSlots[dateString]}
+                      onAddSlot={onAddSlot}
+                      onUpdateSlot={onUpdateSlot}
+                      onDeleteSlot={onDeleteSlot}
+                    />
+                  );
+                })}
+            </div>
           </div>
+          )}
         </div>
       </RadioGroup>
 

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
@@ -51,7 +51,10 @@ function InactiveScheduleNote({
   summary: string;
 }) {
   return (
-    <div className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
+    <div
+      aria-live="polite"
+      className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500"
+    >
       <p className="font-medium text-zinc-600">{label} is inactive</p>
       <p className="mt-1">
         {summary}. Select this schedule type above to view and edit.

--- a/app/dashboard/organization/[orgId]/layout.tsx
+++ b/app/dashboard/organization/[orgId]/layout.tsx
@@ -55,7 +55,7 @@ import {
   type CollapsibleSidebarGroup,
 } from "@/components/dashboard/CollapsibleSidebar";
 import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
-import { TabPendingIcon } from "@/components/dashboard/PersonalDashboardShell";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { useSession } from "@/lib/auth-client";
 import { signOutEverywhere } from "@/lib/auth/sign-out";
@@ -677,7 +677,7 @@ export default function OrgLayout({
                     : "text-zinc-500 hover:text-zinc-700"
                 }`}
               >
-                <TabPendingIcon
+                <LinkPendingIcon
                   Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900" : "text-zinc-400"}`}
                 />

--- a/app/dashboard/organization/[orgId]/layout.tsx
+++ b/app/dashboard/organization/[orgId]/layout.tsx
@@ -55,6 +55,7 @@ import {
   type CollapsibleSidebarGroup,
 } from "@/components/dashboard/CollapsibleSidebar";
 import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
+import { TabPendingIcon } from "@/components/dashboard/PersonalDashboardShell";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { useSession } from "@/lib/auth-client";
 import { signOutEverywhere } from "@/lib/auth/sign-out";
@@ -676,7 +677,8 @@ export default function OrgLayout({
                     : "text-zinc-500 hover:text-zinc-700"
                 }`}
               >
-                <Icon
+                <TabPendingIcon
+                  Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900" : "text-zinc-400"}`}
                 />
                 {label}

--- a/components/dashboard/CollapsibleSidebar.tsx
+++ b/components/dashboard/CollapsibleSidebar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { cn } from "@/utils/tailwind";
-import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, Loader2, LogOut, type LucideIcon } from "lucide-react";
-import Link, { useLinkStatus } from "next/link";
+import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, LogOut, type LucideIcon } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 import {
   Tooltip,
   TooltipContent,
@@ -124,23 +125,6 @@ export interface CollapsibleSidebarProps {
    * wins over the default `bg-white`.
    */
   className?: string;
-}
-
-/**
- * Nav item icon that flips to a spinner the moment its enclosing Link's
- * navigation starts. On a cold route (dev compile, slow RSC fetch) the
- * app-router blocks BEFORE the destination's loading.tsx can render —
- * without this, a click looks dead for seconds and then switches abruptly.
- * The spinner is the instant acknowledgement; the route skeleton takes
- * over once the segment mounts.
- */
-function NavPendingIcon({ Icon }: { Icon: LucideIcon }) {
-  const { pending } = useLinkStatus();
-  return pending ? (
-    <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" aria-hidden />
-  ) : (
-    <Icon className="h-5 w-5 flex-shrink-0" />
-  );
 }
 
 /**
@@ -387,7 +371,7 @@ export function CollapsibleSidebar({
                                       : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                                   )}
                                 >
-                                  <NavPendingIcon Icon={item.icon} />
+                                  <LinkPendingIcon Icon={item.icon} />
                                   {collapsed ? (
                                     <span className="sr-only">{item.name}</span>
                                   ) : (
@@ -439,7 +423,7 @@ export function CollapsibleSidebar({
                             : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                         )}
                       >
-                        <NavPendingIcon Icon={item.icon} />
+                        <LinkPendingIcon Icon={item.icon} />
                         {collapsed ? (
                           <span className="sr-only">{item.name}</span>
                         ) : (

--- a/components/dashboard/CollapsibleSidebar.tsx
+++ b/components/dashboard/CollapsibleSidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { cn } from "@/utils/tailwind";
-import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, LogOut, type LucideIcon } from "lucide-react";
-import Link from "next/link";
+import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, Loader2, LogOut, type LucideIcon } from "lucide-react";
+import Link, { useLinkStatus } from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -124,6 +124,23 @@ export interface CollapsibleSidebarProps {
    * wins over the default `bg-white`.
    */
   className?: string;
+}
+
+/**
+ * Nav item icon that flips to a spinner the moment its enclosing Link's
+ * navigation starts. On a cold route (dev compile, slow RSC fetch) the
+ * app-router blocks BEFORE the destination's loading.tsx can render —
+ * without this, a click looks dead for seconds and then switches abruptly.
+ * The spinner is the instant acknowledgement; the route skeleton takes
+ * over once the segment mounts.
+ */
+function NavPendingIcon({ Icon }: { Icon: LucideIcon }) {
+  const { pending } = useLinkStatus();
+  return pending ? (
+    <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" aria-hidden />
+  ) : (
+    <Icon className="h-5 w-5 flex-shrink-0" />
+  );
 }
 
 /**
@@ -370,7 +387,7 @@ export function CollapsibleSidebar({
                                       : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                                   )}
                                 >
-                                  <item.icon className="h-5 w-5 flex-shrink-0" />
+                                  <NavPendingIcon Icon={item.icon} />
                                   {collapsed ? (
                                     <span className="sr-only">{item.name}</span>
                                   ) : (
@@ -422,7 +439,7 @@ export function CollapsibleSidebar({
                             : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                         )}
                       >
-                        <item.icon className="h-5 w-5 flex-shrink-0" />
+                        <NavPendingIcon Icon={item.icon} />
                         {collapsed ? (
                           <span className="sr-only">{item.name}</span>
                         ) : (

--- a/components/dashboard/PersonalDashboardShell.tsx
+++ b/components/dashboard/PersonalDashboardShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link, { useLinkStatus } from "next/link";
-import { Loader2, type LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { type LucideIcon } from "lucide-react";
 import {
   CollapsibleSidebar,
   CollapsibleSidebarSkeleton,
@@ -14,32 +14,12 @@ import {
 } from "@/components/dashboard/DashboardContextBar";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { isActiveRoute } from "@/components/dashboard/route-active";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 
 export interface PersonalDashboardMobileTab {
   label: string;
   path: string;
   Icon: LucideIcon;
-}
-
-/**
- * Tab icon that flips to a spinner the moment its Link's navigation starts —
- * instant acknowledgement on cold routes where the app-router blocks before
- * the destination's loading.tsx can render (same pattern as the sidebar's
- * NavPendingIcon).
- */
-export function TabPendingIcon({
-  Icon,
-  className,
-}: {
-  Icon: LucideIcon;
-  className: string;
-}) {
-  const { pending } = useLinkStatus();
-  return pending ? (
-    <Loader2 className={`${className} animate-spin`} aria-hidden />
-  ) : (
-    <Icon className={className} />
-  );
 }
 
 export interface PersonalDashboardShellProps {
@@ -147,7 +127,7 @@ export function PersonalDashboardShell({
                     : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
                 }`}
               >
-                <TabPendingIcon
+                <LinkPendingIcon
                   Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
                 />

--- a/components/dashboard/PersonalDashboardShell.tsx
+++ b/components/dashboard/PersonalDashboardShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import type { LucideIcon } from "lucide-react";
+import Link, { useLinkStatus } from "next/link";
+import { Loader2, type LucideIcon } from "lucide-react";
 import {
   CollapsibleSidebar,
   CollapsibleSidebarSkeleton,
@@ -19,6 +19,27 @@ export interface PersonalDashboardMobileTab {
   label: string;
   path: string;
   Icon: LucideIcon;
+}
+
+/**
+ * Tab icon that flips to a spinner the moment its Link's navigation starts —
+ * instant acknowledgement on cold routes where the app-router blocks before
+ * the destination's loading.tsx can render (same pattern as the sidebar's
+ * NavPendingIcon).
+ */
+export function TabPendingIcon({
+  Icon,
+  className,
+}: {
+  Icon: LucideIcon;
+  className: string;
+}) {
+  const { pending } = useLinkStatus();
+  return pending ? (
+    <Loader2 className={`${className} animate-spin`} aria-hidden />
+  ) : (
+    <Icon className={className} />
+  );
 }
 
 export interface PersonalDashboardShellProps {
@@ -126,7 +147,8 @@ export function PersonalDashboardShell({
                     : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
                 }`}
               >
-                <Icon
+                <TabPendingIcon
+                  Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
                 />
                 {label}

--- a/components/ui/NavLink.tsx
+++ b/components/ui/NavLink.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link, { useLinkStatus } from "next/link";
-import { Loader2 } from "lucide-react";
+import { Loader2, type LucideIcon } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 
 /**
@@ -25,6 +25,32 @@ function PendingIndicator({ className }: { className?: string }) {
         className,
       )}
     />
+  );
+}
+
+/**
+ * Icon-swap variant of the pending affordance for icon-led nav items
+ * (sidebar rows, mobile tab bars): the item's own icon flips to a spinner
+ * while its enclosing Link's navigation is in flight. Same #15.5 contract —
+ * MUST be a descendant of the <Link> it reports on. Single shared
+ * implementation for every dashboard shell (sidebar, personal mobile tabs,
+ * org mobile tabs) so the subtle useLinkStatus contract can't drift.
+ */
+export function LinkPendingIcon({
+  Icon,
+  className = "h-5 w-5 flex-shrink-0",
+}: {
+  Icon: LucideIcon;
+  className?: string;
+}) {
+  const { pending } = useLinkStatus();
+  return pending ? (
+    <Loader2
+      className={cn(className, "animate-spin motion-reduce:animate-none")}
+      aria-hidden
+    />
+  ) : (
+    <Icon className={className} />
   );
 }
 


### PR DESCRIPTION
Follow-up to #960 from live testing:

1. **Sudden tab switches on cold start**: sidebar + mobile-tab icons now flip to a spinner the instant navigation starts (`useLinkStatus`), bridging the gap where the app-router blocks before the destination's `loading.tsx` can mount. Route skeleton coverage audited — every consultant/consultee feature route has a real skeleton `loading.tsx`. Applies to org dashboard chrome too (shared components).
2. **Endless white space in consultant availability settings**: the inactive schedule type rendered its entire editor at opacity-40 — up to 40+ custom-date grids of washed-out rows. Inactive type now collapses to a one-line summary; the active custom-date list scrolls in its own contained region. (Only occurrence of this pattern in the repo.)

Verified: tsc clean, eslint clean, jest 122/1498 green. Build via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard navigation icons now show a loading spinner while their links are pending (mobile bottom tabs and sidebar).
  * Availability settings now display a compact inactive-schedule note (with computed summaries) instead of a disabled/faded editor.

* **Bug Fixes**
  * Long custom-date availability lists are now contained in a fixed-height, scrollable area to prevent page stretching.
  * Custom schedules now show a clearer “date(s) configured” count when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->