### PR TITLE
fix(requests): keep Allocate Slots dialog within viewport

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -742,8 +742,8 @@ export function RequestSlotAllocationTab({
 
         {/* Single Allocation Dialog - moved outside map loop to prevent multiple dialogs */}
         <ResponsiveModal open={dialogOpen} onOpenChange={setDialogOpen}>
-          <ResponsiveModalContent className="max-w-[95vw] w-[1400px]">
-            <ResponsiveModalHeader>
+          <ResponsiveModalContent className="max-w-[95vw] w-[1400px] max-h-[90dvh] overflow-hidden flex flex-col">
+            <ResponsiveModalHeader className="shrink-0">
               <ResponsiveModalTitle>Allocate Slots</ResponsiveModalTitle>
               <ResponsiveModalDescription asChild>
                 {selectedRequest && (
@@ -790,6 +790,7 @@ export function RequestSlotAllocationTab({
             </ResponsiveModalHeader>
             {selectedRequest && (
               <SafeUnifiedCalendar
+                className="min-h-0 flex-1"
                 consultantId={consultantId}
                 eventType={
                   selectedRequest.type.toLowerCase() as

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -1060,7 +1060,7 @@ export function UnifiedCalendar({
     };
 
     return (
-      <div className="grid grid-cols-7 gap-1 h-[600px] overflow-y-auto">
+      <div className="grid grid-cols-7 gap-1 flex-1 min-h-[12rem] max-h-[min(600px,calc(90dvh-16rem))] overflow-y-auto">
         {DAYS.map((day) => (
           <div key={day} className="text-center font-bold p-2">
             {day.slice(0, 3)}
@@ -1150,10 +1150,10 @@ export function UnifiedCalendar({
   }
 
   return (
-    <div className={`flex flex-col gap-4 ${className}`}>
+    <div className={`flex flex-col gap-4 min-h-0 ${className}`}>
       {/* Warning Banner */}
       {configWarning && (
-        <div className="rounded-md bg-yellow-50 border border-yellow-200 px-4 py-3">
+        <div className="shrink-0 rounded-md bg-yellow-50 border border-yellow-200 px-4 py-3">
           <div className="flex items-start">
             <span className="text-yellow-600 mr-2">⚠️</span>
             <div className="flex-1">
@@ -1168,7 +1168,7 @@ export function UnifiedCalendar({
 
       {/* Scheduling Period Info Banner */}
       {allowedStart && allowedEnd && (
-        <div className="rounded-md bg-blue-50 border border-blue-200 px-4 py-3">
+        <div className="shrink-0 rounded-md bg-blue-50 border border-blue-200 px-4 py-3">
           <div className="flex items-start">
             <Calendar className="h-5 w-5 text-blue-600 mr-2 flex-shrink-0" />
             <div className="flex-1">
@@ -1184,7 +1184,7 @@ export function UnifiedCalendar({
       )}
 
       {/* Header */}
-      <div className="flex justify-between items-center gap-4">
+      <div className="shrink-0 flex justify-between items-center gap-4">
         <div className="flex gap-2">
           <Button
             variant={view === "week" ? "default" : "outline"}
@@ -1253,9 +1253,9 @@ export function UnifiedCalendar({
 
       {/* Calendar View */}
       {view === "week" ? (
-        <div className="flex flex-col h-[calc(100vh-24rem)] xl:h-[65vh] max-h-[500px]">
+        <div className="flex flex-col flex-1 min-h-[12rem] max-h-[min(500px,calc(90dvh-16rem))]">
           {/* Week header */}
-          <div className="grid grid-cols-8 gap-0.5 md:gap-1 sticky top-0 bg-background z-20 pb-1">
+          <div className="shrink-0 grid grid-cols-8 gap-0.5 md:gap-1 bg-background z-20 pb-1">
             <div className="w-14 md:w-20"></div>
             {weekDates.map((date, index) => {
               const isToday = isSameDay(date, new Date());
@@ -1322,7 +1322,7 @@ export function UnifiedCalendar({
       )}
 
       {/* Footer */}
-      <div className="flex items-center justify-between gap-4">
+      <div className="shrink-0 flex items-center justify-between gap-4">
         <div className="flex items-center gap-4">
           <div className="text-sm">
             {(() => {
@@ -1405,7 +1405,7 @@ export function UnifiedCalendar({
 
       {/* Allocation Buttons - Bottom */}
       {showAllocationButtons && mode === "allocate" && (
-        <div className="flex justify-end gap-2 mt-2">
+        <div className="shrink-0 flex justify-end gap-2 mt-2">
           {onClose && (
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary
- Pin the consultant Requests **Allocate Slots** modal to `max-h-[90dvh]` with `overflow-hidden` so the dialog itself does not scroll
- Make `UnifiedCalendar` fill remaining height with `shrink-0` chrome/footer; only the week/month grid scrolls

## Test plan
- [ ] Open consultant dashboard → Requests → **Allocate Slots** on a short viewport (~900px height or zoomed browser)
- [ ] Confirm the full dialog stays in frame (title + Auto Allocate / Allocate Manual Slots always visible)
- [ ] Confirm only the time-slot grid scrolls in Week view
- [ ] Switch to Month view; confirm month grid scrolls internally and footer stays pinned
- [ ] Resize below `sm` and confirm bottom sheet still fits within `90dvh` without outer dialog scroll
- [ ] Spot-check appointments **Manage Timings** calendar still usable (shared `UnifiedCalendar`)


Made with [Cursor](https://cursor.com)