### PR TITLE
feat(org-workspace): operator shell alignment + route boundaries

### DIFF
--- a/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
@@ -3,41 +3,35 @@
 /**
  * Client-side shell for the org-workspace (operator) dashboard. Sits inside
  * the server-side layout that runs the IDOR guard and resolves the user
- * identity props on the server (so the sidebar's displayed name is
- * the same on the server-rendered HTML and the first client render —
- * no hydration mismatch).
+ * identity props on the server (so the sidebar's displayed name is the same
+ * on the server-rendered HTML and the first client render — no hydration
+ * mismatch).
  *
- * Renders the same CollapsibleSidebar pattern as /dashboard/admin and
- * /dashboard/staff, with a top context bar carrying OrganizationSwitcher
- * + NotificationInbox.
+ * Same chrome contract as the other role dashboards: a collapsible sidebar
+ * (md+), a sticky h-14 DashboardContextBar, and a mobile bottom tab bar
+ * (<md) so the w-64 aside never crushes the content column on a phone.
  *
- * Visual differentiation from the per-org dashboard:
- *   - Sidebar carries a silver/dark-grey gradient (via the new
- *     `className` prop on CollapsibleSidebar) — this is the agreed
- *     accent location, NOT the page background.
- *   - Sidebar subtitle reads "Cross-org dashboard" so the title +
- *     subtitle pair (Operator / Cross-org dashboard) names the scope.
- *   - Page body stays on flat zinc-50 — content cards keep their
- *     existing visual weight.
- *
- * Sidebar items are intentionally lean (Overview / Activity / Billing /
- * Settings). Per-org operator surfaces (members, programs, payouts) live
- * one level deeper at /dashboard/organization/[orgId]/* and have their
- * own sidebar — this dashboard is the *cross-org* operator view.
+ * Visual differentiation from the per-org dashboard: the sidebar carries a
+ * jet-black gradient accent (via CollapsibleSidebar's `className` prop, with
+ * `dark` scoped to the aside) — the one cue that says "cross-org operator",
+ * not "inside a single org". Per-org operator surfaces (members, programs,
+ * payouts) live one level deeper at /dashboard/organization/[orgId]/*.
  */
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Activity, CreditCard, Home, Settings } from "lucide-react";
+import { Activity, CreditCard, Home, Settings, UserRound } from "lucide-react";
 
 import {
   CollapsibleSidebar,
   type CollapsibleSidebarItem,
 } from "@/components/dashboard/CollapsibleSidebar";
+import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
+import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
+import { isActiveRoute } from "@/components/dashboard/route-active";
 import { OrganizationSwitcher } from "@/components/dashboard/OrganizationSwitcher";
 import { NotificationInbox } from "@/components/notifications/NotificationInbox";
