### PR TITLE
feat(waitlist): seat soft-hold after notify + transactional join

### DIFF
--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -55,9 +55,12 @@ export async function POST(request: NextRequest) {
     });
 
     if (!result.success) {
+      // Friendly 409 for the already-on-waitlist conflict (incl. the concurrent
+      // double-join race that P2002 catches); everything else is a 400.
+      const status = result.code === "ALREADY_ON_WAITLIST" ? 409 : 400;
       return NextResponse.json(
         { success: false, error: result.message },
-        { status: 400 },
+        { status },
       );
     }
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -37,7 +37,10 @@ import {
   isUserEnrolled,
   countWebinarParticipants,
 } from "@/lib/payments/utils/participants";
-import { markWaitlistAsBooked } from "@/lib/waitlist/slot-handler";
+import {
+  markWaitlistAsBooked,
+  countWaitlistHolds,
+} from "@/lib/waitlist/slot-handler";
 import { getExchangeRates } from "@/lib/currency";
 import {
   applyCreditsToPayment,
@@ -1274,7 +1277,18 @@ async function revalidateInsideLock(
           [consultantUserId || ""],
         );
 
-        if (currentParticipants >= webinar.webinarPlan.maxParticipants) {
+        // #837 — count NOTIFIED waitlist holds (seats offered to waitlisted
+        // users) so an FCFS buyer can't take one; exclude this buyer's own hold
+        // so a waitlisted user's fromWaitlist checkout still fits.
+        const webinarHolds = await countWaitlistHolds(tx, {
+          webinarId: data.eventId,
+          excludeUserId: userId,
+        });
+
+        if (
+          currentParticipants + webinarHolds >=
+          webinar.webinarPlan.maxParticipants
+        ) {
           throw new Error("Webinar is full");
         }
         break;
@@ -1310,7 +1324,16 @@ async function revalidateInsideLock(
           ownerUserId ? [ownerUserId] : [],
         );
 
-        if (currentParticipants >= classInstance.classPlan.maxParticipants) {
+        // #837 — count NOTIFIED waitlist holds; exclude this buyer's own.
+        const classHolds = await countWaitlistHolds(tx, {
+          classId: data.eventId,
+          excludeUserId: userId,
+        });
+
+        if (
+          currentParticipants + classHolds >=
+          classInstance.classPlan.maxParticipants
+        ) {
           throw new Error("Class is full");
         }
         break;
@@ -1600,10 +1623,17 @@ export async function handleWebinarCheckout(
     consultantUserId || "",
   ]);
 
+  // #837 — NOTIFIED waitlist holds occupy seats; exclude this buyer's own hold
+  // so a waitlisted user's fromWaitlist checkout still fits.
+  const webinarHolds = await countWaitlistHolds(tx, {
+    webinarId: webinar.id,
+    excludeUserId: userId,
+  });
+
   // Check if max participants reached
   // NOTE: Waitlist creation happens OUTSIDE the transaction in handleCheckout's catch block,
   // because creating it here (inside the transaction) would be rolled back on throw.
-  if (currentParticipants >= plan.maxParticipants) {
+  if (currentParticipants + webinarHolds >= plan.maxParticipants) {
     throw new Error("Webinar is full");
   }
 
@@ -1725,10 +1755,16 @@ export async function handleClassCheckout(
     consultantUserId ? [consultantUserId] : [],
   );
 
+  // #837 — NOTIFIED waitlist holds occupy seats; exclude this buyer's own.
+  const classHolds = await countWaitlistHolds(tx, {
+    classId: classInstance.id,
+    excludeUserId: userId,
+  });
+
   // Check if max participants reached
   // NOTE: Waitlist creation happens OUTSIDE the transaction in handleCheckout's catch block,
   // because creating it here (inside the transaction) would be rolled back on throw.
-  if (currentParticipants >= plan.maxParticipants) {
+  if (currentParticipants + classHolds >= plan.maxParticipants) {
     throw new Error("Class is full");
   }
 

--- a/lib/waitlist/slot-handler.ts
+++ b/lib/waitlist/slot-handler.ts
@@ -5,7 +5,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
-import { WaitlistStatus } from "@prisma/client";
+import { Prisma, WaitlistStatus } from "@prisma/client";
 import {
   getNextBatchInQueue,
   updatePositions,
@@ -16,6 +16,40 @@ import { countWebinarParticipants } from "@/lib/payments/utils/participants";
 
 // Notification window in hours (48 hours to respond)
 const NOTIFICATION_WINDOW_HOURS = 48;
+
+/**
+ * #837 seat soft-hold. A NOTIFIED waitlist entry inside its response window IS
+ * the held seat — the notified user has an exclusive offer to take it, so
+ * capacity checks must count these holds or an FCFS buyer grabs a seat already
+ * promised to a waitlisted user. Release needs no explicit step: decline/skip/
+ * leave/expire all move the row out of NOTIFIED (or past expiresAt), dropping
+ * the count. Webinar/class seats are shared-slot user-connections (isTentative
+ * is per-slot, not per-user), so the NOTIFIED status — not a tentative slot —
+ * is the only schema-free way to hold one seat for one user.
+ *
+ * `excludeUserId` drops the caller's OWN hold so a notified user's fromWaitlist
+ * checkout isn't rejected by the very seat being reserved for them.
+ */
+export async function countWaitlistHolds(
+  db: Prisma.TransactionClient,
+  params: {
+    webinarId?: string | null;
+    classId?: string | null;
+    excludeUserId?: string;
+  },
+): Promise<number> {
+  const { webinarId, classId, excludeUserId } = params;
+  if (!webinarId && !classId) return 0;
+  return db.waitlist.count({
+    where: {
+      status: WaitlistStatus.NOTIFIED,
+      ...(webinarId ? { webinarId } : { classId }),
+      ...(excludeUserId ? { userId: { not: excludeUserId } } : {}),
+      // A NOTIFIED row past its window isn't a live hold (expiry cron can lag).
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+  });
+}
 
 // Type for slot opening params
 export interface SlotOpeningParams {
@@ -224,9 +258,10 @@ export async function handleWaitlistResponse(params: {
 
   switch (action) {
     case "ACCEPT": {
-      // Mark as accepted (actual booking will happen through checkout)
-      // We don't mark as BOOKED yet - that happens after successful payment
-      // For now, redirect them to checkout with a reserved spot
+      // #837 — the seat is already held: the entry stays NOTIFIED through the
+      // response window and countWaitlistHolds() blocks FCFS buyers from taking
+      // it at checkout. So we can safely redirect to checkout without racing.
+      // Booking is stamped BOOKED only after successful payment.
 
       const eventType = entry.webinarId ? "webinar" : "class";
       const planId = entry.webinar?.webinarPlan.id || entry.class?.classPlan.id;
@@ -407,8 +442,12 @@ export async function checkEventAvailability(params: {
     );
     const maxParticipants = webinar.webinarPlan.maxParticipants;
 
+    // #837 — held seats (NOTIFIED offers) count against availability so we
+    // don't tell a new user "register directly" for a seat already reserved.
+    const holds = await countWaitlistHolds(prisma, { webinarId });
+
     return {
-      available: currentParticipants < maxParticipants,
+      available: currentParticipants + holds < maxParticipants,
       currentParticipants,
       maxParticipants,
       waitlistCount: webinar.waitlist.length,
@@ -460,8 +499,11 @@ export async function checkEventAvailability(params: {
     const currentParticipants = uniqueParticipantIds.size;
     const maxParticipants = classInstance.classPlan.maxParticipants;
 
+    // #837 — held seats (NOTIFIED offers) count against availability.
+    const holds = await countWaitlistHolds(prisma, { classId });
+
     return {
-      available: currentParticipants < maxParticipants,
+      available: currentParticipants + holds < maxParticipants,
       currentParticipants,
       maxParticipants,
       waitlistCount: classInstance.waitlist.length,
@@ -483,6 +525,8 @@ export async function joinWaitlist(params: {
   success: boolean;
   waitlistId?: string;
   position?: number;
+  // Set on friendly conflicts so the route can map to HTTP 409, not a 500.
+  code?: "ALREADY_ON_WAITLIST";
   message: string;
 }> {
   const { userId, webinarId, classId, preferences } = params;
@@ -514,6 +558,7 @@ export async function joinWaitlist(params: {
   if (existingEntry) {
     return {
       success: false,
+      code: "ALREADY_ON_WAITLIST",
       message: "You are already on the waitlist for this event",
     };
   }
@@ -529,16 +574,34 @@ export async function joinWaitlist(params: {
     };
   }
 
-  // Create waitlist entry
-  const entry = await prisma.waitlist.create({
-    data: {
-      userId,
-      webinarId,
-      classId,
-      preferences: preferences as object | undefined,
-      status: WaitlistStatus.WAITING,
-    },
-  });
+  // Create waitlist entry. The WAITING/NOTIFIED pre-check above is a race
+  // window — two concurrent joins both pass it, then @@unique([userId,
+  // webinarId])/([userId, classId]) rejects the loser with P2002. Catch it and
+  // return the same friendly conflict instead of a generic 500.
+  let entry: Awaited<ReturnType<typeof prisma.waitlist.create>>;
+  try {
+    entry = await prisma.waitlist.create({
+      data: {
+        userId,
+        webinarId,
+        classId,
+        preferences: preferences as object | undefined,
+        status: WaitlistStatus.WAITING,
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        code: "ALREADY_ON_WAITLIST",
+        message: "You are already on the waitlist for this event",
+      };
+    }
+    throw error;
+  }
 
   // Calculate position using priority-based queue
   const position = await calculatePosition(entry.id);


### PR DESCRIPTION
Closes the seat-hold-after-notify gap from the CTO sub-audit (bugs/waitlist).

## Fix 1 — Seat soft-hold after notify (`lib/waitlist/slot-handler.ts:226`)
Previously ACCEPT just built a `/checkout/...?fromWaitlist=` URL with no inventory held, so "your spot is available" was an FCFS race under contention.

A NOTIFIED waitlist entry inside its response window now IS the held seat — the notified user has an exclusive offer, so capacity checks count it. New `countWaitlistHolds()` (`slot-handler.ts`) counts live NOTIFIED holds and is added to the participant count at every capacity gate:
- `checkout.ts` WEBINAR/CLASS re-validation (inside the Serializable tx + distributed lock)
- `handleWebinarCheckout` / `handleClassCheckout` (the authoritative allocation)
- `checkEventAvailability` (so we don't tell a new user "register directly" for a reserved seat)

The buyer's own hold is excluded (`excludeUserId`) so a notified user's `fromWaitlist` checkout still fits. Release needs no new code: decline/skip/leave/expire already move the row out of NOTIFIED (or past `expiresAt`) under the existing #834 CAS guards, so the hold count drops automatically.

**Hold mechanism:** reuses the existing NOTIFIED status as the per-user reservation. Webinar/class seats are shared-slot user-connections and `isTentative` is per-slot (not per-user), so a tentative slot can't hold one seat for one user — NOTIFIED is the only schema-free hold that fits. Enforcement is CAS-safe: it only reads counts inside the same locked/serializable tx that already guards allocation.

## Fix 2 — Transactional join with friendly conflict (`slot-handler.ts:506`, `app/api/waitlist/route.ts`)
`findFirst`-then-`create` outside a tx relied on `@@unique([userId, webinarId])`/`([userId, classId])`; a concurrent double-join threw P2002 → generic 500. Now the create catches P2002 and returns an `ALREADY_ON_WAITLIST` code that the route maps to a friendly **409**, matching the pre-check message.

## Schema
No `schema.prisma` changes — the hold reuses the existing `WaitlistStatus.NOTIFIED` + `expiresAt`.

## #834 tag
Not `Closes #834`. #834's scope (slot-assignment CAS, partial multi-session enrollment, missing SlotOfAppointment↔User unique constraint) already shipped and is unrelated to this post-notify hold gap. Tagged **Part of #837**.

Local `tsc --noEmit` could not complete on this 8 GB box (cold-run OOM, exit 144, even on node@22 + 12 GB heap — the documented env trap); changes are mechanical and type-reviewed, full type-check defers to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
