### PR TITLE
Dashboard follow-ups: cold-start nav + consultee slots + org-workspace redesign

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
@@ -38,6 +38,29 @@ interface AvailabilitySectionProps {
 }
 
 /**
+ * Compact stand-in for the schedule type that is NOT selected. Editing is
+ * per-type; rendering the inactive editor in full (even faded) doubled the
+ * page height — with 40+ custom dates it produced screens of washed-out
+ * rows that read as endless empty space.
+ */
+function InactiveScheduleNote({
+  label,
+  summary,
+}: {
+  label: string;
+  summary: string;
+}) {
+  return (
+    <div className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
+      <p className="font-medium text-zinc-600">{label} is inactive</p>
+      <p className="mt-1">
+        {summary}. Select this schedule type above to view and edit.
+      </p>
+    </div>
+  );
+}
+
+/**
  * Availability tab of the consultant settings form. Presentational only —
  * all slot state, validation, and the WEEKLY↔CUSTOM switch lock live in
  * SettingsTab so the combined settings PUT payload stays exactly as it was
@@ -141,21 +164,33 @@ export function AvailabilitySection({
             </Label>
             <RadioGroupItem id="WEEKLY" value={ScheduleType.WEEKLY} />
           </div>
-          <div
-            className={`space-y-4 transition-opacity ${scheduleType !== ScheduleType.WEEKLY ? "opacity-40 pointer-events-none" : ""}`}
-          >
-            {DAYS_OF_WEEK.map((day) => (
-              <AvailabilityGrid
-                key={day}
-                dayKey={day.toLowerCase()}
-                label={formatDayDisplay(day)}
-                slots={weeklySlots[day.toLowerCase()]}
-                onAddSlot={onAddSlot}
-                onUpdateSlot={onUpdateSlot}
-                onDeleteSlot={onDeleteSlot}
-              />
-            ))}
-          </div>
+          {/* Only the ACTIVE schedule type renders its full editor. The old
+              opacity-40 treatment still rendered the inactive editor at full
+              height — with a season of custom dates that meant screens of
+              washed-out rows that read as endless empty space. */}
+          {scheduleType === ScheduleType.WEEKLY ? (
+            <div className="space-y-4">
+              {DAYS_OF_WEEK.map((day) => (
+                <AvailabilityGrid
+                  key={day}
+                  dayKey={day.toLowerCase()}
+                  label={formatDayDisplay(day)}
+                  slots={weeklySlots[day.toLowerCase()]}
+                  onAddSlot={onAddSlot}
+                  onUpdateSlot={onUpdateSlot}
+                  onDeleteSlot={onDeleteSlot}
+                />
+              ))}
+            </div>
+          ) : (
+            <InactiveScheduleNote
+              label="Weekly Recurring"
+              summary={`${Object.values(weeklySlots).reduce(
+                (n, s) => n + (s?.length ?? 0),
+                0,
+              )} recurring slot(s) configured`}
+            />
+          )}
         </div>
 
         {/* Custom Schedule */}
