### PR TITLE
fix(reviews): integrity + rating-denorm correctness + drop email from public search

### DIFF
--- a/app/api/staff/moderation/reviews/[reviewId]/route.ts
+++ b/app/api/staff/moderation/reviews/[reviewId]/route.ts
@@ -6,6 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 
 import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+import { recomputeConsultantRating } from "@/lib/reviews";
 interface RouteParams {
   params: Promise<{ reviewId: string }>;
 }
@@ -38,24 +39,10 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
 
     // Delete review and recalculate consultant rating
     await prisma.$transaction(async (tx) => {
-      // Delete the review
       await tx.consultantReview.delete({
         where: { id: reviewId },
       });
-
-      // Recalculate average rating
-      const remainingReviews = await tx.consultantReview.aggregate({
-        where: { consultantProfileId: review.consultantProfileId },
-        _avg: { rating: true },
-        _count: { id: true },
-      });
-
-      await tx.consultantProfile.update({
-        where: { id: review.consultantProfileId },
-        data: {
-          rating: remainingReviews._avg.rating || 0,
-        },
-      });
+      await recomputeConsultantRating(tx, review.consultantProfileId);
     });
 
     return NextResponse.json({

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -125,7 +125,8 @@ export async function GET(request: NextRequest) {
       conditions.push({
         OR: [
           { user: { name: { contains: search, mode: "insensitive" } } },
-          { user: { email: { contains: search, mode: "insensitive" } } },
+          // No email match here — this is a public endpoint and email
+          // substring search is a PII enumeration key.
           { description: { contains: search, mode: "insensitive" } },
           { headline: { contains: search, mode: "insensitive" } },
           { domain: { name: { contains: search, mode: "insensitive" } } },

--- a/app/api/user/reviews/[id]/route.ts
+++ b/app/api/user/reviews/[id]/route.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import {
   requireApiAuth,
@@ -8,6 +9,8 @@ import {
   forbiddenResponse,
 } from "@/lib/auth-helpers";
 import { recomputeConsultantRating } from "@/lib/reviews";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
+import { UpdateReviewSchema } from "@/schemas/feedbacks";
 
 // GET: Public read (for trust/SEO purposes)
 export async function GET(
@@ -73,26 +76,41 @@ export async function PUT(
       return forbiddenResponse("You can only update your own reviews");
     }
 
-    const body = await req.json();
+    const parsed = UpdateReviewSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const body = parsed.data;
+
     // Update + rating recompute in one transaction — ConsultantProfile.rating
     // is denormalized for explore sort/filter and must track every mutation.
-    const updatedReview = await prisma.$transaction(async (tx) => {
-      const updated = await tx.consultantReview.update({
-        where: { id: id },
-        data: {
-          rating: body.rating,
-          reviewDescription: body.reviewDescription,
-        },
-        include: {
-          consultantProfile: true,
-          consulteeProfile: true,
-        },
-      });
+    // Serializable + retry so concurrent review writes for the same consultant
+    // can't lose-update the recomputed average (P2034 aborts one, retry blocks).
+    const updatedReview = await withSerializableRetry(() =>
+      prisma.$transaction(
+        async (tx) => {
+          const updated = await tx.consultantReview.update({
+            where: { id: id },
+            data: {
+              rating: body.rating,
+              reviewDescription: body.reviewDescription,
+            },
+            include: {
+              consultantProfile: true,
+              consulteeProfile: true,
+            },
+          });
 
-      await recomputeConsultantRating(tx, review.consultantProfileId);
+          await recomputeConsultantRating(tx, review.consultantProfileId);
 
-      return updated;
-    });
+          return updated;
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
 
     return NextResponse.json(updatedReview, { status: 200 });
   } catch (error) {
@@ -139,12 +157,17 @@ export async function DELETE(
     }
 
     // Delete + rating recompute in one transaction — see PUT.
-    await prisma.$transaction(async (tx) => {
-      await tx.consultantReview.delete({
-        where: { id: id },
-      });
-      await recomputeConsultantRating(tx, review.consultantProfileId);
-    });
+    await withSerializableRetry(() =>
+      prisma.$transaction(
+        async (tx) => {
+          await tx.consultantReview.delete({
+            where: { id: id },
+          });
+          await recomputeConsultantRating(tx, review.consultantProfileId);
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
 
     return NextResponse.json(
       { message: "Review deleted successfully" },

--- a/app/api/user/reviews/[id]/route.ts
+++ b/app/api/user/reviews/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   checkOwnership,
   forbiddenResponse,
 } from "@/lib/auth-helpers";
+import { recomputeConsultantRating } from "@/lib/reviews";
 
 // GET: Public read (for trust/SEO purposes)
 export async function GET(
@@ -55,7 +56,7 @@ export async function PUT(
     // Fetch the review to check ownership
     const review = await prisma.consultantReview.findUnique({
       where: { id: id },
-      select: { consulteeProfileId: true },
+      select: { consulteeProfileId: true, consultantProfileId: true },
     });
 
     if (!review) {
@@ -73,16 +74,24 @@ export async function PUT(
     }
 
     const body = await req.json();
-    const updatedReview = await prisma.consultantReview.update({
-      where: { id: id },
-      data: {
-        rating: body.rating,
-        reviewDescription: body.reviewDescription,
-      },
-      include: {
-        consultantProfile: true,
-        consulteeProfile: true,
-      },
+    // Update + rating recompute in one transaction — ConsultantProfile.rating
+    // is denormalized for explore sort/filter and must track every mutation.
+    const updatedReview = await prisma.$transaction(async (tx) => {
+      const updated = await tx.consultantReview.update({
+        where: { id: id },
+        data: {
+          rating: body.rating,
+          reviewDescription: body.reviewDescription,
+        },
+        include: {
+          consultantProfile: true,
+          consulteeProfile: true,
+        },
+      });
+
+      await recomputeConsultantRating(tx, review.consultantProfileId);
+
+      return updated;
     });
 
     return NextResponse.json(updatedReview, { status: 200 });
@@ -112,7 +121,7 @@ export async function DELETE(
     // Fetch the review to check ownership
     const review = await prisma.consultantReview.findUnique({
       where: { id: id },
-      select: { consulteeProfileId: true },
+      select: { consulteeProfileId: true, consultantProfileId: true },
     });
 
     if (!review) {
@@ -129,8 +138,12 @@ export async function DELETE(
       return forbiddenResponse("You can only delete your own reviews");
     }
 
-    await prisma.consultantReview.delete({
-      where: { id: id },
+    // Delete + rating recompute in one transaction — see PUT.
+    await prisma.$transaction(async (tx) => {
+      await tx.consultantReview.delete({
+        where: { id: id },
+      });
+      await recomputeConsultantRating(tx, review.consultantProfileId);
     });
 
     return NextResponse.json(

--- a/app/api/user/reviews/route.ts
+++ b/app/api/user/reviews/route.ts
@@ -11,6 +11,7 @@ import {
   hasCompletedBookingWith,
   recomputeConsultantRating,
 } from "@/lib/reviews";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
 
 export async function GET(req: NextRequest) {
   try {
@@ -140,8 +141,11 @@ export async function POST(req: NextRequest) {
     }
 
     // Create + rating recompute in one transaction so the denormalized
-    // ConsultantProfile.rating (explore sort/filter) never drifts.
-    const newReview = await prisma.$transaction(async (tx) => {
+    // ConsultantProfile.rating (explore sort/filter) never drifts. Serializable
+    // + retry so two concurrent reviews for the same consultant can't lose-update
+    // the recomputed average (P2034 aborts one, retry then sees the committed row).
+    const newReview = await withSerializableRetry(() =>
+      prisma.$transaction(async (tx) => {
       const created = await tx.consultantReview.create({
         data: {
           rating: validatedData.rating,
@@ -175,7 +179,10 @@ export async function POST(req: NextRequest) {
       await recomputeConsultantRating(tx, created.consultantProfileId);
 
       return created;
-    });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
 
     // Notify the consultant about the new review
     void notifyNewReview(newReview.consultantProfile.userId, {

--- a/app/api/user/reviews/route.ts
+++ b/app/api/user/reviews/route.ts
@@ -7,6 +7,10 @@ import { CreateReviewSchema } from "@/schemas/feedbacks";
 import { apiError } from "@/lib/errors";
 import { getSession } from "@/lib/auth-server";
 import { spamLimiter, applyRateLimit } from "@/lib/rate-limit";
+import {
+  hasCompletedBookingWith,
+  recomputeConsultantRating,
+} from "@/lib/reviews";
 
 export async function GET(req: NextRequest) {
   try {
@@ -104,34 +108,73 @@ export async function POST(req: NextRequest) {
     }
     const validatedData = result.data;
 
-    const newReview = await prisma.consultantReview.create({
-      data: {
-        rating: validatedData.rating,
-        reviewDescription: validatedData.reviewDescription,
-        consultantProfileId: validatedData.consultantProfileId,
-        consulteeProfileId: validatedData.consulteeProfileId,
-      },
-      include: {
-        consultantProfile: {
-          include: {
-            user: {
-              select: {
-                name: true,
+    // Reviews are always authored as the session user's own consultee
+    // profile — the body's consulteeProfileId is only accepted if it matches.
+    const sessionConsulteeProfileId = session.user.consulteeProfileId;
+    if (!sessionConsulteeProfileId) {
+      return NextResponse.json(
+        { error: "You need a consultee profile to post a review" },
+        { status: 403 },
+      );
+    }
+    if (validatedData.consulteeProfileId !== sessionConsulteeProfileId) {
+      return NextResponse.json(
+        { error: "You can only post reviews as yourself" },
+        { status: 403 },
+      );
+    }
+
+    // Only consultees with a completed booking may review the consultant.
+    const eligible = await hasCompletedBookingWith(
+      sessionConsulteeProfileId,
+      validatedData.consultantProfileId,
+    );
+    if (!eligible) {
+      return NextResponse.json(
+        {
+          error:
+            "You can only review consultants after a completed session with them",
+        },
+        { status: 403 },
+      );
+    }
+
+    // Create + rating recompute in one transaction so the denormalized
+    // ConsultantProfile.rating (explore sort/filter) never drifts.
+    const newReview = await prisma.$transaction(async (tx) => {
+      const created = await tx.consultantReview.create({
+        data: {
+          rating: validatedData.rating,
+          reviewDescription: validatedData.reviewDescription,
+          consultantProfileId: validatedData.consultantProfileId,
+          consulteeProfileId: sessionConsulteeProfileId,
+        },
+        include: {
+          consultantProfile: {
+            include: {
+              user: {
+                select: {
+                  name: true,
+                },
+              },
+            },
+          },
+          consulteeProfile: {
+            include: {
+              user: {
+                select: {
+                  name: true,
+                  image: true,
+                },
               },
             },
           },
         },
-        consulteeProfile: {
-          include: {
-            user: {
-              select: {
-                name: true,
-                image: true,
-              },
-            },
-          },
-        },
-      },
+      });
+
+      await recomputeConsultantRating(tx, created.consultantProfileId);
+
+      return created;
     });
 
     // Notify the consultant about the new review
@@ -145,6 +188,16 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(newReview, { status: 201 });
   } catch (error) {
+    // @@unique([consultantProfileId, consulteeProfileId]) — one review per pair.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "You have already reviewed this consultant" },
+        { status: 409 },
+      );
+    }
     Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "auth" } });
     return apiError({ tag: "[Reviews.POST]", error });
   }

--- a/lib/reviews.ts
+++ b/lib/reviews.ts
@@ -1,0 +1,88 @@
+import prisma, { type Tx } from "@/lib/prisma";
+
+/**
+ * Recomputes the denormalized ConsultantProfile.rating after a review
+ * mutation. Explore sort (orderByForSort) and the minRating filter read this
+ * column, so every create/update/delete must call it or ratings drift.
+ * Accepts a transaction client so the recompute stays atomic with the
+ * mutation that triggered it.
+ */
+export async function recomputeConsultantRating(
+  tx: Tx,
+  consultantProfileId: string,
+): Promise<void> {
+  const agg = await tx.consultantReview.aggregate({
+    where: { consultantProfileId },
+    _avg: { rating: true },
+  });
+
+  await tx.consultantProfile.update({
+    where: { id: consultantProfileId },
+    data: { rating: agg._avg.rating ?? 0 },
+  });
+}
+
+/**
+ * Review eligibility: the consultee must have at least one completed booking
+ * with the consultant. "Completed" means a Consultation or Subscription whose
+ * status reached COMPLETED (or that has at least one held session — a slot
+ * with completionStatus COMPLETED, which covers in-flight subscriptions), or
+ * a trial that reached COMPLETED/CONVERTED.
+ */
+export async function hasCompletedBookingWith(
+  consulteeProfileId: string,
+  consultantProfileId: string,
+): Promise<boolean> {
+  const completedBooking = {
+    OR: [
+      { status: "COMPLETED" as const },
+      {
+        appointment: {
+          slotsOfAppointment: {
+            some: { completionStatus: "COMPLETED" as const },
+          },
+        },
+      },
+    ],
+  };
+
+  const [consultation, subscription, trial] = await Promise.all([
+    prisma.consultation.findFirst({
+      where: {
+        requestedById: consulteeProfileId,
+        consultationPlan: { consultantProfileId },
+        ...completedBooking,
+      },
+      select: { id: true },
+    }),
+    prisma.subscription.findFirst({
+      where: {
+        requestedById: consulteeProfileId,
+        subscriptionPlan: { consultantProfileId },
+        OR: [
+          { status: "COMPLETED" },
+          {
+            appointments: {
+              some: {
+                slotsOfAppointment: {
+                  some: { completionStatus: "COMPLETED" },
+                },
+              },
+            },
+          },
+        ],
+      },
+      select: { id: true },
+    }),
+    prisma.trialSession.findFirst({
+      where: {
+        consulteeProfileId,
+        consultantProfileId,
+        status: { in: ["COMPLETED", "CONVERTED"] },
+      },
+      select: { id: true },
+    }),
+  ]);
+
+  return Boolean(consultation || subscription || trial);
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2349,10 +2349,13 @@ model ConsultantReview {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // One review per consultee per consultant — POST maps P2002 here to 409.
+  @@unique([consultantProfileId, consulteeProfileId])
   // #696 — explore "trending" sort orders ConsultantProfile by
   // reviews._count; without this the per-profile aggregate seq-scans the
   // whole review table. Also serves the FK join + rating>=4 social-proof reads.
-  @@index([consultantProfileId])
+  // (The @@unique above already prefixes consultantProfileId, so no separate
+  // single-column index is needed for it.)
   @@index([consulteeProfileId])
 }
 

--- a/schemas/feedbacks.ts
+++ b/schemas/feedbacks.ts
@@ -22,3 +22,9 @@ export const CreateReviewSchema = z.object({
   consultantProfileId: z.string().min(1, "Consultant profile ID is required"),
   consulteeProfileId: z.string().min(1, "Consultee profile ID is required"),
 });
+
+// PUT only mutates the two consultee-owned fields; a partial keeps either optional.
+export const UpdateReviewSchema = CreateReviewSchema.pick({
+  rating: true,
+  reviewDescription: true,
+}).partial();


### PR DESCRIPTION
Review-subsystem correctness from the CTO sub-audit (bugs/feedback-reviews).

- **Ownership:** `POST /api/user/reviews` no longer trusts `consulteeProfileId` from the body — derived from the session (anyone could previously review-as-anyone).
- **Eligibility:** review create now requires a completed booking with that consultant.
- **Uniqueness:** `@@unique([consultantProfileId, consulteeProfileId])` on `ConsultantReview`; POST maps P2002 → 409.
- **Rating denorm:** `ConsultantProfile.rating` now recomputes on create/user-update/user-delete (previously only staff-delete did), fixing explore sort/filter drift. Recompute extracted to `lib/reviews.ts`.
- **PII:** dropped `email` from the public consultant-search OR clause (`app/api/user/consultants/route.ts`).

**Schema change** (new `@@unique`) — needs the centralized `prisma db push` at wave end; existing duplicate (consultant,consultee) review rows must be de-duped first (flagged for the pre-push check). Type-check via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)