### PR TITLE
fix(enterprise): onboarding/SSO CAS, SCIM seat governance, session revocation

### DIFF
--- a/app/api/organizations/[orgId]/sso/route.ts
+++ b/app/api/organizations/[orgId]/sso/route.ts
@@ -114,12 +114,20 @@ export async function PATCH(
 
       // Optimistic lock — two admins editing SSO settings from stale tabs
       // would last-write-wins the enforcement/domain config without this.
-      // CAS takes the row lock, serializing the upsert below behind it. Only
-      // meaningful once a row exists; the create path is guarded by the
-      // organizationId unique constraint.
-      if (existing && body.expectedVersion !== undefined) {
+      // The version bump is UNCONDITIONAL on any settings write to an
+      // existing row: it is the increment (not the caller's expectedVersion)
+      // that makes a concurrent stale writer's CAS miss. expectedVersion only
+      // gates the 409 conflict check — a client that supplies it opts into
+      // failing fast, but omitting it must never silently bypass the clock.
+      // The create path is guarded by the organizationId unique constraint.
+      if (existing) {
         const cas = await tx.organizationSSOSettings.updateMany({
-          where: { organizationId: orgId, version: body.expectedVersion },
+          where: {
+            organizationId: orgId,
+            ...(body.expectedVersion !== undefined && {
+              version: body.expectedVersion,
+            }),
+          },
           data: { version: { increment: 1 } },
         });
         if (cas.count === 0) {

--- a/app/api/organizations/[orgId]/sso/route.ts
+++ b/app/api/organizations/[orgId]/sso/route.ts
@@ -35,8 +35,11 @@ const PatchBodySchema = z
     // = "OWNER"` would make the first SSO user co-owner. See audit
     // Phase A.1 + docs/enterprise/20-iam-and-security/01-sso-and-authentication.md.
     defaultRoleForAutoJoin: JitDefaultRoleSchema.optional(),
+    // Optimistic-lock clock. When present, a concurrent admin PATCH that
+    // already bumped the version 409s instead of silently clobbering.
+    expectedVersion: z.coerce.number().int().min(1).optional(),
   })
-  .refine((v) => Object.keys(v).length > 0, {
+  .refine((v) => Object.keys(v).filter((k) => k !== "expectedVersion").length > 0, {
     message: "PATCH body must contain at least one field",
   });
 
@@ -75,6 +78,7 @@ export async function GET(
       allowedEmailDomains: [],
       enforceSSO: false,
       defaultRoleForAutoJoin: "LEARNER",
+      version: 1,
     },
     providers: providers.map(({ samlConfig, oidcConfig, ...rest }) => ({
       ...rest,
@@ -107,6 +111,30 @@ export async function PATCH(
       const existing = await tx.organizationSSOSettings.findUnique({
         where: { organizationId: orgId },
       });
+
+      // Optimistic lock — two admins editing SSO settings from stale tabs
+      // would last-write-wins the enforcement/domain config without this.
+      // CAS takes the row lock, serializing the upsert below behind it. Only
+      // meaningful once a row exists; the create path is guarded by the
+      // organizationId unique constraint.
+      if (existing && body.expectedVersion !== undefined) {
+        const cas = await tx.organizationSSOSettings.updateMany({
+          where: { organizationId: orgId, version: body.expectedVersion },
+          data: { version: { increment: 1 } },
+        });
+        if (cas.count === 0) {
+          throw Object.assign(
+            new Error(
+              "SSO settings were changed in another session — reload and retry",
+            ),
+            {
+              httpStatus: 409,
+              code: "VERSION_CONFLICT",
+              currentVersion: existing.version,
+            },
+          );
+        }
+      }
 
       // Enforcing SSO without at least one allowed domain OR an SSO
       // provider would lock every user out of the org. Catch it here.
@@ -209,7 +237,22 @@ export async function PATCH(
     if (err instanceof Error && "httpStatus" in err) {
       const status =
         typeof err.httpStatus === "number" ? err.httpStatus : 500;
-      return NextResponse.json({ error: err.message }, { status });
+      // VERSION_CONFLICT carries currentVersion so the client can
+      // refetch-and-retry without an extra GET.
+      const code =
+        "code" in err && typeof err.code === "string" ? err.code : undefined;
+      const currentVersion =
+        "currentVersion" in err && typeof err.currentVersion === "number"
+          ? err.currentVersion
+          : undefined;
+      return NextResponse.json(
+        {
+          error: err.message,
+          ...(code && { code }),
+          ...(currentVersion !== undefined && { currentVersion }),
+        },
+        { status },
+      );
     }
     Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "enterprise" } });
     throw err;

--- a/app/scim/v2/Users/route.ts
+++ b/app/scim/v2/Users/route.ts
@@ -9,6 +9,7 @@
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { requireScimAuth } from "@/lib/scim/auth";
 import { scimError } from "@/lib/scim/errors";
@@ -140,6 +141,20 @@ export async function POST(req: NextRequest) {
       return scimError(
         403,
         `Seat cap reached — verify a domain to provision more than ${UNVERIFIED_ORG_SEAT_CAP} members.`,
+      );
+    }
+    // Concurrent provisioning of the same user raced past the membership
+    // lookup; the (userId, organizationId) unique index is the backstop.
+    // Idempotent — the member already exists — so surface RFC 7644's
+    // uniqueness conflict rather than a 500 the IdP would keep retrying.
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return scimError(
+        409,
+        "User is already provisioned in this organization",
+        "uniqueness",
       );
     }
     throw err;

--- a/app/scim/v2/Users/route.ts
+++ b/app/scim/v2/Users/route.ts
@@ -14,6 +14,10 @@ import { requireScimAuth } from "@/lib/scim/auth";
 import { scimError } from "@/lib/scim/errors";
 import { createOrReprovisionScimUser } from "@/lib/scim/operations";
 import { toScimUser } from "@/lib/scim/resource-user";
+import {
+  DomainVerificationRequiredError,
+  UNVERIFIED_ORG_SEAT_CAP,
+} from "@/lib/enterprise/governance";
 
 const SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User";
 const SCIM_LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
@@ -118,15 +122,28 @@ export async function POST(req: NextRequest) {
     .map((g) => (typeof g === "string" ? g : (g.value ?? g.display ?? "")))
     .filter((s): s is string => s.length > 0);
 
-  const result = await createOrReprovisionScimUser(prisma, {
-    organizationId,
-    userName,
-    givenName: body.name?.givenName,
-    familyName: body.name?.familyName,
-    active: body.active ?? true,
-    externalId: body.externalId,
-    groupNames,
-  });
+  let result: Awaited<ReturnType<typeof createOrReprovisionScimUser>>;
+  try {
+    result = await createOrReprovisionScimUser(prisma, {
+      organizationId,
+      userName,
+      givenName: body.name?.givenName,
+      familyName: body.name?.familyName,
+      active: body.active ?? true,
+      externalId: body.externalId,
+      groupNames,
+    });
+  } catch (err) {
+    // Unverified-org seat cap — surface as a permanent SCIM error so the
+    // IdP's provisioning report tells the admin to verify a domain.
+    if (err instanceof DomainVerificationRequiredError) {
+      return scimError(
+        403,
+        `Seat cap reached — verify a domain to provision more than ${UNVERIFIED_ORG_SEAT_CAP} members.`,
+      );
+    }
+    throw err;
+  }
 
   if ("kind" in result) {
     if (result.kind === "USER_ERASED") {

--- a/lib/api/organizations/membership-transitions.ts
+++ b/lib/api/organizations/membership-transitions.ts
@@ -136,12 +136,17 @@ export async function applyMembershipRoleEffects(
  * Why we don't force logout
  * -------------------------
  * The UX cost of "you've been signed out, please log in again" is high
- * relative to the marginal security benefit. Role *downgrades* (the
- * stale-OWNER-session risk) are typically followed by an explicit
- * member-removal flow that calls BetterAuth's `revokeSession` — the
- * harder kill. The bump pattern handles the middle case: role changed,
- * membership still active, session payload must reflect the new role
- * within a single round-trip.
+ * relative to the marginal security benefit, so removal uses this same
+ * generation bump rather than a hard session kill. There is no
+ * server-side revoke-by-userId available: the `admin` plugin (which
+ * exposes `auth.api.revokeUserSessions({ body: { userId } })`) is not
+ * installed, and core BetterAuth `revokeSession`/`revokeSessions` need
+ * the target user's own session token/headers — which an admin removing
+ * someone else does not hold. This code also runs inside a Prisma
+ * `$transaction`, where a BetterAuth API call (writing outside the tx)
+ * would be unsound. So membership removal, role downgrade, and
+ * soft-suspend all rely on the bump: the next request through
+ * `customSession` sees the stale generation and refetches.
  *
  * Failure mode if not called
  * --------------------------

--- a/lib/scim/operations.ts
+++ b/lib/scim/operations.ts
@@ -26,6 +26,11 @@ import {
   bumpUserSessionGeneration,
 } from "@/lib/api/organizations/membership-transitions";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import {
+  DomainVerificationRequiredError,
+  UNVERIFIED_ORG_SEAT_CAP,
+  hasVerifiedDomain,
+} from "@/lib/enterprise/governance";
 import { dispatchWebhookEvent } from "@/lib/enterprise/outbound-webhooks/dispatch";
 import { resolveRoleFromGroupNames } from "./resource-user";
 
@@ -201,6 +206,25 @@ export async function createOrReprovisionScimUser(
         role: updated.role,
         status: updated.status,
       } satisfies ScimUserOpResult;
+    }
+
+    // #675 parity with the invite path — an unverified org is hard-capped at
+    // UNVERIFIED_ORG_SEAT_CAP seats; SCIM auto-provisioning must honor the same
+    // gate or an IdP could bulk-provision straight past it. Only brand-new
+    // seats count (reprovisions returned above). Throw (not a CONFLICT return)
+    // so the User/profile writes above roll back instead of orphaning.
+    if (!(await hasVerifiedDomain(tx, organizationId))) {
+      const [activeMembers, pendingInvites] = await Promise.all([
+        tx.membership.count({
+          where: { organizationId, status: "ACTIVE" },
+        }),
+        tx.invitation.count({
+          where: { organizationId, status: "pending" },
+        }),
+      ]);
+      if (activeMembers + pendingInvites >= UNVERIFIED_ORG_SEAT_CAP) {
+        throw new DomainVerificationRequiredError("BULK_SEATS");
+      }
     }
 
     const created = await tx.membership.create({

--- a/lib/scim/operations.ts
+++ b/lib/scim/operations.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type { PrismaLike } from "@/lib/prisma";
 /**
  * SCIM 2.0 User operations — `createUser`, `patchUser`, `deprovisionUser`,
@@ -113,6 +114,12 @@ export async function createOrReprovisionScimUser(
     return { kind: "USER_ERASED", userId: existingUser.id };
   }
 
+  // Serializable, matching the invite path (organizations/[orgId]/
+  // invitations): the seat-cap gate below is a count-then-create TOCTOU
+  // that a parallel IdP provisioning burst could slip past at READ
+  // COMMITTED. Serializable makes concurrent transactions that both read
+  // the seat counts and insert fail one side at commit (P2034) instead of
+  // both overshooting UNVERIFIED_ORG_SEAT_CAP.
   return prisma.$transaction(async (tx) => {
     const user = existingUser
       ? await tx.user.update({
@@ -276,7 +283,7 @@ export async function createOrReprovisionScimUser(
       role: created.role,
       status: created.status,
     } satisfies ScimUserOpResult;
-  });
+  }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
 }
 
 /**

--- a/utils/onboarding-server.ts
+++ b/utils/onboarding-server.ts
@@ -591,56 +591,83 @@ export async function processOnboardingData(
     // onboardingCompleted flag at launch. This path now only handles
     // CONSULTANT / CONSULTEE / STAFF / ADMIN profiles.
 
-    const updatedUser = await prisma.$transaction(
-      async (tx) => {
-        const baseUserData: Prisma.UserUpdateInput = {
-          ...buildUserUpdateData(validatedBody),
-          // Reset profile IDs (will be set by profileFkData)
-          consultantProfileId: null,
-          consulteeProfileId: null,
-          staffProfileId: null,
-          adminProfileId: null,
-        };
-
-        const profileFkData = await upsertProfileByRole(
-          userId,
-          validatedBody,
-          tx,
-        );
-
-        await persistProfessionalBackground(
-          userId,
-          profileFkData.consultantProfileId,
-          body as Record<string, unknown>,
-          tx,
-        );
-
-        const user = await tx.user.update({
-          where: { id: userId },
-          data: { ...baseUserData, ...profileFkData },
-          include: {
-            consultantProfile: {
-              include: {
-                slotsOfAvailabilityWeekly: true,
-                slotsOfAvailabilityCustom: true,
-                domain: true,
-                subDomains: true,
-                tags: true,
-              },
-            },
-            consulteeProfile: true,
-            workExperiences: true,
-            education: true,
-            certifications: true,
-            staffProfile: true,
-            adminProfile: true,
-          },
-        });
-
-        return user;
+    const onboardingUserInclude = {
+      consultantProfile: {
+        include: {
+          slotsOfAvailabilityWeekly: true,
+          slotsOfAvailabilityCustom: true,
+          domain: true,
+          subDomains: true,
+          tags: true,
+        },
       },
-      { maxWait: 15000, timeout: 45000 },
-    );
+      consulteeProfile: true,
+      workExperiences: true,
+      education: true,
+      certifications: true,
+      staffProfile: true,
+      adminProfile: true,
+    } satisfies Prisma.UserInclude;
+
+    let updatedUser: Prisma.UserGetPayload<{
+      include: typeof onboardingUserInclude;
+    }>;
+    try {
+      updatedUser = await prisma.$transaction(
+        async (tx) => {
+          const baseUserData: Prisma.UserUpdateInput = {
+            ...buildUserUpdateData(validatedBody),
+            // Reset profile IDs (will be set by profileFkData)
+            consultantProfileId: null,
+            consulteeProfileId: null,
+            staffProfileId: null,
+            adminProfileId: null,
+          };
+
+          const profileFkData = await upsertProfileByRole(
+            userId,
+            validatedBody,
+            tx,
+          );
+
+          await persistProfessionalBackground(
+            userId,
+            profileFkData.consultantProfileId,
+            body as Record<string, unknown>,
+            tx,
+          );
+
+          const user = await tx.user.update({
+            // #724, #840: CAS guard — only apply the role/profile transition
+            // while the user is still un-onboarded, so two devices onboarding
+            // the same email can't last-write-wins each other. A no-match
+            // throws P2025 and rolls back the whole tx (incl. profile upserts).
+            where: { id: userId, onboardingCompleted: { not: true } },
+            data: { ...baseUserData, ...profileFkData },
+            include: onboardingUserInclude,
+          });
+
+          return user;
+        },
+        { maxWait: 15000, timeout: 45000 },
+      );
+    } catch (error: unknown) {
+      // #724, #840: another device already completed onboarding for this user;
+      // treat as idempotent success rather than clobbering their transition.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        const existing = await prisma.user.findUnique({
+          where: { id: userId },
+          include: onboardingUserInclude,
+        });
+        if (existing?.onboardingCompleted) {
+          return { success: true, user: existing };
+        }
+      }
+      throw error;
+    }
 
     // Post-transaction: consultant verification
     let verificationWarning: string | undefined;


### PR DESCRIPTION
Concurrency-hardening for the onboarding + enterprise identity surface. Kills last-write-wins races and closes a seat-governance bypass. Part of #724, #840.

## Fixes

### 1. Onboarding submit CAS (last-write-wins)
`utils/onboarding-server.ts:618` did an unconditional `tx.user.update({ where: { id } })` at final submit, so two devices onboarding the same email raced with last-write-wins on role/profile. Added a compare-and-swap guard `where: { id, onboardingCompleted: { not: true } }`: the transition only applies while the user is still un-onboarded. A no-match throws P2025 and rolls back the whole transaction (including the profile upserts); the outer handler treats an already-completed user as idempotent success (first-write-wins) instead of clobbering.

### 2. SSO settings version CAS
`app/api/organizations/[orgId]/sso/route.ts` upserted SSO settings with no version check despite `OrganizationSSOSettings.version` existing. Added an optional `expectedVersion` in the PATCH body and an optimistic-lock `updateMany` CAS inside the transaction (increments version, takes the row lock), mirroring the canonical `Organization.version` pattern in `app/api/organizations/[orgId]/route.ts`. A stale-tab PATCH now 409s with `code: VERSION_CONFLICT` + `currentVersion` instead of silently overwriting.

### 3. SCIM seat governance bypass
`lib/scim/operations.ts` (behind `app/scim/v2/Users/route.ts` POST) created memberships without the 5-seat unverified-org cap that the invite path enforces in `app/api/organizations/[orgId]/invitations/route.ts`. Applied the same `hasVerifiedDomain` + `UNVERIFIED_ORG_SEAT_CAP` guard (active members + pending invites) in the new-membership branch; it throws to roll back the User/profile writes rather than orphan them, and the route surfaces a SCIM 403 so the IdP's provisioning report tells the admin to verify a domain. Reprovisions of existing memberships are unaffected.

### 4. revokeSession comment was fiction — corrected (path b)
`lib/api/organizations/membership-transitions.ts:141` claimed the removal flow "calls BetterAuth's `revokeSession`", but no such call exists anywhere and the real mechanism is `bumpUserSessionGeneration`. I could **not** implement a real revoke (path a): the BetterAuth `admin` plugin — which exposes `auth.api.revokeUserSessions({ body: { userId } })`, the only revoke-by-userId API — is not installed, core `revokeSession`/`revokeSessions` require the target user's own session token/headers (an admin removing someone else does not hold them), and the code runs inside a Prisma `$transaction` where a BetterAuth out-of-tx write would be unsound. So I took **path (b)**: corrected the misleading comment to accurately describe the generation-bump mechanism (customSession reader honors it) with the 24h cookie-cache window as backstop.

## Verification
`tsc --noEmit` passes clean (EXIT=0, node@22, 12GB heap). No `prisma/schema.prisma` changes — the `version` column already existed on `OrganizationSSOSettings`, and onboarding CAS reuses the existing `onboardingCompleted` column.

Part of #724, #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)