-import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
-import { signOut } from "@/lib/auth-client";
-import { disconnectStreamClients } from "@/providers/StreamProvider";
+import { signOutEverywhere } from "@/lib/auth/sign-out";
 
 const sidebarItems: CollapsibleSidebarItem[] = [
   { name: "Overview", icon: Home, path: "home" },
@@ -45,6 +39,15 @@ const sidebarItems: CollapsibleSidebarItem[] = [
   { name: "Billing", icon: CreditCard, path: "billing" },
   { name: "Settings", icon: Settings, path: "settings" },
 ];
+
+/** Breadcrumb labels per first path segment (mirrors the sidebar + /create). */
+const PAGE_LABELS: Record<string, string> = {
+  home: "Overview",
+  activity: "Activity",
+  billing: "Billing",
+  settings: "Settings",
+  create: "New organization",
+};
 
 export function OrgWorkspaceShell({
   orgWorkspaceId,
@@ -60,57 +63,86 @@ export function OrgWorkspaceShell({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-
-  const handleSignOut = async () => {
-    try {
-      await disconnectStreamClients();
-    } catch {
-      // Stream cleanup is best-effort.
-    }
-    signOut({
-      fetchOptions: {
-        onSuccess: () => {
-          window.location.href = "/auth/signin";
-        },
-      },
-    });
-  };
+  const basePath = `/dashboard/org-workspace/${orgWorkspaceId}`;
 
   const displayName = userName ?? "Operator";
   const avatarFallback = displayName.charAt(0).toUpperCase();
 
+  // Active page label for the context-bar breadcrumb trail. The segment is
+  // the first path part after the workspace id (defaults to the overview).
+  const segment =
+    pathname.slice(basePath.length).split("/").filter(Boolean)[0] ?? "home";
+  const pageLabel = PAGE_LABELS[segment] ?? "Overview";
+
   return (
     <div className="flex h-screen-maintenance bg-zinc-50 dark:bg-zinc-950">
-      <CollapsibleSidebar
-        items={sidebarItems}
-        basePath={`/dashboard/org-workspace/${orgWorkspaceId}`}
-        title="Operator"
-        avatarFallback={avatarFallback}
-        userName={displayName}
-        userEmail={userEmail ?? undefined}
-        userImage={userImage}
-        userSubtitle="Cross-org dashboard"
-        pathname={pathname}
-        onSignOut={handleSignOut}
-        // Jet-black sidebar accent — applied via the new className
-        // prop on CollapsibleSidebar. The shared component's text +
-        // icons are styled with `text-zinc-900 dark:text-zinc-100`
-        // pairs, so we scope `dark` mode to this aside (Tailwind uses
-        // class strategy per tailwind.config.ts:4) — every descendant's
-        // `dark:*` variants kick in, flipping copy and icons to light
-        // without affecting any other surface in the app.
-        className="dark bg-gradient-to-b from-black via-zinc-900 to-black"
-      />
+      {/* Sidebar — hidden on mobile, visible md+ */}
+      <div className="hidden md:block shrink-0">
+        <CollapsibleSidebar
+          items={sidebarItems}
+          basePath={basePath}
+          title="Operator"
+          avatarFallback={avatarFallback}
+          userName={displayName}
+          userEmail={userEmail ?? undefined}
+          userImage={userImage}
+          userSubtitle="Cross-org dashboard"
+          pathname={pathname}
+          onSignOut={() => void signOutEverywhere()}
+          // Jet-black sidebar accent via the shared className prop. The
+          // component's text/icons use `text-zinc-900 dark:text-zinc-100`
+          // pairs, so scoping `dark` to this aside (Tailwind class strategy)
+          // flips copy + icons to light without touching any other surface.
+          className="dark bg-gradient-to-b from-black via-zinc-900 to-black"
+        />
+      </div>
 
-      <main className="flex-1 overflow-y-auto">
-        <div className="sticky top-0 z-30 flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-xl">
-          <OrganizationSwitcher />
-          <NotificationInbox />
-        </div>
-        <div className="p-6">
-          <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
-        </div>
-      </main>
+      {/* Right panel: context bar + page content + mobile tabs */}
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+        <DashboardContextBar
+          identity={{
+            name: displayName,
+            image: userImage,
+            FallbackIcon: UserRound,
+          }}
+          breadcrumbs={["Operator", pageLabel]}
+          rightSlot={
+            <div className="flex items-center gap-2">
+              <OrganizationSwitcher />
+              <NotificationInbox />
+            </div>
+          }
+        />
+
+        <main className="flex-1 overflow-y-auto pb-16 md:pb-0">
+          <div className="p-6">
+            <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
+          </div>
+        </main>
+
+        {/* Mobile bottom tab bar — only visible below md breakpoint */}
+        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-20 bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 flex">
+          {sidebarItems.map(({ name, icon: Icon, path }) => {
+            const isActive = isActiveRoute(pathname, basePath, path);
+            return (
+              <Link
+                key={path}
+                href={`${basePath}/${path}`}
+                className={`flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[10px] font-medium transition-colors ${
+                  isActive
+                    ? "text-zinc-900 dark:text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                }`}
+              >
+                <Icon
+                  className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
+                />
+                {name}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
@@ -62,7 +62,10 @@ export function OrgWorkspaceShell({
   userImage: string | null;
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
+  // usePathname() returns the URL-encoded path, while orgWorkspaceId (from
+  // route params) is decoded — decode so basePath.slice + isActiveRoute compare
+  // like-for-like even for ids that need encoding. `?? ""` guards a null path.
+  const pathname = decodeURIComponent(usePathname() ?? "");
   const basePath = `/dashboard/org-workspace/${orgWorkspaceId}`;
 
   const displayName = userName ?? "Operator";
@@ -114,14 +117,15 @@ export function OrgWorkspaceShell({
           }
         />
 
-        <main className="flex-1 overflow-y-auto pb-16 md:pb-0">
+        <main className="flex-1 overflow-y-auto pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
           <div className="p-6">
             <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
           </div>
         </main>
 
-        {/* Mobile bottom tab bar — only visible below md breakpoint */}
-        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-20 bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 flex">
+        {/* Mobile bottom tab bar — only visible below md breakpoint. The
+            safe-area inset keeps the tabs clear of the iPhone home indicator. */}
+        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-20 bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 flex pb-[env(safe-area-inset-bottom)]">
           {sidebarItems.map(({ name, icon: Icon, path }) => {
             const isActive = isActiveRoute(pathname, basePath, path);
             return (

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/activity/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/activity/loading.tsx
@@ -1,0 +1,5 @@
+import { TableSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <TableSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/billing/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/billing/loading.tsx
@@ -1,0 +1,5 @@
+import { TableSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <TableSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/create/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/create/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/error.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { DashboardRouteError } from "@/components/dashboard/DashboardRouteError";
+
+export default function OrgWorkspaceDashboardError({
+  error,
+  reset,
+}: Readonly<{
+  error: Error & { digest?: string };
+  reset: () => void;
+}>) {
+  const params = useParams<{ orgWorkspaceId: string }>();
+
+  return (
+    <DashboardRouteError
+      error={error}
+      reset={reset}
+      scope="dashboard/org-workspace"
+      event="org_workspace_dashboard_error"
+      entityKey="orgWorkspaceId"
+      entityId={params?.orgWorkspaceId ?? "unknown"}
+      title="Something went wrong in this workspace"
+      devFallbackMessage="An unexpected error occurred while loading the operator dashboard."
+      escape={{ href: "/dashboard", label: "Back to dashboard" }}
+    />
+  );
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/home/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/home/loading.tsx
@@ -1,0 +1,5 @@
+import { HomeSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <HomeSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
@@ -23,11 +23,9 @@ export default function OrgWorkspaceNotFound() {
           doesn&apos;t have access to it.
         </p>
       </div>
-      <Link href="/dashboard">
-        <Button variant="outline" size="sm">
-          Back to dashboard
-        </Button>
-      </Link>
+      <Button variant="outline" size="sm" asChild>
+        <Link href="/dashboard">Back to dashboard</Link>
+      </Button>
     </div>
   );
 }

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { Building2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Scoped 404 for the operator dashboard. The layout's IDOR guard calls
+ * notFound() when the URL's orgWorkspaceId doesn't match the caller's own
+ * profile — this gives that case a friendly, self-contained page with a way
+ * back instead of the bare global 404.
+ */
+export default function OrgWorkspaceNotFound() {
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-zinc-100">
+        <Building2 className="h-7 w-7 text-zinc-400" />
+      </div>
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-zinc-900">
+          Workspace not found
+        </h2>
+        <p className="max-w-sm text-sm text-zinc-500">
+          This operator workspace doesn&apos;t exist, or your account
+          doesn&apos;t have access to it.
+        </p>
+      </div>
+      <Link href="/dashboard">
+        <Button variant="outline" size="sm">
+          Back to dashboard
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/settings/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { SettingsSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <SettingsSkeleton />;
+}


### PR DESCRIPTION
## What

Bring the org-workspace (cross-org operator) dashboard onto the same shell contract as the org/personal dashboards, and add the route-level loading/error/not-found boundaries the tree was completely missing.

**PR-A of a 2-PR chain** (task #18). PR-B (`redesign/ows-02-pages`) follows with page-level correctness — real API-error states, billing query dedup, `ResponsiveTable`, `next/image`, `date-fns`.

## Shell (`OrgWorkspaceShell.tsx`)
- **Mobile fix (P1-4):** sidebar wrapped in `hidden md:block` + a mobile bottom tab bar (Overview/Activity/Billing/Settings), `pb-16 md:pb-0` on `main`. Previously the bare `w-64` aside crushed the content column on phones.
- **Context bar (P2-1):** bespoke top strip → shared `DashboardContextBar` (operator identity, `Operator › <page>` breadcrumbs, `rightSlot` = OrganizationSwitcher + NotificationInbox).
- **Sign-out (P2-2):** inline copy → `signOutEverywhere()`, adding the `onError` redirect fallback the inline handler lacked (a failed server call previously stranded the user).
- Jet-black sidebar accent kept unchanged.

## Route boundaries (none existed anywhere in the tree)
- `error.tsx` → shared `DashboardRouteError` (Sentry capture + digest + `reset()`).
- `not-found.tsx` → scoped 404 with a Back-to-dashboard escape for the layout's IDOR `notFound()` (P2-9).
- `loading.tsx` for home / activity / billing / settings / create from `DashboardSkeletons` (P1-6).

## Product decisions
You were away when I asked — recommended defaults applied, **overridable in review**:
1. **Sidebar accent:** kept black-gradient (operator wayfinding).
2. **OrganizationSwitcher:** stays in the top bar.
3. **Multi-currency:** deferred (INR-only).

## Verification
- `npx tsc --noEmit` clean; `eslint` clean on all touched files.
- No test files cover these paths; full jest suite left to CI.
- No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly bottom navigation bar in the workspace dashboard.
  * Added breadcrumb-style context in the dashboard header for easier navigation.
  * Added dedicated loading states for home, billing, create, activity, and settings pages.
  * Added a workspace-specific “not found” page and improved error handling with a clear return path.

* **Bug Fixes**
  * Improved sign-out behavior across the workspace dashboard for a more consistent logout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->