### PR TITLE
ui(dashboard): consultant Allocate Slots, polish, responsive, and appointment actions

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/ConsultantAppointmentsAdapter.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/ConsultantAppointmentsAdapter.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { CalendarClock, Loader2 } from "lucide-react";
 import type {
   AppointmentActionAdapter,
   OverflowItem,
@@ -11,6 +12,11 @@ import {
   CONSULTANT_JOIN_WINDOW_MS,
   getJoinableSlot,
 } from "@/lib/appointments/slots";
+import {
+  isApprovedStatus,
+  isConfirmedStatus,
+  isInactiveStatus,
+} from "@/lib/appointments/status";
 import type { AppointmentVM } from "@/lib/appointments/view-model";
 import type {
   ConsultantTrialLike,
@@ -30,10 +36,64 @@ import {
   supportsParticipantManagement,
 } from "./utils/participantHelpers";
 import { EventTimingsCalendar } from "./components/EventTimingsCalendar";
+import { useConsultantEventActions } from "./components/useConsultantEventActions";
+import { CancelConfirmationDialog } from "@/app/dashboard/consultee/[consulteeId]/(features)/appointments/CancelConfirmationDialog";
+import { RescheduleSessionsModal } from "@/app/dashboard/consultee/[consulteeId]/(features)/appointments/components/RescheduleSessionsModal";
+import { ConsultantResponseUpload } from "../documents/ConsultantResponseUpload";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 interface TimingsTarget {
   appointment: TAppointment | UnscheduledAppointment;
   groupProgress: { completedSessions: number; totalSessions: number } | null;
+}
+
+type DialogKind =
+  | "cancel"
+  | "reschedule-single"
+  | "reschedule-multi"
+  | "documents";
+
+const TYPE_LABEL: Record<AppointmentVM["kind"], string> = {
+  CONSULTATION: "Consultation",
+  SUBSCRIPTION: "Subscription",
+  WEBINAR: "Webinar",
+  CLASS: "Class",
+  TRIAL: "Trial",
+};
+
+/** Webinar/class cancel+reschedule is plan-owner only (API rejects collaborators). */
+function canManageBookingLifecycle(vm: AppointmentVM): boolean {
+  if (vm.kind === "WEBINAR" || vm.kind === "CLASS") {
+    return !vm.collaboratorRole || vm.collaboratorRole === "HOST";
+  }
+  return true;
+}
+
+function actionableRawSlots(vm: AppointmentVM) {
+  if (vm.raw.rawSlots?.length) return vm.raw.rawSlots;
+  const sources =
+    vm.raw.groupAppointments && vm.raw.groupAppointments.length > 0
+      ? vm.raw.groupAppointments
+      : vm.raw.appointment
+        ? [vm.raw.appointment]
+        : [];
+  const now = Date.now();
+  return sources
+    .flatMap((a) => a.slotsOfAppointment ?? [])
+    .filter((slot) => new Date(slot.endsAt).getTime() >= now)
+    .sort(
+      (a, b) =>
+        new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
+    );
 }
 
 export function useConsultantAppointmentsAdapter(
@@ -45,10 +105,38 @@ export function useConsultantAppointmentsAdapter(
     null,
   );
   const [joiningId, setJoiningId] = useState<string | null>(null);
+  const [activeVm, setActiveVm] = useState<AppointmentVM | null>(null);
+  const [dialog, setDialog] = useState<DialogKind | null>(null);
 
-  // Dev affordance parity with the old group card: joining outside the
-  // window stays possible in non-prod builds — it's how flows get tested.
   const isDev = process.env.NODE_ENV !== "production";
+
+  const typeLabel = activeVm
+    ? TYPE_LABEL[activeVm.kind]
+    : ("Consultation" as const);
+
+  const rawSlots = useMemo(
+    () => (activeVm ? actionableRawSlots(activeVm) : []),
+    [activeVm],
+  );
+
+  const actions = useConsultantEventActions({
+    consultantId,
+    appointmentId: activeVm?.appointmentId ?? undefined,
+    rawSlots,
+    title: activeVm?.title ?? "",
+    type: typeLabel as
+      | "Consultation"
+      | "Subscription"
+      | "Webinar"
+      | "Class"
+      | "Trial",
+  });
+
+  const openDialog = (vm: AppointmentVM, kind: DialogKind) => {
+    setActiveVm(vm);
+    setDialog(kind);
+  };
+  const closeDialog = () => setDialog(null);
 
   const joinableSlotOf = (vm: AppointmentVM) =>
     getJoinableSlot(vm.raw.appointment?.slotsOfAppointment ?? [], {
@@ -59,8 +147,6 @@ export function useConsultantAppointmentsAdapter(
     setJoiningId(vm.id);
     let navigating = false;
     if (vm.kind === "TRIAL") {
-      // Trials come from the side query, not the appointments read — build
-      // the minimal meeting shape (old handleJoinTrialMeeting).
       const trial = vm.raw.source as ConsultantTrialLike;
       const slot = trial.appointment?.slotsOfAppointment?.[0];
       if (trial.appointment && slot) {
@@ -166,6 +252,11 @@ export function useConsultantAppointmentsAdapter(
   const overflowItems = (vm: AppointmentVM): OverflowItem[] => {
     const items: OverflowItem[] = [];
     const appointment = vm.raw.appointment;
+    const inactive = isInactiveStatus(vm.status);
+    const firstRaw = actionableRawSlots(vm)[0];
+    const tentative = firstRaw?.isTentative ?? false;
+    const lifecycleOk = canManageBookingLifecycle(vm);
+    const isTrial = vm.kind === "TRIAL";
 
     if (appointment && vm.bucket !== "cancelled" && vm.bucket !== "past") {
       items.push({
@@ -182,6 +273,46 @@ export function useConsultantAppointmentsAdapter(
           router.push(getParticipantManagementUrl(appointment, consultantId)),
       });
     }
+
+    if (
+      vm.appointmentId &&
+      !isTrial &&
+      lifecycleOk &&
+      !inactive &&
+      !tentative &&
+      isApprovedStatus(vm.status)
+    ) {
+      items.push({
+        key: "reschedule",
+        label: "Reschedule",
+        onClick: () =>
+          openDialog(vm, vm.group ? "reschedule-multi" : "reschedule-single"),
+      });
+    }
+
+    if (vm.appointmentId && !isTrial && lifecycleOk && !inactive) {
+      items.push({
+        key: "cancel",
+        label: "Cancel booking",
+        destructive: true,
+        onClick: () => openDialog(vm, "cancel"),
+      });
+    }
+
+    if (
+      vm.appointmentId &&
+      isConfirmedStatus(vm.status) &&
+      (vm.kind === "CONSULTATION" ||
+        vm.kind === "SUBSCRIPTION" ||
+        vm.kind === "TRIAL")
+    ) {
+      items.push({
+        key: "documents",
+        label: "Upload document",
+        onClick: () => openDialog(vm, "documents"),
+      });
+    }
+
     if (
       isDev &&
       vm.kind !== "TRIAL" &&
@@ -198,18 +329,105 @@ export function useConsultantAppointmentsAdapter(
     return items;
   };
 
-  const renderDialogs = () => {
-    if (!timingsTarget) return null;
-    return (
-      <EventTimingsCalendar
-        isOpen
-        onClose={() => setTimingsTarget(null)}
-        appointment={timingsTarget.appointment}
-        completedSessions={timingsTarget.groupProgress?.completedSessions}
-        groupTotalSessions={timingsTarget.groupProgress?.totalSessions}
-      />
-    );
-  };
+  const renderDialogs = () => (
+    <>
+      {timingsTarget && (
+        <EventTimingsCalendar
+          isOpen
+          onClose={() => setTimingsTarget(null)}
+          appointment={timingsTarget.appointment}
+          completedSessions={timingsTarget.groupProgress?.completedSessions}
+          groupTotalSessions={timingsTarget.groupProgress?.totalSessions}
+        />
+      )}
+
+      {activeVm && (
+        <>
+          <CancelConfirmationDialog
+            isOpen={dialog === "cancel"}
+            onConfirm={async () => {
+              await actions.handleCancelConfirm();
+              closeDialog();
+            }}
+            onCancel={closeDialog}
+            title={activeVm.title}
+            consultant={activeVm.counterpart.name}
+            appointmentType={typeLabel}
+            isLoading={actions.isLoading}
+          />
+
+          <RescheduleSessionsModal
+            open={dialog === "reschedule-multi"}
+            onOpenChange={(open) => !open && closeDialog()}
+            typeLabel={typeLabel}
+            rawSlots={rawSlots}
+            isLoading={actions.isLoading}
+            onConfirm={(slotIds) => {
+              closeDialog();
+              void actions.handleReschedule(slotIds);
+            }}
+          />
+
+          <AlertDialog
+            open={dialog === "reschedule-single"}
+            onOpenChange={(open) => !open && closeDialog()}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle className="flex items-center gap-2">
+                  <CalendarClock className="h-5 w-5 text-muted-foreground" />
+                  Reschedule {typeLabel}?
+                </AlertDialogTitle>
+                <AlertDialogDescription asChild>
+                  <div className="space-y-2">
+                    <p>
+                      Are you sure you want to reschedule{" "}
+                      <strong>&quot;{activeVm.title}&quot;</strong> with{" "}
+                      <strong>{activeVm.counterpart.name}</strong>?
+                    </p>
+                    <p className="text-muted-foreground">
+                      The current time slot will be released and the{" "}
+                      {typeLabel.toLowerCase()} status will revert to{" "}
+                      <strong>Pending</strong> until a new time is allocated.
+                    </p>
+                  </div>
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={actions.isLoading}>
+                  Keep Current Time
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => {
+                    closeDialog();
+                    void actions.handleReschedule();
+                  }}
+                  disabled={actions.isLoading}
+                  className="bg-primary text-primary-foreground hover:bg-primary/90"
+                >
+                  {actions.isLoading ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <CalendarClock className="mr-2 h-4 w-4" />
+                  )}
+                  Reschedule
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          {activeVm.appointmentId && dialog === "documents" && (
+            <ConsultantResponseUpload
+              appointmentId={activeVm.appointmentId}
+              isOpen
+              onClose={closeDialog}
+              onSuccess={closeDialog}
+            />
+          )}
+        </>
+      )}
+    </>
+  );
 
   return {
     role: "consultant",

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/[appointmentId]/DetailPageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/[appointmentId]/DetailPageClient.tsx
@@ -1,20 +1,30 @@
 "use client";
 
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Upload } from "lucide-react";
 import { AppointmentDetailClient } from "@/components/appointments/detail/AppointmentDetailClient";
 import { AppointmentDocumentsList } from "@/components/appointments/detail/AppointmentDocumentsList";
+import { Button } from "@/components/ui/button";
+import { isConfirmedStatus } from "@/lib/appointments/status";
 import { CONSULTANT_JOIN_WINDOW_MS } from "@/lib/appointments/slots";
 import type { TAppointment } from "@/types/appointment";
+import { ConsultantResponseUpload } from "../../documents/ConsultantResponseUpload";
 import { useConsultantAppointmentsAdapter } from "../ConsultantAppointmentsAdapter";
 import {
   getParticipantManagementUrl,
   supportsParticipantManagement,
 } from "../utils/participantHelpers";
 
+const DOCUMENT_KINDS = new Set(["CONSULTATION", "SUBSCRIPTION", "TRIAL"]);
+
 export default function DetailPageClient({
   consultantId,
   appointmentId,
 }: Readonly<{ consultantId: string; appointmentId: string }>) {
   const adapter = useConsultantAppointmentsAdapter(consultantId);
+  const queryClient = useQueryClient();
+  const [uploadOpen, setUploadOpen] = useState(false);
 
   return (
     <>
@@ -24,9 +34,30 @@ export default function DetailPageClient({
         adapter={adapter}
         backHref={`/dashboard/consultant/${consultantId}/appointments`}
         joinWindowMs={CONSULTANT_JOIN_WINDOW_MS}
-        renderDocuments={() => (
-          <AppointmentDocumentsList appointmentId={appointmentId} />
-        )}
+        renderDocuments={(vm) => {
+          const canUpload =
+            DOCUMENT_KINDS.has(vm.kind) && isConfirmedStatus(vm.status);
+
+          return (
+            <div className="space-y-3">
+              <AppointmentDocumentsList appointmentId={appointmentId} />
+              {canUpload ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setUploadOpen(true)}
+                >
+                  <Upload className="mr-1.5 h-3.5 w-3.5" />
+                  Upload document
+                </Button>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Documents can be uploaded once the booking is confirmed.
+                </p>
+              )}
+            </div>
+          );
+        }}
         participantsHref={(detail) => {
           const appointment = detail.appointment as unknown as TAppointment;
           return supportsParticipantManagement(appointment)
@@ -34,8 +65,18 @@ export default function DetailPageClient({
             : null;
         }}
       />
-      {/* Timings / schedule dialogs live on the adapter — must mount here too */}
       {adapter.renderDialogs()}
+      <ConsultantResponseUpload
+        appointmentId={appointmentId}
+        isOpen={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+        onSuccess={() => {
+          setUploadOpen(false);
+          void queryClient.invalidateQueries({
+            queryKey: ["appointment-documents", appointmentId],
+          });
+        }}
+      />
     </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/[appointmentId]/DetailPageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/[appointmentId]/DetailPageClient.tsx
@@ -17,21 +17,25 @@ export default function DetailPageClient({
   const adapter = useConsultantAppointmentsAdapter(consultantId);
 
   return (
-    <AppointmentDetailClient
-      appointmentId={appointmentId}
-      role="consultant"
-      adapter={adapter}
-      backHref={`/dashboard/consultant/${consultantId}/appointments`}
-      joinWindowMs={CONSULTANT_JOIN_WINDOW_MS}
-      renderDocuments={() => (
-        <AppointmentDocumentsList appointmentId={appointmentId} />
-      )}
-      participantsHref={(detail) => {
-        const appointment = detail.appointment as unknown as TAppointment;
-        return supportsParticipantManagement(appointment)
-          ? getParticipantManagementUrl(appointment, consultantId)
-          : null;
-      }}
-    />
+    <>
+      <AppointmentDetailClient
+        appointmentId={appointmentId}
+        role="consultant"
+        adapter={adapter}
+        backHref={`/dashboard/consultant/${consultantId}/appointments`}
+        joinWindowMs={CONSULTANT_JOIN_WINDOW_MS}
+        renderDocuments={() => (
+          <AppointmentDocumentsList appointmentId={appointmentId} />
+        )}
+        participantsHref={(detail) => {
+          const appointment = detail.appointment as unknown as TAppointment;
+          return supportsParticipantManagement(appointment)
+            ? getParticipantManagementUrl(appointment, consultantId)
+            : null;
+        }}
+      />
+      {/* Timings / schedule dialogs live on the adapter — must mount here too */}
+      {adapter.renderDialogs()}
+    </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/EventTimingsCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/EventTimingsCalendar.tsx
@@ -170,9 +170,8 @@ export function EventTimingsCalendar({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      {/* FIX: Added max-h-[90vh] + overflow-y-auto to prevent footer cutoff on small screens */}
-      <DialogContent className="max-w-7xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="max-w-7xl max-h-[90dvh] overflow-hidden flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle>
             {appointment.appointmentType === "CLASS"
               ? "Manage Class Timings"
@@ -180,7 +179,7 @@ export function EventTimingsCalendar({
           </DialogTitle>
           <DialogDescription>{getDescriptionText()}</DialogDescription>
           {appointment.appointmentType === "CLASS" && (
-            <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="outline">
                 Plan: {eventDetails.planType || "Custom"}
               </Badge>
@@ -196,7 +195,7 @@ export function EventTimingsCalendar({
 
         {/* Guidance prompt for class rules */}
         {appointment.appointmentType === "CLASS" && (
-          <div className="mb-2 rounded-md border bg-muted/30 px-3 py-2 text-xs">
+          <div className="mb-2 shrink-0 rounded-md border bg-muted/30 px-3 py-2 text-xs">
             Tip: Each class is{" "}
             {Math.ceil((eventDetails.durationInHours || 1) / 0.5)} consecutive
             30‑min slots. Complete an in‑progress class before starting another.
@@ -233,7 +232,7 @@ export function EventTimingsCalendar({
           onAllocationComplete={handleAllocationComplete}
           onClose={onClose}
           showAllocationButtons={true}
-          className="min-h-[500px]"
+          className="min-h-0 flex-1"
           // UI guard rails: restrict selection window based on validation period
           allowedStart={
             appointment.appointmentType === "SUBSCRIPTION"

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/useConsultantEventActions.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/useConsultantEventActions.ts
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { useToast } from "@/hooks/use-toast";
+import { useQueryClient } from "@tanstack/react-query";
+import type { SlotOfAppointment } from "@prisma/client";
+
+interface UseConsultantEventActionsOptions {
+  consultantId: string;
+  appointmentId?: string;
+  rawSlots: Array<Pick<SlotOfAppointment, "id" | "startsAt" | "endsAt"> & {
+    isTentative?: boolean;
+    appointmentId?: string | null;
+  }>;
+  title: string;
+  type: "Consultation" | "Subscription" | "Webinar" | "Class" | "Trial";
+}
+
+/**
+ * Cancel / reschedule mutations for the consultant appointments surface.
+ * Mirrors consultee `useEventActions` against the same APIs, with consultant
+ * query-cache invalidation.
+ */
+export function useConsultantEventActions({
+  consultantId,
+  appointmentId,
+  title,
+  type,
+}: UseConsultantEventActionsOptions) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const invalidateBookingData = () => {
+    void queryClient.invalidateQueries({
+      queryKey: ["consultant-appointments", consultantId],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ["consultant-dashboard", consultantId],
+    });
+    if (appointmentId) {
+      void queryClient.invalidateQueries({
+        queryKey: ["appointment-detail", appointmentId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["appointment-documents", appointmentId],
+      });
+    }
+  };
+
+  const handleReschedule = async (slotIds?: string[]) => {
+    if (!appointmentId) {
+      toast({
+        title: "Error",
+        description: "Appointment ID is missing",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const url =
+        type === "Subscription"
+          ? `/api/appointments/${appointmentId}/reschedule?type=SUBSCRIPTION`
+          : `/api/appointments/${appointmentId}/reschedule`;
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body:
+          slotIds && slotIds.length > 0
+            ? JSON.stringify({ slotIds })
+            : undefined,
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to request reschedule");
+      }
+
+      const sessionsAffected =
+        data.sessionsAffected ?? data.slotsAffected ?? slotIds?.length ?? 1;
+
+      toast({
+        title: "Ready to reschedule",
+        description:
+          sessionsAffected === 1
+            ? "Select a new time for this session."
+            : `Select new times for ${sessionsAffected} sessions.`,
+      });
+
+      invalidateBookingData();
+    } catch (error) {
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        { tags: { subsystem: "client" } },
+      );
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to request reschedule",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancelConfirm = async () => {
+    if (!appointmentId) {
+      toast({
+        title: "Error",
+        description: "Appointment ID is missing",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await fetch(
+        `/api/appointments/${appointmentId}/cancel`,
+        { method: "POST", headers: { "Content-Type": "application/json" } },
+      );
+      const data = await response.json();
+      if (!response.ok) {
+        if (response.status === 409) {
+          toast({
+            title: "Booking already updated",
+            description:
+              "This booking changed state in the meantime — refreshing.",
+          });
+          invalidateBookingData();
+          return;
+        }
+        throw new Error(data.error || "Failed to cancel appointment");
+      }
+
+      const refundNote =
+        type === "Consultation" || type === "Subscription"
+          ? " Any eligible refund follows your cancellation policy."
+          : "";
+
+      toast({
+        title: "Appointment cancelled",
+        description: `${type} "${title}" has been cancelled.${refundNote}`,
+      });
+      invalidateBookingData();
+    } catch (error) {
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        { tags: { subsystem: "client" } },
+      );
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to cancel appointment",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    handleReschedule,
+    handleCancelConfirm,
+  };
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/useConsultantEventActions.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/useConsultantEventActions.ts
@@ -4,15 +4,13 @@ import { useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { useToast } from "@/hooks/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
-import type { SlotOfAppointment } from "@prisma/client";
+import type { SlotLike } from "@/lib/appointments/view-model";
 
 interface UseConsultantEventActionsOptions {
   consultantId: string;
   appointmentId?: string;
-  rawSlots: Array<Pick<SlotOfAppointment, "id" | "startsAt" | "endsAt"> & {
-    isTentative?: boolean;
-    appointmentId?: string | null;
-  }>;
+  /** Kept for call-site parity with consultee actions / reschedule modal. */
+  rawSlots: SlotLike[];
   title: string;
   type: "Consultation" | "Subscription" | "Webinar" | "Class" | "Trial";
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
@@ -19,7 +19,7 @@ export function ChatsTab({ userId: _userId }: Readonly<ChatsTabProps>) {
   return (
     <>
       <DashboardHeader title="Chats" subtitle="Messages and conversations" />
-      <div className="mt-4 w-full bg-card rounded-xl border border-border shadow-sm overflow-hidden h-[calc(100vh-15rem)] min-h-[400px]">
+      <div className="mt-4 w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-14rem)] min-h-[280px] max-h-[calc(100dvh-10rem)] sm:h-[calc(100dvh-15rem)] sm:min-h-[360px]">
         {error ? (
           <ChatUnavailable description={error} onRetry={retryConnection} />
         ) : chatConnected ? (

--- a/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
@@ -16,7 +16,7 @@ export function ChatsTab({ userId: _userId }: Readonly<ChatsTabProps>) {
   const { chatConnected, error, retryConnection } = useStreamConnection();
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[280px] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[360px]">
+    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[min(280px,calc(100dvh-8rem))] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[min(360px,calc(100dvh-9rem))]">
       {error ? (
         <ChatUnavailable description={error} onRetry={retryConnection} />
       ) : chatConnected ? (

--- a/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
@@ -3,7 +3,6 @@
 import { Loader2 } from "lucide-react";
 import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ChatUnavailable } from "@/components/chat/ChatUnavailable";
-import { DashboardHeader } from "@/components/dashboard/PageScaffold";
 import { useStreamConnection } from "@/providers/StreamProvider";
 
 interface ChatsTabProps {
@@ -17,20 +16,17 @@ export function ChatsTab({ userId: _userId }: Readonly<ChatsTabProps>) {
   const { chatConnected, error, retryConnection } = useStreamConnection();
 
   return (
-    <>
-      <DashboardHeader title="Chats" subtitle="Messages and conversations" />
-      <div className="mt-4 w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-14rem)] min-h-[280px] max-h-[calc(100dvh-10rem)] sm:h-[calc(100dvh-15rem)] sm:min-h-[360px]">
-        {error ? (
-          <ChatUnavailable description={error} onRetry={retryConnection} />
-        ) : chatConnected ? (
-          <ChatLayout />
-        ) : (
-          <div className="flex h-full items-center justify-center text-muted-foreground">
-            <Loader2 className="h-6 w-6 animate-spin mr-2" />
-            Connecting to chat…
-          </div>
-        )}
-      </div>
-    </>
+    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[280px] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[360px]">
+      {error ? (
+        <ChatUnavailable description={error} onRetry={retryConnection} />
+      ) : chatConnected ? (
+        <ChatLayout />
+      ) : (
+        <div className="flex h-full items-center justify-center text-muted-foreground">
+          <Loader2 className="mr-2 h-6 w-6 animate-spin" />
+          Connecting to chat…
+        </div>
+      )}
+    </div>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/chats/ChatsTab.tsx
@@ -10,13 +10,17 @@ interface ChatsTabProps {
   userRole: string | null;
 }
 
+/**
+ * Full-bleed chat surface: cancels PageScaffold padding and fills the
+ * content column under the context bar (and above the mobile tab bar).
+ */
 export function ChatsTab({ userId: _userId }: Readonly<ChatsTabProps>) {
   // Connection state from the lazy Stream provider: render the chat UI only
   // once the chat client is live; surface failures instead of a blank box.
   const { chatConnected, error, retryConnection } = useStreamConnection();
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[min(280px,calc(100dvh-8rem))] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[min(360px,calc(100dvh-9rem))]">
+    <div className="-m-4 h-[calc(100dvh-3.5rem-4rem)] overflow-hidden border-border bg-card sm:-m-6 md:h-[calc(100dvh-3.5rem)] lg:-m-8">
       {error ? (
         <ChatUnavailable description={error} onRetry={retryConnection} />
       ) : chatConnected ? (

--- a/app/dashboard/consultant/[consultantId]/(features)/documents/ConsultantResponseUpload.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/documents/ConsultantResponseUpload.tsx
@@ -110,8 +110,8 @@ export function ConsultantResponseUpload({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="sm:max-w-[500px]">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[500px] max-h-[90dvh] overflow-hidden flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle>
             {responseToDocument
               ? "Upload Response Document"

--- a/app/dashboard/consultant/[consultantId]/(features)/documents/ConsultantResponseUpload.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/documents/ConsultantResponseUpload.tsx
@@ -124,7 +124,7 @@ export function ConsultantResponseUpload({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4">
           {/* Show original document info if this is a response */}
           {responseToDocument && (
             <div className="bg-muted p-3 rounded-lg">
@@ -199,7 +199,7 @@ export function ConsultantResponseUpload({
           )}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0">
           <Button
             variant="outline"
             onClick={handleClose}

--- a/app/dashboard/consultant/[consultantId]/(features)/documents/DocumentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/documents/DocumentsTab.tsx
@@ -654,8 +654,8 @@ export function DocumentsTab({
 
       {/* Review Dialog */}
       <ResponsiveModal open={reviewDialogOpen} onOpenChange={setReviewDialogOpen}>
-        <ResponsiveModalContent className="sm:max-w-[425px]">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="sm:max-w-[425px] max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle>Review Document</ResponsiveModalTitle>
             <ResponsiveModalDescription>
               Update the review status and add notes for{" "}
@@ -736,8 +736,8 @@ export function DocumentsTab({
           }
         }}
       >
-        <ResponsiveModalContent className="sm:max-w-[500px]">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="sm:max-w-[500px] max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle>
               Review {selectedIds.size} Documents
             </ResponsiveModalTitle>

--- a/app/dashboard/consultant/[consultantId]/(features)/documents/DocumentsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/documents/DocumentsTab.tsx
@@ -662,7 +662,7 @@ export function DocumentsTab({
               {selectedDocument?.originalName}
             </ResponsiveModalDescription>
           </ResponsiveModalHeader>
-          <div className="grid gap-4 py-4">
+          <div className="min-h-0 flex-1 grid gap-4 overflow-y-auto py-4">
             <div className="space-y-2">
               <label className="text-sm font-medium">Review Status</label>
               <Select value={reviewStatus} onValueChange={setReviewStatus}>
@@ -707,7 +707,7 @@ export function DocumentsTab({
               </div>
             )}
           </div>
-          <ResponsiveModalFooter>
+          <ResponsiveModalFooter className="shrink-0">
             <Button
               variant="outline"
               onClick={() => setReviewDialogOpen(false)}
@@ -745,7 +745,7 @@ export function DocumentsTab({
               Set a review status and optional notes for all selected documents.
             </ResponsiveModalDescription>
           </ResponsiveModalHeader>
-          <div className="grid gap-4 py-4">
+          <div className="min-h-0 flex-1 grid gap-4 overflow-y-auto py-4">
             <div className="space-y-2">
               <label className="text-sm font-medium">Review Status</label>
               <Select value={bulkReviewStatus} onValueChange={setBulkReviewStatus}>
@@ -795,7 +795,7 @@ export function DocumentsTab({
               </div>
             </div>
           </div>
-          <ResponsiveModalFooter>
+          <ResponsiveModalFooter className="shrink-0">
             <Button
               variant="outline"
               onClick={() => setBulkReviewDialogOpen(false)}

--- a/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
@@ -379,7 +379,7 @@ export default function EarningsPage({
 
           {/* Pagination */}
           {pagination && pagination.total > limit && (
-            <div className="flex items-center justify-between px-4 py-3 border-t border-zinc-200 bg-zinc-50">
+            <div className="flex flex-col gap-3 border-t border-zinc-200 bg-zinc-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-zinc-500">
                 Showing {page * limit + 1}–
                 {Math.min((page + 1) * limit, pagination.total)} of{" "}

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
@@ -55,7 +55,6 @@ function formatCollaboratorRole(role: string): string {
   return labels[role] || role;
 }
 
-// Type guards
 function isWebinarEvent(event: Event): event is WebinarEvent {
   return event.type === "webinar";
 }
@@ -72,48 +71,50 @@ function isSubscriptionPlanEvent(event: Event): event is SubscriptionPlanEvent {
   return event.type === "subscription";
 }
 
-// Event type configuration
 const eventTypeConfig: Record<
   EventType,
   {
     icon: typeof MessageSquare;
     iconBg: string;
     iconColor: string;
-    gradientColor: string;
+    accent: string;
+    label: string;
   }
 > = {
   consultation: {
     icon: MessageSquare,
-    iconBg: "bg-blue-50",
-    iconColor: "text-blue-600",
-    gradientColor: "from-blue-100/50",
+    iconBg: "bg-sky-50",
+    iconColor: "text-sky-700",
+    accent: "bg-sky-600",
+    label: "Consultation",
   },
   subscription: {
     icon: CalendarRange,
-    iconBg: "bg-purple-50",
-    iconColor: "text-purple-600",
-    gradientColor: "from-purple-100/50",
+    iconBg: "bg-teal-50",
+    iconColor: "text-teal-700",
+    accent: "bg-teal-600",
+    label: "Subscription",
   },
   webinar: {
     icon: Video,
     iconBg: "bg-emerald-50",
-    iconColor: "text-emerald-600",
-    gradientColor: "from-emerald-100/50",
+    iconColor: "text-emerald-700",
+    accent: "bg-emerald-600",
+    label: "Webinar",
   },
   class: {
     icon: GraduationCap,
     iconBg: "bg-amber-50",
-    iconColor: "text-amber-600",
-    gradientColor: "from-amber-100/50",
+    iconColor: "text-amber-700",
+    accent: "bg-amber-600",
+    label: "Class",
   },
 };
 
-// Currency formatting utility — prices are stored in smallest unit (paise for INR)
 const formatCurrency = (price: number, currency: string) => {
   return formatCurrencyAmount(price, currency);
 };
 
-// Helper functions for extracting event data
 function getEventTitle(event: Event): string {
   if (isWebinarEvent(event)) return event.webinarPlan.title;
   if (isClassEvent(event)) return event.classPlan.title;
@@ -173,7 +174,6 @@ function getEventDuration(event: Event): string {
 function getMaxParticipants(event: Event): number {
   if (isWebinarEvent(event)) return event.webinarPlan.maxParticipants;
   if (isClassEvent(event)) return event.classPlan.maxParticipants;
-  // Consultations and subscriptions are 1-on-1
   return 1;
 }
 
@@ -257,192 +257,195 @@ export function EventCard({
   const isLiveSession = eventType === "webinar" || eventType === "class";
   const durationSuffix = isRecurringEventType(eventType) ? "/mo" : "";
 
-  // Check if subscription plan has trials enabled
   const hasTrialEnabled =
     isSubscriptionPlanEvent(event) && event.subscriptionPlan.trialEnabled;
 
   return (
     <motion.div
-      whileHover={{ y: -4, boxShadow: "0 12px 40px -12px rgba(0, 0, 0, 0.15)" }}
+      whileHover={{ y: -2 }}
       transition={{ duration: 0.2 }}
-      className="group relative overflow-hidden rounded-xl border border-zinc-200/80 bg-white p-5 sm:p-6 h-full flex flex-col"
+      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-zinc-200/80 bg-white shadow-sm transition-shadow hover:shadow-md"
     >
-      {/* Decorative gradient blob */}
-      <div
-        className={cn(
-          "absolute -right-8 -top-8 h-24 w-24 rounded-full bg-gradient-to-br to-transparent opacity-60",
-          config.gradientColor,
-        )}
-      />
+      {/* Accent strip */}
+      <div className={cn("h-1 w-full shrink-0", config.accent)} />
 
-      {/* Hover action buttons - hidden for collaborated plans */}
-      {!isCollaborated && (
-        <div className="absolute top-3 right-3 sm:top-4 sm:right-4 flex items-center gap-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all duration-200 sm:transform sm:translate-y-1 sm:group-hover:translate-y-0 z-10">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 sm:h-9 sm:w-9 bg-white/90 backdrop-blur-sm shadow-sm hover:bg-white border border-zinc-200/60"
-            aria-label={`Edit ${title}`}
-            title={`Edit ${title}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onEdit();
-            }}
-          >
-            <Edit className="h-4 w-4 text-zinc-600" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 sm:h-9 sm:w-9 bg-white/90 backdrop-blur-sm shadow-sm hover:bg-red-50 border border-zinc-200/60"
-            aria-label={`Delete ${title}`}
-            title={`Delete ${title}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-          >
-            <Trash2 className="h-4 w-4 text-zinc-400 hover:text-red-500" />
-          </Button>
-        </div>
-      )}
-
-      {/* Main content */}
-      <div className="flex items-start gap-3 sm:gap-4">
-        {/* Icon badge */}
-        <div
-          className={cn(
-            "flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-xl shrink-0",
-            config.iconBg,
-          )}
-        >
-          <Icon className={cn("h-5 w-5 sm:h-6 sm:w-6", config.iconColor)} />
-        </div>
-
-        {/* Content area */}
-        <div className="flex-1 min-w-0 pr-12 sm:pr-16">
-          <h3 className="font-semibold text-zinc-900 text-base sm:text-lg leading-tight line-clamp-2">
-            {title}
-          </h3>
-          {collaboratorRole && (
-            <span
-              className={`inline-block mt-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-                isCollaborated
-                  ? "bg-purple-50 text-purple-700"
-                  : "bg-zinc-100 text-zinc-600"
-              }`}
-            >
-              {formatCollaboratorRole(collaboratorRole)}
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* Description - expanded */}
-      <p className="text-sm text-zinc-500 line-clamp-3 mt-3 flex-grow">
-        {description || "No description provided"}
-      </p>
-
-      {/* Live session info (webinar/class only) */}
-      {isLiveSession && (
-        <div className="mt-4 flex items-center gap-2 flex-wrap">
-          <span className="text-xs sm:text-sm text-zinc-500 font-medium">
-            {formatDateTime(startDate)}
-          </span>
-          {status && (
-            <Badge variant={getStatusVariant(status)} className="text-xs">
-              {status.toString().replace("_", " ")}
-            </Badge>
-          )}
-        </div>
-      )}
-
-      {/* Join Meeting button for live sessions */}
-      {isLiveSession && onJoinMeeting && (
-        <div className="mt-3">
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onJoinMeeting();
-            }}
-            disabled={
-              process.env.NODE_ENV === "production"
-                ? !canJoinNow || isJoiningMeeting
-                : isJoiningMeeting
-            }
+      <div className="flex flex-1 flex-col p-4 sm:p-5">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div
             className={cn(
-              "w-full gap-2 font-medium",
-              canJoinNow
-                ? "bg-emerald-600 hover:bg-emerald-700 text-white"
-                : "bg-zinc-100 text-zinc-500",
+              "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl",
+              config.iconBg,
             )}
-            size="sm"
           >
-            {isJoiningMeeting ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Joining...
-              </>
-            ) : (
-              <>
-                <Video className="h-4 w-4" />
-                {process.env.NODE_ENV === "production"
-                  ? canJoinNow
-                    ? "Join Meeting"
-                    : "Not Available Yet"
-                  : "Join (Dev)"}
-              </>
-            )}
-          </Button>
-        </div>
-      )}
+            <Icon className={cn("h-5 w-5", config.iconColor)} />
+          </div>
 
-      {/* Participants row - only for multi-participant event types */}
-      {(eventType === "webinar" || eventType === "class") && (
-        <div className="mt-3 flex items-center gap-1.5 text-xs sm:text-sm text-zinc-500">
-          <Users className="h-4 w-4" />
-          <span>
-            {participantCount}/{maxParticipants} participants
-          </span>
-        </div>
-      )}
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 flex flex-wrap items-center gap-1.5">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-400">
+                {config.label}
+              </span>
+              {collaboratorRole && (
+                <span
+                  className={cn(
+                    "rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+                    isCollaborated
+                      ? "bg-teal-50 text-teal-800"
+                      : "bg-zinc-100 text-zinc-600",
+                  )}
+                >
+                  {formatCollaboratorRole(collaboratorRole)}
+                </span>
+              )}
+            </div>
+            <h3
+              className="text-[15px] font-semibold leading-snug tracking-tight text-zinc-900"
+              title={title}
+            >
+              {title}
+            </h3>
+          </div>
 
-      {/* Trial Button (subscription plans with trial enabled) */}
-      {hasTrialEnabled && onTrialsClick && (
-        <div className="mt-3">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              onTrialsClick();
-            }}
-            className="w-full gap-2 border-purple-200 text-purple-700 hover:bg-purple-50 hover:border-purple-300"
-          >
-            <Gift className="h-4 w-4" />
-            {pendingTrialCount && pendingTrialCount > 0
-              ? `${pendingTrialCount} Trial Request${pendingTrialCount > 1 ? "s" : ""}`
-              : "Trials"}
-          </Button>
-        </div>
-      )}
-
-      {/* Price/Duration row */}
-      <div className="mt-4 pt-4 border-t border-zinc-100 flex items-center justify-between">
-        <div className="flex items-baseline gap-1">
-          <span className="text-lg sm:text-xl font-bold tracking-tight text-zinc-900">
-            {formatCurrency(price, currency)}
-          </span>
-          {durationSuffix && (
-            <span className="text-xs sm:text-sm text-zinc-400">
-              {durationSuffix}
-            </span>
+          {!isCollaborated && (
+            <div className="flex shrink-0 items-center gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900"
+                aria-label={`Edit ${title}`}
+                title={`Edit ${title}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+              >
+                <Edit className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-zinc-400 hover:bg-red-50 hover:text-red-600"
+                aria-label={`Delete ${title}`}
+                title={`Delete ${title}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
           )}
         </div>
 
-        <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-zinc-100 text-zinc-600">
-          <Clock className="h-3.5 w-3.5" />
-          <span className="text-xs font-medium">{duration}</span>
+        {/* Description — 2 lines max, full title always visible above */}
+        <p className="mt-3 line-clamp-2 text-sm leading-relaxed text-zinc-500">
+          {description || "No description provided"}
+        </p>
+
+        {isLiveSession && (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium text-zinc-500">
+              {formatDateTime(startDate)}
+            </span>
+            {status && (
+              <Badge variant={getStatusVariant(status)} className="text-[10px]">
+                {status.toString().replace("_", " ")}
+              </Badge>
+            )}
+          </div>
+        )}
+
+        {isLiveSession && onJoinMeeting && (
+          <div className="mt-3">
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onJoinMeeting();
+              }}
+              disabled={
+                process.env.NODE_ENV === "production"
+                  ? !canJoinNow || isJoiningMeeting
+                  : isJoiningMeeting
+              }
+              className={cn(
+                "w-full gap-2 font-medium",
+                canJoinNow
+                  ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                  : "bg-zinc-100 text-zinc-500",
+              )}
+              size="sm"
+            >
+              {isJoiningMeeting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Joining...
+                </>
+              ) : (
+                <>
+                  <Video className="h-4 w-4" />
+                  {process.env.NODE_ENV === "production"
+                    ? canJoinNow
+                      ? "Join Meeting"
+                      : "Not Available Yet"
+                    : "Join (Dev)"}
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+
+        {(eventType === "webinar" || eventType === "class") && (
+          <div className="mt-3 flex items-center gap-1.5 text-xs text-zinc-500">
+            <Users className="h-3.5 w-3.5" />
+            <span>
+              {participantCount}/{maxParticipants} participants
+            </span>
+          </div>
+        )}
+
+        {hasTrialEnabled && onTrialsClick && (
+          <div className="mt-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onTrialsClick();
+              }}
+              className="w-full gap-2 border-teal-200 text-teal-800 hover:border-teal-300 hover:bg-teal-50"
+            >
+              <Gift className="h-4 w-4" />
+              {pendingTrialCount && pendingTrialCount > 0
+                ? `${pendingTrialCount} Trial Request${pendingTrialCount > 1 ? "s" : ""}`
+                : "Trials"}
+            </Button>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="mt-auto flex items-end justify-between gap-3 border-t border-zinc-100 pt-4">
+          <div className="min-w-0">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-400">
+              Price
+            </p>
+            <div className="mt-0.5 flex items-baseline gap-1">
+              <span className="text-lg font-semibold tracking-tight text-zinc-900">
+                {formatCurrency(price, currency)}
+              </span>
+              {durationSuffix && (
+                <span className="text-xs text-zinc-400">{durationSuffix}</span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1.5 rounded-lg bg-zinc-50 px-2.5 py-1.5 text-zinc-600 ring-1 ring-zinc-100">
+            <Clock className="h-3.5 w-3.5 shrink-0 text-zinc-400" />
+            <span className="whitespace-nowrap text-xs font-medium">
+              {duration}
+            </span>
+          </div>
         </div>
       </div>
     </motion.div>

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCard.tsx
@@ -308,7 +308,7 @@ export function EventCard({
           </div>
 
           {!isCollaborated && (
-            <div className="flex shrink-0 items-center gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
+            <div className="flex shrink-0 items-center gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
               <Button
                 variant="ghost"
                 size="icon"

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventCarousel.tsx
@@ -117,8 +117,8 @@ const emptyStateConfig = {
     title: "No subscription plans",
     description:
       "Set up subscription plans for ongoing mentorship relationships.",
-    iconBg: "bg-purple-50",
-    iconColor: "text-purple-600",
+    iconBg: "bg-teal-50",
+    iconColor: "text-teal-600",
   },
 };
 
@@ -264,20 +264,20 @@ export function EventCarousel({
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
-        className="flex flex-col items-center justify-center py-10 sm:py-16 text-center rounded-xl border border-dashed border-zinc-200 bg-zinc-50/50 mx-1 sm:mx-0"
+        className="mx-0 flex flex-col items-center justify-center rounded-2xl border border-dashed border-zinc-200 bg-gradient-to-b from-zinc-50/80 to-white px-6 py-12 text-center sm:py-14"
       >
         <div
           className={cn(
-            "mb-3 sm:mb-4 flex h-12 w-12 sm:h-16 sm:w-16 items-center justify-center rounded-xl sm:rounded-2xl",
+            "mb-4 flex h-12 w-12 items-center justify-center rounded-2xl ring-1 ring-black/5",
             config.iconBg,
           )}
         >
-          <Icon className={cn("h-6 w-6 sm:h-8 sm:w-8", config.iconColor)} />
+          <Icon className={cn("h-6 w-6", config.iconColor)} />
         </div>
-        <h4 className="text-base sm:text-lg font-semibold text-zinc-900">
+        <h4 className="text-sm font-semibold tracking-tight text-zinc-900 sm:text-base">
           {config.title}
         </h4>
-        <p className="mt-1.5 sm:mt-2 text-xs sm:text-sm text-zinc-500 max-w-sm px-4">
+        <p className="mt-1.5 max-w-sm text-xs leading-relaxed text-zinc-500 sm:text-sm">
           {config.description}
         </p>
       </motion.div>
@@ -287,7 +287,7 @@ export function EventCarousel({
   return (
     <div className="w-full">
       <motion.div
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 sm:gap-5 lg:gap-6 w-full"
+        className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-5 xl:grid-cols-3"
         variants={containerVariants}
         initial="hidden"
         animate="visible"

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventManagementDashboard.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventManagementDashboard.tsx
@@ -533,18 +533,22 @@ export function EventManagementDashboard({
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3 }}
-          className="mb-8 flex flex-wrap items-center gap-2 sm:gap-3"
+          className="mb-8 flex flex-wrap items-center gap-2 sm:mb-10 sm:gap-3"
         >
-          <div className="flex items-center gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded-full bg-zinc-100 border border-zinc-200/60">
-            <LayoutTemplate className="h-4 w-4 text-zinc-600" />
-            <span className="text-xs sm:text-sm font-medium text-zinc-700">
-              {totalPlans} Plans
+          <div className="flex items-center gap-2 rounded-xl border border-zinc-200/80 bg-white px-3.5 py-2 shadow-sm">
+            <LayoutTemplate className="h-4 w-4 text-zinc-500" />
+            <span className="text-sm font-medium text-zinc-800">
+              {totalPlans}{" "}
+              <span className="font-normal text-zinc-500">Plans</span>
             </span>
           </div>
-          <div className="flex items-center gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded-full bg-zinc-100 border border-zinc-200/60">
-            <Radio className="h-4 w-4 text-zinc-600" />
-            <span className="text-xs sm:text-sm font-medium text-zinc-700">
-              {totalSessions} Upcoming Sessions
+          <div className="flex items-center gap-2 rounded-xl border border-zinc-200/80 bg-white px-3.5 py-2 shadow-sm">
+            <Radio className="h-4 w-4 text-zinc-500" />
+            <span className="text-sm font-medium text-zinc-800">
+              {totalSessions}{" "}
+              <span className="font-normal text-zinc-500">
+                Upcoming Sessions
+              </span>
             </span>
           </div>
         </motion.div>
@@ -554,55 +558,49 @@ export function EventManagementDashboard({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, delay: 0.1 }}
-          className="mb-10 sm:mb-16"
+          className="mb-12 sm:mb-16"
         >
-          {/* Section Header */}
-          <div className="flex items-center gap-3 sm:gap-4 mb-6 sm:mb-8">
-            <div className="flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-xl bg-zinc-900 shrink-0">
-              <LayoutTemplate className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
-            </div>
-            <div className="min-w-0">
-              <h2 className="text-xl sm:text-2xl font-bold text-zinc-900">
-                Plan Templates
-              </h2>
-              <p className="text-xs sm:text-sm text-zinc-500">
-                Create reusable service templates
-              </p>
-            </div>
-            <div className="flex-1 h-px bg-gradient-to-r from-zinc-200 to-transparent hidden sm:block" />
+          <div className="mb-6 sm:mb-8">
+            <h2 className="text-lg font-semibold tracking-tight text-zinc-900 sm:text-xl">
+              Plan Templates
+            </h2>
+            <p className="mt-0.5 text-sm text-zinc-500">
+              Create reusable service templates
+            </p>
           </div>
 
           {/* Consultation Plans */}
-          <div className="mb-6 sm:mb-10 bg-zinc-50/50 border border-zinc-100 rounded-xl p-4 sm:p-6">
-            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-4 sm:mb-6">
+          <div className="mb-8 sm:mb-10">
+            <div className="mb-4 flex flex-col gap-3 sm:mb-5 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 shrink-0">
-                  <MessageSquare className="h-4 w-4 sm:h-5 sm:w-5 text-blue-600" />
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-50 ring-1 ring-sky-100">
+                  <MessageSquare className="h-4 w-4 text-sky-700" />
                 </div>
                 <div>
-                  <h3 className="text-base sm:text-lg font-semibold text-zinc-900">
+                  <h3 className="text-sm font-semibold text-zinc-900 sm:text-base">
                     Consultation Plans
                   </h3>
-                  <p className="text-xs sm:text-sm text-zinc-500">
+                  <p className="text-xs text-zinc-500 sm:text-sm">
                     One-on-one session templates
                   </p>
                 </div>
               </div>
               <Button
                 onClick={() => setIsConsultationDialogOpen(true)}
-                className="bg-zinc-900 hover:bg-zinc-800 text-white font-medium gap-2 w-full sm:w-auto"
+                variant="outline"
+                className="w-full gap-2 border-zinc-200 bg-white font-medium text-zinc-900 hover:bg-zinc-50 sm:w-auto"
               >
                 <Plus className="h-4 w-4" />
                 New Plan
               </Button>
             </div>
             {consultationPlansLoading ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 sm:gap-5 lg:gap-6">
-                {[...Array(4)].map((_, i) => (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-5 xl:grid-cols-3">
+                {[...Array(3)].map((_, i) => (
                   <div
                     key={i}
-                    className="h-56 sm:h-64 bg-zinc-200 rounded-xl animate-pulse"
-                  ></div>
+                    className="h-52 animate-pulse rounded-2xl bg-zinc-100"
+                  />
                 ))}
               </div>
             ) : (
@@ -625,36 +623,37 @@ export function EventManagementDashboard({
           </div>
 
           {/* Subscription Plans */}
-          <div className="bg-zinc-50/50 border border-zinc-100 rounded-xl p-4 sm:p-6">
-            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-4 sm:mb-6">
+          <div>
+            <div className="mb-4 flex flex-col gap-3 sm:mb-5 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-purple-50 shrink-0">
-                  <CalendarRange className="h-4 w-4 sm:h-5 sm:w-5 text-purple-600" />
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-teal-50 ring-1 ring-teal-100">
+                  <CalendarRange className="h-4 w-4 text-teal-700" />
                 </div>
                 <div>
-                  <h3 className="text-base sm:text-lg font-semibold text-zinc-900">
+                  <h3 className="text-sm font-semibold text-zinc-900 sm:text-base">
                     Subscription Plans
                   </h3>
-                  <p className="text-xs sm:text-sm text-zinc-500">
+                  <p className="text-xs text-zinc-500 sm:text-sm">
                     Recurring mentorship offerings
                   </p>
                 </div>
               </div>
               <Button
                 onClick={() => setIsSubscriptionDialogOpen(true)}
-                className="bg-zinc-900 hover:bg-zinc-800 text-white font-medium gap-2 w-full sm:w-auto"
+                variant="outline"
+                className="w-full gap-2 border-zinc-200 bg-white font-medium text-zinc-900 hover:bg-zinc-50 sm:w-auto"
               >
                 <Plus className="h-4 w-4" />
                 New Plan
               </Button>
             </div>
             {subscriptionPlansLoading ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 sm:gap-5 lg:gap-6">
-                {[...Array(4)].map((_, i) => (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-5 xl:grid-cols-3">
+                {[...Array(3)].map((_, i) => (
                   <div
                     key={i}
-                    className="h-56 sm:h-64 bg-zinc-200 rounded-xl animate-pulse"
-                  ></div>
+                    className="h-52 animate-pulse rounded-2xl bg-zinc-100"
+                  />
                 ))}
               </div>
             ) : (
@@ -684,43 +683,37 @@ export function EventManagementDashboard({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, delay: 0.2 }}
-          className="mb-10 sm:mb-16"
+          className="mb-12 sm:mb-16"
         >
-          {/* Section Header */}
-          <div className="flex items-center gap-3 sm:gap-4 mb-6 sm:mb-8">
-            <div className="flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-xl bg-zinc-900 shrink-0">
-              <Radio className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
-            </div>
-            <div className="min-w-0">
-              <h2 className="text-xl sm:text-2xl font-bold text-zinc-900">
-                Live Sessions
-              </h2>
-              <p className="text-xs sm:text-sm text-zinc-500">
-                Schedule and manage your live events
-              </p>
-            </div>
-            <div className="flex-1 h-px bg-gradient-to-r from-zinc-200 to-transparent hidden sm:block" />
+          <div className="mb-6 sm:mb-8">
+            <h2 className="text-lg font-semibold tracking-tight text-zinc-900 sm:text-xl">
+              Live Sessions
+            </h2>
+            <p className="mt-0.5 text-sm text-zinc-500">
+              Schedule and manage your live events
+            </p>
           </div>
 
           {/* Webinar Events */}
-          <div className="mb-6 sm:mb-10 bg-zinc-50/50 border border-zinc-100 rounded-xl p-4 sm:p-6">
-            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-4 sm:mb-6">
+          <div className="mb-8 sm:mb-10">
+            <div className="mb-4 flex flex-col gap-3 sm:mb-5 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-50 shrink-0">
-                  <Video className="h-4 w-4 sm:h-5 sm:w-5 text-emerald-600" />
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-50 ring-1 ring-emerald-100">
+                  <Video className="h-4 w-4 text-emerald-700" />
                 </div>
                 <div>
-                  <h3 className="text-base sm:text-lg font-semibold text-zinc-900">
+                  <h3 className="text-sm font-semibold text-zinc-900 sm:text-base">
                     Webinar Events
                   </h3>
-                  <p className="text-xs sm:text-sm text-zinc-500">
+                  <p className="text-xs text-zinc-500 sm:text-sm">
                     Live sessions with multiple participants
                   </p>
                 </div>
               </div>
               <Button
                 onClick={() => setIsWebinarDialogOpen(true)}
-                className="bg-zinc-900 hover:bg-zinc-800 text-white font-medium gap-2 w-full sm:w-auto"
+                variant="outline"
+                className="w-full gap-2 border-zinc-200 bg-white font-medium text-zinc-900 hover:bg-zinc-50 sm:w-auto"
               >
                 <Plus className="h-4 w-4" />
                 New Webinar
@@ -739,24 +732,25 @@ export function EventManagementDashboard({
           </div>
 
           {/* Class Events */}
-          <div className="bg-zinc-50/50 border border-zinc-100 rounded-xl p-4 sm:p-6">
-            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-4 sm:mb-6">
+          <div>
+            <div className="mb-4 flex flex-col gap-3 sm:mb-5 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-50 shrink-0">
-                  <GraduationCap className="h-4 w-4 sm:h-5 sm:w-5 text-amber-600" />
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-50 ring-1 ring-amber-100">
+                  <GraduationCap className="h-4 w-4 text-amber-700" />
                 </div>
                 <div>
-                  <h3 className="text-base sm:text-lg font-semibold text-zinc-900">
+                  <h3 className="text-sm font-semibold text-zinc-900 sm:text-base">
                     Class Events
                   </h3>
-                  <p className="text-xs sm:text-sm text-zinc-500">
+                  <p className="text-xs text-zinc-500 sm:text-sm">
                     Multi-session structured learning
                   </p>
                 </div>
               </div>
               <Button
                 onClick={() => setIsClassDialogOpen(true)}
-                className="bg-zinc-900 hover:bg-zinc-800 text-white font-medium gap-2 w-full sm:w-auto"
+                variant="outline"
+                className="w-full gap-2 border-zinc-200 bg-white font-medium text-zinc-900 hover:bg-zinc-50 sm:w-auto"
               >
                 <Plus className="h-4 w-4" />
                 New Class

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForClass.tsx
@@ -395,8 +395,8 @@ export function EventPlannerForClass({
           if (!open) onClose();
         }}
       >
-        <ResponsiveModalContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="max-w-3xl max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle className="text-xl">
               {initialData ? "Edit" : "Create New"} Class
             </ResponsiveModalTitle>
@@ -408,7 +408,8 @@ export function EventPlannerForClass({
           </ResponsiveModalHeader>
 
           <Form {...form}>
-            <form onSubmit={handleFormSubmit} className="space-y-6 py-4">
+            <form onSubmit={handleFormSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 space-y-6 overflow-y-auto py-4">
               {/* Basic Information Section */}
               <FormSection
                 title="Basic Information"
@@ -1071,7 +1072,8 @@ export function EventPlannerForClass({
                 )}
               </FormSection>
 
-              <ResponsiveModalFooter className="pt-6 border-t">
+              </div>
+              <ResponsiveModalFooter className="shrink-0 border-t pt-4">
                 <Button
                   type="button"
                   variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForConsultation.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForConsultation.tsx
@@ -242,8 +242,8 @@ export function EventPlannerForConsultation({
           if (!open) onClose();
         }}
       >
-        <ResponsiveModalContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="max-w-3xl max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle className="text-xl">
               {initialData ? "Edit" : "Create New"} Consultation Plan
             </ResponsiveModalTitle>
@@ -265,7 +265,8 @@ export function EventPlannerForConsultation({
           </ResponsiveModalHeader>
 
           <Form {...form}>
-            <form onSubmit={handleFormSubmit} className="space-y-6 py-4">
+            <form onSubmit={handleFormSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 space-y-6 overflow-y-auto py-4">
               {/* Basic Information Section */}
               <FormSection
                 title="Basic Information"
@@ -469,7 +470,8 @@ export function EventPlannerForConsultation({
                 </FormSection>
               )}
 
-              <ResponsiveModalFooter className="pt-6 border-t">
+              </div>
+              <ResponsiveModalFooter className="shrink-0 border-t pt-4">
                 <Button
                   type="button"
                   variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForSubscription.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForSubscription.tsx
@@ -380,8 +380,8 @@ export function EventPlannerForSubscription({
           if (!open) onClose();
         }}
       >
-        <ResponsiveModalContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="max-w-3xl max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle className="text-xl">
               {initialData ? "Edit" : "Create New"} Subscription Plan
             </ResponsiveModalTitle>
@@ -403,7 +403,8 @@ export function EventPlannerForSubscription({
           </ResponsiveModalHeader>
 
           <Form {...form}>
-            <form onSubmit={handleFormSubmit} className="space-y-6 py-4">
+            <form onSubmit={handleFormSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 space-y-6 overflow-y-auto py-4">
               {/* Basic Information Section */}
               <FormSection
                 title="Basic Information"
@@ -939,7 +940,8 @@ export function EventPlannerForSubscription({
                 </FormSection>
               )}
 
-              <ResponsiveModalFooter className="pt-6 border-t">
+              </div>
+              <ResponsiveModalFooter className="shrink-0 border-t pt-4">
                 <Button
                   type="button"
                   variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/EventPlannerForWebinar.tsx
@@ -337,8 +337,8 @@ export function EventPlannerForWebinar({
           if (!open) onClose();
         }}
       >
-        <ResponsiveModalContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="max-w-3xl max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle className="text-xl">
               {initialData ? "Edit" : "Create New"} Webinar
             </ResponsiveModalTitle>
@@ -350,7 +350,8 @@ export function EventPlannerForWebinar({
           </ResponsiveModalHeader>
 
           <Form {...form}>
-            <form onSubmit={handleFormSubmit} className="space-y-6 py-4">
+            <form onSubmit={handleFormSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="min-h-0 flex-1 space-y-6 overflow-y-auto py-4">
               {/* Basic Information Section */}
               <FormSection
                 title="Basic Information"
@@ -756,7 +757,8 @@ export function EventPlannerForWebinar({
                 )}
               </FormSection>
 
-              <ResponsiveModalFooter className="pt-6 border-t">
+              </div>
+              <ResponsiveModalFooter className="shrink-0 border-t pt-4">
                 <Button
                   type="button"
                   variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/planner/components/PlanMaterialsUpload.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/planner/components/PlanMaterialsUpload.tsx
@@ -202,8 +202,8 @@ export function PlanMaterialsUpload({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-[600px] max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[600px] max-h-[90dvh] overflow-hidden flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle>Plan Materials</DialogTitle>
           <DialogDescription>
             Upload materials for &ldquo;{planTitle}&rdquo;. These materials will
@@ -211,7 +211,7 @@ export function PlanMaterialsUpload({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6 py-4">
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto py-4">
           {/* Upload Section */}
           <div className="space-y-4">
             <h3 className="text-sm font-medium">Upload New Material</h3>
@@ -355,7 +355,7 @@ export function PlanMaterialsUpload({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="shrink-0 border-t pt-4">
           <Button variant="outline" onClick={onClose}>
             Close
           </Button>

--- a/app/dashboard/consultant/[consultantId]/(features)/recordings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/recordings/page.tsx
@@ -36,7 +36,7 @@ export default function RecordingsPage({ params }: RecordingsPageProps) {
         onValueChange={(v) => setActiveTab(v as "all" | "webinar" | "class")}
         className="space-y-6"
       >
-        <TabsList className="grid w-full max-w-[400px] grid-cols-3">
+        <TabsList className="grid w-full max-w-full grid-cols-3 sm:max-w-[400px]">
           <TabsTrigger value="all" className="flex items-center gap-2">
             <Video className="w-4 h-4" />
             <span>All</span>

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -742,8 +742,8 @@ export function RequestSlotAllocationTab({
 
         {/* Single Allocation Dialog - moved outside map loop to prevent multiple dialogs */}
         <ResponsiveModal open={dialogOpen} onOpenChange={setDialogOpen}>
-          <ResponsiveModalContent className="max-w-[95vw] w-[1400px]">
-            <ResponsiveModalHeader>
+          <ResponsiveModalContent className="max-w-[95vw] w-[1400px] max-h-[90dvh] overflow-hidden flex flex-col">
+            <ResponsiveModalHeader className="shrink-0">
               <ResponsiveModalTitle>Allocate Slots</ResponsiveModalTitle>
               <ResponsiveModalDescription asChild>
                 {selectedRequest && (
@@ -790,6 +790,7 @@ export function RequestSlotAllocationTab({
             </ResponsiveModalHeader>
             {selectedRequest && (
               <SafeUnifiedCalendar
+                className="min-h-0 flex-1"
                 consultantId={consultantId}
                 eventType={
                   selectedRequest.type.toLowerCase() as

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -742,7 +742,7 @@ export function RequestSlotAllocationTab({
 
         {/* Single Allocation Dialog - moved outside map loop to prevent multiple dialogs */}
         <ResponsiveModal open={dialogOpen} onOpenChange={setDialogOpen}>
-          <ResponsiveModalContent className="max-w-[95vw] w-[1400px] max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalContent className="max-w-[95vw] w-full lg:max-w-[1400px] max-h-[90dvh] overflow-hidden flex flex-col">
             <ResponsiveModalHeader className="shrink-0">
               <ResponsiveModalTitle>Allocate Slots</ResponsiveModalTitle>
               <ResponsiveModalDescription asChild>

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
@@ -195,7 +195,7 @@ export function RequestedSlotsDialog({
             <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
               <span>📊</span> Validation Summary
             </h3>
-            <div className="grid grid-cols-2 gap-3 text-sm">
+            <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
               <div className="flex items-center justify-between">
                 <span className="text-gray-600">Total Slots:</span>
                 <span className="font-semibold text-gray-900">
@@ -426,40 +426,42 @@ export function RequestedSlotsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
+      <DialogContent className="max-w-2xl max-h-[90dvh] overflow-hidden flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle>Confirm Slot Allocation</DialogTitle>
           <DialogDescription>
             Review requested slots before allocation
           </DialogDescription>
         </DialogHeader>
 
-        {/* Reschedule indicator */}
-        {hasReschedule && (
-          <div className="mb-4">
-            {isFullReschedule ? (
-              <div className="flex items-center gap-2 text-sm font-medium text-blue-600 bg-blue-50 px-3 py-2 rounded-md border border-blue-200">
-                <RefreshCw className="h-4 w-4" />
-                <span>
-                  Full Reschedule - All {totalCount} session
-                  {totalCount !== 1 ? "s" : ""} need new times
-                </span>
-              </div>
-            ) : (
-              <div className="flex items-center gap-2 text-sm font-medium text-amber-600 bg-amber-50 px-3 py-2 rounded-md border border-amber-200">
-                <AlertTriangle className="h-4 w-4" />
-                <span>
-                  Partial Reschedule - {tentativeCount} of {totalCount} session
-                  {tentativeCount !== 1 ? "s" : ""} need new times
-                </span>
-              </div>
-            )}
-          </div>
-        )}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {/* Reschedule indicator */}
+          {hasReschedule && (
+            <div className="mb-4">
+              {isFullReschedule ? (
+                <div className="flex items-center gap-2 text-sm font-medium text-blue-600 bg-blue-50 px-3 py-2 rounded-md border border-blue-200">
+                  <RefreshCw className="h-4 w-4" />
+                  <span>
+                    Full Reschedule - All {totalCount} session
+                    {totalCount !== 1 ? "s" : ""} need new times
+                  </span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-sm font-medium text-amber-600 bg-amber-50 px-3 py-2 rounded-md border border-amber-200">
+                  <AlertTriangle className="h-4 w-4" />
+                  <span>
+                    Partial Reschedule - {tentativeCount} of {totalCount}{" "}
+                    session{tentativeCount !== 1 ? "s" : ""} need new times
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
 
-        {renderDialogContent()}
+          {renderDialogContent()}
+        </div>
 
-        <DialogFooter className="gap-2">
+        <DialogFooter className="shrink-0 gap-2 border-t pt-4">
           <Button variant="outline" onClick={onCancel} disabled={loading}>
             Cancel
           </Button>

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/components/RequestedSlotsDialog.tsx
@@ -228,7 +228,7 @@ export function RequestedSlotsDialog({
                 </span>
               </div>
               {requestType === AppointmentsType.SUBSCRIPTION && (
-                <div className="flex items-center justify-between col-span-2">
+                <div className="col-span-1 flex items-center justify-between sm:col-span-2">
                   <span className="text-gray-600 flex items-center gap-1">
                     <span className="text-blue-600">🔵</span> Outside Period:
                   </span>

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
@@ -616,10 +616,11 @@ export function SettingsTab({ consultant }: Readonly<SettingsTabProps>) {
       {/* Action Buttons — the combined profile+availability save. Rendered
           on every tab (verification/notifications have their own flows but
           the form save remains reachable, matching the old single-page UX). */}
-      <div className="flex justify-end items-center space-x-4">
+      <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:space-x-4">
         <Button
           type="button"
           variant="outline"
+          className="w-full sm:w-auto"
           onClick={() => {
             React.startTransition(() => {
               setFormData(getInitialFormData(consultant));
@@ -638,7 +639,7 @@ export function SettingsTab({ consultant }: Readonly<SettingsTabProps>) {
         </Button>
         <Button
           type="submit"
-          className="bg-primary hover:bg-primary/90 text-primary-foreground min-w-[200px]"
+          className="w-full bg-primary hover:bg-primary/90 text-primary-foreground sm:w-auto sm:min-w-[200px]"
           disabled={isLoading}
         >
           {isLoading && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/SettingsTab.tsx
@@ -616,7 +616,7 @@ export function SettingsTab({ consultant }: Readonly<SettingsTabProps>) {
       {/* Action Buttons — the combined profile+availability save. Rendered
           on every tab (verification/notifications have their own flows but
           the form save remains reachable, matching the old single-page UX). */}
-      <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:space-x-4">
+      <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end sm:space-x-4">
         <Button
           type="button"
           variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilityGrid.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/sections/AvailabilityGrid.tsx
@@ -52,33 +52,33 @@ export function AvailabilityGrid({
       </div>
       {slots?.map((slot, slotIndex) => (
         <div key={`${dayKey}-${slotIndex}`} className="space-y-2">
-          <div className="grid grid-cols-7 gap-2 items-center">
+          <div className="grid grid-cols-[1fr_auto_1fr_auto] items-center gap-2 sm:grid-cols-7">
             <Input
               type="time"
               value={slot.startTime}
               onChange={(e) =>
                 onUpdateSlot(dayKey, slotIndex, "startTime", e.target.value)
               }
-              className={`col-span-3 ${!slot.isValid ? "border-red-500" : ""}`}
+              className={`min-w-0 sm:col-span-3 ${!slot.isValid ? "border-red-500" : ""}`}
               step="900"
             />
-            <span className="text-center">to</span>
+            <span className="text-center text-sm text-zinc-500">to</span>
             <Input
               type="time"
               value={slot.endTime}
               onChange={(e) =>
                 onUpdateSlot(dayKey, slotIndex, "endTime", e.target.value)
               }
-              className={`col-span-2 ${!slot.isValid ? "border-red-500" : ""}`}
+              className={`min-w-0 sm:col-span-2 ${!slot.isValid ? "border-red-500" : ""}`}
               step="900"
             />
             <button
               type="button"
               onClick={() => onDeleteSlot(dayKey, slotIndex)}
-              className="p-1 hover:bg-zinc-100 rounded"
+              className="rounded p-1 hover:bg-zinc-100 justify-self-end sm:justify-self-center"
               aria-label={`Delete slot ${slotIndex + 1} for ${label}`}
             >
-              <TrashIcon className="w-5 h-5" />
+              <TrashIcon className="h-5 w-5" />
             </button>
           </div>
           {!slot.isValid && slot.errorMessage && (

--- a/app/dashboard/consultant/[consultantId]/(features)/settings/sections/VerificationSection.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/settings/sections/VerificationSection.tsx
@@ -361,11 +361,11 @@ export function VerificationSection({
 
       {/* Verification Resubmission Modal */}
       <ResponsiveModal open={isModalOpen} onOpenChange={setIsModalOpen}>
-        <ResponsiveModalContent className="max-w-2xl max-h-[90vh] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-          <ResponsiveModalHeader>
+        <ResponsiveModalContent className="max-w-2xl max-h-[90dvh] overflow-hidden flex flex-col">
+          <ResponsiveModalHeader className="shrink-0">
             <ResponsiveModalTitle>Verification Details</ResponsiveModalTitle>
           </ResponsiveModalHeader>
-          <div className="mt-4">
+          <div className="mt-4 min-h-0 flex-1 overflow-y-auto px-1">
             <ConsultantVerificationForm
               onNext={handleVerificationSubmit}
               onBack={() => setIsModalOpen(false)}

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -1060,7 +1060,7 @@ export function UnifiedCalendar({
     };
 
     return (
-      <div className="grid grid-cols-7 gap-1 flex-1 min-h-[12rem] max-h-[min(600px,calc(90dvh-16rem))] overflow-y-auto">
+      <div className="grid grid-cols-7 gap-1 flex-1 min-h-[12rem] max-h-[min(600px,calc(90dvh_-_16rem))] overflow-y-auto">
         {DAYS.map((day) => (
           <div key={day} className="text-center font-bold p-2">
             {day.slice(0, 3)}
@@ -1253,7 +1253,7 @@ export function UnifiedCalendar({
 
       {/* Calendar View */}
       {view === "week" ? (
-        <div className="flex flex-col flex-1 min-h-[12rem] max-h-[min(500px,calc(90dvh-16rem))]">
+        <div className="flex flex-col flex-1 min-h-[12rem] max-h-[min(500px,calc(90dvh_-_16rem))]">
           {/* Week header */}
           <div className="shrink-0 grid grid-cols-8 gap-0.5 md:gap-1 bg-background z-20 pb-1">
             <div className="w-14 md:w-20"></div>

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -1184,7 +1184,7 @@ export function UnifiedCalendar({
       )}
 
       {/* Header */}
-      <div className="shrink-0 flex justify-between items-center gap-4">
+      <div className="shrink-0 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
         <div className="flex gap-2">
           <Button
             variant={view === "week" ? "default" : "outline"}
@@ -1216,7 +1216,7 @@ export function UnifiedCalendar({
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <div className="text-lg font-bold text-center min-w-[150px]">
+          <div className="min-w-0 text-center text-sm font-bold sm:min-w-[150px] sm:text-lg">
             {view === "week"
               ? `${format(startOfWeek(currentDate), "MMM d")} - ${format(endOfWeek(currentDate), "MMM d, yyyy")}`
               : format(currentDate, "MMMM yyyy")}
@@ -1247,7 +1247,7 @@ export function UnifiedCalendar({
             Clear Selection
           </Button>
         ) : (
-          <div className="w-20"></div>
+          <div className="hidden w-20 sm:block"></div>
         )}
       </div>
 
@@ -1322,8 +1322,8 @@ export function UnifiedCalendar({
       )}
 
       {/* Footer */}
-      <div className="shrink-0 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
+      <div className="shrink-0 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div className="flex flex-wrap items-center gap-2 sm:gap-4">
           <div className="text-sm">
             {(() => {
               try {
@@ -1405,7 +1405,7 @@ export function UnifiedCalendar({
 
       {/* Allocation Buttons - Bottom */}
       {showAllocationButtons && mode === "allocate" && (
-        <div className="shrink-0 flex justify-end gap-2 mt-2">
+        <div className="mt-2 flex shrink-0 flex-wrap justify-end gap-2">
           {onClose && (
             <Button
               variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -1060,7 +1060,7 @@ export function UnifiedCalendar({
     };
 
     return (
-      <div className="grid grid-cols-7 gap-1 h-[600px] overflow-y-auto">
+      <div className="grid grid-cols-7 gap-1 flex-1 min-h-[12rem] max-h-[min(600px,calc(90dvh-16rem))] overflow-y-auto">
         {DAYS.map((day) => (
           <div key={day} className="text-center font-bold p-2">
             {day.slice(0, 3)}
@@ -1150,10 +1150,10 @@ export function UnifiedCalendar({
   }
 
   return (
-    <div className={`flex flex-col gap-4 ${className}`}>
+    <div className={`flex flex-col gap-4 min-h-0 ${className}`}>
       {/* Warning Banner */}
       {configWarning && (
-        <div className="rounded-md bg-yellow-50 border border-yellow-200 px-4 py-3">
+        <div className="shrink-0 rounded-md bg-yellow-50 border border-yellow-200 px-4 py-3">
           <div className="flex items-start">
             <span className="text-yellow-600 mr-2">⚠️</span>
             <div className="flex-1">
@@ -1168,7 +1168,7 @@ export function UnifiedCalendar({
 
       {/* Scheduling Period Info Banner */}
       {allowedStart && allowedEnd && (
-        <div className="rounded-md bg-blue-50 border border-blue-200 px-4 py-3">
+        <div className="shrink-0 rounded-md bg-blue-50 border border-blue-200 px-4 py-3">
           <div className="flex items-start">
             <Calendar className="h-5 w-5 text-blue-600 mr-2 flex-shrink-0" />
             <div className="flex-1">
@@ -1184,7 +1184,7 @@ export function UnifiedCalendar({
       )}
 
       {/* Header */}
-      <div className="flex justify-between items-center gap-4">
+      <div className="shrink-0 flex justify-between items-center gap-4">
         <div className="flex gap-2">
           <Button
             variant={view === "week" ? "default" : "outline"}
@@ -1253,9 +1253,9 @@ export function UnifiedCalendar({
 
       {/* Calendar View */}
       {view === "week" ? (
-        <div className="flex flex-col h-[calc(100vh-24rem)] xl:h-[65vh] max-h-[500px]">
+        <div className="flex flex-col flex-1 min-h-[12rem] max-h-[min(500px,calc(90dvh-16rem))]">
           {/* Week header */}
-          <div className="grid grid-cols-8 gap-0.5 md:gap-1 sticky top-0 bg-background z-20 pb-1">
+          <div className="shrink-0 grid grid-cols-8 gap-0.5 md:gap-1 bg-background z-20 pb-1">
             <div className="w-14 md:w-20"></div>
             {weekDates.map((date, index) => {
               const isToday = isSameDay(date, new Date());
@@ -1322,7 +1322,7 @@ export function UnifiedCalendar({
       )}
 
       {/* Footer */}
-      <div className="flex items-center justify-between gap-4">
+      <div className="shrink-0 flex items-center justify-between gap-4">
         <div className="flex items-center gap-4">
           <div className="text-sm">
             {(() => {
@@ -1405,7 +1405,7 @@ export function UnifiedCalendar({
 
       {/* Allocation Buttons - Bottom */}
       {showAllocationButtons && mode === "allocate" && (
-        <div className="flex justify-end gap-2 mt-2">
+        <div className="shrink-0 flex justify-end gap-2 mt-2">
           {onClose && (
             <Button
               variant="outline"

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -1060,7 +1060,7 @@ export function UnifiedCalendar({
     };
 
     return (
-      <div className="grid grid-cols-7 gap-1 flex-1 min-h-[12rem] max-h-[min(600px,calc(90dvh_-_16rem))] overflow-y-auto">
+      <div className="grid grid-cols-7 gap-1 flex-1 min-h-0 max-h-[min(600px,calc(90dvh_-_16rem))] overflow-y-auto">
         {DAYS.map((day) => (
           <div key={day} className="text-center font-bold p-2">
             {day.slice(0, 3)}
@@ -1253,7 +1253,7 @@ export function UnifiedCalendar({
 
       {/* Calendar View */}
       {view === "week" ? (
-        <div className="flex flex-col flex-1 min-h-[12rem] max-h-[min(500px,calc(90dvh_-_16rem))]">
+        <div className="flex flex-col flex-1 min-h-0 max-h-[min(500px,calc(90dvh_-_16rem))]">
           {/* Week header */}
           <div className="shrink-0 grid grid-cols-8 gap-0.5 md:gap-1 bg-background z-20 pb-1">
             <div className="w-14 md:w-20"></div>

--- a/app/dashboard/consultant/[consultantId]/(features)/trials/TrialsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/trials/TrialsTab.tsx
@@ -476,7 +476,7 @@ export function TrialsTab() {
     <TooltipProvider>
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold text-zinc-900">
             Trial Requests
@@ -485,7 +485,12 @@ export function TrialsTab() {
             Manage trial session requests from potential subscribers
           </p>
         </div>
-        <Button variant="outline" onClick={handleRefresh} disabled={isRefreshing}>
+        <Button
+          variant="outline"
+          onClick={handleRefresh}
+          disabled={isRefreshing}
+          className="w-full sm:w-auto"
+        >
           <RefreshCw
             className={`h-4 w-4 mr-2 ${isRefreshing ? "animate-spin" : ""}`}
           />
@@ -866,24 +871,26 @@ export function TrialsTab() {
 
       {/* Schedule Dialog with Calendar */}
       <Dialog open={showScheduleDialog} onOpenChange={setShowScheduleDialog}>
-        <DialogContent className="max-w-4xl">
+        <DialogContent className="max-w-4xl max-h-[90dvh] overflow-hidden flex flex-col">
           <VisuallyHidden>
             <DialogTitle>Schedule Trial Session</DialogTitle>
           </VisuallyHidden>
           {selectedTrial && (
-            <TrialScheduleCalendar
-              consultantId={consultantId}
-              trialDurationMinutes={
-                selectedTrial.subscriptionPlan.trialDurationMinutes
-              }
-              onSlotSelect={handleSlotSelected}
-              onCancel={() => {
-                setShowScheduleDialog(false);
-                setSelectedTrial(null);
-              }}
-              isProcessing={isProcessing}
-              consulteeUserName={selectedTrial.consulteeProfile.user.name}
-            />
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <TrialScheduleCalendar
+                consultantId={consultantId}
+                trialDurationMinutes={
+                  selectedTrial.subscriptionPlan.trialDurationMinutes
+                }
+                onSlotSelect={handleSlotSelected}
+                onCancel={() => {
+                  setShowScheduleDialog(false);
+                  setSelectedTrial(null);
+                }}
+                isProcessing={isProcessing}
+                consulteeUserName={selectedTrial.consulteeProfile.user.name}
+              />
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/app/dashboard/consultant/[consultantId]/layout.tsx
+++ b/app/dashboard/consultant/[consultantId]/layout.tsx
@@ -452,14 +452,35 @@ export default function ConsultantLayout({
   }, [session?.user]);
 
   // Full breadcrumb trail — every URL segment after the consultant id
-  // becomes a crumb; opaque record ids are dropped.
+  // becomes a crumb; opaque record ids are dropped. Parent crumbs keep an
+  // href so users can click back (e.g. Appointments from a detail page).
   const breadcrumbs = useMemo(() => {
-    return pathname
+    const parts = pathname
       .replace(basePath, "")
       .split("/")
-      .filter(Boolean)
-      .filter((seg) => !looksLikeRecordId(seg))
-      .map((seg) => PAGE_LABELS[seg] ?? seg);
+      .filter(Boolean);
+
+    const crumbs: { label: string; href?: string }[] = [];
+    let acc = basePath;
+
+    for (const seg of parts) {
+      acc = `${acc}/${seg}`;
+      if (looksLikeRecordId(seg)) continue;
+      crumbs.push({
+        label: PAGE_LABELS[seg] ?? seg,
+        href: acc,
+      });
+    }
+
+    return crumbs.map((crumb, index) => {
+      const isLast = index === crumbs.length - 1;
+      // Keep a link when the visible crumb is still a parent of the URL
+      // (happens when the last segment was an opaque id we stripped).
+      if (isLast && crumb.href && pathname === crumb.href) {
+        return { label: crumb.label };
+      }
+      return crumb;
+    });
   }, [pathname, basePath]);
 
   // Memoize StreamProvider children to prevent re-initialization on tab

--- a/app/dashboard/consultant/[consultantId]/layout.tsx
+++ b/app/dashboard/consultant/[consultantId]/layout.tsx
@@ -33,6 +33,10 @@ import {
   PersonalDashboardShellSkeleton,
 } from "@/components/dashboard/PersonalDashboardShell";
 import type { CollapsibleSidebarGroup } from "@/components/dashboard/CollapsibleSidebar";
+import {
+  BreadcrumbOverrideProvider,
+  useBreadcrumbOverride,
+} from "@/components/dashboard/breadcrumb-override";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import StreamProvider from "@/providers/StreamProvider";
 import NovuProvider from "@/providers/NovuProvider";
@@ -120,8 +124,12 @@ const PAGE_LABELS: Record<string, string> = {
   help: "Help",
 };
 
-// Opaque record ids (cuids) in nested routes carry no meaning as crumbs.
-const looksLikeRecordId = (segment: string) => /^[a-z0-9]{20,}$/i.test(segment);
+// Opaque record ids (cuid / uuid) in nested routes carry no meaning as crumbs.
+const looksLikeRecordId = (segment: string) =>
+  /^[a-z0-9]{20,}$/i.test(segment) ||
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    segment,
+  );
 
 interface PageProps {
   children: React.ReactNode;
@@ -307,7 +315,15 @@ function AccessCard({
   );
 }
 
-export default function ConsultantLayout({
+export default function ConsultantLayout(props: Readonly<PageProps>) {
+  return (
+    <BreadcrumbOverrideProvider>
+      <ConsultantLayoutInner {...props} />
+    </BreadcrumbOverrideProvider>
+  );
+}
+
+function ConsultantLayoutInner({
   children,
   params,
 }: Readonly<PageProps>) {
@@ -451,8 +467,11 @@ export default function ConsultantLayout({
     }));
   }, [session?.user]);
 
+  const { overrideLabel } = useBreadcrumbOverride();
+
   // Full breadcrumb trail — every URL segment after the consultant id
-  // becomes a crumb; opaque record ids are dropped. Parent crumbs keep an
+  // becomes a crumb; opaque record ids are dropped (or replaced with an
+  // override label such as the appointment title). Parent crumbs keep an
   // href so users can click back (e.g. Appointments from a detail page).
   const breadcrumbs = useMemo(() => {
     const parts = pathname
@@ -462,14 +481,23 @@ export default function ConsultantLayout({
 
     const crumbs: { label: string; href?: string }[] = [];
     let acc = basePath;
+    let lastSegWasRecordId = false;
 
     for (const seg of parts) {
       acc = `${acc}/${seg}`;
-      if (looksLikeRecordId(seg)) continue;
+      if (looksLikeRecordId(seg)) {
+        lastSegWasRecordId = true;
+        continue;
+      }
+      lastSegWasRecordId = false;
       crumbs.push({
         label: PAGE_LABELS[seg] ?? seg,
         href: acc,
       });
+    }
+
+    if (lastSegWasRecordId && overrideLabel) {
+      crumbs.push({ label: overrideLabel });
     }
 
     return crumbs.map((crumb, index) => {
@@ -481,7 +509,7 @@ export default function ConsultantLayout({
       }
       return crumb;
     });
-  }, [pathname, basePath]);
+  }, [pathname, basePath, overrideLabel]);
 
   // Memoize StreamProvider children to prevent re-initialization on tab
   // switches. Must be called before any early returns (Rules of Hooks).

--- a/app/dashboard/consultee/[consulteeId]/(features)/appointments/CancelConfirmationDialog.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/appointments/CancelConfirmationDialog.tsx
@@ -61,9 +61,18 @@ export function CancelConfirmationDialog({
                   request without any payment.
                 </p>
               ) : (
-                <p className="text-red-600 font-medium">
-                  This action cannot be undone.
-                </p>
+                <>
+                  <p className="text-red-600 font-medium">
+                    This action cannot be undone.
+                  </p>
+                  {(appointmentType === "Consultation" ||
+                    appointmentType === "Subscription") && (
+                    <p className="text-muted-foreground text-sm">
+                      If a payment was captured, any refund follows the
+                      booking&apos;s cancellation policy.
+                    </p>
+                  )}
+                </>
               )}
             </div>
           </AlertDialogDescription>

--- a/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
@@ -12,7 +12,7 @@ export default function MessagesTab() {
   const { chatConnected, error, retryConnection } = useStreamConnection();
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[280px] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[360px]">
+    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[min(280px,calc(100dvh-8rem))] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[min(360px,calc(100dvh-9rem))]">
       {error ? (
         <ChatUnavailable description={error} onRetry={retryConnection} />
       ) : chatConnected ? (

--- a/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
@@ -3,7 +3,6 @@
 import { Loader2 } from "lucide-react";
 import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ChatUnavailable } from "@/components/chat/ChatUnavailable";
-import { DashboardHeader } from "@/components/dashboard/PageScaffold";
 import { useStreamConnection } from "@/providers/StreamProvider";
 
 export default function MessagesTab() {
@@ -13,20 +12,17 @@ export default function MessagesTab() {
   const { chatConnected, error, retryConnection } = useStreamConnection();
 
   return (
-    <>
-      <DashboardHeader title="Messages" subtitle="Chat with your consultants" />
-      <div className="mt-4 w-full bg-card rounded-xl border border-border shadow-sm overflow-hidden h-[calc(100vh-15rem)] min-h-[400px]">
-        {error ? (
-          <ChatUnavailable description={error} onRetry={retryConnection} />
-        ) : chatConnected ? (
-          <ChatLayout />
-        ) : (
-          <div className="flex h-full items-center justify-center text-muted-foreground">
-            <Loader2 className="h-6 w-6 animate-spin mr-2" />
-            Connecting to chat…
-          </div>
-        )}
-      </div>
-    </>
+    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[280px] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[360px]">
+      {error ? (
+        <ChatUnavailable description={error} onRetry={retryConnection} />
+      ) : chatConnected ? (
+        <ChatLayout />
+      ) : (
+        <div className="flex h-full items-center justify-center text-muted-foreground">
+          <Loader2 className="mr-2 h-6 w-6 animate-spin" />
+          Connecting to chat…
+        </div>
+      )}
+    </div>
   );
 }

--- a/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/messages/MessagesTab.tsx
@@ -5,6 +5,10 @@ import { ChatLayout } from "@/components/chat/ChatLayout";
 import { ChatUnavailable } from "@/components/chat/ChatUnavailable";
 import { useStreamConnection } from "@/providers/StreamProvider";
 
+/**
+ * Full-bleed chat surface: cancels PageScaffold padding and fills the
+ * content column under the context bar (and above the mobile tab bar).
+ */
 export default function MessagesTab() {
   // Connection state from the Stream provider: render the chat UI only once
   // the chat client is live; surface failures instead of a blank box (same
@@ -12,7 +16,7 @@ export default function MessagesTab() {
   const { chatConnected, error, retryConnection } = useStreamConnection();
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm h-[calc(100dvh-8rem)] min-h-[min(280px,calc(100dvh-8rem))] max-h-[calc(100dvh-6rem)] sm:h-[calc(100dvh-9rem)] sm:min-h-[min(360px,calc(100dvh-9rem))]">
+    <div className="-m-4 h-[calc(100dvh-3.5rem-4rem)] overflow-hidden border-border bg-card sm:-m-6 md:h-[calc(100dvh-3.5rem)] lg:-m-8">
       {error ? (
         <ChatUnavailable description={error} onRetry={retryConnection} />
       ) : chatConnected ? (

--- a/app/dashboard/consultee/[consulteeId]/layout.tsx
+++ b/app/dashboard/consultee/[consulteeId]/layout.tsx
@@ -26,6 +26,10 @@ import {
   PersonalDashboardShellSkeleton,
 } from "@/components/dashboard/PersonalDashboardShell";
 import type { CollapsibleSidebarGroup } from "@/components/dashboard/CollapsibleSidebar";
+import {
+  BreadcrumbOverrideProvider,
+  useBreadcrumbOverride,
+} from "@/components/dashboard/breadcrumb-override";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import StreamProvider from "@/providers/StreamProvider";
 import NovuProvider from "@/providers/NovuProvider";
@@ -90,8 +94,12 @@ const PAGE_LABELS: Record<string, string> = {
   settings: "Settings",
 };
 
-// Opaque record ids (cuids) in nested routes carry no meaning as crumbs.
-const looksLikeRecordId = (segment: string) => /^[a-z0-9]{20,}$/i.test(segment);
+// Opaque record ids (cuid / uuid) in nested routes carry no meaning as crumbs.
+const looksLikeRecordId = (segment: string) =>
+  /^[a-z0-9]{20,}$/i.test(segment) ||
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    segment,
+  );
 
 interface PageProps {
   children: React.ReactNode;
@@ -132,7 +140,15 @@ function AccessCard({
   );
 }
 
-export default function ConsulteeLayout({
+export default function ConsulteeLayout(props: Readonly<PageProps>) {
+  return (
+    <BreadcrumbOverrideProvider>
+      <ConsulteeLayoutInner {...props} />
+    </BreadcrumbOverrideProvider>
+  );
+}
+
+function ConsulteeLayoutInner({
   children,
   params,
 }: Readonly<PageProps>) {
@@ -246,16 +262,45 @@ export default function ConsulteeLayout({
     }));
   }, [session?.user]);
 
-  // Full breadcrumb trail — every URL segment after the consultee id
-  // becomes a crumb; opaque record ids are dropped.
+  const { overrideLabel } = useBreadcrumbOverride();
+
+  // Full breadcrumb trail — opaque record ids are dropped (or replaced with
+  // an override label such as the appointment title).
   const breadcrumbs = useMemo(() => {
-    return pathname
+    const parts = pathname
       .replace(basePath, "")
       .split("/")
-      .filter(Boolean)
-      .filter((seg) => !looksLikeRecordId(seg))
-      .map((seg) => PAGE_LABELS[seg] ?? seg);
-  }, [pathname, basePath]);
+      .filter(Boolean);
+
+    const crumbs: { label: string; href?: string }[] = [];
+    let acc = basePath;
+    let lastSegWasRecordId = false;
+
+    for (const seg of parts) {
+      acc = `${acc}/${seg}`;
+      if (looksLikeRecordId(seg)) {
+        lastSegWasRecordId = true;
+        continue;
+      }
+      lastSegWasRecordId = false;
+      crumbs.push({
+        label: PAGE_LABELS[seg] ?? seg,
+        href: acc,
+      });
+    }
+
+    if (lastSegWasRecordId && overrideLabel) {
+      crumbs.push({ label: overrideLabel });
+    }
+
+    return crumbs.map((crumb, index) => {
+      const isLast = index === crumbs.length - 1;
+      if (isLast && crumb.href && pathname === crumb.href) {
+        return { label: crumb.label };
+      }
+      return crumb;
+    });
+  }, [pathname, basePath, overrideLabel]);
 
   const isLoading = isLoadingUser || isLoadingProfile;
   const error = (userError || profileError) as Error | null;

--- a/components/appointments/AppointmentSheet.tsx
+++ b/components/appointments/AppointmentSheet.tsx
@@ -68,7 +68,8 @@ export function AppointmentSheet({
 
   return (
     <Sheet open onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-md overflow-y-auto">
+      <SheetContent className="flex w-full flex-col overflow-hidden sm:max-w-md max-h-[100dvh]">
+        <div className="min-h-0 flex-1 overflow-y-auto">
         <SheetHeader className="text-left space-y-3">
           <div className="flex items-start gap-3">
             <Avatar className="h-11 w-11 border border-border shrink-0">
@@ -251,6 +252,7 @@ export function AppointmentSheet({
               )}
             </div>
           )}
+        </div>
         </div>
       </SheetContent>
     </Sheet>

--- a/components/appointments/AppointmentSheet.tsx
+++ b/components/appointments/AppointmentSheet.tsx
@@ -68,9 +68,9 @@ export function AppointmentSheet({
 
   return (
     <Sheet open onOpenChange={onOpenChange}>
-      <SheetContent className="flex w-full flex-col overflow-hidden sm:max-w-md max-h-[100dvh]">
-        <div className="min-h-0 flex-1 overflow-y-auto">
-        <SheetHeader className="text-left space-y-3">
+      <SheetContent className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-md max-h-[100dvh]">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6 sm:py-6">
+        <SheetHeader className="space-y-3 p-0 text-left">
           <div className="flex items-start gap-3">
             <Avatar className="h-11 w-11 border border-border shrink-0">
               <AvatarImage

--- a/components/appointments/AppointmentSheet.tsx
+++ b/components/appointments/AppointmentSheet.tsx
@@ -69,8 +69,7 @@ export function AppointmentSheet({
   return (
     <Sheet open onOpenChange={onOpenChange}>
       <SheetContent className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-md max-h-[100dvh]">
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6 sm:py-6">
-        <SheetHeader className="space-y-3 p-0 text-left">
+        <SheetHeader className="shrink-0 space-y-3 border-b border-border px-5 py-5 text-left sm:px-6 sm:py-6">
           <div className="flex items-start gap-3">
             <Avatar className="h-11 w-11 border border-border shrink-0">
               <AvatarImage
@@ -113,7 +112,8 @@ export function AppointmentSheet({
           </div>
         </SheetHeader>
 
-        <div className="mt-5 space-y-5">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6 sm:py-6">
+        <div className="space-y-5">
           {/* Next session */}
           {vm.nextAt && (
             <div className="rounded-lg bg-muted border border-border p-3">

--- a/components/appointments/SessionTimeline.tsx
+++ b/components/appointments/SessionTimeline.tsx
@@ -29,8 +29,8 @@ interface SessionTimelineProps {
   /** Rows rendered when collapsed (default 1 focus row). */
   className?: string;
   /**
-   * When true, show every session up front (detail pages for subscriptions /
-   * classes). Default collapses to a single focus row with an expander.
+   * When false, collapse to a single focus row with an expander.
+   * Defaults to true so multi-session plans show the full list.
    */
   defaultExpanded?: boolean;
 }
@@ -116,7 +116,7 @@ export function SessionTimeline({
   onJoinSession,
   joinWindowMs = CONSULTEE_JOIN_WINDOW_MS,
   className,
-  defaultExpanded = false,
+  defaultExpanded = true,
 }: SessionTimelineProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   useEffect(() => {

--- a/components/appointments/SessionTimeline.tsx
+++ b/components/appointments/SessionTimeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { format } from "date-fns";
 import { Video, Loader2, ChevronDown } from "lucide-react";
 import { cn } from "@/utils/tailwind";
@@ -28,6 +28,11 @@ interface SessionTimelineProps {
   joinWindowMs?: number;
   /** Rows rendered when collapsed (default 1 focus row). */
   className?: string;
+  /**
+   * When true, show every session up front (detail pages for subscriptions /
+   * classes). Default collapses to a single focus row with an expander.
+   */
+  defaultExpanded?: boolean;
 }
 
 interface SessionGroup {
@@ -111,8 +116,12 @@ export function SessionTimeline({
   onJoinSession,
   joinWindowMs = CONSULTEE_JOIN_WINDOW_MS,
   className,
+  defaultExpanded = false,
 }: SessionTimelineProps) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  useEffect(() => {
+    setExpanded(defaultExpanded);
+  }, [defaultExpanded]);
 
   const nonTentative = useMemo(
     () => sessions.filter((s) => !s.isTentative),

--- a/components/appointments/detail/AppointmentDetailClient.tsx
+++ b/components/appointments/detail/AppointmentDetailClient.tsx
@@ -54,8 +54,8 @@ function Section({
   children: ReactNode;
 }) {
   return (
-    <div className="rounded-2xl border border-border bg-card shadow-sm p-4 sm:p-5">
-      <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+    <div className="rounded-2xl border border-border bg-card p-5 shadow-sm sm:p-6">
+      <p className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         {title}
       </p>
       {children}
@@ -221,7 +221,11 @@ export function AppointmentDetailClient({
                 </p>
               )}
             </div>
-            <div className="flex items-center gap-2 shrink-0">
+          </div>
+
+          {/* Actions — full-width bar so buttons aren't cramped beside the title */}
+          {(action.kind !== "view" || overflow.length > 0) && (
+            <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-border pt-4">
               {action.kind !== "view" && (
                 <RowPrimaryAction action={action} size="default" />
               )}
@@ -242,7 +246,7 @@ export function AppointmentDetailClient({
                 </Button>
               ))}
             </div>
-          </div>
+          )}
 
           {vm.group && vm.group.total > 0 && (
             <div className="mt-4 pt-4 border-t border-border">
@@ -260,7 +264,7 @@ export function AppointmentDetailClient({
           )}
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
           {/* Sessions */}
           <Section title="Sessions">
             {vm.sessions.some((s) => !s.isTentative) ? (

--- a/components/appointments/detail/AppointmentDetailClient.tsx
+++ b/components/appointments/detail/AppointmentDetailClient.tsx
@@ -9,6 +9,7 @@ import {
   CalendarX,
   CreditCard,
   ExternalLink,
+  FileText,
   Users,
   Video,
 } from "lucide-react";
@@ -19,6 +20,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/dashboard/DataCard";
 import { StatusBadge } from "@/components/dashboard/StatusBadge";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
+import { useSetBreadcrumbLabel } from "@/components/dashboard/breadcrumb-override";
 import type { AppointmentActionAdapter } from "@/lib/appointments/adapter";
 import { mapAppointmentDetail } from "@/lib/appointments/map-detail";
 import { eventUnionStatusBadge } from "@/lib/appointments/status";
@@ -36,6 +38,8 @@ import { CountdownBadge } from "../CountdownBadge";
 import { KIND_LABEL } from "../AppointmentRow";
 import { RowPrimaryAction } from "../RowPrimaryAction";
 import { SessionTimeline } from "../SessionTimeline";
+
+const PARTICIPANTS_PREVIEW = 5;
 
 function initials(name: string): string {
   return name
@@ -56,6 +60,26 @@ function Section({
   return (
     <div className="rounded-2xl border border-border bg-card p-5 shadow-sm sm:p-6">
       <p className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function ResourceSubgroup({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: typeof FileText;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <p className="flex items-center gap-1.5 text-[11px] font-semibold text-foreground">
+        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
         {title}
       </p>
       {children}
@@ -103,6 +127,9 @@ export function AppointmentDetailClient({
     },
   });
 
+  const mapped = detail ? mapAppointmentDetail(detail, role) : null;
+  useSetBreadcrumbLabel(mapped?.vm.title);
+
   if (isLoading && !detail) {
     return (
       <div className="space-y-4">
@@ -113,7 +140,7 @@ export function AppointmentDetailClient({
     );
   }
 
-  if (error || !detail) {
+  if (error || !detail || !mapped) {
     return (
       <EmptyState
         icon={CalendarX}
@@ -130,7 +157,7 @@ export function AppointmentDetailClient({
     );
   }
 
-  const { vm, recordings } = mapAppointmentDetail(detail, role);
+  const { vm, recordings } = mapped;
   const action = adapter.primaryAction(vm);
   const overflow = adapter.overflowItems(vm);
   const badge = eventUnionStatusBadge(vm.status);
@@ -148,13 +175,20 @@ export function AppointmentDetailClient({
         .map((u) => [u.id, u]),
     ).values(),
   );
+  const previewParticipants = participants.slice(0, PARTICIPANTS_PREVIEW);
+  const hiddenParticipantCount = Math.max(
+    0,
+    participants.length - PARTICIPANTS_PREVIEW,
+  );
+  const manageHref = participantsHref?.(detail) ?? null;
   const anchorSession = vm.nextAt
     ? vm.sessions.find((s) => s.startsAt.getTime() === vm.nextAt?.getTime())
     : undefined;
+  const hasConfirmedSessions = vm.sessions.some((s) => !s.isTentative);
 
   return (
     <DashboardErrorBoundary>
-      <div className="space-y-4">
+      <div className="w-full space-y-4">
         <Button variant="ghost" size="sm" className="-ml-2" asChild>
           <Link href={backHref}>
             <ArrowLeft className="h-4 w-4 mr-1.5" />
@@ -264,178 +298,196 @@ export function AppointmentDetailClient({
           )}
         </div>
 
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
-          {/* Sessions */}
-          <Section title="Sessions">
-            {vm.sessions.some((s) => !s.isTentative) ? (
-              <SessionTimeline
-                sessions={vm.sessions}
-                joinWindowMs={joinWindowMs}
-                isJoining={action.kind === "join" && !!action.busy}
-                onJoinSession={
-                  action.kind === "join" && action.onClick
-                    ? () => action.onClick!()
-                    : undefined
-                }
-              />
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                {vm.sessions.length > 0
-                  ? "Awaiting schedule confirmation."
-                  : "No sessions scheduled yet."}
-              </p>
-            )}
-          </Section>
-
-          {/* Payment & sponsorship */}
-          <Section title="Payment & sponsorship">
-            {payments.length === 0 && !orgName ? (
-              <p className="text-xs text-muted-foreground">
-                No payment is attached to this booking.
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {payments.map((payment) => (
-                  <div
-                    key={payment.id}
-                    className="flex items-center justify-between gap-2 rounded-lg bg-muted border border-border px-3 py-2"
-                  >
-                    <div className="flex items-center gap-2 text-sm">
-                      <CreditCard className="h-3.5 w-3.5 text-muted-foreground" />
-                      <span className="font-medium text-foreground tabular-nums">
-                        {formatCurrencyAmount(
-                          Number(payment.amount),
-                          payment.currency?.toString() ?? "INR",
-                        )}
-                      </span>
-                      <span className="text-xs text-muted-foreground">
-                        {format(new Date(payment.createdAt), "d MMM yyyy")}
-                      </span>
-                    </div>
-                    <StatusBadge
-                      {...paymentStatusBadge(
-                        payment.paymentStatus as PaymentDisplayStatus,
-                      )}
-                      size="sm"
-                    />
-                  </div>
-                ))}
-                {orgName && (
-                  <p className="text-xs text-muted-foreground">
-                    This booking is sponsored by <strong>{orgName}</strong>.
-                  </p>
-                )}
-                {vm.needsActionReason === "PAY_NOW" && vm.pendingPaymentUrl && (
-                  <Button
-                    size="sm"
-                    className="w-full bg-amber-500 hover:bg-amber-600 text-white dark:bg-amber-600 dark:hover:bg-amber-500"
-                    onClick={() => {
-                      if (/^https?:\/\//.test(vm.pendingPaymentUrl!)) {
-                        window.open(
-                          vm.pendingPaymentUrl!,
-                          "_blank",
-                          "noopener,noreferrer",
-                        );
-                      }
-                    }}
-                  >
-                    <CreditCard className="h-4 w-4 mr-2" />
-                    Pay Now to Confirm
-                  </Button>
-                )}
-              </div>
-            )}
-          </Section>
-
-          {/* Documents */}
-          {renderDocuments && (
-            <Section title="Documents">{renderDocuments(vm)}</Section>
-          )}
-
-          {/* Recordings */}
-          <Section title="Recordings">
-            {recordings.length === 0 ? (
-              <p className="text-xs text-muted-foreground">
-                Recordings of completed sessions will appear here.
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {recordings.map((rec) => (
-                  <div
-                    key={rec.id}
-                    className="flex items-center justify-between gap-2 rounded-lg bg-muted border border-border px-3 py-2"
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <Video className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium text-foreground truncate">
-                          {rec.title}
-                        </p>
-                        <p className="text-[11px] text-muted-foreground">
-                          {format(rec.recordedAt, "d MMM yyyy")} ·{" "}
-                          {rec.durationInMinutes} min
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <StatusBadge
-                        {...recordingStatusBadge(rec.status)}
-                        size="sm"
-                      />
-                      {rec.url && (
-                        <Button variant="outline" size="sm" asChild>
-                          <a
-                            href={rec.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            Watch
-                            <ExternalLink className="h-3 w-3 ml-1" />
-                          </a>
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </Section>
-
-          {/* Participants (consultant) */}
-          {role === "consultant" && (
-            <Section title="Participants">
-              {participants.length === 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  No participants on this session yet.
-                </p>
+        <div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(260px,340px)] lg:items-start">
+          <div className="flex min-w-0 flex-col gap-4">
+            <Section title="Sessions">
+              {hasConfirmedSessions ? (
+                <SessionTimeline
+                  sessions={vm.sessions}
+                  joinWindowMs={joinWindowMs}
+                  defaultExpanded
+                  isJoining={action.kind === "join" && !!action.busy}
+                  onJoinSession={
+                    action.kind === "join" && action.onClick
+                      ? () => action.onClick!()
+                      : undefined
+                  }
+                />
               ) : (
-                <div className="flex flex-wrap gap-2 mb-3">
-                  {participants.map((u) => (
-                    <span
-                      key={u.id}
-                      className="flex items-center gap-1.5 rounded-full border border-border bg-muted pl-1 pr-2.5 py-0.5 text-xs text-foreground"
-                    >
-                      <Avatar className="h-5 w-5">
-                        <AvatarImage src={u.image ?? undefined} alt={u.name} />
-                        <AvatarFallback className="text-[9px]">
-                          {initials(u.name) || "?"}
-                        </AvatarFallback>
-                      </Avatar>
-                      {u.name}
-                    </span>
-                  ))}
-                </div>
-              )}
-              {participantsHref?.(detail) && (
-                <Button variant="outline" size="sm" asChild>
-                  <Link href={participantsHref(detail)!}>
-                    <Users className="h-3.5 w-3.5 mr-1.5" />
-                    Manage participants
-                  </Link>
-                </Button>
+                <p className="text-xs text-muted-foreground">
+                  {vm.sessions.length > 0
+                    ? "Awaiting schedule confirmation."
+                    : "No sessions scheduled yet."}
+                </p>
               )}
             </Section>
-          )}
+
+            <Section title="Payment & sponsorship">
+              {payments.length === 0 && !orgName ? (
+                <p className="text-xs text-muted-foreground">
+                  No payment is attached to this booking.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {payments.map((payment) => (
+                    <div
+                      key={payment.id}
+                      className="flex items-center justify-between gap-2 rounded-lg bg-muted border border-border px-3 py-2"
+                    >
+                      <div className="flex items-center gap-2 text-sm">
+                        <CreditCard className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="font-medium text-foreground tabular-nums">
+                          {formatCurrencyAmount(
+                            Number(payment.amount),
+                            payment.currency?.toString() ?? "INR",
+                          )}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {format(new Date(payment.createdAt), "d MMM yyyy")}
+                        </span>
+                      </div>
+                      <StatusBadge
+                        {...paymentStatusBadge(
+                          payment.paymentStatus as PaymentDisplayStatus,
+                        )}
+                        size="sm"
+                      />
+                    </div>
+                  ))}
+                  {orgName && (
+                    <p className="text-xs text-muted-foreground">
+                      This booking is sponsored by <strong>{orgName}</strong>.
+                    </p>
+                  )}
+                  {vm.needsActionReason === "PAY_NOW" &&
+                    vm.pendingPaymentUrl && (
+                      <Button
+                        size="sm"
+                        className="w-full bg-amber-500 hover:bg-amber-600 text-white dark:bg-amber-600 dark:hover:bg-amber-500"
+                        onClick={() => {
+                          if (/^https?:\/\//.test(vm.pendingPaymentUrl!)) {
+                            window.open(
+                              vm.pendingPaymentUrl!,
+                              "_blank",
+                              "noopener,noreferrer",
+                            );
+                          }
+                        }}
+                      >
+                        <CreditCard className="h-4 w-4 mr-2" />
+                        Pay Now to Confirm
+                      </Button>
+                    )}
+                </div>
+              )}
+            </Section>
+
+            {role === "consultant" && (
+              <Section title="Participants">
+                {participants.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No participants on this session yet.
+                  </p>
+                ) : (
+                  <div className="mb-3 flex flex-wrap gap-2">
+                    {previewParticipants.map((u) => (
+                      <span
+                        key={u.id}
+                        className="flex items-center gap-1.5 rounded-full border border-border bg-muted py-0.5 pl-1 pr-2.5 text-xs text-foreground"
+                      >
+                        <Avatar className="h-5 w-5">
+                          <AvatarImage
+                            src={u.image ?? undefined}
+                            alt={u.name}
+                          />
+                          <AvatarFallback className="text-[9px]">
+                            {initials(u.name) || "?"}
+                          </AvatarFallback>
+                        </Avatar>
+                        {u.name}
+                      </span>
+                    ))}
+                    {hiddenParticipantCount > 0 && (
+                      <span className="inline-flex items-center rounded-full border border-border bg-muted px-2.5 py-0.5 text-xs text-muted-foreground">
+                        +{hiddenParticipantCount} more
+                      </span>
+                    )}
+                  </div>
+                )}
+                {manageHref && (
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={manageHref}>
+                      <Users className="mr-1.5 h-3.5 w-3.5" />
+                      Manage participants
+                    </Link>
+                  </Button>
+                )}
+              </Section>
+            )}
+          </div>
+
+          <aside className="min-w-0 lg:sticky lg:top-20">
+            <Section title="Resources">
+              <div className="space-y-5">
+                <ResourceSubgroup title="Documents" icon={FileText}>
+                  {renderDocuments ? (
+                    renderDocuments(vm)
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      Documents for this booking will appear here.
+                    </p>
+                  )}
+                </ResourceSubgroup>
+
+                <div className="border-t border-border" />
+
+                <ResourceSubgroup title="Recordings" icon={Video}>
+                  {recordings.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      Recordings of completed sessions will appear here.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {recordings.map((rec) => (
+                        <div
+                          key={rec.id}
+                          className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted px-3 py-2"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium text-foreground">
+                              {rec.title}
+                            </p>
+                            <p className="text-[11px] text-muted-foreground">
+                              {format(rec.recordedAt, "d MMM yyyy")} ·{" "}
+                              {rec.durationInMinutes} min
+                            </p>
+                          </div>
+                          <div className="flex shrink-0 items-center gap-2">
+                            <StatusBadge
+                              {...recordingStatusBadge(rec.status)}
+                              size="sm"
+                            />
+                            {rec.url && (
+                              <Button variant="outline" size="sm" asChild>
+                                <a
+                                  href={rec.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  Watch
+                                  <ExternalLink className="ml-1 h-3 w-3" />
+                                </a>
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </ResourceSubgroup>
+              </div>
+            </Section>
+          </aside>
         </div>
       </div>
     </DashboardErrorBoundary>

--- a/components/chat/ChatSidebar.tsx
+++ b/components/chat/ChatSidebar.tsx
@@ -676,11 +676,20 @@ export const ChatSidebar = () => {
     activeChannelIdRef.current = activeChannelId;
   }, [activeChannelId]);
 
+  // Debug Stream tools: local hostname only — never on deployed/preview hosts
+  // even if NODE_ENV were somehow still "development".
+  const [showLocalDebugTools, setShowLocalDebugTools] = useState(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    const host = window.location.hostname;
+    setShowLocalDebugTools(host === "localhost" || host === "127.0.0.1");
+  }, []);
+
   return (
     <div className="w-80 bg-blue-600 text-white flex flex-col h-full">
       {/* Header with Title and Refresh */}
       <div className="p-4 border-b border-blue-700 flex justify-between items-center">
-        <h1 className="text-xl font-bold">Familiarise</h1>
+        <h1 className="text-xl font-bold">Chats</h1>
         <TooltipProvider delayDuration={200}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -819,9 +828,9 @@ export const ChatSidebar = () => {
         )}
       </div>
 
-      {/* Footer Section — Debug tools, hidden in production */}
-      {process.env.NODE_ENV === "development" && (
-        <div className="p-4 border-t border-blue-700 mt-auto space-y-2">
+      {/* Footer Section — Debug tools, localhost only */}
+      {showLocalDebugTools && (
+        <div className="mt-auto space-y-2 border-t border-blue-700 p-4">
           <InitializeUserChannelsButton
             userId={client?.userID || ""}
             className="w-full"

--- a/components/collaborators/ActiveCollaborationCard.tsx
+++ b/components/collaborators/ActiveCollaborationCard.tsx
@@ -59,9 +59,11 @@ export function ActiveCollaborationCard({
   );
   const totalCollabShare =
     countedCollaborators.reduce((sum, c) => sum + c.revenueShareBps, 0) / 100;
-  const hostShare = 100 - totalCollabShare;
-  const youShare = collab.revenueShareBps / 100;
-  const otherShare = Math.max(0, totalCollabShare - youShare);
+  const hostShare = Number((100 - totalCollabShare).toFixed(2));
+  const youShare = Number((collab.revenueShareBps / 100).toFixed(2));
+  const otherShare = Number(
+    Math.max(0, totalCollabShare - youShare).toFixed(2),
+  );
 
   const hasExpandableDetails =
     (collab.planType === "webinar" &&
@@ -166,7 +168,7 @@ export function ActiveCollaborationCard({
         {/* Team — host + other collaborators (self is in the header/share) */}
         <div className="mt-4">
           <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
-            Team ({2 + otherCollaborators.length})
+            Team ({(owner ? 1 : 0) + otherCollaborators.length})
           </p>
           <div className="space-y-1.5">
             {owner && (

--- a/components/collaborators/ActiveCollaborationCard.tsx
+++ b/components/collaborators/ActiveCollaborationCard.tsx
@@ -2,8 +2,7 @@
 
 /**
  * Collaborator-perspective card: a plan the current consultant was invited
- * onto and has accepted. Extracted verbatim from InvitationsPanel.tsx.
- * Requires an ancestor <TooltipProvider> (the panel provides it).
+ * onto and has accepted. Requires an ancestor <TooltipProvider>.
  */
 
 import { useState } from "react";
@@ -24,6 +23,7 @@ import {
   ROLE_DESCRIPTIONS,
   formatRole,
 } from "./format";
+import { RevenueSplitBar } from "./RevenueSplitBar";
 import {
   ClassEventList,
   ClassScheduleSummary,
@@ -45,7 +45,6 @@ export function ActiveCollaborationCard({
       ? collab.webinarPlan?.consultantProfile
       : collab.classPlan?.consultantProfile;
 
-  // Filter out the current user from the collaborators list (they're shown in the banner)
   const allCollaboratorsOnPlan =
     (collab.planType === "webinar"
       ? collab.webinarPlan?.collaborators
@@ -53,6 +52,16 @@ export function ActiveCollaborationCard({
   const otherCollaborators = allCollaboratorsOnPlan.filter(
     (c) => c.id !== collab.id,
   );
+
+  // Accurate shares: host = remainder after PENDING+ACCEPTED collaborators
+  const countedCollaborators = allCollaboratorsOnPlan.filter(
+    (c) => c.status === "PENDING" || c.status === "ACCEPTED",
+  );
+  const totalCollabShare =
+    countedCollaborators.reduce((sum, c) => sum + c.revenueShareBps, 0) / 100;
+  const hostShare = 100 - totalCollabShare;
+  const youShare = collab.revenueShareBps / 100;
+  const otherShare = Math.max(0, totalCollabShare - youShare);
 
   const hasExpandableDetails =
     (collab.planType === "webinar" &&
@@ -62,144 +71,165 @@ export function ActiveCollaborationCard({
       collab.classPlan &&
       collab.classPlan.classes.length > 1);
 
-  return (
-    <Card className="overflow-hidden">
-      {/* Role banner */}
-      <div className="bg-purple-600 px-3 py-1.5 flex items-center justify-between">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="text-xs font-semibold text-white tracking-wide uppercase cursor-help">
-              {formatRole(collab.role)}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{ROLE_DESCRIPTIONS[collab.role] ?? formatRole(collab.role)}</p>
-          </TooltipContent>
-        </Tooltip>
-        <Badge
-          variant="secondary"
-          className="text-[10px] bg-purple-500 text-purple-100 border-purple-400"
-        >
-          {collab.planType === "webinar" ? "Webinar" : "Class"}
-        </Badge>
-      </div>
+  const planTypeLabel = collab.planType === "webinar" ? "Webinar" : "Class";
+  const roleLabel = formatRole(collab.role);
 
-      <div className="p-3">
+  return (
+    <Card className="overflow-hidden border-zinc-200/80 shadow-sm transition-shadow hover:shadow-md">
+      <div className="p-4 sm:p-5">
         {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="min-w-0">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex flex-wrap items-center gap-1.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge className="cursor-help rounded-md border-0 bg-teal-700 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white hover:bg-teal-700">
+                    {roleLabel}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    {ROLE_DESCRIPTIONS[collab.role] ?? formatRole(collab.role)}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+              <Badge
+                variant="secondary"
+                className="rounded-md border border-zinc-200 bg-white px-2 py-0.5 text-[10px] font-medium text-zinc-600"
+              >
+                {planTypeLabel}
+              </Badge>
+            </div>
             {owner?.id ? (
               <Link
                 href={`/dashboard/consultant/${owner.id}/planner`}
-                className="text-sm font-medium text-zinc-800 truncate hover:underline block"
+                className="block truncate text-[15px] font-semibold tracking-tight text-zinc-900 hover:underline"
               >
                 {collab.planTitle}
               </Link>
             ) : (
-              <p className="text-sm font-medium text-zinc-800 truncate">
+              <p className="truncate text-[15px] font-semibold tracking-tight text-zinc-900">
                 {collab.planTitle}
               </p>
             )}
-            <p className="text-xs text-zinc-500">
+            <p className="mt-0.5 text-sm text-zinc-500">
               by {owner?.user.name ?? "Unknown"}
             </p>
           </div>
         </div>
 
-        {/* Revenue share */}
-        <div className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-zinc-50 rounded-md border border-zinc-100">
-          <div className="flex items-center gap-1.5 text-xs text-zinc-600">
-            {currentUser && (
-              <Avatar className="w-5 h-5">
-                <AvatarImage src={currentUser.image ?? undefined} />
-                <AvatarFallback className="text-[8px]">
-                  {(currentUser.name ?? "Y").charAt(0)}
-                </AvatarFallback>
-              </Avatar>
-            )}
-            <span className="font-medium">
-              You {collab.revenueShareBps / 100}%
-            </span>
-            {owner && (
-              <span>
-                &middot; {owner.user.name} {100 - collab.revenueShareBps / 100}
-                %
-              </span>
-            )}
-          </div>
+        {/* Revenue share — accurate host remainder, not 100 − you alone */}
+        <div className="mt-3.5">
+          <RevenueSplitBar
+            avatar={currentUser}
+            segments={[
+              {
+                key: "you",
+                percent: youShare,
+                className: "bg-teal-600",
+              },
+              {
+                key: "host",
+                percent: hostShare,
+                className: "bg-zinc-800",
+              },
+              {
+                key: "others",
+                percent: otherShare,
+                className: "bg-zinc-300",
+              },
+            ]}
+            label={
+              <>
+                <span className="font-semibold text-zinc-800">
+                  You {youShare}%
+                </span>
+                {owner && (
+                  <>
+                    <span className="text-zinc-400"> · </span>
+                    <span>
+                      {owner.user.name} {hostShare}%
+                    </span>
+                  </>
+                )}
+                {otherShare > 0 && (
+                  <>
+                    <span className="text-zinc-400"> · </span>
+                    <span>Others {otherShare}%</span>
+                  </>
+                )}
+              </>
+            }
+          />
         </div>
 
-        {/* Team — host + self + other collaborators */}
-        <div className="border-t border-zinc-100 mt-3 pt-3">
-          <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+        {/* Team — host + other collaborators (self is in the header/share) */}
+        <div className="mt-4">
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
             Team ({2 + otherCollaborators.length})
           </p>
-          <div className="space-y-2">
-            {/* Host (plan owner) */}
+          <div className="space-y-1.5">
             {owner && (
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2.5">
-                  <Avatar className="w-7 h-7">
+              <div className="flex items-center justify-between gap-3 rounded-xl border border-zinc-100 bg-white px-2.5 py-2">
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <Avatar className="h-8 w-8 ring-1 ring-zinc-100">
                     <AvatarImage src={owner.user.image ?? undefined} />
-                    <AvatarFallback className="text-[10px]">
+                    <AvatarFallback className="bg-zinc-100 text-[11px] text-zinc-600">
                       {(owner.user.name ?? "H").charAt(0)}
                     </AvatarFallback>
                   </Avatar>
-                  <div>
-                    <p className="text-xs font-medium text-zinc-800">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-zinc-900">
                       {owner.user.name ?? "Unknown"}
                     </p>
-                    <p className="text-[11px] text-zinc-500">
-                      Host &middot;{" "}
-                      {100 -
-                        allCollaboratorsOnPlan.reduce(
-                          (sum, c) => sum + c.revenueShareBps,
-                          0,
-                        ) /
-                          100}
-                      % share
+                    <p className="truncate text-xs text-zinc-500">
+                      Host · {hostShare}% share
                     </p>
                   </div>
                 </div>
                 <Badge
                   variant="default"
-                  className="bg-zinc-100 text-zinc-700 border-zinc-200 text-[10px]"
+                  className="border-zinc-200 bg-zinc-100 text-[10px] text-zinc-700"
                 >
                   Owner
                 </Badge>
               </div>
             )}
-            {/* Other collaborators (not the current user) */}
             {otherCollaborators.map((c) => (
-              <div key={c.id} className="flex items-center justify-between">
-                <div className="flex items-center gap-2.5">
-                  <Avatar className="w-7 h-7">
+              <div
+                key={c.id}
+                className="flex items-center justify-between gap-3 rounded-xl border border-zinc-100 bg-white px-2.5 py-2"
+              >
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <Avatar className="h-8 w-8 ring-1 ring-zinc-100">
                     <AvatarImage
                       src={c.consultantProfile.user.image ?? undefined}
                     />
-                    <AvatarFallback className="text-[10px]">
+                    <AvatarFallback className="bg-zinc-100 text-[11px] text-zinc-600">
                       {(c.consultantProfile.user.name ?? "?").charAt(0)}
                     </AvatarFallback>
                   </Avatar>
-                  <div>
-                    <p className="text-xs font-medium text-zinc-800">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-zinc-900">
                       {c.consultantProfile.user.name ?? "Unknown"}
                     </p>
-                    <p className="text-[11px] text-zinc-500">
-                      {formatRole(c.role)} &middot; {c.revenueShareBps / 100}%
-                      share
+                    <p className="truncate text-xs text-zinc-500">
+                      {formatRole(c.role)} · {c.revenueShareBps / 100}% share
                     </p>
                   </div>
                 </div>
-                <StatusBadge size="sm" {...COLLABORATOR_STATUS_BADGE[c.status]} />
+                <StatusBadge
+                  size="sm"
+                  {...COLLABORATOR_STATUS_BADGE[c.status]}
+                />
               </div>
             ))}
           </div>
         </div>
 
         {/* Schedule summary */}
-        <div className="border-t border-zinc-100 mt-3 pt-3">
-          <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+        <div className="mt-4 rounded-xl border border-zinc-100 bg-zinc-50/50 px-3 py-3">
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
             Schedule
           </p>
           {collab.planType === "webinar" && collab.webinarPlan ? (
@@ -207,38 +237,37 @@ export function ActiveCollaborationCard({
           ) : collab.planType === "class" && collab.classPlan ? (
             <ClassScheduleSummary plan={collab.classPlan} />
           ) : (
-            <p className="text-xs text-zinc-400 italic">
+            <p className="text-xs italic text-zinc-400">
               No schedule data available
             </p>
           )}
-        </div>
 
-        {/* All events — collapsible */}
-        {hasExpandableDetails && (
-          <div className="mt-2">
-            <button
-              type="button"
-              onClick={() => setSlotsExpanded((prev) => !prev)}
-              className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-700 transition-colors"
-            >
-              {slotsExpanded ? (
-                <ChevronUp className="w-3 h-3" />
-              ) : (
-                <ChevronDown className="w-3 h-3" />
+          {hasExpandableDetails && (
+            <div className="mt-2.5 border-t border-zinc-100 pt-2.5">
+              <button
+                type="button"
+                onClick={() => setSlotsExpanded((prev) => !prev)}
+                className="flex items-center gap-1 text-[11px] text-zinc-500 transition-colors hover:text-zinc-800"
+              >
+                {slotsExpanded ? (
+                  <ChevronUp className="h-3 w-3" />
+                ) : (
+                  <ChevronDown className="h-3 w-3" />
+                )}
+                {slotsExpanded ? "Hide" : "Show"} all events
+              </button>
+              {slotsExpanded && (
+                <div className="mt-2">
+                  {collab.planType === "webinar" && collab.webinarPlan ? (
+                    <WebinarEventList plan={collab.webinarPlan} />
+                  ) : collab.planType === "class" && collab.classPlan ? (
+                    <ClassEventList plan={collab.classPlan} />
+                  ) : null}
+                </div>
               )}
-              {slotsExpanded ? "Hide" : "Show"} all events
-            </button>
-            {slotsExpanded && (
-              <div className="mt-2 border-t border-zinc-100 pt-2">
-                {collab.planType === "webinar" && collab.webinarPlan ? (
-                  <WebinarEventList plan={collab.webinarPlan} />
-                ) : collab.planType === "class" && collab.classPlan ? (
-                  <ClassEventList plan={collab.classPlan} />
-                ) : null}
-              </div>
-            )}
-          </div>
-        )}
+            </div>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/components/collaborators/CollaboratorsTab.tsx
+++ b/components/collaborators/CollaboratorsTab.tsx
@@ -313,7 +313,7 @@ export function CollaboratorsTab({
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="text-xs font-medium text-zinc-600">Role</label>
               <Select value={inviteRole} onValueChange={setInviteRole}>

--- a/components/collaborators/HostedPlanCard.tsx
+++ b/components/collaborators/HostedPlanCard.tsx
@@ -31,11 +31,14 @@ export function HostedPlanCard({
 }) {
   const [eventsExpanded, setEventsExpanded] = useState(false);
 
-  const totalCollabShare =
-    plan.collaborators
-      .filter((c) => c.status === "PENDING" || c.status === "ACCEPTED")
-      .reduce((sum, c) => sum + c.revenueShareBps, 0) / 100;
-  const hostShare = 100 - totalCollabShare;
+  const totalCollabShare = Number(
+    (
+      plan.collaborators
+        .filter((c) => c.status === "PENDING" || c.status === "ACCEPTED")
+        .reduce((sum, c) => sum + c.revenueShareBps, 0) / 100
+    ).toFixed(2),
+  );
+  const hostShare = Number((100 - totalCollabShare).toFixed(2));
 
   const pendingCollabs = plan.collaborators.filter(
     (c) => c.status === "PENDING",

--- a/components/collaborators/HostedPlanCard.tsx
+++ b/components/collaborators/HostedPlanCard.tsx
@@ -2,7 +2,7 @@
 
 /**
  * Host-perspective card: one of the current consultant's own plans that
- * has collaborators on it. Extracted verbatim from InvitationsPanel.tsx.
+ * has collaborators on it.
  */
 
 import { useState } from "react";
@@ -14,6 +14,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { formatCurrencyFromMajorUnit } from "@/utils/formatting";
 import type { HostedPlanEntry } from "./types";
 import { COLLABORATOR_STATUS_BADGE, formatRole } from "./format";
+import { RevenueSplitBar } from "./RevenueSplitBar";
 import {
   ClassEventList,
   ClassScheduleSummary,
@@ -51,78 +52,90 @@ export function HostedPlanCard({
       plan.classPlan &&
       plan.classPlan.classes.length > 1);
 
-  return (
-    <Card className="overflow-hidden">
-      {/* Role banner */}
-      <div className="bg-zinc-800 px-3 py-1.5 flex items-center justify-between">
-        <span className="text-xs font-semibold text-white tracking-wide uppercase">
-          Host
-        </span>
-        <Badge
-          variant="secondary"
-          className="text-[10px] bg-zinc-700 text-zinc-200 border-zinc-600"
-        >
-          {plan.planType === "webinar" ? "Webinar" : "Class"}
-        </Badge>
-      </div>
+  const planTypeLabel = plan.planType === "webinar" ? "Webinar" : "Class";
 
-      <div className="p-3">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-zinc-800 truncate">
+  return (
+    <Card className="overflow-hidden border-zinc-200/80 shadow-sm transition-shadow hover:shadow-md">
+      <div className="p-4 sm:p-5">
+        {/* Header — role chip + plan type instead of solid banner */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex flex-wrap items-center gap-1.5">
+              <Badge className="rounded-md border-0 bg-zinc-900 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white hover:bg-zinc-900">
+                Host
+              </Badge>
+              <Badge
+                variant="secondary"
+                className="rounded-md border border-zinc-200 bg-white px-2 py-0.5 text-[10px] font-medium text-zinc-600"
+              >
+                {planTypeLabel}
+              </Badge>
+            </div>
+            <p className="truncate text-[15px] font-semibold tracking-tight text-zinc-900">
               {plan.title}
             </p>
             {plan.price > 0 && (
-              <p className="text-xs text-zinc-500">
+              <p className="mt-0.5 text-sm text-zinc-500">
                 {formatCurrencyFromMajorUnit(plan.price, "INR")}
               </p>
             )}
           </div>
         </div>
 
-        {/* Revenue split */}
-        <div className="flex items-center gap-2 mt-2 px-2 py-1.5 bg-zinc-50 rounded-md border border-zinc-100">
-          <div className="flex items-center gap-1.5 text-xs text-zinc-600">
-            {hostUser && (
-              <Avatar className="w-5 h-5">
-                <AvatarImage src={hostUser.image ?? undefined} />
-                <AvatarFallback className="text-[8px]">
-                  {(hostUser.name ?? "H").charAt(0)}
-                </AvatarFallback>
-              </Avatar>
-            )}
-            <span className="font-medium">You {hostShare}%</span>
-            <span>&middot; Collaborators {totalCollabShare}%</span>
-          </div>
+        {/* Revenue split — proportional bar */}
+        <div className="mt-3.5">
+          <RevenueSplitBar
+            avatar={hostUser}
+            segments={[
+              {
+                key: "host",
+                percent: hostShare,
+                className: "bg-zinc-800",
+              },
+              {
+                key: "collaborators",
+                percent: totalCollabShare,
+                className: "bg-teal-500/80",
+              },
+            ]}
+            label={
+              <>
+                <span className="font-semibold text-zinc-800">
+                  You {hostShare}%
+                </span>
+                <span className="text-zinc-400"> · </span>
+                <span>Collaborators {totalCollabShare}%</span>
+              </>
+            }
+          />
         </div>
 
         {/* Collaborators list */}
-        <div className="border-t border-zinc-100 mt-3 pt-3">
-          <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+        <div className="mt-4">
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
             Collaborators ({plan.collaborators.length})
           </p>
-          <div className="space-y-2">
+          <div className="space-y-1.5">
             {[...acceptedCollabs, ...pendingCollabs].map((collab) => (
               <div
                 key={collab.id}
-                className="flex items-center justify-between"
+                className="flex items-center justify-between gap-3 rounded-xl border border-zinc-100 bg-white px-2.5 py-2"
               >
-                <div className="flex items-center gap-2.5">
-                  <Avatar className="w-7 h-7">
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <Avatar className="h-8 w-8 ring-1 ring-zinc-100">
                     <AvatarImage
                       src={collab.consultantProfile.user.image ?? undefined}
                     />
-                    <AvatarFallback className="text-[10px]">
+                    <AvatarFallback className="bg-zinc-100 text-[11px] text-zinc-600">
                       {(collab.consultantProfile.user.name ?? "?").charAt(0)}
                     </AvatarFallback>
                   </Avatar>
-                  <div>
-                    <p className="text-xs font-medium text-zinc-800">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-zinc-900">
                       {collab.consultantProfile.user.name ?? "Unknown"}
                     </p>
-                    <p className="text-[11px] text-zinc-500">
-                      {formatRole(collab.role)} &middot;{" "}
+                    <p className="truncate text-xs text-zinc-500">
+                      {formatRole(collab.role)} ·{" "}
                       {collab.revenueShareBps / 100}% share
                     </p>
                   </div>
@@ -137,8 +150,8 @@ export function HostedPlanCard({
         </div>
 
         {/* Schedule summary */}
-        <div className="border-t border-zinc-100 mt-3 pt-3">
-          <p className="text-[11px] font-medium text-zinc-500 uppercase tracking-wider mb-2">
+        <div className="mt-4 rounded-xl border border-zinc-100 bg-zinc-50/50 px-3 py-3">
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
             Schedule
           </p>
           {plan.planType === "webinar" && plan.webinarPlan ? (
@@ -146,38 +159,37 @@ export function HostedPlanCard({
           ) : plan.planType === "class" && plan.classPlan ? (
             <ClassScheduleSummary plan={plan.classPlan} />
           ) : (
-            <p className="text-xs text-zinc-400 italic">
+            <p className="text-xs italic text-zinc-400">
               No schedule data available
             </p>
           )}
-        </div>
 
-        {/* All events — collapsible */}
-        {hasExpandableDetails && (
-          <div className="mt-2">
-            <button
-              type="button"
-              onClick={() => setEventsExpanded((prev) => !prev)}
-              className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-700 transition-colors"
-            >
-              {eventsExpanded ? (
-                <ChevronUp className="w-3 h-3" />
-              ) : (
-                <ChevronDown className="w-3 h-3" />
+          {hasExpandableDetails && (
+            <div className="mt-2.5 border-t border-zinc-100 pt-2.5">
+              <button
+                type="button"
+                onClick={() => setEventsExpanded((prev) => !prev)}
+                className="flex items-center gap-1 text-[11px] text-zinc-500 transition-colors hover:text-zinc-800"
+              >
+                {eventsExpanded ? (
+                  <ChevronUp className="h-3 w-3" />
+                ) : (
+                  <ChevronDown className="h-3 w-3" />
+                )}
+                {eventsExpanded ? "Hide" : "Show"} all events
+              </button>
+              {eventsExpanded && (
+                <div className="mt-2">
+                  {plan.planType === "webinar" && plan.webinarPlan ? (
+                    <WebinarEventList plan={plan.webinarPlan} />
+                  ) : plan.planType === "class" && plan.classPlan ? (
+                    <ClassEventList plan={plan.classPlan} />
+                  ) : null}
+                </div>
               )}
-              {eventsExpanded ? "Hide" : "Show"} all events
-            </button>
-            {eventsExpanded && (
-              <div className="mt-2 border-t border-zinc-100 pt-2">
-                {plan.planType === "webinar" && plan.webinarPlan ? (
-                  <WebinarEventList plan={plan.webinarPlan} />
-                ) : plan.planType === "class" && plan.classPlan ? (
-                  <ClassEventList plan={plan.classPlan} />
-                ) : null}
-              </div>
-            )}
-          </div>
-        )}
+            </div>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -152,14 +152,17 @@ export function InvitationsPanel() {
 
   return (
     <TooltipProvider>
-      <div className="space-y-6">
+      <div className="space-y-8">
         {/* ── Host section: My Plans with Collaborators ── */}
         {hostedPlans.length > 0 && (
           <div>
-            <h2 className="text-base font-semibold text-zinc-700 mb-3">
-              My Plans with Collaborators ({hostedPlans.length})
+            <h2 className="mb-4 text-sm font-semibold tracking-tight text-zinc-900">
+              My Plans with Collaborators{" "}
+              <span className="font-normal text-zinc-400">
+                ({hostedPlans.length})
+              </span>
             </h2>
-            <div className="space-y-2">
+            <div className="space-y-3">
               {hostedPlans.map((plan) => (
                 <HostedPlanCard
                   key={`${plan.planType}-${plan.webinarPlan?.id ?? plan.classPlan?.id}`}
@@ -173,14 +176,17 @@ export function InvitationsPanel() {
 
         {/* ── Collaborator section: Pending Invitations ── */}
         <div>
-          <h2 className="text-base font-semibold text-zinc-700 mb-3">
-            Pending Invitations ({pending.length})
+          <h2 className="mb-4 text-sm font-semibold tracking-tight text-zinc-900">
+            Pending Invitations{" "}
+            <span className="font-normal text-zinc-400">
+              ({pending.length})
+            </span>
           </h2>
           {pending.length === 0 ? (
-            <div className="text-center py-8 text-zinc-500 border border-dashed border-zinc-200 rounded-lg">
-              <Inbox className="w-8 h-8 mx-auto mb-2 text-zinc-300" />
+            <div className="rounded-xl border border-dashed border-zinc-200 py-10 text-center text-zinc-500">
+              <Inbox className="mx-auto mb-2 h-8 w-8 text-zinc-300" />
               <p className="text-sm font-medium">No pending invitations</p>
-              <p className="text-xs mt-1 max-w-xs mx-auto">
+              <p className="mx-auto mt-1 max-w-xs text-xs">
                 When another consultant invites you to co-host a webinar or
                 class, the invitation will appear here.
               </p>
@@ -202,10 +208,13 @@ export function InvitationsPanel() {
         {/* ── Collaborator section: Active Collaborations ── */}
         {accepted.length > 0 && (
           <div>
-            <h2 className="text-base font-semibold text-zinc-700 mb-3">
-              Active Collaborations ({accepted.length})
+            <h2 className="mb-4 text-sm font-semibold tracking-tight text-zinc-900">
+              Active Collaborations{" "}
+              <span className="font-normal text-zinc-400">
+                ({accepted.length})
+              </span>
             </h2>
-            <div className="space-y-2">
+            <div className="space-y-3">
               {accepted.map((collab) => (
                 <ActiveCollaborationCard
                   key={collab.id}

--- a/components/collaborators/PendingInvitationCard.tsx
+++ b/components/collaborators/PendingInvitationCard.tsx
@@ -2,11 +2,10 @@
 
 /**
  * A pending collaboration invitation with Accept / Decline actions.
- * Extracted verbatim from InvitationsPanel.tsx — the mutation lives in
- * the panel and is passed down so the invalidation/toast flow is
- * unchanged. Requires an ancestor <TooltipProvider>.
+ * Requires an ancestor <TooltipProvider>.
  */
 
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -33,24 +32,29 @@ export function PendingInvitationCard({
   }) => void;
   isResponding: boolean;
 }) {
+  const inviter = collab.invitedBy.user;
+  const planTypeLabel = collab.planType === "webinar" ? "Webinar" : "Class";
+
   return (
-    <Card className="p-4 border-amber-200 bg-amber-50">
-      <div className="flex items-start justify-between">
-        <div>
-          <p className="font-medium text-zinc-800">{collab.planTitle}</p>
-          <p className="text-sm text-zinc-600 mt-0.5">
-            Invited by{" "}
-            <span className="font-medium">
-              {collab.invitedBy.user.name ?? "Unknown"}
-            </span>
-          </p>
-          <div className="flex items-center gap-2 mt-2">
-            <Badge variant="secondary" className="text-xs">
-              {collab.planType === "webinar" ? "Webinar" : "Class"}
+    <Card className="overflow-hidden border-amber-200/80 bg-gradient-to-br from-amber-50/90 to-white shadow-sm">
+      <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between sm:p-5">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex flex-wrap items-center gap-1.5">
+            <Badge className="rounded-md border-0 bg-amber-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white hover:bg-amber-600">
+              Invitation
+            </Badge>
+            <Badge
+              variant="secondary"
+              className="rounded-md border border-amber-200/80 bg-white px-2 py-0.5 text-[10px] font-medium text-zinc-600"
+            >
+              {planTypeLabel}
             </Badge>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Badge variant="outline" className="text-xs cursor-help">
+                <Badge
+                  variant="outline"
+                  className="cursor-help rounded-md border-amber-200 bg-white px-2 py-0.5 text-[10px] text-zinc-700"
+                >
                   {formatRole(collab.role)}
                 </Badge>
               </TooltipTrigger>
@@ -60,28 +64,55 @@ export function PendingInvitationCard({
                 </p>
               </TooltipContent>
             </Tooltip>
-            <span className="text-xs text-zinc-500">
+          </div>
+
+          <p className="text-[15px] font-semibold tracking-tight text-zinc-900">
+            {collab.planTitle}
+          </p>
+
+          <div className="mt-2 flex items-center gap-2">
+            <Avatar className="h-6 w-6 ring-1 ring-amber-100">
+              <AvatarFallback className="bg-amber-100 text-[9px] text-amber-900">
+                {(inviter.name ?? "?").charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+            <p className="text-sm text-zinc-600">
+              Invited by{" "}
+              <span className="font-medium text-zinc-800">
+                {inviter.name ?? "Unknown"}
+              </span>
+            </p>
+          </div>
+
+          <div className="mt-2.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-500">
+            <span className="font-medium text-zinc-700">
               {collab.revenueShareBps / 100}% revenue share
             </span>
             {collab.planPrice > 0 && (
-              <span className="text-xs text-zinc-500">
-                &middot; Plan price{" "}
-                {formatCurrencyFromMajorUnit(collab.planPrice, "INR")}
-              </span>
+              <>
+                <span className="text-zinc-300">·</span>
+                <span>
+                  Plan price{" "}
+                  {formatCurrencyFromMajorUnit(collab.planPrice, "INR")}
+                </span>
+              </>
             )}
           </div>
-          <div className="flex items-center gap-1.5 mt-2 text-xs text-amber-700">
-            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+
+          <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200/70 bg-amber-50/80 px-2.5 py-2 text-xs text-amber-800">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <span>
               You won&apos;t earn from purchases made before you accept the
               collaborations request.
             </span>
           </div>
         </div>
-        <div className="flex gap-2 ml-4">
+
+        <div className="flex shrink-0 gap-2 sm:flex-col sm:items-stretch">
           <Button
             size="sm"
             variant="default"
+            className="flex-1 sm:flex-none"
             onClick={() =>
               onRespond({
                 id: collab.id,
@@ -91,12 +122,13 @@ export function PendingInvitationCard({
             }
             disabled={isResponding}
           >
-            <Check className="w-3.5 h-3.5 mr-1" />
+            <Check className="mr-1 h-3.5 w-3.5" />
             Accept
           </Button>
           <Button
             size="sm"
             variant="outline"
+            className="flex-1 border-zinc-200 bg-white sm:flex-none"
             onClick={() =>
               onRespond({
                 id: collab.id,
@@ -106,7 +138,7 @@ export function PendingInvitationCard({
             }
             disabled={isResponding}
           >
-            <X className="w-3.5 h-3.5 mr-1" />
+            <X className="mr-1 h-3.5 w-3.5" />
             Decline
           </Button>
         </div>

--- a/components/collaborators/RevenueSplitBar.tsx
+++ b/components/collaborators/RevenueSplitBar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * Proportional revenue-split visualization for collaboration cards.
+ * Segments must already sum to ~100; labels are passed as React nodes
+ * so callers keep full control of the accurate copy.
+ */
+
+import type { ReactNode } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+export type RevenueSplitSegment = {
+  key: string;
+  percent: number;
+  className: string;
+};
+
+export function RevenueSplitBar({
+  segments,
+  label,
+  avatar,
+}: {
+  segments: RevenueSplitSegment[];
+  label: ReactNode;
+  avatar?: { name: string | null; image: string | null } | null;
+}) {
+  const visible = segments.filter((s) => s.percent > 0);
+
+  return (
+    <div className="rounded-xl border border-zinc-200/80 bg-zinc-50/80 px-3 py-2.5">
+      <div className="flex items-center gap-2.5">
+        {avatar && (
+          <Avatar className="h-6 w-6 ring-2 ring-white shrink-0">
+            <AvatarImage src={avatar.image ?? undefined} />
+            <AvatarFallback className="text-[9px] bg-zinc-200 text-zinc-700">
+              {(avatar.name ?? "?").charAt(0)}
+            </AvatarFallback>
+          </Avatar>
+        )}
+        <div className="min-w-0 flex-1 text-xs text-zinc-600">{label}</div>
+      </div>
+      {visible.length > 0 && (
+        <div
+          className="mt-2 flex h-1.5 w-full overflow-hidden rounded-full bg-zinc-200/80"
+          role="img"
+          aria-label="Revenue split"
+        >
+          {visible.map((segment) => (
+            <div
+              key={segment.key}
+              className={`h-full ${segment.className}`}
+              style={{ width: `${Math.min(100, Math.max(0, segment.percent))}%` }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/collaborators/RevenueSplitBar.tsx
+++ b/components/collaborators/RevenueSplitBar.tsx
@@ -33,7 +33,7 @@ export function RevenueSplitBar({
           <Avatar className="h-6 w-6 ring-2 ring-white shrink-0">
             <AvatarImage src={avatar.image ?? undefined} />
             <AvatarFallback className="text-[9px] bg-zinc-200 text-zinc-700">
-              {(avatar.name ?? "?").charAt(0)}
+              {(avatar.name || "?").charAt(0)}
             </AvatarFallback>
           </Avatar>
         )}

--- a/components/dashboard/CollapsibleSidebar.tsx
+++ b/components/dashboard/CollapsibleSidebar.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/utils/tailwind";
 import { ChevronLeft, ChevronRight, ChevronDown, ChevronsUpDown, LogOut, type LucideIcon } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { LinkPendingIcon } from "@/components/ui/NavLink";
@@ -153,6 +154,7 @@ export function CollapsibleSidebar({
   onSignOut,
   className,
 }: CollapsibleSidebarProps) {
+  const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
 
   // Per-group collapsed map, keyed by the group's label. Defaults to
@@ -170,6 +172,13 @@ export function CollapsibleSidebar({
   );
 
   const isActive = (path: string) => isActiveRoute(pathname, basePath, path);
+
+  /** Navigate to the tab root even when already under a nested child route. */
+  const goToNavPath = (path: string) => {
+    const href = path ? `${basePath}/${path}` : basePath;
+    if (pathname === href) return;
+    router.push(href);
+  };
 
   const fallbackChar =
     avatarFallback ??
@@ -322,7 +331,7 @@ export function CollapsibleSidebar({
             // visibility. When the whole sidebar is in icon-only mode,
             // group headers hide and all items render flat so the user
             // can still navigate via tooltips.
-            <div className="space-y-2 px-2">
+            <div className="space-y-3 px-3">
               {groups.map((group, gi) => {
                 const isHeaderless = !group.label;
                 const isGroupCollapsed =
@@ -360,6 +369,10 @@ export function CollapsibleSidebar({
                               <TooltipTrigger asChild>
                                 <Link
                                   href={`${basePath}/${item.path}`}
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    goToNavPath(item.path);
+                                  }}
                                   aria-label={collapsed ? item.name : undefined}
                                   aria-current={
                                     isActive(item.path) ? "page" : undefined
@@ -407,13 +420,17 @@ export function CollapsibleSidebar({
               })}
             </div>
           ) : (
-            <ul className="space-y-1 px-2">
+            <ul className="space-y-1.5 px-3">
               {(items ?? []).map((item) => (
                 <li key={item.path}>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Link
                         href={`${basePath}/${item.path}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          goToNavPath(item.path);
+                        }}
                         aria-label={collapsed ? item.name : undefined}
                         aria-current={isActive(item.path) ? "page" : undefined}
                         className={cn(

--- a/components/dashboard/DashboardContextBar.tsx
+++ b/components/dashboard/DashboardContextBar.tsx
@@ -11,6 +11,14 @@ export interface DashboardContextBarBadge {
   className: string;
 }
 
+export type DashboardBreadcrumb =
+  | string
+  | {
+      label: string;
+      /** When set, the crumb is a clickable link (use for parents of the current page). */
+      href?: string;
+    };
+
 export interface DashboardContextBarProps {
   identity: {
     name: string;
@@ -27,9 +35,10 @@ export interface DashboardContextBarProps {
   badges?: DashboardContextBarBadge[];
   /**
    * Ordered breadcrumb segments from root to current page.
-   * The last entry is highlighted as the active page.
+   * The last entry is highlighted as the active page unless it has an href
+   * (parent of a nested record id that was stripped from the trail).
    */
-  breadcrumbs?: string[];
+  breadcrumbs?: DashboardBreadcrumb[];
   /**
    * Escape hatch rendered at the far left (e.g. "← Personal" from an org
    * dashboard). Hidden when omitted — personal dashboards have nothing to
@@ -40,20 +49,17 @@ export interface DashboardContextBarProps {
   rightSlot?: React.ReactNode;
 }
 
+function normalizeCrumb(crumb: DashboardBreadcrumb): {
+  label: string;
+  href?: string;
+} {
+  return typeof crumb === "string" ? { label: crumb } : crumb;
+}
+
 /**
  * Sticky info strip at the top of every dashboard page — the generalized
  * successor of the org-only OrgContextBar, shared by the organization,
  * consultant, and consultee shells.
- *
- * Responsibility: orientation (which context, which page) via identity +
- * badges + breadcrumbs. Context-SWITCHING (personal dashboard, other orgs,
- * sign out) deliberately lives in the sidebar's bottom user chip so all
- * navigation is in one discoverable place.
- *
- * Desktop (md+): identity name text is hidden because the sidebar header
- * already shows it — no duplication. Mobile: name text is shown because
- * the sidebar is hidden. Height is h-14 to pixel-match the sidebar header
- * so the border intersection lines up at the crossroad.
  */
 export function DashboardContextBar({
   identity,
@@ -113,21 +119,28 @@ export function DashboardContextBar({
           aria-label="Breadcrumb"
           className="flex items-center gap-1 min-w-0 shrink"
         >
-          {breadcrumbs.map((crumb, i) => {
+          {breadcrumbs.map((raw, i) => {
+            const crumb = normalizeCrumb(raw);
             const isLast = i === breadcrumbs.length - 1;
+            const className = isLast && !crumb.href
+              ? "text-zinc-900 dark:text-zinc-100 font-semibold truncate"
+              : "text-zinc-500 dark:text-zinc-400 truncate hover:text-zinc-800 dark:hover:text-zinc-200 transition-colors";
+
             return (
-              <span key={i} className="flex items-center gap-1 min-w-0">
+              <span key={`${crumb.label}-${i}`} className="flex items-center gap-1 min-w-0">
                 <ChevronRight className="h-3.5 w-3.5 text-zinc-300 dark:text-zinc-600 shrink-0" />
-                <span
-                  className={
-                    isLast
-                      ? "text-zinc-900 dark:text-zinc-100 font-semibold truncate"
-                      : "text-zinc-500 dark:text-zinc-400 truncate"
-                  }
-                  aria-current={isLast ? "page" : undefined}
-                >
-                  {crumb}
-                </span>
+                {crumb.href ? (
+                  <Link href={crumb.href} className={className}>
+                    {crumb.label}
+                  </Link>
+                ) : (
+                  <span
+                    className={className}
+                    aria-current={isLast ? "page" : undefined}
+                  >
+                    {crumb.label}
+                  </span>
+                )}
               </span>
             );
           })}

--- a/components/dashboard/PageScaffold.tsx
+++ b/components/dashboard/PageScaffold.tsx
@@ -51,19 +51,19 @@ export function DashboardHeader({
           </nav>
         )}
 
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0">
-            <h1 className="text-xl sm:text-2xl font-bold text-zinc-900 truncate">
+            <h1 className="text-xl sm:text-2xl font-bold text-zinc-900 sm:truncate">
               {title}
             </h1>
             {subtitle && (
-              <p className="text-xs sm:text-sm text-zinc-500 mt-0.5 truncate">
+              <p className="text-xs sm:text-sm text-zinc-500 mt-0.5 sm:truncate">
                 {subtitle}
               </p>
             )}
           </div>
           {actions && (
-            <div className="flex items-center gap-2 sm:gap-3 shrink-0">
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:gap-3 sm:shrink-0">
               {actions}
             </div>
           )}

--- a/components/dashboard/PersonalDashboardShell.tsx
+++ b/components/dashboard/PersonalDashboardShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { type LucideIcon } from "lucide-react";
 import {
   CollapsibleSidebar,
@@ -82,6 +83,14 @@ export function PersonalDashboardShell({
   onSignOut,
   children,
 }: PersonalDashboardShellProps) {
+  const router = useRouter();
+
+  const goToNavPath = (path: string) => {
+    const href = path ? `${basePath}/${path}` : basePath;
+    if (pathname === href) return;
+    router.push(href);
+  };
+
   return (
     <div className="flex h-screen-maintenance bg-zinc-50 dark:bg-zinc-950">
       {/* Collapsible sidebar — hidden on mobile, visible on md+ */}
@@ -108,7 +117,7 @@ export function PersonalDashboardShell({
         {banner}
 
         <main className="flex-1 overflow-y-auto pb-16 md:pb-0">
-          <div className="p-6">
+          <div className="p-4 sm:p-6 lg:p-8">
             <DashboardErrorBoundary>{children}</DashboardErrorBoundary>
           </div>
         </main>
@@ -121,6 +130,10 @@ export function PersonalDashboardShell({
               <Link
                 key={path}
                 href={`${basePath}/${path}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  goToNavPath(path);
+                }}
                 className={`flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[10px] font-medium transition-colors ${
                   isActive
                     ? "text-zinc-900 dark:text-zinc-100"

--- a/components/dashboard/breadcrumb-override.tsx
+++ b/components/dashboard/breadcrumb-override.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface BreadcrumbOverrideContextValue {
+  /** Optional label replacing a stripped record-id crumb (e.g. appointment title). */
+  overrideLabel: string | null;
+  setOverrideLabel: (label: string | null) => void;
+}
+
+const BreadcrumbOverrideContext =
+  createContext<BreadcrumbOverrideContextValue | null>(null);
+
+export function BreadcrumbOverrideProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [overrideLabel, setOverrideLabelState] = useState<string | null>(null);
+  const setOverrideLabel = useCallback((label: string | null) => {
+    setOverrideLabelState(label);
+  }, []);
+
+  const value = useMemo(
+    () => ({ overrideLabel, setOverrideLabel }),
+    [overrideLabel, setOverrideLabel],
+  );
+
+  return (
+    <BreadcrumbOverrideContext.Provider value={value}>
+      {children}
+    </BreadcrumbOverrideContext.Provider>
+  );
+}
+
+export function useBreadcrumbOverride() {
+  const ctx = useContext(BreadcrumbOverrideContext);
+  if (!ctx) {
+    return {
+      overrideLabel: null as string | null,
+      setOverrideLabel: (_label: string | null) => {},
+    };
+  }
+  return ctx;
+}
+
+/** Sets the breadcrumb override while mounted; clears on unmount. */
+export function useSetBreadcrumbLabel(label: string | null | undefined) {
+  const { setOverrideLabel } = useBreadcrumbOverride();
+  useEffect(() => {
+    if (!label) return;
+    setOverrideLabel(label);
+    return () => setOverrideLabel(null);
+  }, [label, setOverrideLabel]);
+}


### PR DESCRIPTION
## Summary
- Keep Allocate Slots / calendar dialogs within the viewport (header/footer pinned; only the grid scrolls)
- Modernize collaborations + event planner cards (readable titles, accurate revenue splits)
- Multi-screen responsive pass across consultant tabs and dialogs
- Appointment detail UX:
  - Nav/breadcrumb returns to the appointments list from nested routes
  - Full-width two-column layout with a **Resources** sidebar (documents + recordings)
  - Participants preview (top 5) + Manage participants
  - Breadcrumb shows appointment **name**, not ID
  - Session timeline expanded by default (all sessions for subscriptions/classes)
- Consultant booking actions: Join, Timings, Participants, Reschedule, Cancel (policy refund messaging), Documents upload — no standalone Refund button

## Test plan
- [ ] Short/narrow viewport: Allocate Slots, Create Plan, Manage Timings fit; footers stay visible
- [ ] From appointment detail/participants: click Appointments in nav or breadcrumb → returns to list
- [ ] Detail page: two-column Resources layout on desktop; sessions list shows all sessions expanded
- [ ] Breadcrumb shows appointment title (not the raw ID)
- [ ] Participants section shows ≤5 chips + Manage participants
- [ ] Reschedule (single + multi-session) works for consultation/subscription; webinar/class only for host
- [ ] Cancel booking shows policy refund note for consultation/subscription; list/detail refresh
- [ ] Upload document from detail Resources → Documents and from overflow menu
- [ ] Calendar month/week grids respect `max-h` with `calc(90dvh - 16rem)` (underscored Tailwind arbitrary value)