@@ -170,9 +205,13 @@ export function AvailabilitySection({
             </Label>
             <RadioGroupItem id="CUSTOM" value={ScheduleType.CUSTOM} />
           </div>
-          <div
-            className={`space-y-4 transition-opacity ${scheduleType !== ScheduleType.CUSTOM ? "opacity-40 pointer-events-none" : ""}`}
-          >
+          {scheduleType !== ScheduleType.CUSTOM ? (
+            <InactiveScheduleNote
+              label="Custom Schedule"
+              summary={`${Object.keys(customSlots).length} date(s) configured`}
+            />
+          ) : (
+          <div className="space-y-4">
             <div className="calendar-container bg-card border p-4 rounded-lg">
               <div className="flex justify-between items-center mb-4">
                 <button
@@ -205,31 +244,41 @@ export function AvailabilitySection({
               </div>
             </div>
 
-            {Object.keys(customSlots)
-              .sort((a, b) => a.localeCompare(b))
-              .map((dateString) => {
-                // Parse YYYY-MM-DD as a LOCAL date — new Date("YYYY-MM-DD")
-                // is UTC midnight, which renders as the PREVIOUS day for
-                // users in timezones behind UTC.
-                const [year, month, day] = dateString.split("-").map(Number);
-                const date = new Date(year, month - 1, day);
-                return (
-                  <AvailabilityGrid
-                    key={dateString}
-                    dayKey={dateString}
-                    label={date.toLocaleDateString("en-US", {
-                      weekday: "long",
-                      month: "long",
-                      day: "numeric",
-                    })}
-                    slots={customSlots[dateString]}
-                    onAddSlot={onAddSlot}
-                    onUpdateSlot={onUpdateSlot}
-                    onDeleteSlot={onDeleteSlot}
-                  />
-                );
-              })}
+            {/* A season of custom dates can run 40+ entries — contain them in
+                their own scroll region instead of stretching the page. */}
+            {Object.keys(customSlots).length > 0 && (
+              <p className="text-xs text-zinc-500">
+                {Object.keys(customSlots).length} date(s) configured
+              </p>
+            )}
+            <div className="max-h-[560px] overflow-y-auto pr-2 space-y-4">
+              {Object.keys(customSlots)
+                .sort((a, b) => a.localeCompare(b))
+                .map((dateString) => {
+                  // Parse YYYY-MM-DD as a LOCAL date — new Date("YYYY-MM-DD")
+                  // is UTC midnight, which renders as the PREVIOUS day for
+                  // users in timezones behind UTC.
+                  const [year, month, day] = dateString.split("-").map(Number);
+                  const date = new Date(year, month - 1, day);
+                  return (
+                    <AvailabilityGrid
+                      key={dateString}
+                      dayKey={dateString}
+                      label={date.toLocaleDateString("en-US", {
+                        weekday: "long",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                      slots={customSlots[dateString]}
+                      onAddSlot={onAddSlot}
+                      onUpdateSlot={onUpdateSlot}
+                      onDeleteSlot={onDeleteSlot}
+                    />
+                  );
+                })}
+            </div>
           </div>
+          )}
         </div>
       </RadioGroup>
 

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilitySection.tsx
@@ -51,7 +51,10 @@ function InactiveScheduleNote({
   summary: string;
 }) {
   return (
-    <div className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500">
+    <div
+      aria-live="polite"
+      className="rounded-lg border border-dashed border-zinc-300 bg-zinc-50 p-4 text-sm text-zinc-500"
+    >
       <p className="font-medium text-zinc-600">{label} is inactive</p>
       <p className="mt-1">
         {summary}. Select this schedule type above to view and edit.

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/SessionTimeline.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/SessionTimeline.tsx
@@ -134,14 +134,15 @@ export function SessionTimeline({
   // made multi-session cards read as a congested wall — the full timeline
   // is one click away behind the expander, and the card's progress bar
   // already summarises completion.
-  const focusSession =
-    sessions.find(
-      (s) => sessionStatuses.get(s.appointmentId) === "joinable",
-    ) ??
-    sessions.find(
-      (s) => sessionStatuses.get(s.appointmentId) === "upcoming",
-    ) ??
-    sessions[sessions.length - 1];
+  const focusSession = (() => {
+    let upcoming: SessionGroup | undefined;
+    for (const s of sessions) {
+      const status = sessionStatuses.get(s.appointmentId);
+      if (status === "joinable") return s;
+      if (status === "upcoming" && !upcoming) upcoming = s;
+    }
+    return upcoming ?? sessions[sessions.length - 1];
+  })();
 
   const visibleSessions =
     showExpand && !expanded && focusSession ? [focusSession] : sessions;

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/SessionTimeline.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/SessionTimeline.tsx
@@ -101,8 +101,18 @@ export function SessionTimeline({
 }: SessionTimelineProps) {
   const [expanded, setExpanded] = useState(false);
 
-  const nonTentativeSlots = slots.filter((s) => !s.isTentative);
-  const sessions = groupSlotsBySession(nonTentativeSlots);
+  // Whole derivation chain is memoized so the session status / focus-row
+  // computations below don't recompute (and reallocate) on every unrelated
+  // render — e.g. the per-second CountdownBadge tick. Each link is keyed on
+  // the previous so a new `slots` prop cascades once.
+  const nonTentativeSlots = useMemo(
+    () => slots.filter((s) => !s.isTentative),
+    [slots],
+  );
+  const sessions = useMemo(
+    () => groupSlotsBySession(nonTentativeSlots),
+    [nonTentativeSlots],
+  );
   const showExpand = sessions.length > 1;
 
   // Pre-compute session statuses once to avoid repeated getSlotStatus calls
@@ -134,7 +144,7 @@ export function SessionTimeline({
   // made multi-session cards read as a congested wall — the full timeline
   // is one click away behind the expander, and the card's progress bar
   // already summarises completion.
-  const focusSession = (() => {
+  const focusSession = useMemo(() => {
     let upcoming: SessionGroup | undefined;
     for (const s of sessions) {
       const status = sessionStatuses.get(s.appointmentId);
@@ -142,7 +152,7 @@ export function SessionTimeline({
       if (status === "upcoming" && !upcoming) upcoming = s;
     }
     return upcoming ?? sessions[sessions.length - 1];
-  })();
+  }, [sessions, sessionStatuses]);
 
   const visibleSessions =
     showExpand && !expanded && focusSession ? [focusSession] : sessions;

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/SessionTimeline.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/SessionTimeline.tsx
@@ -94,8 +94,6 @@ const statusLabel: Record<SessionStatus, string> = {
   upcoming: "upcoming",
 };
 
-const COLLAPSED_LIMIT = 5;
-
 export function SessionTimeline({
   slots,
   isJoining,
@@ -105,7 +103,7 @@ export function SessionTimeline({
 
   const nonTentativeSlots = slots.filter((s) => !s.isTentative);
   const sessions = groupSlotsBySession(nonTentativeSlots);
-  const showExpand = sessions.length > COLLAPSED_LIMIT;
+  const showExpand = sessions.length > 1;
 
   // Pre-compute session statuses once to avoid repeated getSlotStatus calls
   const sessionStatuses = useMemo(
@@ -131,48 +129,40 @@ export function SessionTimeline({
     return null;
   }, [sessions, sessionStatuses]);
 
-  // When collapsed and > COLLAPSED_LIMIT: show dot summary + next upcoming/joinable sessions
+  // Collapsed = ONE focus row: the live/joinable session, else the next
+  // upcoming one, else the most recent past one. Listing every slot inline
+  // made multi-session cards read as a congested wall — the full timeline
+  // is one click away behind the expander, and the card's progress bar
+  // already summarises completion.
+  const focusSession =
+    sessions.find(
+      (s) => sessionStatuses.get(s.appointmentId) === "joinable",
+    ) ??
+    sessions.find(
+      (s) => sessionStatuses.get(s.appointmentId) === "upcoming",
+    ) ??
+    sessions[sessions.length - 1];
+
   const visibleSessions =
-    showExpand && !expanded
-      ? (() => {
-          const firstUpcomingIdx = sessions.findIndex((session) => {
-            const status = sessionStatuses.get(session.appointmentId)!;
-            return status === "upcoming" || status === "joinable";
-          });
+    showExpand && !expanded && focusSession ? [focusSession] : sessions;
 
-          if (firstUpcomingIdx === -1) {
-            return sessions.slice(-3);
-          }
-
-          const startIdx = Math.max(0, firstUpcomingIdx - 1);
-          return sessions.slice(startIdx, startIdx + 3);
-        })()
-      : sessions;
-
-  // Dot summary for collapsed view (one dot per session)
-  const dotSummary =
-    showExpand && !expanded
-      ? sessions.map((session) => {
-          const st = sessionStatuses.get(session.appointmentId)!;
-          if (st === "completed") return "\u2705";
-          if (st === "noRecord") return "\u26A0\uFE0F";
-          if (st === "joinable") return "\u25C9";
-          return "\u25CB";
-        })
-      : null;
+  const focusStatus = focusSession
+    ? sessionStatuses.get(focusSession.appointmentId)
+    : undefined;
+  const collapsedCaption =
+    focusStatus === "joinable"
+      ? "Live now"
+      : focusStatus === "upcoming"
+        ? "Next session"
+        : "Last session";
 
   return (
     <div className="space-y-1">
-      {/* Dot summary when collapsed */}
-      {dotSummary && dotSummary.length > 0 && (
-        <div className="flex items-center gap-0.5 px-1 py-1 text-xs">
-          <span className="text-muted-foreground/70 mr-1">Sessions:</span>
-          {dotSummary.map((dot, i) => (
-            <span key={i} className="text-[10px]">
-              {dot}
-            </span>
-          ))}
-        </div>
+      {/* Focus-row caption when collapsed */}
+      {showExpand && !expanded && (
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+          {collapsedCaption}
+        </p>
       )}
 
       {/* Session rows (one row per appointment group) */}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
@@ -29,6 +29,7 @@ import {
 import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { isActiveRoute } from "@/components/dashboard/route-active";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 import { OrganizationSwitcher } from "@/components/dashboard/OrganizationSwitcher";
 import { NotificationInbox } from "@/components/notifications/NotificationInbox";
 import { signOutEverywhere } from "@/lib/auth/sign-out";
@@ -64,8 +65,16 @@ export function OrgWorkspaceShell({
 }) {
   // usePathname() returns the URL-encoded path, while orgWorkspaceId (from
   // route params) is decoded — decode so basePath.slice + isActiveRoute compare
-  // like-for-like even for ids that need encoding. `?? ""` guards a null path.
-  const pathname = decodeURIComponent(usePathname() ?? "");
+  // like-for-like even for ids that need encoding. `?? ""` guards a null path;
+  // the try/catch guards a malformed %-sequence (decodeURIComponent throws a
+  // URIError) — fall back to the raw path so a bad URL never blanks the shell.
+  const rawPathname = usePathname() ?? "";
+  let pathname = rawPathname;
+  try {
+    pathname = decodeURIComponent(rawPathname);
+  } catch {
+    pathname = rawPathname;
+  }
   const basePath = `/dashboard/org-workspace/${orgWorkspaceId}`;
 
   const displayName = userName ?? "Operator";
@@ -138,7 +147,8 @@ export function OrgWorkspaceShell({
                     : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
                 }`}
               >
-                <Icon
+                <LinkPendingIcon
+                  Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
                 />
                 {name}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
@@ -3,41 +3,35 @@
 /**
  * Client-side shell for the org-workspace (operator) dashboard. Sits inside
  * the server-side layout that runs the IDOR guard and resolves the user
- * identity props on the server (so the sidebar's displayed name is
- * the same on the server-rendered HTML and the first client render —
- * no hydration mismatch).
+ * identity props on the server (so the sidebar's displayed name is the same
+ * on the server-rendered HTML and the first client render — no hydration
+ * mismatch).
  *
- * Renders the same CollapsibleSidebar pattern as /dashboard/admin and
- * /dashboard/staff, with a top context bar carrying OrganizationSwitcher
- * + NotificationInbox.
+ * Same chrome contract as the other role dashboards: a collapsible sidebar
+ * (md+), a sticky h-14 DashboardContextBar, and a mobile bottom tab bar
+ * (<md) so the w-64 aside never crushes the content column on a phone.
  *
- * Visual differentiation from the per-org dashboard:
- *   - Sidebar carries a silver/dark-grey gradient (via the new
- *     `className` prop on CollapsibleSidebar) — this is the agreed
- *     accent location, NOT the page background.
- *   - Sidebar subtitle reads "Cross-org dashboard" so the title +
- *     subtitle pair (Operator / Cross-org dashboard) names the scope.
- *   - Page body stays on flat zinc-50 — content cards keep their
- *     existing visual weight.
- *
- * Sidebar items are intentionally lean (Overview / Activity / Billing /
- * Settings). Per-org operator surfaces (members, programs, payouts) live
- * one level deeper at /dashboard/organization/[orgId]/* and have their
- * own sidebar — this dashboard is the *cross-org* operator view.
+ * Visual differentiation from the per-org dashboard: the sidebar carries a
+ * jet-black gradient accent (via CollapsibleSidebar's `className` prop, with
+ * `dark` scoped to the aside) — the one cue that says "cross-org operator",
+ * not "inside a single org". Per-org operator surfaces (members, programs,
+ * payouts) live one level deeper at /dashboard/organization/[orgId]/*.
  */
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Activity, CreditCard, Home, Settings } from "lucide-react";
+import { Activity, CreditCard, Home, Settings, UserRound } from "lucide-react";
 
 import {
   CollapsibleSidebar,
   type CollapsibleSidebarItem,
 } from "@/components/dashboard/CollapsibleSidebar";
+import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
+import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
+import { isActiveRoute } from "@/components/dashboard/route-active";
 import { OrganizationSwitcher } from "@/components/dashboard/OrganizationSwitcher";
 import { NotificationInbox } from "@/components/notifications/NotificationInbox";
-import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
-import { signOut } from "@/lib/auth-client";
-import { disconnectStreamClients } from "@/providers/StreamProvider";
+import { signOutEverywhere } from "@/lib/auth/sign-out";
 
 const sidebarItems: CollapsibleSidebarItem[] = [
   { name: "Overview", icon: Home, path: "home" },
@@ -45,6 +39,15 @@ const sidebarItems: CollapsibleSidebarItem[] = [
   { name: "Billing", icon: CreditCard, path: "billing" },
   { name: "Settings", icon: Settings, path: "settings" },
 ];
+
+/** Breadcrumb labels per first path segment (mirrors the sidebar + /create). */
+const PAGE_LABELS: Record<string, string> = {
+  home: "Overview",
+  activity: "Activity",
+  billing: "Billing",
+  settings: "Settings",
+  create: "New organization",
+};
 
 export function OrgWorkspaceShell({
   orgWorkspaceId,
@@ -60,57 +63,86 @@ export function OrgWorkspaceShell({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-
-  const handleSignOut = async () => {
-    try {
-      await disconnectStreamClients();
-    } catch {
-      // Stream cleanup is best-effort.
-    }
-    signOut({
-      fetchOptions: {
-        onSuccess: () => {
-          window.location.href = "/auth/signin";
-        },
-      },
-    });
-  };
+  const basePath = `/dashboard/org-workspace/${orgWorkspaceId}`;
 
   const displayName = userName ?? "Operator";
   const avatarFallback = displayName.charAt(0).toUpperCase();
 
+  // Active page label for the context-bar breadcrumb trail. The segment is
+  // the first path part after the workspace id (defaults to the overview).
+  const segment =
+    pathname.slice(basePath.length).split("/").filter(Boolean)[0] ?? "home";
+  const pageLabel = PAGE_LABELS[segment] ?? "Overview";
+
   return (
     <div className="flex h-screen-maintenance bg-zinc-50 dark:bg-zinc-950">
-      <CollapsibleSidebar
-        items={sidebarItems}
-        basePath={`/dashboard/org-workspace/${orgWorkspaceId}`}
-        title="Operator"
-        avatarFallback={avatarFallback}
-        userName={displayName}
-        userEmail={userEmail ?? undefined}
-        userImage={userImage}
-        userSubtitle="Cross-org dashboard"
-        pathname={pathname}
-        onSignOut={handleSignOut}
-        // Jet-black sidebar accent — applied via the new className
-        // prop on CollapsibleSidebar. The shared component's text +
-        // icons are styled with `text-zinc-900 dark:text-zinc-100`
-        // pairs, so we scope `dark` mode to this aside (Tailwind uses
-        // class strategy per tailwind.config.ts:4) — every descendant's
-        // `dark:*` variants kick in, flipping copy and icons to light
-        // without affecting any other surface in the app.
-        className="dark bg-gradient-to-b from-black via-zinc-900 to-black"
-      />
+      {/* Sidebar — hidden on mobile, visible md+ */}
+      <div className="hidden md:block shrink-0">
+        <CollapsibleSidebar
+          items={sidebarItems}
+          basePath={basePath}
+          title="Operator"
+          avatarFallback={avatarFallback}
+          userName={displayName}
+          userEmail={userEmail ?? undefined}
+          userImage={userImage}
+          userSubtitle="Cross-org dashboard"
+          pathname={pathname}
+          onSignOut={() => void signOutEverywhere()}
+          // Jet-black sidebar accent via the shared className prop. The
+          // component's text/icons use `text-zinc-900 dark:text-zinc-100`
+          // pairs, so scoping `dark` to this aside (Tailwind class strategy)
+          // flips copy + icons to light without touching any other surface.
+          className="dark bg-gradient-to-b from-black via-zinc-900 to-black"
+        />
+      </div>
 
-      <main className="flex-1 overflow-y-auto">
-        <div className="sticky top-0 z-30 flex items-center justify-end gap-2 px-6 py-2 border-b border-zinc-200/50 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-xl">
-          <OrganizationSwitcher />
-          <NotificationInbox />
-        </div>
-        <div className="p-6">
-          <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
-        </div>
-      </main>
+      {/* Right panel: context bar + page content + mobile tabs */}
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+        <DashboardContextBar
+          identity={{
+            name: displayName,
+            image: userImage,
+            FallbackIcon: UserRound,
+          }}
+          breadcrumbs={["Operator", pageLabel]}
+          rightSlot={
+            <div className="flex items-center gap-2">
+              <OrganizationSwitcher />
+              <NotificationInbox />
+            </div>
+          }
+        />
+
+        <main className="flex-1 overflow-y-auto pb-16 md:pb-0">
+          <div className="p-6">
+            <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
+          </div>
+        </main>
+
+        {/* Mobile bottom tab bar — only visible below md breakpoint */}
+        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-20 bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 flex">
+          {sidebarItems.map(({ name, icon: Icon, path }) => {
+            const isActive = isActiveRoute(pathname, basePath, path);
+            return (
+              <Link
+                key={path}
+                href={`${basePath}/${path}`}
+                className={`flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[10px] font-medium transition-colors ${
+                  isActive
+                    ? "text-zinc-900 dark:text-zinc-100"
+                    : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+                }`}
+              >
+                <Icon
+                  className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
+                />
+                {name}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
@@ -62,7 +62,10 @@ export function OrgWorkspaceShell({
   userImage: string | null;
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
+  // usePathname() returns the URL-encoded path, while orgWorkspaceId (from
+  // route params) is decoded — decode so basePath.slice + isActiveRoute compare
+  // like-for-like even for ids that need encoding. `?? ""` guards a null path.
+  const pathname = decodeURIComponent(usePathname() ?? "");
   const basePath = `/dashboard/org-workspace/${orgWorkspaceId}`;
 
   const displayName = userName ?? "Operator";
@@ -114,14 +117,15 @@ export function OrgWorkspaceShell({
           }
         />
 
-        <main className="flex-1 overflow-y-auto pb-16 md:pb-0">
+        <main className="flex-1 overflow-y-auto pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
           <div className="p-6">
             <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
           </div>
         </main>
 
-        {/* Mobile bottom tab bar — only visible below md breakpoint */}
-        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-20 bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 flex">
+        {/* Mobile bottom tab bar — only visible below md breakpoint. The
+            safe-area inset keeps the tabs clear of the iPhone home indicator. */}
+        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-20 bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800 flex pb-[env(safe-area-inset-bottom)]">
           {sidebarItems.map(({ name, icon: Icon, path }) => {
             const isActive = isActiveRoute(pathname, basePath, path);
             return (

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/OrgWorkspaceShell.tsx
@@ -141,6 +141,7 @@ export function OrgWorkspaceShell({
               <Link
                 key={path}
                 href={`${basePath}/${path}`}
+                aria-current={isActive ? "page" : undefined}
                 className={`flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[10px] font-medium transition-colors ${
                   isActive
                     ? "text-zinc-900 dark:text-zinc-100"

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/activity/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/activity/loading.tsx
@@ -1,0 +1,5 @@
+import { TableSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <TableSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
@@ -24,6 +24,9 @@ import {
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/dashboard/DataCard";
+import { formatDistanceToNow } from "date-fns";
 
 interface ActivityRow {
   id: string;
@@ -74,19 +77,18 @@ const CATEGORY_LABEL: Record<string, string> = {
 };
 
 function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString("en-IN", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
+  const date = new Date(iso);
+  // Beyond 30 days a relative label ("2 months ago") loses the precision an
+  // audit feed wants — fall back to an absolute date there.
+  const days = (Date.now() - date.getTime()) / 86_400_000;
+  if (days > 30) {
+    return date.toLocaleDateString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  }
+  return formatDistanceToNow(date, { addSuffix: true });
 }
 
 export default function OrgWorkspaceActivityPage({
@@ -115,7 +117,37 @@ export default function OrgWorkspaceActivityPage({
       />
       <DashboardContent>
         {query.isLoading ? (
-          <p className="text-sm text-zinc-500">Loading activity…</p>
+          <Card>
+            <CardContent className="p-0">
+              <ul className="divide-y">
+                {[1, 2, 3, 4, 5].map((i) => (
+                  <li key={i} className="p-4">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="mt-2 h-4 w-3/4" />
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        ) : query.isError ? (
+          <Card>
+            <CardContent className="py-10">
+              <EmptyState
+                icon={ActivityIcon}
+                title="Couldn't load activity"
+                description="We hit an error fetching your cross-org activity feed."
+                action={
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => query.refetch()}
+                  >
+                    Retry
+                  </Button>
+                }
+              />
+            </CardContent>
+          </Card>
         ) : rows.length === 0 ? (
           <Card>
             <CardContent className="py-10 text-center">

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/activity/page.tsx
@@ -78,6 +78,9 @@ const CATEGORY_LABEL: Record<string, string> = {
 
 function timeAgo(iso: string): string {
   const date = new Date(iso);
+  // Guard a malformed timestamp — formatDistanceToNow throws a RangeError on an
+  // Invalid Date instead of degrading gracefully.
+  if (Number.isNaN(date.getTime())) return "—";
   // Beyond 30 days a relative label ("2 months ago") loses the precision an
   // audit feed wants — fall back to an absolute date there.
   const days = (Date.now() - date.getTime()) / 86_400_000;

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/billing/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/billing/loading.tsx
@@ -1,0 +1,5 @@
+import { TableSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <TableSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/billing/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/billing/page.tsx
@@ -13,9 +13,7 @@
 
 import { use } from "react";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import { CreditCard, Wallet, Receipt, Building2 } from "lucide-react";
-import type { FundingSource } from "@prisma/client";
 
 import {
   DashboardHeader,
@@ -23,42 +21,93 @@ import {
   DashboardGrid,
 } from "@/components/dashboard/PageScaffold";
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/StatCard";
+import { EmptyState } from "@/components/dashboard/DataCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/ui/responsive-table";
 import { formatCurrencyAmount } from "@/utils/formatting";
 import {
   FUNDING_SOURCE_LABEL,
   FUNDING_SOURCE_BADGE_CLASS,
 } from "@/lib/labels/org-labels";
+import {
+  useWorkspaceBilling,
+  type WorkspaceBillingPerOrgRow,
+} from "../hooks/useWorkspaceBilling";
 
-interface PerOrgRow {
-  organizationId: string;
-  organizationName: string;
-  organizationSlug: string;
-  organizationStatus: string;
-  fundingSource: FundingSource | null;
-  currency: string;
-  walletBalancePaise: number;
-  outstandingCount: number;
-  outstandingPaise: number;
-  activeMembers: number;
-}
-
-interface RollupResponse {
-  summary: {
-    orgsOwned: number;
-    totalActiveMembers: number;
-    totalOutstandingPaise: number;
-    totalWalletPaise: number;
-  };
-  perOrg: PerOrgRow[];
-}
-
-async function fetchRollup(orgWorkspaceId: string): Promise<RollupResponse> {
-  const res = await fetch(`/api/org-workspace/${orgWorkspaceId}/billing`);
-  if (!res.ok) throw new Error("Failed to load billing roll-up");
-  return res.json();
-}
+const columns: ResponsiveColumn<WorkspaceBillingPerOrgRow>[] = [
+  {
+    key: "org",
+    header: "Organisation",
+    primary: true,
+    cell: (r) => (
+      <Link
+        href={`/dashboard/organization/${r.organizationId}/billing`}
+        className="hover:underline"
+      >
+        <div className="font-medium">{r.organizationName}</div>
+        <div className="text-xs text-muted-foreground">
+          {r.organizationSlug}
+          {r.organizationStatus !== "ACTIVE" && (
+            <span className="ml-2 text-amber-600">
+              · {r.organizationStatus.toLowerCase()}
+            </span>
+          )}
+        </div>
+      </Link>
+    ),
+  },
+  {
+    key: "funding",
+    header: "Funding",
+    cell: (r) =>
+      r.fundingSource ? (
+        <Badge
+          variant="outline"
+          className={FUNDING_SOURCE_BADGE_CLASS[r.fundingSource]}
+        >
+          {FUNDING_SOURCE_LABEL[r.fundingSource]}
+        </Badge>
+      ) : (
+        <span className="text-xs text-muted-foreground">None</span>
+      ),
+  },
+  {
+    key: "wallet",
+    header: "Wallet",
+    className: "text-right tabular-nums",
+    headClassName: "text-right",
+    cell: (r) => formatCurrencyAmount(r.walletBalancePaise, "INR"),
+  },
+  {
+    key: "outstanding",
+    header: "Outstanding",
+    className: "text-right tabular-nums",
+    headClassName: "text-right",
+    cell: (r) => (
+      <div>
+        <div>{formatCurrencyAmount(r.outstandingPaise, "INR")}</div>
+        {r.outstandingCount > 0 && (
+          <div className="text-xs text-muted-foreground">
+            {r.outstandingCount} open
+          </div>
+        )}
+      </div>
+    ),
+  },
+  {
+    key: "members",
+    header: "Members",
+    className: "text-right tabular-nums",
+    headClassName: "text-right",
+    cell: (r) => r.activeMembers.toLocaleString("en-IN"),
+  },
+];
 
 export default function OrgWorkspaceBillingPage({
   params,
@@ -67,10 +116,8 @@ export default function OrgWorkspaceBillingPage({
 }) {
   const { orgWorkspaceId } = use(params);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ["org-workspace-billing", orgWorkspaceId],
-    queryFn: () => fetchRollup(orgWorkspaceId),
-  });
+  const { data, isLoading, isError, refetch } =
+    useWorkspaceBilling(orgWorkspaceId);
 
   const summary = data?.summary;
   const rows = data?.perOrg ?? [];
@@ -82,131 +129,89 @@ export default function OrgWorkspaceBillingPage({
         subtitle="Outstanding invoices and wallet balances across the organisations you operate"
       />
       <DashboardContent>
-        <DashboardGrid>
-          {isLoading || !summary ? (
-            <>
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </>
-          ) : (
-            <>
-              <StatCard
-                title="Outstanding"
-                subtitle={`across ${summary.orgsOwned} organisation${summary.orgsOwned === 1 ? "" : "s"}`}
-                value={formatCurrencyAmount(
-                  summary.totalOutstandingPaise,
-                  "INR",
-                )}
+        {isError ? (
+          <Card>
+            <CardContent className="py-10">
+              <EmptyState
                 icon={Receipt}
-                variant={
-                  summary.totalOutstandingPaise > 0 ? "warning" : "default"
+                title="Couldn't load the billing overview"
+                description="We hit an error fetching your cross-org billing roll-up."
+                action={
+                  <Button size="sm" variant="outline" onClick={() => refetch()}>
+                    Retry
+                  </Button>
                 }
               />
-              <StatCard
-                title="Wallet balance"
-                subtitle="prepaid funds across orgs"
-                value={formatCurrencyAmount(summary.totalWalletPaise, "INR")}
-                icon={Wallet}
-              />
-              <StatCard
-                title="Funded orgs"
-                subtitle="have a billing account"
-                value={rows
-                  .filter((r) => r.fundingSource !== null)
-                  .length.toString()}
-                icon={CreditCard}
-              />
-            </>
-          )}
-        </DashboardGrid>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <DashboardGrid>
+              {isLoading || !summary ? (
+                <>
+                  <StatCardSkeleton />
+                  <StatCardSkeleton />
+                  <StatCardSkeleton />
+                </>
+              ) : (
+                <>
+                  <StatCard
+                    title="Outstanding"
+                    subtitle={`across ${summary.orgsOwned} organisation${summary.orgsOwned === 1 ? "" : "s"}`}
+                    value={formatCurrencyAmount(
+                      summary.totalOutstandingPaise,
+                      "INR",
+                    )}
+                    icon={Receipt}
+                    variant={
+                      summary.totalOutstandingPaise > 0 ? "warning" : "default"
+                    }
+                  />
+                  <StatCard
+                    title="Wallet balance"
+                    subtitle="prepaid funds across orgs"
+                    value={formatCurrencyAmount(summary.totalWalletPaise, "INR")}
+                    icon={Wallet}
+                  />
+                  <StatCard
+                    title="Funded orgs"
+                    subtitle="have a billing account"
+                    value={rows
+                      .filter((r) => r.fundingSource !== null)
+                      .length.toString()}
+                    icon={CreditCard}
+                  />
+                </>
+              )}
+            </DashboardGrid>
 
-        <section className="mt-6">
-          <h2 className="text-lg font-medium mb-3">Per-organisation breakdown</h2>
-          {isLoading ? (
-            <p className="text-sm text-zinc-500">Loading…</p>
-          ) : rows.length === 0 ? (
-            <Card>
-              <CardContent className="py-10 text-center">
-                <Building2 className="w-10 h-10 mx-auto mb-3 text-zinc-400" />
-                <p className="text-sm text-zinc-600">
-                  No organisations to bill yet. Create your first org from the
-                  Overview tab.
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="overflow-hidden rounded-lg border bg-card">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/40 text-left text-xs uppercase text-muted-foreground">
-                  <tr>
-                    <th className="px-4 py-2 font-medium">Organisation</th>
-                    <th className="px-4 py-2 font-medium">Funding</th>
-                    <th className="px-4 py-2 font-medium text-right">Wallet</th>
-                    <th className="px-4 py-2 font-medium text-right">
-                      Outstanding
-                    </th>
-                    <th className="px-4 py-2 font-medium text-right">Members</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((r) => (
-                    <tr key={r.organizationId} className="border-t">
-                      <td className="px-4 py-3">
-                        <Link
-                          href={`/dashboard/organization/${r.organizationId}/billing`}
-                          className="hover:underline"
-                        >
-                          <div className="font-medium">{r.organizationName}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {r.organizationSlug}
-                            {r.organizationStatus !== "ACTIVE" && (
-                              <span className="ml-2 text-amber-600">
-                                · {r.organizationStatus.toLowerCase()}
-                              </span>
-                            )}
-                          </div>
-                        </Link>
-                      </td>
-                      <td className="px-4 py-3">
-                        {r.fundingSource ? (
-                          <Badge
-                            variant="outline"
-                            className={
-                              FUNDING_SOURCE_BADGE_CLASS[r.fundingSource]
-                            }
-                          >
-                            {FUNDING_SOURCE_LABEL[r.fundingSource]}
-                          </Badge>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">
-                            None
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {formatCurrencyAmount(r.walletBalancePaise, "INR")}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <div>
-                          {formatCurrencyAmount(r.outstandingPaise, "INR")}
-                        </div>
-                        {r.outstandingCount > 0 && (
-                          <div className="text-xs text-muted-foreground">
-                            {r.outstandingCount} open
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {r.activeMembers.toLocaleString("en-IN")}
-                      </td>
-                    </tr>
+            <section className="mt-6">
+              <h2 className="text-lg font-medium mb-3">
+                Per-organisation breakdown
+              </h2>
+              {isLoading ? (
+                <div className="space-y-2">
+                  {[1, 2, 3, 4].map((i) => (
+                    <Skeleton key={i} className="h-14 w-full rounded-lg" />
                   ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </section>
+                </div>
+              ) : (
+                <ResponsiveTable
+                  columns={columns}
+                  rows={rows}
+                  getRowId={(r) => r.organizationId}
+                  empty={
+                    <EmptyState
+                      icon={Building2}
+                      title="No organisations to bill yet"
+                      description="Create your first org from the Overview tab."
+                    />
+                  }
+                />
+              )}
+            </section>
+          </>
+        )}
       </DashboardContent>
     </>
   );

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/create/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/create/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <PageSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/error.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { DashboardRouteError } from "@/components/dashboard/DashboardRouteError";
+
+export default function OrgWorkspaceDashboardError({
+  error,
+  reset,
+}: Readonly<{
+  error: Error & { digest?: string };
+  reset: () => void;
+}>) {
+  const params = useParams<{ orgWorkspaceId: string }>();
+
+  return (
+    <DashboardRouteError
+      error={error}
+      reset={reset}
+      scope="dashboard/org-workspace"
+      event="org_workspace_dashboard_error"
+      entityKey="orgWorkspaceId"
+      entityId={params?.orgWorkspaceId ?? "unknown"}
+      title="Something went wrong in this workspace"
+      devFallbackMessage="An unexpected error occurred while loading the operator dashboard."
+      escape={{ href: "/dashboard", label: "Back to dashboard" }}
+    />
+  );
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/home/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/home/loading.tsx
@@ -1,0 +1,5 @@
+import { HomeSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <HomeSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
@@ -30,8 +30,10 @@ import {
   DashboardGrid,
 } from "@/components/dashboard/PageScaffold";
 import { StatCard, StatCardSkeleton } from "@/components/dashboard/StatCard";
+import { EmptyState, DataCardSkeleton } from "@/components/dashboard/DataCard";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Card,
   CardContent,
@@ -48,6 +50,7 @@ import {
   FUNDING_SOURCE_BADGE_CLASS,
   MEMBER_ROLE_LABEL,
 } from "@/lib/labels/org-labels";
+import { useWorkspaceBilling } from "../hooks/useWorkspaceBilling";
 
 interface OrgMembershipRow {
   membershipId: string;
@@ -75,20 +78,6 @@ async function fetchOrgs(): Promise<{ data: OrgMembershipRow[] }> {
   return res.json();
 }
 
-interface BillingRollup {
-  orgsOwned: number;
-  totalActiveMembers: number;
-  totalOutstandingPaise: number;
-  totalWalletPaise: number;
-}
-
-async function fetchRollup(orgWorkspaceId: string): Promise<BillingRollup> {
-  const res = await fetch(`/api/org-workspace/${orgWorkspaceId}/billing`);
-  if (!res.ok) throw new Error("Failed to load billing roll-up");
-  const json = (await res.json()) as { summary: BillingRollup };
-  return json.summary;
-}
-
 export default function OrgWorkspaceHomePage({
   params,
 }: {
@@ -100,10 +89,9 @@ export default function OrgWorkspaceHomePage({
     queryKey: ["org-workspace-orgs"],
     queryFn: fetchOrgs,
   });
-  const rollup = useQuery({
-    queryKey: ["org-workspace-rollup", orgWorkspaceId],
-    queryFn: () => fetchRollup(orgWorkspaceId),
-  });
+  // Shared with the billing page under one query key — see useWorkspaceBilling.
+  const rollup = useWorkspaceBilling(orgWorkspaceId);
+  const summary = rollup.data?.summary;
 
   const rows = (orgs.data?.data ?? []).filter((r) => r.role === "OWNER");
 
@@ -121,48 +109,90 @@ export default function OrgWorkspaceHomePage({
         }
       />
       <DashboardContent>
-        <DashboardGrid>
-          {rollup.isLoading ? (
-            <>
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-              <StatCardSkeleton />
-            </>
-          ) : (
-            <>
-              <StatCard
-                title="Organisations"
-                value={rollup.data?.orgsOwned.toString() ?? "0"}
-                icon={Building2}
-              />
-              <StatCard
-                title="Active members"
-                value={
-                  rollup.data?.totalActiveMembers.toLocaleString("en-IN") ?? "0"
-                }
-                icon={Users}
-              />
-              <StatCard
-                title="Outstanding (INR)"
-                value={formatCurrencyAmount(
-                  rollup.data?.totalOutstandingPaise ?? 0,
-                  "INR",
-                )}
+        {rollup.isError ? (
+          <Card>
+            <CardContent className="py-6">
+              <EmptyState
                 icon={Wallet}
-                variant={
-                  rollup.data && rollup.data.totalOutstandingPaise > 0
-                    ? "warning"
-                    : "default"
+                title="Couldn't load the billing roll-up"
+                description="We hit an error fetching your cross-org totals."
+                action={
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => rollup.refetch()}
+                  >
+                    Retry
+                  </Button>
                 }
               />
-            </>
-          )}
-        </DashboardGrid>
+            </CardContent>
+          </Card>
+        ) : (
+          <DashboardGrid>
+            {rollup.isLoading ? (
+              <>
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+                <StatCardSkeleton />
+              </>
+            ) : (
+              <>
+                <StatCard
+                  title="Organisations"
+                  value={summary?.orgsOwned.toString() ?? "0"}
+                  icon={Building2}
+                />
+                <StatCard
+                  title="Active members"
+                  value={summary?.totalActiveMembers.toLocaleString("en-IN") ?? "0"}
+                  icon={Users}
+                />
+                <StatCard
+                  title="Outstanding (INR)"
+                  value={formatCurrencyAmount(
+                    summary?.totalOutstandingPaise ?? 0,
+                    "INR",
+                  )}
+                  icon={Wallet}
+                  variant={
+                    summary && summary.totalOutstandingPaise > 0
+                      ? "warning"
+                      : "default"
+                  }
+                />
+              </>
+            )}
+          </DashboardGrid>
+        )}
 
         <section className="mt-6">
           <h2 className="text-lg font-medium mb-3">Your organisations</h2>
           {orgs.isLoading ? (
-            <p className="text-sm text-zinc-500">Loading organizations…</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <DataCardSkeleton />
+              <DataCardSkeleton />
+              <DataCardSkeleton />
+            </div>
+          ) : orgs.isError ? (
+            <Card>
+              <CardContent className="py-10">
+                <EmptyState
+                  icon={Building2}
+                  title="Couldn't load your organisations"
+                  description="We hit an error fetching your org list. Check your connection and try again."
+                  action={
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => orgs.refetch()}
+                    >
+                      Retry
+                    </Button>
+                  }
+                />
+              </CardContent>
+            </Card>
           ) : rows.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {rows.map((row) => {
@@ -178,18 +208,16 @@ export default function OrgWorkspaceHomePage({
                     <Card className="h-full hover:border-zinc-400 transition-colors">
                       <CardHeader>
                         <div className="flex items-center gap-3">
-                          <div className="w-10 h-10 rounded-lg bg-zinc-100 flex items-center justify-center overflow-hidden">
-                            {org.logo ? (
-                              // eslint-disable-next-line @next/next/no-img-element
-                              <img
-                                src={org.logo}
-                                alt={org.name}
-                                className="w-full h-full object-cover"
-                              />
-                            ) : (
-                              <Building2 className="w-5 h-5 text-zinc-500" />
-                            )}
-                          </div>
+                          <Avatar className="h-10 w-10 rounded-lg">
+                            <AvatarImage
+                              src={org.logo ?? undefined}
+                              alt={org.name}
+                              className="object-cover"
+                            />
+                            <AvatarFallback className="rounded-lg bg-zinc-100 text-zinc-500">
+                              <Building2 className="h-5 w-5" />
+                            </AvatarFallback>
+                          </Avatar>
                           <div className="min-w-0">
                             <CardTitle className="truncate text-base">
                               {org.name}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/home/page.tsx
@@ -140,12 +140,12 @@ export default function OrgWorkspaceHomePage({
               <>
                 <StatCard
                   title="Organisations"
-                  value={summary?.orgsOwned.toString() ?? "0"}
+                  value={summary?.orgsOwned?.toString() ?? "0"}
                   icon={Building2}
                 />
                 <StatCard
                   title="Active members"
-                  value={summary?.totalActiveMembers.toLocaleString("en-IN") ?? "0"}
+                  value={summary?.totalActiveMembers?.toLocaleString("en-IN") ?? "0"}
                   icon={Users}
                 />
                 <StatCard

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/hooks/useWorkspaceBilling.ts
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/hooks/useWorkspaceBilling.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { FundingSource } from "@prisma/client";
+
+/**
+ * Cross-org billing roll-up — the single source of truth shared by the
+ * operator home overview (which reads `.summary`) and the billing page
+ * (which reads both `.summary` and `.perOrg`).
+ *
+ * Both surfaces previously fetched `/api/org-workspace/[id]/billing` under
+ * two different query keys ("org-workspace-rollup" vs "org-workspace-billing"),
+ * doubling the network request and splitting the cache. One key + one fetcher
+ * here collapses that to a single cached entry.
+ */
+
+export interface WorkspaceBillingSummary {
+  orgsOwned: number;
+  totalActiveMembers: number;
+  totalOutstandingPaise: number;
+  totalWalletPaise: number;
+}
+
+export interface WorkspaceBillingPerOrgRow {
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  organizationStatus: string;
+  fundingSource: FundingSource | null;
+  currency: string;
+  walletBalancePaise: number;
+  outstandingCount: number;
+  outstandingPaise: number;
+  activeMembers: number;
+}
+
+export interface WorkspaceBillingResponse {
+  summary: WorkspaceBillingSummary;
+  perOrg: WorkspaceBillingPerOrgRow[];
+}
+
+export function workspaceBillingQueryKey(orgWorkspaceId: string) {
+  return ["org-workspace-billing", orgWorkspaceId] as const;
+}
+
+async function fetchWorkspaceBilling(
+  orgWorkspaceId: string,
+): Promise<WorkspaceBillingResponse> {
+  const res = await fetch(`/api/org-workspace/${orgWorkspaceId}/billing`);
+  if (!res.ok) throw new Error("Failed to load billing roll-up");
+  return res.json();
+}
+
+export function useWorkspaceBilling(orgWorkspaceId: string) {
+  return useQuery({
+    queryKey: workspaceBillingQueryKey(orgWorkspaceId),
+    queryFn: () => fetchWorkspaceBilling(orgWorkspaceId),
+  });
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
@@ -23,11 +23,9 @@ export default function OrgWorkspaceNotFound() {
           doesn&apos;t have access to it.
         </p>
       </div>
-      <Link href="/dashboard">
-        <Button variant="outline" size="sm">
-          Back to dashboard
-        </Button>
-      </Link>
+      <Button variant="outline" size="sm" asChild>
+        <Link href="/dashboard">Back to dashboard</Link>
+      </Button>
     </div>
   );
 }

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { Building2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Scoped 404 for the operator dashboard. The layout's IDOR guard calls
+ * notFound() when the URL's orgWorkspaceId doesn't match the caller's own
+ * profile — this gives that case a friendly, self-contained page with a way
+ * back instead of the bare global 404.
+ */
+export default function OrgWorkspaceNotFound() {
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-zinc-100">
+        <Building2 className="h-7 w-7 text-zinc-400" />
+      </div>
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold text-zinc-900">
+          Workspace not found
+        </h2>
+        <p className="max-w-sm text-sm text-zinc-500">
+          This operator workspace doesn&apos;t exist, or your account
+          doesn&apos;t have access to it.
+        </p>
+      </div>
+      <Link href="/dashboard">
+        <Button variant="outline" size="sm">
+          Back to dashboard
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/settings/loading.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { SettingsSkeleton } from "@/components/dashboard/DashboardSkeletons";
+
+export default function Loading() {
+  return <SettingsSkeleton />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/settings/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/settings/page.tsx
@@ -30,6 +30,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 import { DefaultLandingOrgSection } from "./components/DefaultLandingOrgSection";
 import { LocaleAndCurrencySection } from "./components/LocaleAndCurrencySection";
@@ -70,9 +71,18 @@ export default function OrgWorkspaceSettingsPage({
                 Couldn’t load preferences
               </CardTitle>
             </CardHeader>
-            <CardContent className="text-sm text-zinc-600">
-              Try refreshing the page. If the problem persists, contact
-              support — the workspace profile row may be missing.
+            <CardContent className="space-y-3 text-sm text-zinc-600">
+              <p>
+                If the problem persists, contact support — the workspace
+                profile row may be missing.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => settings.refetch()}
+              >
+                Retry
+              </Button>
             </CardContent>
           </Card>
         ) : (

--- a/app/dashboard/organization/[orgId]/layout.tsx
+++ b/app/dashboard/organization/[orgId]/layout.tsx
@@ -55,7 +55,7 @@ import {
   type CollapsibleSidebarGroup,
 } from "@/components/dashboard/CollapsibleSidebar";
 import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
-import { TabPendingIcon } from "@/components/dashboard/PersonalDashboardShell";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { useSession } from "@/lib/auth-client";
 import { signOutEverywhere } from "@/lib/auth/sign-out";
@@ -677,7 +677,7 @@ export default function OrgLayout({
                     : "text-zinc-500 hover:text-zinc-700"
                 }`}
               >
-                <TabPendingIcon
+                <LinkPendingIcon
                   Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900" : "text-zinc-400"}`}
                 />

--- a/app/dashboard/organization/[orgId]/layout.tsx
+++ b/app/dashboard/organization/[orgId]/layout.tsx
@@ -55,6 +55,7 @@ import {
   type CollapsibleSidebarGroup,
 } from "@/components/dashboard/CollapsibleSidebar";
 import { DashboardContextBar } from "@/components/dashboard/DashboardContextBar";
+import { TabPendingIcon } from "@/components/dashboard/PersonalDashboardShell";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { useSession } from "@/lib/auth-client";
 import { signOutEverywhere } from "@/lib/auth/sign-out";
@@ -676,7 +677,8 @@ export default function OrgLayout({
                     : "text-zinc-500 hover:text-zinc-700"
                 }`}
               >
-                <Icon
+                <TabPendingIcon
+                  Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900" : "text-zinc-400"}`}
                 />
                 {label}

--- a/components/dashboard/CollapsibleSidebar.tsx
+++ b/components/dashboard/CollapsibleSidebar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { cn } from "@/utils/tailwind";
-import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, Loader2, LogOut, type LucideIcon } from "lucide-react";
-import Link, { useLinkStatus } from "next/link";
+import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, LogOut, type LucideIcon } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 import {
   Tooltip,
   TooltipContent,
@@ -124,23 +125,6 @@ export interface CollapsibleSidebarProps {
    * wins over the default `bg-white`.
    */
   className?: string;
-}
-
-/**
- * Nav item icon that flips to a spinner the moment its enclosing Link's
- * navigation starts. On a cold route (dev compile, slow RSC fetch) the
- * app-router blocks BEFORE the destination's loading.tsx can render —
- * without this, a click looks dead for seconds and then switches abruptly.
- * The spinner is the instant acknowledgement; the route skeleton takes
- * over once the segment mounts.
- */
-function NavPendingIcon({ Icon }: { Icon: LucideIcon }) {
-  const { pending } = useLinkStatus();
-  return pending ? (
-    <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" aria-hidden />
-  ) : (
-    <Icon className="h-5 w-5 flex-shrink-0" />
-  );
 }
 
 /**
@@ -387,7 +371,7 @@ export function CollapsibleSidebar({
                                       : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                                   )}
                                 >
-                                  <NavPendingIcon Icon={item.icon} />
+                                  <LinkPendingIcon Icon={item.icon} />
                                   {collapsed ? (
                                     <span className="sr-only">{item.name}</span>
                                   ) : (
@@ -439,7 +423,7 @@ export function CollapsibleSidebar({
                             : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                         )}
                       >
-                        <NavPendingIcon Icon={item.icon} />
+                        <LinkPendingIcon Icon={item.icon} />
                         {collapsed ? (
                           <span className="sr-only">{item.name}</span>
                         ) : (

--- a/components/dashboard/CollapsibleSidebar.tsx
+++ b/components/dashboard/CollapsibleSidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { cn } from "@/utils/tailwind";
-import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, LogOut, type LucideIcon } from "lucide-react";
-import Link from "next/link";
+import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, Loader2, LogOut, type LucideIcon } from "lucide-react";
+import Link, { useLinkStatus } from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -124,6 +124,23 @@ export interface CollapsibleSidebarProps {
    * wins over the default `bg-white`.
    */
   className?: string;
+}
+
+/**
+ * Nav item icon that flips to a spinner the moment its enclosing Link's
+ * navigation starts. On a cold route (dev compile, slow RSC fetch) the
+ * app-router blocks BEFORE the destination's loading.tsx can render —
+ * without this, a click looks dead for seconds and then switches abruptly.
+ * The spinner is the instant acknowledgement; the route skeleton takes
+ * over once the segment mounts.
+ */
+function NavPendingIcon({ Icon }: { Icon: LucideIcon }) {
+  const { pending } = useLinkStatus();
+  return pending ? (
+    <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" aria-hidden />
+  ) : (
+    <Icon className="h-5 w-5 flex-shrink-0" />
+  );
 }
 
 /**
@@ -370,7 +387,7 @@ export function CollapsibleSidebar({
                                       : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                                   )}
                                 >
-                                  <item.icon className="h-5 w-5 flex-shrink-0" />
+                                  <NavPendingIcon Icon={item.icon} />
                                   {collapsed ? (
                                     <span className="sr-only">{item.name}</span>
                                   ) : (
@@ -422,7 +439,7 @@ export function CollapsibleSidebar({
                             : "text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-800",
                         )}
                       >
-                        <item.icon className="h-5 w-5 flex-shrink-0" />
+                        <NavPendingIcon Icon={item.icon} />
                         {collapsed ? (
                           <span className="sr-only">{item.name}</span>
                         ) : (

--- a/components/dashboard/PersonalDashboardShell.tsx
+++ b/components/dashboard/PersonalDashboardShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link, { useLinkStatus } from "next/link";
-import { Loader2, type LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { type LucideIcon } from "lucide-react";
 import {
   CollapsibleSidebar,
   CollapsibleSidebarSkeleton,
@@ -14,32 +14,12 @@ import {
 } from "@/components/dashboard/DashboardContextBar";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { isActiveRoute } from "@/components/dashboard/route-active";
+import { LinkPendingIcon } from "@/components/ui/NavLink";
 
 export interface PersonalDashboardMobileTab {
   label: string;
   path: string;
   Icon: LucideIcon;
-}
-
-/**
- * Tab icon that flips to a spinner the moment its Link's navigation starts —
- * instant acknowledgement on cold routes where the app-router blocks before
- * the destination's loading.tsx can render (same pattern as the sidebar's
- * NavPendingIcon).
- */
-export function TabPendingIcon({
-  Icon,
-  className,
-}: {
-  Icon: LucideIcon;
-  className: string;
-}) {
-  const { pending } = useLinkStatus();
-  return pending ? (
-    <Loader2 className={`${className} animate-spin`} aria-hidden />
-  ) : (
-    <Icon className={className} />
-  );
 }
 
 export interface PersonalDashboardShellProps {
@@ -147,7 +127,7 @@ export function PersonalDashboardShell({
                     : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
                 }`}
               >
-                <TabPendingIcon
+                <LinkPendingIcon
                   Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
                 />

--- a/components/dashboard/PersonalDashboardShell.tsx
+++ b/components/dashboard/PersonalDashboardShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import type { LucideIcon } from "lucide-react";
+import Link, { useLinkStatus } from "next/link";
+import { Loader2, type LucideIcon } from "lucide-react";
 import {
   CollapsibleSidebar,
   CollapsibleSidebarSkeleton,
@@ -19,6 +19,27 @@ export interface PersonalDashboardMobileTab {
   label: string;
   path: string;
   Icon: LucideIcon;
+}
+
+/**
+ * Tab icon that flips to a spinner the moment its Link's navigation starts —
+ * instant acknowledgement on cold routes where the app-router blocks before
+ * the destination's loading.tsx can render (same pattern as the sidebar's
+ * NavPendingIcon).
+ */
+export function TabPendingIcon({
+  Icon,
+  className,
+}: {
+  Icon: LucideIcon;
+  className: string;
+}) {
+  const { pending } = useLinkStatus();
+  return pending ? (
+    <Loader2 className={`${className} animate-spin`} aria-hidden />
+  ) : (
+    <Icon className={className} />
+  );
 }
 
 export interface PersonalDashboardShellProps {
@@ -126,7 +147,8 @@ export function PersonalDashboardShell({
                     : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
                 }`}
               >
-                <Icon
+                <TabPendingIcon
+                  Icon={Icon}
                   className={`h-5 w-5 ${isActive ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
                 />
                 {label}

--- a/components/ui/NavLink.tsx
+++ b/components/ui/NavLink.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link, { useLinkStatus } from "next/link";
-import { Loader2 } from "lucide-react";
+import { Loader2, type LucideIcon } from "lucide-react";
 import { cn } from "@/utils/tailwind";
 
 /**
@@ -25,6 +25,32 @@ function PendingIndicator({ className }: { className?: string }) {
         className,
       )}
     />
+  );
+}
+
+/**
+ * Icon-swap variant of the pending affordance for icon-led nav items
+ * (sidebar rows, mobile tab bars): the item's own icon flips to a spinner
+ * while its enclosing Link's navigation is in flight. Same #15.5 contract —
+ * MUST be a descendant of the <Link> it reports on. Single shared
+ * implementation for every dashboard shell (sidebar, personal mobile tabs,
+ * org mobile tabs) so the subtle useLinkStatus contract can't drift.
+ */
+export function LinkPendingIcon({
+  Icon,
+  className = "h-5 w-5 flex-shrink-0",
+}: {
+  Icon: LucideIcon;
+  className?: string;
+}) {
+  const { pending } = useLinkStatus();
+  return pending ? (
+    <Loader2
+      className={cn(className, "animate-spin motion-reduce:animate-none")}
+      aria-hidden
+    />
+  ) : (
+    <Icon className={className} />
   );
 }
 


### PR DESCRIPTION
## Overview

Bundles the four post-#960 dashboard follow-up PRs into one reviewable change to `dev`. Each was individually triaged (Gemini/CodeRabbit) with **all review threads resolved** before rolling up here.

Rolls up:
- **#961** `fix/dashboard-loading-and-availability` — cold-start nav feedback + availability editor height
- **#962** `feat/consultee-slot-expander` — consultee session-timeline single focus row
- **#963** `redesign/ows-01-shell` — org-workspace operator shell + route boundaries
- **#964** `redesign/ows-02-pages` — org-workspace page correctness + billing dedup

## What's inside

### Cold-start navigation + availability (#961)
- Shared `LinkPendingIcon` (one `useLinkStatus` + spinner impl) replaces the triplicated pending-icon across sidebar / personal shell / org shell — instant tab-switch feedback on cold routes.
- Availability settings: inactive schedule type collapses to a one-line summary (was rendering the full editor at `opacity-40` → screens of white space with 40+ custom dates); active custom-date list capped with scroll. `aria-live` on the inactive note.

### Consultee session timeline (#962)
- Multi-session cards collapse to a single focus row (Live now → Next → Last); full timeline behind an expander. Derivation chain (`nonTentativeSlots → sessions → focusSession`) fully memoized.

### Org-workspace operator dashboard (#963 + #964)
- **Shell**: `hidden md:block` sidebar + mobile bottom tab bar (was crushing content on phones), `DashboardContextBar`, `signOutEverywhere`, black-gradient accent kept. **New** `error.tsx` / `not-found.tsx` / 5× `loading.tsx` — the tree had **zero** route boundaries. Safe-area inset on the mobile tabs; decoded `usePathname`.
- **Pages**: `useWorkspaceBilling` dedups the double billing fetch; real `isError` states on home/billing/activity (were false empty-states / infinite skeletons on API failure); raw `<table>` → `ResponsiveTable`; `<img>` → `Avatar`; `timeAgo` → `date-fns` (with invalid-date guard).

### Product decisions (org-workspace — overridable in review)
Black-gradient sidebar kept · OrganizationSwitcher in the top bar · multi-currency deferred (INR-only).

## Verification
- `tsc --noEmit` + `eslint` clean on the **combined** branch.
- No API or schema changes. Full jest suite → CI.

## Review threads
All Gemini/CodeRabbit threads on #961–#964 triaged + resolved (6 Gemini items fixed on #963/#964; earlier items on #961/#962). CodeRabbit will re-review this mega PR (default base) — those get triaged too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
