### PR TITLE
fix(org-workspace): page error states + billing dedup + ResponsiveTable

### DIFF
--- a/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
@@ -24,6 +24,9 @@ import {
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/dashboard/DataCard";
+import { formatDistanceToNow } from "date-fns";
 
 interface ActivityRow {
   id: string;
@@ -74,19 +77,18 @@ const CATEGORY_LABEL: Record<string, string> = {
 };
 
 function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString("en-IN", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
+  const date = new Date(iso);
+  // Beyond 30 days a relative label ("2 months ago") loses the precision an
+  // audit feed wants — fall back to an absolute date there.
+  const days = (Date.now() - date.getTime()) / 86_400_000;
+  if (days > 30) {
+    return date.toLocaleDateString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  }
+  return formatDistanceToNow(date, { addSuffix: true });
 }
 
 export default function OrgWorkspaceActivityPage({
@@ -115,7 +117,37 @@ export default function OrgWorkspaceActivityPage({
       />
       <DashboardContent>
         {query.isLoading ? (
-          <p className="text-sm text-zinc-500">Loading activity…</p>
+          <Card>
+            <CardContent className="p-0">
+              <ul className="divide-y">
+                {[1, 2, 3, 4, 5].map((i) => (
+                  <li key={i} className="p-4">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="mt-2 h-4 w-3/4" />
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ) : query.isError ? (
+          <Card>
+            <CardContent className="py-10">
+              <EmptyState
+                icon={ActivityIcon}
+                title="Couldn't load activity"
+                description="We hit an error fetching your cross-org activity feed."
+                action={
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => query.refetch()}
+                  >
+                    Retry
+                  </Button>
+                }
+              />
+            </CardContent>
+          </Card>
         ) : rows.length === 0 ? (
           <Card>
             <CardContent className="py-10 text-center">

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
@@ -78,6 +78,9 @@ const CATEGORY_LABEL: Record<string, string> = {
 
 function timeAgo(iso: string): string {
   const date = new Date(iso);
+  // Guard a malformed timestamp — formatDistanceToNow throws a RangeError on an
+  // Invalid Date instead of degrading gracefully.
+  if (Number.isNaN(date.getTime())) return "—";
   // Beyond 30 days a relative label ("2 months ago") loses the precision an
   // audit feed wants — fall back to an absolute date there.
   const days = (Date.now() - date.getTime()) / 86_400_000;

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/billing/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/billing/page.tsx
@@ -13,9 +13,7 @@
 
 import { use } from "react";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import { CreditCard, Wallet, Receipt, Building2 } from "lucide-react";
-import type { FundingSource } from "@prisma/client";
 
 import {
   DashboardHeader,
@@ -23,42 +21,93 @@ import {
   DashboardGrid,
 } from "@/components/dashboard/PageScaffold";
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/StatCard";
+import { EmptyState } from "@/components/dashboard/DataCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/ui/responsive-table";
 import { formatCurrencyAmount } from "@/utils/formatting";
 import {
   FUNDING_SOURCE_LABEL,
   FUNDING_SOURCE_BADGE_CLASS,
 } from "@/lib/labels/org-labels";
+import {
+  useWorkspaceBilling,
+  type WorkspaceBillingPerOrgRow,
+} from "../hooks/useWorkspaceBilling";
 
-interface PerOrgRow {
-  organizationId: string;
-  organizationName: string;
-  organizationSlug: string;
-  organizationStatus: string;
-  fundingSource: FundingSource | null;
-  currency: string;
-  walletBalancePaise: number;
-  outstandingCount: number;
-  outstandingPaise: number;
-  activeMembers: number;
-}
-
-interface RollupResponse {
-  summary: {
-    orgsOwned: number;
-    totalActiveMembers: number;
-    totalOutstandingPaise: number;
-    totalWalletPaise: number;
-  };
-  perOrg: PerOrgRow[];
-}
-
-async function fetchRollup(orgWorkspaceId: string): Promise<RollupResponse> {
-  const res = await fetch(`/api/org-workspace/${orgWorkspaceId}/billing`);
-  if (!res.ok) throw new Error("Failed to load billing roll-up");
-  return res.json();
-}
+const columns: ResponsiveColumn<WorkspaceBillingPerOrgRow>[] = [
+  {
+    key: "org",
+    header: "Organisation",
+    primary: true,
+    cell: (r) => (
+      <Link
+        href={`/dashboard/organization/${r.organizationId}/billing`}
+        className="hover:underline"
+      >
+        <div className="font-medium">{r.organizationName}</div>
+        <div className="text-xs text-muted-foreground">
+          {r.organizationSlug}
+          {r.organizationStatus !== "ACTIVE" && (
+            <span className="ml-2 text-amber-600">
+              · {r.organizationStatus.toLowerCase()}
+            </span>
+          )}
+        </div>
+      </Link>
+    ),
+  },
+  {
+    key: "funding",
+    header: "Funding",
+    cell: (r) =>
+      r.fundingSource ? (
+        <Badge
+          variant="outline"
+          className={FUNDING_SOURCE_BADGE_CLASS[r.fundingSource]}
+        >
+          {FUNDING_SOURCE_LABEL[r.fundingSource]}
+        </Badge>
+      ) : (
+        <span className="text-xs text-muted-foreground">None</span>
+      ),
+  },
+  {
+    key: "wallet",
+    header: "Wallet",
+    className: "text-right tabular-nums",
+    headClassName: "text-right",
+    cell: (r) => formatCurrencyAmount(r.walletBalancePaise, "INR"),
+  },
+  {
+    key: "outstanding",
+    header: "Outstanding",
+    className: "text-right tabular-nums",
+    headClassName: "text-right",
+    cell: (r) => (
+      <div>
+        <div>{formatCurrencyAmount(r.outstandingPaise, "INR")}</div>
+        {r.outstandingCount > 0 && (
+          <div className="text-xs text-muted-foreground">
+            {r.outstandingCount} open
+          </div>
+        )}
+      </div>
+    ),
+  },
+  {
+    key: "members",
+    header: "Members",
+    className: "text-right tabular-nums",
+    headClassName: "text-right",
+    cell: (r) => r.activeMembers.toLocaleString("en-IN"),
+  },
+];
 
 export default function OrgWorkspaceBillingPage({
   params,
@@ -67,10 +116,8 @@ export default function OrgWorkspaceBillingPage({
 }) {
   const { orgWorkspaceId } = use(params);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["org-workspace-billing", orgWorkspaceId],
-    queryFn: () => fetchRollup(orgWorkspaceId),
-  });
+  const { data, isLoading, isError, refetch } =
+    useWorkspaceBilling(orgWorkspaceId);
 
   const summary = data?.summary;
   const rows = data?.perOrg ?? [];
@@ -82,131 +129,89 @@ export default function OrgWorkspaceBillingPage({
         subtitle="Outstanding invoices and wallet balances across the organisations you operate"
       />
       <DashboardContent>
-        <DashboardGrid>
-          {isLoading || !summary ? (
-            <>
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </>
-          ) : (
-            <>
-              <StatCard
-                title="Outstanding"
-                subtitle={`across ${summary.orgsOwned} organisation${summary.orgsOwned === 1 ? "" : "s"}`}
-                value={formatCurrencyAmount(
-                  summary.totalOutstandingPaise,
-                  "INR",
-                )}
+        {isError ? (
+          <Card>
+            <CardContent className="py-10">
+              <EmptyState
                 icon={Receipt}
-                variant={
-                  summary.totalOutstandingPaise > 0 ? "warning" : "default"
+                title="Couldn't load the billing overview"
+                description="We hit an error fetching your cross-org billing roll-up."
+                action={
+                  <Button size="sm" variant="outline" onClick={() => refetch()}>
+                    Retry
+                  </Button>
                 }
               />
-              <StatCard
-                title="Wallet balance"
-                subtitle="prepaid funds across orgs"
-                value={formatCurrencyAmount(summary.totalWalletPaise, "INR")}
-                icon={Wallet}
-              />
-              <StatCard
-                title="Funded orgs"
-                subtitle="have a billing account"
-                value={rows
-                  .filter((r) => r.fundingSource !== null)
-                  .length.toString()}
-                icon={CreditCard}
-              />
-            </>
-          )}
-        </DashboardGrid>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <DashboardGrid>
+              {isLoading || !summary ? (
+                <>
+                  <StatCardSkeleton />
+                  <StatCardSkeleton />
+                  <StatCardSkeleton />
+                </>
+              ) : (
+                <>
+                  <StatCard
+                    title="Outstanding"
+                    subtitle={`across ${summary.orgsOwned} organisation${summary.orgsOwned === 1 ? "" : "s"}`}
+                    value={formatCurrencyAmount(
+                      summary.totalOutstandingPaise,
+                      "INR",
+                    )}
+                    icon={Receipt}
+                    variant={
+                      summary.totalOutstandingPaise > 0 ? "warning" : "default"
+                    }
+                  />
+                  <StatCard
+                    title="Wallet balance"
+                    subtitle="prepaid funds across orgs"
+                    value={formatCurrencyAmount(summary.totalWalletPaise, "INR")}
+                    icon={Wallet}
+                  />
+                  <StatCard
+                    title="Funded orgs"
+                    subtitle="have a billing account"
+                    value={rows
+                      .filter((r) => r.fundingSource !== null)
+                      .length.toString()}
+                    icon={CreditCard}
+                  />
+                </>
+              )}
+            </DashboardGrid>
 
-        <section className="mt-6">
-          <h2 className="text-lg font-medium mb-3">Per-organisation breakdown</h2>
-          {isLoading ? (
-            <p className="text-sm text-zinc-500">Loading…</p>
-          ) : rows.length === 0 ? (
-            <Card>
-              <CardContent className="py-10 text-center">
-                <Building2 className="w-10 h-10 mx-auto mb-3 text-zinc-400" />
-                <p className="text-sm text-zinc-600">
-                  No organisations to bill yet. Create your first org from the
-                  Overview tab.
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="overflow-hidden rounded-lg border bg-card">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/40 text-left text-xs uppercase text-muted-foreground">
-                  <tr>
-                    <th className="px-4 py-2 font-medium">Organisation</th>
-                    <th className="px-4 py-2 font-medium">Funding</th>
-                    <th className="px-4 py-2 font-medium text-right">Wallet</th>
-                    <th className="px-4 py-2 font-medium text-right">
-                      Outstanding
-                    </th>
-                    <th className="px-4 py-2 font-medium text-right">Members</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((r) => (
-                    <tr key={r.organizationId} className="border-t">
-                      <td className="px-4 py-3">
-                        <Link
-                          href={`/dashboard/organization/${r.organizationId}/billing`}
-                          className="hover:underline"
-                        >
-                          <div className="font-medium">{r.organizationName}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {r.organizationSlug}
-                            {r.organizationStatus !== "ACTIVE" && (
-                              <span className="ml-2 text-amber-600">
-                                · {r.organizationStatus.toLowerCase()}
-                              </span>
-                            )}
-                          </div>
-                        </Link>
-                      </td>
-                      <td className="px-4 py-3">
-                        {r.fundingSource ? (
-                          <Badge
-                            variant="outline"
-                            className={
-                              FUNDING_SOURCE_BADGE_CLASS[r.fundingSource]
-                            }
-                          >
-                            {FUNDING_SOURCE_LABEL[r.fundingSource]}
-                          </Badge>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">
-                            None
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {formatCurrencyAmount(r.walletBalancePaise, "INR")}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <div>
-                          {formatCurrencyAmount(r.outstandingPaise, "INR")}
-                        </div>
-                        {r.outstandingCount > 0 && (
-                          <div className="text-xs text-muted-foreground">
-                            {r.outstandingCount} open
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {r.activeMembers.toLocaleString("en-IN")}
-                      </td>
-                    </tr>
+            <section className="mt-6">
+              <h2 className="text-lg font-medium mb-3">
+                Per-organisation breakdown
+              </h2>
+              {isLoading ? (
+                <div className="space-y-2">
+                  {[1, 2, 3, 4].map((i) => (
+                    <Skeleton key={i} className="h-14 w-full rounded-lg" />
                   ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </section>
+                </div>
+              ) : (
+                <ResponsiveTable
+                  columns={columns}
+                  rows={rows}
+                  getRowId={(r) => r.organizationId}
+                  empty={
+                    <EmptyState
+                      icon={Building2}
+                      title="No organisations to bill yet"
+                      description="Create your first org from the Overview tab."
+                    />
+                  }
+                />
+              )}
+            </section>
+          </>
+        )}
       </DashboardContent>
     </>
   );

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
@@ -30,8 +30,10 @@ import {
   DashboardGrid,
 } from "@/components/dashboard/PageScaffold";
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/StatCard";
+import { EmptyState, DataCardSkeleton } from "@/components/dashboard/DataCard";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Card,
   CardContent,
@@ -48,6 +50,7 @@ import {
   FUNDING_SOURCE_BADGE_CLASS,
   MEMBER_ROLE_LABEL,
 } from "@/lib/labels/org-labels";
+import { useWorkspaceBilling } from "../hooks/useWorkspaceBilling";
 
 interface OrgMembershipRow {
   membershipId: string;
@@ -75,20 +78,6 @@ async function fetchOrgs(): Promise<{ data: OrgMembershipRow[] }> {
   return res.json();
 }
 
-interface BillingRollup {
-  orgsOwned: number;
-  totalActiveMembers: number;
-  totalOutstandingPaise: number;
-  totalWalletPaise: number;
-}
-
-async function fetchRollup(orgWorkspaceId: string): Promise<BillingRollup> {
-  const res = await fetch(`/api/org-workspace/${orgWorkspaceId}/billing`);
-  if (!res.ok) throw new Error("Failed to load billing roll-up");
-  const json = (await res.json()) as { summary: BillingRollup };
-  return json.summary;
-}
-
 export default function OrgWorkspaceHomePage({
   params,
 }: {
@@ -100,10 +89,9 @@ export default function OrgWorkspaceHomePage({
     queryKey: ["org-workspace-orgs"],
     queryFn: fetchOrgs,
   });
-  const rollup = useQuery({
-    queryKey: ["org-workspace-rollup", orgWorkspaceId],
-    queryFn: () => fetchRollup(orgWorkspaceId),
-  });
+  // Shared with the billing page under one query key — see useWorkspaceBilling.
+  const rollup = useWorkspaceBilling(orgWorkspaceId);
+  const summary = rollup.data?.summary;
 
   const rows = (orgs.data?.data ?? []).filter((r) => r.role === "OWNER");
 
@@ -121,48 +109,90 @@ export default function OrgWorkspaceHomePage({
         }
       />
       <DashboardContent>
-        <DashboardGrid>
-          {rollup.isLoading ? (
-            <>
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </>
-          ) : (
-            <>
-              <StatCard
-                title="Organisations"
-                value={rollup.data?.orgsOwned.toString() ?? "0"}
-                icon={Building2}
-              />
-              <StatCard
-                title="Active members"
-                value={
-                  rollup.data?.totalActiveMembers.toLocaleString("en-IN") ?? "0"
-                }
-                icon={Users}
-              />
-              <StatCard
-                title="Outstanding (INR)"
-                value={formatCurrencyAmount(
-                  rollup.data?.totalOutstandingPaise ?? 0,
-                  "INR",
-                )}
+        {rollup.isError ? (
+          <Card>
+            <CardContent className="py-6">
+              <EmptyState
                 icon={Wallet}
-                variant={
-                  rollup.data && rollup.data.totalOutstandingPaise > 0
-                    ? "warning"
-                    : "default"
+                title="Couldn't load the billing roll-up"
+                description="We hit an error fetching your cross-org totals."
+                action={
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => rollup.refetch()}
+                  >
+                    Retry
+                  </Button>
                 }
               />
-            </>
-          )}
-        </DashboardGrid>
+            </CardContent>
+          </Card>
+        ) : (
+          <DashboardGrid>
+            {rollup.isLoading ? (
+              <>
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+              </>
+            ) : (
+              <>
+                <StatCard
+                  title="Organisations"
+                  value={summary?.orgsOwned.toString() ?? "0"}
+                  icon={Building2}
+                />
+                <StatCard
+                  title="Active members"
+                  value={summary?.totalActiveMembers.toLocaleString("en-IN") ?? "0"}
+                  icon={Users}
+                />
+                <StatCard
+                  title="Outstanding (INR)"
+                  value={formatCurrencyAmount(
+                    summary?.totalOutstandingPaise ?? 0,
+                    "INR",
+                  )}
+                  icon={Wallet}
+                  variant={
+                    summary && summary.totalOutstandingPaise > 0
+                      ? "warning"
+                      : "default"
+                  }
+                />
+              </>
+            )}
+          </DashboardGrid>
+        )}
 
         <section className="mt-6">
           <h2 className="text-lg font-medium mb-3">Your organisations</h2>
           {orgs.isLoading ? (
-            <p className="text-sm text-zinc-500">Loading organizations…</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <DataCardSkeleton />
+              <DataCardSkeleton />
+              <DataCardSkeleton />
+            </div>
+          ) : orgs.isError ? (
+            <Card>
+              <CardContent className="py-10">
+                <EmptyState
+                  icon={Building2}
+                  title="Couldn't load your organisations"
+                  description="We hit an error fetching your org list. Check your connection and try again."
+                  action={
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => orgs.refetch()}
+                    >
+                      Retry
+                    </Button>
+                  }
+                />
+              </CardContent>
+            </Card>
           ) : rows.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {rows.map((row) => {
@@ -178,18 +208,16 @@ export default function OrgWorkspaceHomePage({
                     <Card className="h-full hover:border-zinc-400 transition-colors">
                       <CardHeader>
                         <div className="flex items-center gap-3">
-                          <div className="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center overflow-hidden">
-                            {org.logo ? (
-                              // eslint-disable-next-line @next/next/no-img-element
-                              <img
-                                src={org.logo}
-                                alt={org.name}
-                                className="w-full h-full object-cover"
-                              />
-                            ) : (
-                              <Building2 className="w-5 h-5 text-zinc-500" />
-                            )}
-                          </div>
+                          <Avatar className="h-10 w-10 rounded-lg">
+                            <AvatarImage
+                              src={org.logo ?? undefined}
+                              alt={org.name}
+                              className="object-cover"
+                            />
+                            <AvatarFallback className="rounded-lg bg-zinc-100 text-zinc-500">
+                              <Building2 className="h-5 w-5" />
+                            </AvatarFallback>
+                          </Avatar>
                           <div className="min-w-0">
                             <CardTitle className="truncate text-base">
                               {org.name}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
@@ -140,12 +140,12 @@ export default function OrgWorkspaceHomePage({
               <>
                 <StatCard
                   title="Organisations"
-                  value={summary?.orgsOwned.toString() ?? "0"}
+                  value={summary?.orgsOwned?.toString() ?? "0"}
                   icon={Building2}
                 />
                 <StatCard
                   title="Active members"
-                  value={summary?.totalActiveMembers.toLocaleString("en-IN") ?? "0"}
+                  value={summary?.totalActiveMembers?.toLocaleString("en-IN") ?? "0"}
                   icon={Users}
                 />
                 <StatCard

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/hooks/useWorkspaceBilling.ts
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/hooks/useWorkspaceBilling.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { FundingSource } from "@prisma/client";
+
+/**
+ * Cross-org billing roll-up — the single source of truth shared by the
+ * operator home overview (which reads `.summary`) and the billing page
+ * (which reads both `.summary` and `.perOrg`).
+ *
+ * Both surfaces previously fetched `/api/org-workspace/[id]/billing` under
+ * two different query keys ("org-workspace-rollup" vs "org-workspace-billing"),
+ * doubling the network request and splitting the cache. One key + one fetcher
+ * here collapses that to a single cached entry.
+ */
+
+export interface WorkspaceBillingSummary {
+  orgsOwned: number;
+  totalActiveMembers: number;
+  totalOutstandingPaise: number;
+  totalWalletPaise: number;
+}
+
+export interface WorkspaceBillingPerOrgRow {
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  organizationStatus: string;
+  fundingSource: FundingSource | null;
+  currency: string;
+  walletBalancePaise: number;
+  outstandingCount: number;
+  outstandingPaise: number;
+  activeMembers: number;
+}
+
+export interface WorkspaceBillingResponse {
+  summary: WorkspaceBillingSummary;
+  perOrg: WorkspaceBillingPerOrgRow[];
+}
+
+export function workspaceBillingQueryKey(orgWorkspaceId: string) {
+  return ["org-workspace-billing", orgWorkspaceId] as const;
+}
+
+async function fetchWorkspaceBilling(
+  orgWorkspaceId: string,
+): Promise<WorkspaceBillingResponse> {
+  const res = await fetch(`/api/org-workspace/${orgWorkspaceId}/billing`);
+  if (!res.ok) throw new Error("Failed to load billing roll-up");
+  return res.json();
+}
+
+export function useWorkspaceBilling(orgWorkspaceId: string) {
+  return useQuery({
+    queryKey: workspaceBillingQueryKey(orgWorkspaceId),
+    queryFn: () => fetchWorkspaceBilling(orgWorkspaceId),
+  });
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/settings/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/settings/page.tsx
@@ -30,6 +30,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 import { DefaultLandingOrgSection } from "./components/DefaultLandingOrgSection";
 import { LocaleAndCurrencySection } from "./components/LocaleAndCurrencySection";
@@ -70,9 +71,18 @@ export default function OrgWorkspaceSettingsPage({
                 Couldn’t load preferences
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-sm text-zinc-600">
-              Try refreshing the page. If the problem persists, contact
-              support — the workspace profile row may be missing.
+            <CardContent className="space-y-3 text-sm text-zinc-600">
+              <p>
+                If the problem persists, contact support — the workspace
+                profile row may be missing.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => settings.refetch()}
+              >
+                Retry
+              </Button>
             </CardContent>
           </Card>
         ) : (


### PR DESCRIPTION
## What

**PR-B of the operator-dashboard chain** (task #18, stacked on #963 `redesign/ows-01-shell`). Fixes the three data pages' failure modes and the duplicated billing fetch.

## Fixes

### Billing query dedup (P2-3)
New `useWorkspaceBilling` hook — one query key + fetcher shared by **home** (reads `.summary`) and **billing** (reads `.summary` + `.perOrg`). Both previously hit `/api/org-workspace/[id]/billing` under different keys (`org-workspace-rollup` vs `org-workspace-billing`), doubling the request and splitting the cache.

### home (P1-1, P2-5, P2-6)
- Both queries get `isError` branches → `EmptyState` + `refetch()`. **An API failure no longer renders "You don't own any organisations yet" + a Create CTA to an owner of N orgs.**
- Org-grid loading → `DataCardSkeleton`s (was "Loading organizations…").
- Raw `<img>` → `Avatar` primitive — drops the `eslint-disable`, matches how every other shell renders org logos (safe with user-uploaded URLs; no next/image domain config needed).

### billing (P1-2, P2-4, P2-5)
- The `isLoading || !summary` guard rendered `StatCardSkeleton`s **forever on error** (isLoading false + summary undefined) → split into `isLoading` (skeleton) / `isError` (`EmptyState` + retry).
- Raw `<table>` → `ResponsiveTable` (org column `primary`, row → per-org billing). 5 columns no longer overflow on mobile.
- Loading text → `Skeleton` rows.

### activity (P1-3, P2-5, P2-7)
- `isError` → `EmptyState` + retry (was falling through to "No activity yet").
- Loading text → skeleton rows.
- Hand-rolled `timeAgo` → `date-fns` `formatDistanceToNow`, keeping the >30-day absolute-date fallback.

### settings (P2-8)
- Retry button on the error card (was "Try refreshing the page").

## Notes
- **Deferred by decision:** multi-currency roll-up — INR-only stays v1.
- `tsc` + `eslint` clean; no test files cover these paths (full jest → CI).
- No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
