### PR TITLE
fix(stream): Phase-0 recording pipeline hardening (enqueue-on-ready, streaming upload, retention object delete)

### DIFF
--- a/app/api/cleanup/transfer-expiring-recordings/route.ts
+++ b/app/api/cleanup/transfer-expiring-recordings/route.ts
@@ -75,10 +75,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       "transfer-expiring-recordings",
       { failMode: "open" },
       async () => {
-        // Phase 1: Auto-transfer SUPABASE_PERMANENT recordings
+        // Phase 1: Auto-transfer SUPABASE_PERMANENT recordings.
+        // #899 — 14-day window sweeps every READY permanent recording
+        // (near-ready transfer), matching the GH Actions entry.
         const transferResult =
           await RecordingTransferService.processExpiringRecordings(
-            5, // 5 days before expiry
+            14, // days before expiry (= full Stream URL lifetime)
             10, // batch size
             "SUPABASE_PERMANENT",
           );

--- a/docs/stream/13-recording-webhooks.md
+++ b/docs/stream/13-recording-webhooks.md
@@ -494,7 +494,7 @@ sequenceDiagram
     participant Stream as Stream S3
     participant Supa as Supabase Storage
 
-    Cron->>DB: Get expiring recordings (3 days out)
+    Cron->>DB: Get READY permanent recordings (14-day window)
     DB-->>Cron: Recording list
 
     loop Each Recording
@@ -502,7 +502,7 @@ sequenceDiagram
         Transfer->>DB: Update status = TRANSFERRING
 
         Transfer->>Stream: Download video file
-        Stream-->>Transfer: Video data (blob)
+        Stream-->>Transfer: Video data (streamed body, #899)
 
         alt File too large (>500MB)
             Transfer->>DB: Revert to READY
@@ -524,7 +524,7 @@ sequenceDiagram
 | ------------------- | ------------ | ------------------------------------- |
 | `MAX_TRANSFER_SIZE` | 500MB        | Maximum file size for direct transfer |
 | `RECORDINGS_BUCKET` | "recordings" | Supabase storage bucket name          |
-| `daysBeforeExpiry`  | 3            | Days before expiry to start transfer  |
+| `daysBeforeExpiry`  | 5            | Days before expiry to start transfer (default). The production jobs pass 14 — the full Stream URL lifetime — so every READY permanent recording is swept near-ready rather than near-expiry (#899). |
 | `batchSize`         | 10           | Max recordings per cron run           |
 
 ### Storage Path Format
@@ -874,7 +874,7 @@ import { RecordingTransferService } from "@/lib/stream/recording-transfer-servic
 
 async function processExpiringRecordings() {
   const result = await RecordingTransferService.processExpiringRecordings(
-    3, // daysBeforeExpiry
+    14, // daysBeforeExpiry — full Stream URL lifetime, sweeps near-ready (#899)
     10, // batchSize
   );
 

--- a/jobs/stream/transfer-expiring-recordings.ts
+++ b/jobs/stream/transfer-expiring-recordings.ts
@@ -67,10 +67,12 @@ async function main(): Promise<void> {
       "transfer-expiring-recordings",
       { failMode: "open" },
       async () => {
-        // Auto-transfer SUPABASE_PERMANENT recordings expiring in 5 days
+        // #899 — 14-day window = every READY permanent recording (Stream URLs
+        // live exactly 14d), so the sweep starts transfers near-ready and
+        // backstops ready-time webhook kicks that died, not just near-expiry.
         const result =
           await RecordingTransferService.processExpiringRecordings(
-            5,
+            14,
             10,
             "SUPABASE_PERMANENT",
           );
@@ -85,6 +87,25 @@ async function main(): Promise<void> {
     // STR-3 — warn consultants whose STREAM_ONLY recordings are about to expire.
     if (expiringStreamOnly.length > 0) {
       await notifyConsultantsOfExpiringRecordings(expiringStreamOnly);
+    }
+
+    // #899 — backlog alert: permanent recordings <72h from Stream expiry that
+    // this sweep still left untransferred. Non-zero means the pipeline is
+    // falling behind or failing repeatedly; page before the bytes lapse.
+    const atRisk =
+      await RecordingTransferService.countAtRiskPermanentRecordings(72);
+    if (atRisk > 0) {
+      console.warn(
+        `⚠️ ${atRisk} permanent recording(s) <72h from Stream expiry, still untransferred`,
+      );
+      Sentry.captureMessage(
+        "Permanent recordings at risk of Stream URL expiry",
+        {
+          level: "warning",
+          tags: { subsystem: "jobs", job: "transfer-expiring-recordings" },
+          extra: { atRisk },
+        },
+      );
     }
 
     const duration = (Date.now() - startTime) / 1000;

--- a/lib/meeting.ts
+++ b/lib/meeting.ts
@@ -51,69 +51,6 @@ export interface MeetingAppointment {
 }
 
 /**
- * Creates a new meeting (This function might need less usage now)
- * @param client The Stream Video client
- * @param options Meeting options. `organizationId` (optional) stamps the
- *   Stream Video call's `custom.organizationId` for #B2 enterprise tagging
- *   so org workspace operators can later list calls scoped to their org. Omit (or pass
- *   `null`) for personal meetings — the key is left out entirely so older
- *   calls don't accumulate stray null fields.
- * @returns The meeting ID (Stream Call ID)
- */
-export const createMeeting = async (
-  client: StreamVideoClient,
-  options: {
-    title: string;
-    dateTime?: Date;
-    description?: string;
-    link?: string;
-    organizationId?: string | null;
-  },
-) => {
-  if (!client) {
-    throw new Error("Stream client not initialized");
-  }
-
-  try {
-    const id = crypto.randomUUID();
-    const call: Call = client.call("default", id);
-
-    if (!call) {
-      throw new Error("Failed to create call");
-    }
-
-    const startsAt =
-      options.dateTime?.toISOString() ?? new Date(Date.now()).toISOString();
-    const description = options.description ?? "Instant Meeting";
-
-    // Build custom payload — only include `organizationId` when set so
-    // legacy calls (no org) remain shape-compatible. camelCase here mirrors
-    // the existing video-call custom data convention (appointmentId/slotId).
-    const custom: Record<string, unknown> = {
-      title: options.title,
-      description: description,
-      link: options.link,
-      ...(options.organizationId
-        ? { organizationId: options.organizationId }
-        : {}),
-    };
-
-    await call.getOrCreate({
-      data: {
-        starts_at: startsAt,
-        custom,
-      },
-    });
-
-    return id;
-  } catch (error) {
-    console.error("Error creating meeting:", error);
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "stream" } });
-    throw error;
-  }
-};
-
-/**
  * Gets an existing meeting session ID from the DB or creates a new Stream call
  * and corresponding DB session if one doesn't exist for the appointment slot.
  * Uses server actions for DB operations.

--- a/lib/stream/recording-handlers.ts
+++ b/lib/stream/recording-handlers.ts
@@ -3,6 +3,7 @@
  * Handles webhook events for recording lifecycle
  */
 
+import { after } from "next/server";
 import prisma from "@/lib/prisma";
 import { RecordingStatus } from "@prisma/client";
 import { streamLogger } from "@/lib/stream-logger";
@@ -311,18 +312,23 @@ export async function handleRecordingReady(
     });
 
     // #899 — permanent-policy recordings start transferring at ready-time
-    // (fire-and-forget, mirrors the notify pattern below) instead of waiting
-    // for the near-expiry window; the 6-hourly cron sweep backstops any kick
-    // that dies with the function.
+    // instead of waiting for the near-expiry window. The transfer is the heavy
+    // Stream-S3-download + Supabase-upload, so it runs via `after()` (not a bare
+    // `void`) — on serverless an unawaited promise is killed once the webhook
+    // response returns, which would drop the kick; `after()` keeps it alive past
+    // the response. The 6-hourly cron sweep still backstops any kick that dies
+    // with the function.
     const storagePolicy =
       appointment?.webinar?.webinarPlan?.recordingStoragePolicy ??
       appointment?.class?.classPlan?.recordingStoragePolicy;
     if (storagePolicy === "SUPABASE_PERMANENT") {
-      void RecordingTransferService.queueRecordingTransfer(recording.id).catch(
-        (err) =>
-          streamLogger.error("Ready-time transfer kick threw", err, {
-            recordingId: recording.id,
-          }),
+      after(() =>
+        RecordingTransferService.queueRecordingTransfer(recording.id).catch(
+          (err) =>
+            streamLogger.error("Ready-time transfer kick threw", err, {
+              recordingId: recording.id,
+            }),
+        ),
       );
     }
 
@@ -359,15 +365,19 @@ export async function handleRecordingReady(
           "Unknown Consultant";
       }
 
-      void notifyRecordingAvailable(userIds, {
-        appointmentType,
-        consultantName,
-        recordingUrl: url,
-        dashboardUrl: `${getAppUrl()}/dashboard`,
-      }).catch((err) =>
-        streamLogger.error("Failed to send recording notification", err, {
-          streamCallId,
-        }),
+      // Same serverless rationale as the transfer kick above: run the
+      // notification via `after()` so it survives the webhook response.
+      after(() =>
+        notifyRecordingAvailable(userIds, {
+          appointmentType,
+          consultantName,
+          recordingUrl: url,
+          dashboardUrl: `${getAppUrl()}/dashboard`,
+        }).catch((err) =>
+          streamLogger.error("Failed to send recording notification", err, {
+            streamCallId,
+          }),
+        ),
       );
     }
   } catch (error) {

--- a/lib/stream/recording-handlers.ts
+++ b/lib/stream/recording-handlers.ts
@@ -15,6 +15,7 @@ import {
   generateRecordingTitle,
   getEventAttendeeIds,
 } from "@/lib/stream/recording-utils";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 
 // Types for Stream webhook payloads
 export interface StreamRecordingStartedEvent {
@@ -308,6 +309,22 @@ export async function handleRecordingReady(
       title,
       durationInMinutes,
     });
+
+    // #899 — permanent-policy recordings start transferring at ready-time
+    // (fire-and-forget, mirrors the notify pattern below) instead of waiting
+    // for the near-expiry window; the 6-hourly cron sweep backstops any kick
+    // that dies with the function.
+    const storagePolicy =
+      appointment?.webinar?.webinarPlan?.recordingStoragePolicy ??
+      appointment?.class?.classPlan?.recordingStoragePolicy;
+    if (storagePolicy === "SUPABASE_PERMANENT") {
+      void RecordingTransferService.queueRecordingTransfer(recording.id).catch(
+        (err) =>
+          streamLogger.error("Ready-time transfer kick threw", err, {
+            recordingId: recording.id,
+          }),
+      );
+    }
 
     // Build recipient list — for webinar/class, include all enrolled attendees
     // (the meeting session slot only has the consultant's allocation slot users)

--- a/lib/stream/recording-transfer-service.ts
+++ b/lib/stream/recording-transfer-service.ts
@@ -21,7 +21,9 @@ const RECORDINGS_BUCKET = "recordings";
 const storageClient = supabaseAdmin || supabase;
 
 // Maximum file size for direct transfer (500MB)
-// Files larger than this should use resumable uploads (future enhancement)
+// #899 — uploads now stream (no in-memory buffering), but the recordings
+// bucket is provisioned with a 500MB fileSizeLimit, so keep the pre-flight
+// reject to fail fast instead of burning a full upload into a server 413.
 const MAX_TRANSFER_SIZE = 500 * 1024 * 1024; // 500MB
 
 // STR-2/3 — page engineering once a recording has burned through this many
@@ -79,27 +81,26 @@ function buildStoragePolicyFilter(
 
 export class RecordingTransferService {
   /**
-   * Queue a recording for transfer to Supabase
+   * Queue a recording for transfer to Supabase.
+   *
+   * #899 — no broker: "queueing" is an immediate best-effort transfer,
+   * fired from the recording_ready webhook so permanent recordings move
+   * near-ready instead of near-expiry. Every failure path in
+   * transferRecordingToSupabase reverts status to READY, and the stale-
+   * TRANSFERRING sweep in processExpiringRecordings recovers kicks that die
+   * mid-flight, so the 6-hourly cron always backstops this.
    * @param recordingId The recording ID to queue
    */
   static async queueRecordingTransfer(recordingId: string): Promise<boolean> {
-    try {
-      // Update status to TRANSFERRING
-      await prisma.recording.update({
-        where: { id: recordingId },
-        data: {
-          status: "TRANSFERRING" as RecordingStatus,
-        },
-      });
-
-      streamLogger.info("Recording queued for transfer", { recordingId });
-      return true;
-    } catch (error) {
-      streamLogger.error("Failed to queue recording for transfer", error, {
+    const { success, error } =
+      await this.transferRecordingToSupabase(recordingId);
+    if (!success) {
+      streamLogger.warn("Ready-time transfer kick failed; cron will retry", {
         recordingId,
+        error,
       });
-      return false;
     }
+    return success;
   }
 
   /**
@@ -270,13 +271,15 @@ export class RecordingTransferService {
         storagePath,
       });
 
-      // Use blob() instead of arrayBuffer() for more efficient memory handling
-      // Blob is more memory-efficient in most JS runtimes for large files
-      const fileBlob = await response.blob();
+      // #899 — pipe the download straight into the storage upload instead of
+      // materializing the file (response.blob() buffered up to 500MB in
+      // memory). storage-js accepts ReadableStream and sets duplex:"half"
+      // itself; blob() is only the fallback for a body-less response.
+      const uploadBody = response.body ?? (await response.blob());
 
       const { error: uploadError } = await storageClient.storage
         .from(RECORDINGS_BUCKET)
-        .upload(storagePath, fileBlob, {
+        .upload(storagePath, uploadBody, {
           contentType,
           cacheControl: "31536000", // 1 year cache
           upsert: true,
@@ -362,6 +365,23 @@ export class RecordingTransferService {
     };
 
     try {
+      // #899 — recover transfers killed mid-flight (serverless webhook kick,
+      // crashed cron run): TRANSFERRING with no update for 2h is stuck, and
+      // nothing else ever revisits it. Revert to READY so this sweep retries.
+      const stale = await prisma.recording.updateMany({
+        where: {
+          status: "TRANSFERRING",
+          storageType: "STREAM_S3",
+          updatedAt: { lt: new Date(Date.now() - 2 * 60 * 60 * 1000) },
+        },
+        data: { status: "READY" as RecordingStatus },
+      });
+      if (stale.count > 0) {
+        streamLogger.warn("Reset stale TRANSFERRING recordings to READY", {
+          count: stale.count,
+        });
+      }
+
       const expiringRecordings = await prisma.recording.findMany({
         where: {
           storageType: "STREAM_S3",
@@ -383,18 +403,29 @@ export class RecordingTransferService {
         policyFilter,
       });
 
-      for (const recording of expiringRecordings) {
-        results.processed++;
+      // #899 — network-bound transfers in chunks of 3: cuts sweep latency
+      // without piling memory/connection pressure onto one invocation.
+      // transferRecordingToSupabase never throws, so Promise.all is safe.
+      const CONCURRENCY = 3;
+      for (let i = 0; i < expiringRecordings.length; i += CONCURRENCY) {
+        const chunk = expiringRecordings.slice(i, i + CONCURRENCY);
+        const outcomes = await Promise.all(
+          chunk.map(async (recording) => ({
+            id: recording.id,
+            result: await this.transferRecordingToSupabase(recording.id),
+          })),
+        );
 
-        const result = await this.transferRecordingToSupabase(recording.id);
-
-        if (result.success) {
-          results.succeeded++;
-        } else {
-          results.failed++;
-          results.errors.push(
-            `Recording ${recording.id}: ${result.error || "Unknown error"}`,
-          );
+        for (const { id, result } of outcomes) {
+          results.processed++;
+          if (result.success) {
+            results.succeeded++;
+          } else {
+            results.failed++;
+            results.errors.push(
+              `Recording ${id}: ${result.error || "Unknown error"}`,
+            );
+          }
         }
       }
 
@@ -405,6 +436,28 @@ export class RecordingTransferService {
       streamLogger.error("Failed to process expiring recordings", error);
       return results;
     }
+  }
+
+  /**
+   * #899 — count permanent-policy recordings still on Stream S3 with less
+   * than `hoursBeforeExpiry` of URL life left. Non-zero after a sweep means
+   * the pipeline is falling behind or failing repeatedly; the transfer job
+   * pages on it before the bytes lapse.
+   */
+  static async countAtRiskPermanentRecordings(
+    hoursBeforeExpiry: number = 72,
+  ): Promise<number> {
+    const threshold = new Date(
+      Date.now() + hoursBeforeExpiry * 60 * 60 * 1000,
+    );
+    return prisma.recording.count({
+      where: {
+        storageType: "STREAM_S3",
+        status: "READY",
+        streamUrlExpiresAt: { lte: threshold, gt: new Date() },
+        ...buildStoragePolicyFilter("SUPABASE_PERMANENT"),
+      },
+    });
   }
 
   /**

--- a/scripts/cleanup/cleanup-old-stream-recordings.ts
+++ b/scripts/cleanup/cleanup-old-stream-recordings.ts
@@ -13,6 +13,10 @@
  * per-recording. The local tombstone is what makes the dashboard
  * stop offering the URL; the underlying S3 object is Stream's problem.
  *
+ * Supabase objects ARE ours, though (#899): recordings already moved to
+ * the permanent bucket get their object deleted before the tombstone,
+ * otherwise the bytes outlive the retention window (DPDP gap).
+ *
  * Schedule: daily at 03:00 UTC (avoids the 02:00 abandoned-top-ups
  * slot + the 02:30 reconcile-ledgers slot — Prisma connection pool
  * contention).
@@ -21,6 +25,7 @@
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
 import { withCronLock } from "@/lib/cron/with-cron-lock";
+import { RecordingTransferService } from "@/lib/stream/recording-transfer-service";
 
 export interface StreamRetentionResult {
   scanned: number;
@@ -72,7 +77,7 @@ async function cleanupOldStreamRecordingsUnlocked(): Promise<StreamRetentionResu
         createdAt: { lt: cutoff },
         status: { notIn: ["EXPIRED", "FAILED"] },
       },
-      select: { id: true },
+      select: { id: true, supabasePath: true },
     });
     result.scanned += candidates.length;
     if (candidates.length === 0) {
@@ -84,10 +89,41 @@ async function cleanupOldStreamRecordingsUnlocked(): Promise<StreamRetentionResu
       continue;
     }
 
+    // DPDP (#899) — purge the Supabase object before tombstoning the row; an
+    // EXPIRED row with bytes still in the bucket is orphaned storage and a
+    // retention violation. A failed delete keeps its row un-tombstoned so
+    // tomorrow's run retries the pair together.
+    const tombstoneIds: string[] = [];
+    for (const candidate of candidates) {
+      if (!candidate.supabasePath) {
+        tombstoneIds.push(candidate.id);
+        continue;
+      }
+      const del = await RecordingTransferService.deleteRecordingFromSupabase(
+        candidate.id,
+      );
+      if (del.success) {
+        tombstoneIds.push(candidate.id);
+      } else {
+        result.success = false;
+        result.errors.push(
+          `org=${org.id} recording=${candidate.id}: ${del.error}`,
+        );
+      }
+    }
+    if (tombstoneIds.length === 0) {
+      result.cutoffsByOrg.push({
+        organizationId: org.id,
+        retentionDays: org.streamRecordingRetentionDays,
+        expiredCount: 0,
+      });
+      continue;
+    }
+
     try {
       await prisma.$transaction(async (tx) => {
         await tx.recording.updateMany({
-          where: { id: { in: candidates.map((c) => c.id) } },
+          where: { id: { in: tombstoneIds } },
           data: { status: "EXPIRED" },
         });
         await tx.orgAuditLog.create({
@@ -95,20 +131,20 @@ async function cleanupOldStreamRecordingsUnlocked(): Promise<StreamRetentionResu
             organizationId: org.id,
             category: "SYSTEM",
             action: AUDIT_ACTIONS.SYSTEM.STREAM_RECORDING_DELETED,
-            description: `Tombstoned ${candidates.length} recording(s) past ${org.streamRecordingRetentionDays}d retention`,
+            description: `Tombstoned ${tombstoneIds.length} recording(s) past ${org.streamRecordingRetentionDays}d retention`,
             details: {
               cutoff: cutoff.toISOString(),
               retentionDays: org.streamRecordingRetentionDays,
-              count: candidates.length,
+              count: tombstoneIds.length,
             },
           },
         });
       });
-      result.expired += candidates.length;
+      result.expired += tombstoneIds.length;
       result.cutoffsByOrg.push({
         organizationId: org.id,
         retentionDays: org.streamRecordingRetentionDays,
-        expiredCount: candidates.length,
+        expiredCount: tombstoneIds.length,
       });
     } catch (err) {
       result.success = false;

--- a/scripts/cleanup/cleanup-old-stream-recordings.ts
+++ b/scripts/cleanup/cleanup-old-stream-recordings.ts
@@ -94,22 +94,37 @@ async function cleanupOldStreamRecordingsUnlocked(): Promise<StreamRetentionResu
     // retention violation. A failed delete keeps its row un-tombstoned so
     // tomorrow's run retries the pair together.
     const tombstoneIds: string[] = [];
+
+    // Rows without a Supabase object need no storage call — tombstone directly.
     for (const candidate of candidates) {
       if (!candidate.supabasePath) {
         tombstoneIds.push(candidate.id);
-        continue;
       }
-      const del = await RecordingTransferService.deleteRecordingFromSupabase(
-        candidate.id,
+    }
+
+    // #899 — network-bound Supabase deletes (read + storage remove + write) in
+    // bounded chunks, mirroring processExpiringRecordings' transfer sweep, so a
+    // large candidate set can't serialise into a timeout or exhaust the pool.
+    const supabaseCandidates = candidates.filter((c) => c.supabasePath);
+    const CONCURRENCY = 5;
+    for (let i = 0; i < supabaseCandidates.length; i += CONCURRENCY) {
+      const chunk = supabaseCandidates.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        chunk.map(async (candidate) => {
+          const del =
+            await RecordingTransferService.deleteRecordingFromSupabase(
+              candidate.id,
+            );
+          if (del.success) {
+            tombstoneIds.push(candidate.id);
+          } else {
+            result.success = false;
+            result.errors.push(
+              `org=${org.id} recording=${candidate.id}: ${del.error}`,
+            );
+          }
+        }),
       );
-      if (del.success) {
-        tombstoneIds.push(candidate.id);
-      } else {
-        result.success = false;
-        result.errors.push(
-          `org=${org.id} recording=${candidate.id}: ${del.error}`,
-        );
-      }
     }
     if (tombstoneIds.length === 0) {
       result.cutoffsByOrg.push({


### PR DESCRIPTION
Phase-0 "stop the bleeding" fixes from the CTO sub-audit (bugs/stream/recording-storage-scale-infrastructure.md). **Supabase stays the permanent store — no S3/external storage** (product decision).

- Wire the dead `queueRecordingTransfer()` so `SUPABASE_PERMANENT` recordings enqueue immediately on `recording_ready` (`lib/stream/recording-handlers.ts`); cron is now a backstop sweeper.
- Stream uploads to Supabase instead of buffering the whole file with `response.blob()` (`lib/stream/recording-transfer-service.ts`) — removes the OOM path.
- Retention now deletes the Supabase object via `deleteRecordingFromSupabase` (was zero-callers) in `scripts/cleanup/cleanup-old-stream-recordings.ts` — closes the orphan-bytes + DPDP gap.
- Bounded transfer concurrency (was sequential); backlog alert for permanent recordings within 72h of expiry; 3-vs-5-day doc drift fixed; dead `createMeeting()` removed.

Part of #899. Type-check via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)