### PR TITLE
fix(trust-safety): referral #891, notifications idempotency, support dedup, collaborator RBAC, legal + DPDP docs

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -145,13 +145,6 @@ export default function AboutPage() {
               <Separator />
               <div>
                 <p className="text-sm font-semibold text-muted-foreground">
-                  Registered Address
-                </p>
-                <p>{COMPANY_INFO.address}</p>
-              </div>
-              <Separator />
-              <div>
-                <p className="text-sm font-semibold text-muted-foreground">
                   Contact Email
                 </p>
                 <p>

--- a/app/(pages)/constants.ts
+++ b/app/(pages)/constants.ts
@@ -1,8 +1,9 @@
 // Company Information - Update these values with your actual business details
 export const COMPANY_INFO = {
-  name: "[COMPANY NAME]",
-  address: "[ADDRESS]",
+  name: "Practitionist",
+  // TODO: real contact email before launch
   email: "[EMAIL]",
+  // TODO: real contact email before launch
   supportEmail: "[SUPPORT_EMAIL]",
   phone: "[PHONE]",
   jurisdiction: "[JURISDICTION]",

--- a/app/(pages)/contactus/page.tsx
+++ b/app/(pages)/contactus/page.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { Mail, MapPin, Phone, Clock, MessageSquare } from "lucide-react";
+import { Mail, Phone, Clock, MessageSquare } from "lucide-react";
 import {
   COMPANY_INFO,
   PAGE_META,
@@ -51,23 +51,6 @@ export default function ContactUsPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
-                {/* Company Address */}
-                <div className="flex items-start gap-4">
-                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-muted flex items-center justify-center">
-                    <MapPin className="h-5 w-5 text-foreground" />
-                  </div>
-                  <div>
-                    <h3 className="font-semibold mb-1">Address</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {COMPANY_INFO.name}
-                      <br />
-                      {COMPANY_INFO.address}
-                    </p>
-                  </div>
-                </div>
-
-                <Separator />
-
                 {/* Email */}
                 <div className="flex items-start gap-4">
                   <div className="flex-shrink-0 w-10 h-10 rounded-full bg-muted flex items-center justify-center">

--- a/app/(pages)/privacy/page.tsx
+++ b/app/(pages)/privacy/page.tsx
@@ -479,9 +479,6 @@ export default function PrivacyPolicyPage() {
                   <strong>Company Name:</strong> {COMPANY_INFO.name}
                 </p>
                 <p>
-                  <strong>Address:</strong> {COMPANY_INFO.address}
-                </p>
-                <p>
                   <strong>Email:</strong>{" "}
                   <a
                     href={getMailtoLink()}

--- a/app/(pages)/refund/page.tsx
+++ b/app/(pages)/refund/page.tsx
@@ -686,9 +686,6 @@ export default function RefundPolicyPage() {
                   <strong>Company Name:</strong> {COMPANY_INFO.name}
                 </p>
                 <p>
-                  <strong>Address:</strong> {COMPANY_INFO.address}
-                </p>
-                <p>
                   <strong>Email:</strong>{" "}
                   <a
                     href={getMailtoLink()}

--- a/app/(pages)/terms/page.tsx
+++ b/app/(pages)/terms/page.tsx
@@ -623,9 +623,6 @@ export default function TermsPage() {
                   <strong>Company Name:</strong> {COMPANY_INFO.name}
                 </p>
                 <p>
-                  <strong>Address:</strong> {COMPANY_INFO.address}
-                </p>
-                <p>
                   <strong>Email:</strong>{" "}
                   <a
                     href={getMailtoLink()}

--- a/app/api/collaborations/class/[planId]/route.ts
+++ b/app/api/collaborations/class/[planId]/route.ts
@@ -83,7 +83,15 @@ export async function POST(
       );
     }
 
-    const { consultantProfileId, role, revenueSharePercentage } = parsed.data;
+    const {
+      consultantProfileId,
+      role,
+      revenueSharePercentage,
+      canApprovePayment,
+      canViewAnalytics,
+      canEditEvent,
+      canSeeAttendees,
+    } = parsed.data;
 
     if (consultantProfileId === ownerProfile.id) {
       return NextResponse.json(
@@ -116,6 +124,7 @@ export async function POST(
       role,
       revenueSharePercentage,
       ownerProfile.id,
+      { canApprovePayment, canViewAnalytics, canEditEvent, canSeeAttendees },
     );
 
     if (!collab) {

--- a/app/api/collaborations/webinar/[planId]/route.ts
+++ b/app/api/collaborations/webinar/[planId]/route.ts
@@ -84,7 +84,15 @@ export async function POST(
       );
     }
 
-    const { consultantProfileId, role, revenueSharePercentage } = parsed.data;
+    const {
+      consultantProfileId,
+      role,
+      revenueSharePercentage,
+      canApprovePayment,
+      canViewAnalytics,
+      canEditEvent,
+      canSeeAttendees,
+    } = parsed.data;
 
     if (consultantProfileId === ownerProfile.id) {
       return NextResponse.json(
@@ -117,6 +125,7 @@ export async function POST(
       role,
       revenueSharePercentage,
       ownerProfile.id,
+      { canApprovePayment, canViewAnalytics, canEditEvent, canSeeAttendees },
     );
 
     if (!collab) {

--- a/app/api/participants/class/[classId]/route.ts
+++ b/app/api/participants/class/[classId]/route.ts
@@ -40,7 +40,8 @@ export async function GET(
 
   try {
     const { classId } = await params;
-    // Non-privileged users can only view participants for classes they own as consultant
+    // Non-privileged users can view the roster if they own the plan OR are an
+    // accepted collaborator granted canSeeAttendees (#768). Everyone else 404s.
     const classEvent = await prisma.class.findUnique({
       where: {
         id: classId,
@@ -48,8 +49,22 @@ export async function GET(
           ? {}
           : {
               classPlan: {
-                consultantProfileId:
-                  session.user.consultantProfileId ?? "__none__",
+                OR: [
+                  {
+                    consultantProfileId:
+                      session.user.consultantProfileId ?? "__none__",
+                  },
+                  {
+                    collaborators: {
+                      some: {
+                        consultantProfileId:
+                          session.user.consultantProfileId ?? "__none__",
+                        status: "ACCEPTED",
+                        canSeeAttendees: true,
+                      },
+                    },
+                  },
+                ],
               },
             }),
       },

--- a/app/api/participants/class/[classId]/route.ts
+++ b/app/api/participants/class/[classId]/route.ts
@@ -42,7 +42,7 @@ export async function GET(
     const { classId } = await params;
     // Non-privileged users can view the roster if they own the plan OR are an
     // accepted collaborator granted canSeeAttendees (#768). Everyone else 404s.
-    const classEvent = await prisma.class.findUnique({
+    const classEvent = await prisma.class.findFirst({
       where: {
         id: classId,
         ...(isPrivileged(session.user.role)
@@ -160,7 +160,7 @@ export async function DELETE(
     // Ownership check only — the old shape loaded the entire roster
     // (every appointment × every slot × every full User row) just to find
     // the one participant being removed.
-    const classEvent = await prisma.class.findUnique({
+    const classEvent = await prisma.class.findFirst({
       where: {
         id: classId,
         ...(isPrivileged(session.user.role)

--- a/app/api/participants/webinar/[webinarId]/route.ts
+++ b/app/api/participants/webinar/[webinarId]/route.ts
@@ -40,7 +40,8 @@ export async function GET(
 
   try {
     const { webinarId } = await params;
-    // Non-privileged users can only view participants for webinars they own as consultant
+    // Non-privileged users can view the roster if they own the plan OR are an
+    // accepted collaborator granted canSeeAttendees (#768). Everyone else 404s.
     const webinarEvent = await prisma.webinar.findUnique({
       where: {
         id: webinarId,
@@ -48,8 +49,22 @@ export async function GET(
           ? {}
           : {
               webinarPlan: {
-                consultantProfileId:
-                  session.user.consultantProfileId ?? "__none__",
+                OR: [
+                  {
+                    consultantProfileId:
+                      session.user.consultantProfileId ?? "__none__",
+                  },
+                  {
+                    collaborators: {
+                      some: {
+                        consultantProfileId:
+                          session.user.consultantProfileId ?? "__none__",
+                        status: "ACCEPTED",
+                        canSeeAttendees: true,
+                      },
+                    },
+                  },
+                ],
               },
             }),
       },

--- a/app/api/participants/webinar/[webinarId]/route.ts
+++ b/app/api/participants/webinar/[webinarId]/route.ts
@@ -42,7 +42,7 @@ export async function GET(
     const { webinarId } = await params;
     // Non-privileged users can view the roster if they own the plan OR are an
     // accepted collaborator granted canSeeAttendees (#768). Everyone else 404s.
-    const webinarEvent = await prisma.webinar.findUnique({
+    const webinarEvent = await prisma.webinar.findFirst({
       where: {
         id: webinarId,
         ...(isPrivileged(session.user.role)
@@ -155,7 +155,7 @@ export async function DELETE(
     // Ownership check only — the old shape loaded the entire roster
     // (every slot × every full User row) just to find the one participant
     // being removed.
-    const webinarEvent = await prisma.webinar.findUnique({
+    const webinarEvent = await prisma.webinar.findFirst({
       where: {
         id: webinarId,
         ...(isPrivileged(session.user.role)

--- a/app/api/staff/support-tickets/[ticketId]/responses/route.ts
+++ b/app/api/staff/support-tickets/[ticketId]/responses/route.ts
@@ -67,8 +67,11 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     // Update ticket status to IN_PROGRESS if it was OPEN
     // Only update if this is not an internal note
     if (ticket.status === "OPEN" && !validatedData.isInternal) {
-      await prisma.supportTicket.update({
-        where: { id: ticketId },
+      // Status-guarded CAS: a concurrent staff edit that already moved the
+      // ticket off OPEN must not be clobbered back. updateMany is a no-op
+      // (count 0) when the guard misses, so the loser silently yields.
+      await prisma.supportTicket.updateMany({
+        where: { id: ticketId, status: "OPEN" },
         data: {
           status: "IN_PROGRESS",
           // Auto-assign to responding staff if not already assigned

--- a/app/api/user/support-tickets/route.ts
+++ b/app/api/user/support-tickets/route.ts
@@ -169,6 +169,24 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Dedup: a payment-linked ticket reuses any still-open ticket the user
+    // already filed for the same payment. Kept a runtime check (not a schema
+    // unique) — a payment can legitimately spawn a second ticket once the
+    // first is RESOLVED/CLOSED, so uniqueness is scoped to open state.
+    if (validatedData.paymentId) {
+      const existing = await prisma.supportTicket.findFirst({
+        where: {
+          paymentId: validatedData.paymentId,
+          userId: session.user.id,
+          status: { notIn: ["RESOLVED", "CLOSED"] },
+        },
+        include: { responses: true, attachments: true },
+      });
+      if (existing) {
+        return NextResponse.json(existing, { status: 200 });
+      }
+    }
+
     const ticket = await prisma.supportTicket.create({
       data: {
         title: validatedData.title,

--- a/app/api/user/support-tickets/route.ts
+++ b/app/api/user/support-tickets/route.ts
@@ -180,7 +180,17 @@ export async function POST(req: NextRequest) {
           userId: session.user.id,
           status: { notIn: ["RESOLVED", "CLOSED"] },
         },
-        include: { responses: true, attachments: true },
+        // Match the user-facing GET shape: hide internal staff notes
+        include: {
+          responses: {
+            where: { isInternal: false },
+            orderBy: { createdAt: "asc" },
+            include: {
+              user: { select: { name: true, role: true } },
+            },
+          },
+          attachments: { orderBy: { uploadedAt: "desc" } },
+        },
       });
       if (existing) {
         return NextResponse.json(existing, { status: 200 });

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
 import { signUp, useSession, sendVerificationEmail } from "@/lib/auth-client";
-import { setPendingReferral, clearPendingReferral } from "@/lib/pending-referral";
+import { setPendingReferral } from "@/lib/pending-referral";
 import { ssoSigninWithGuard } from "@/lib/sso/signin-with-toast";
 import { GlobeIcon } from "@/components/auth/auth-icons";
 import { SocialLoginButtons } from "@/components/auth/social-login-buttons";
@@ -88,9 +88,10 @@ function SignUpContent() {
   // Persist the referral code at first touch so it survives the OAuth redirect
   // and the email-verification gap; it is applied after authentication on the
   // onboarding landing. #880
+  // #891 — landing here WITHOUT ?ref= must not wipe a previously-stashed code;
+  // an explicit different code simply overwrites the stash.
   useEffect(() => {
     if (refCode) setPendingReferral(refCode);
-    else clearPendingReferral();
   }, [refCode]);
 
   // Show loading while checking session status (fallback for when middleware doesn't catch)

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -69,6 +69,28 @@ function asPlanRole(planType: PlanType, role: string): CollaboratorRole | null {
 /**
  * Invite a collaborator to a webinar or class plan.
  */
+// #768 lockdown #12 — capability booleans, set from invite input. Default
+// false so an unspecified permission is never silently granted.
+// Enforced: canSeeAttendees (participant-roster GET).
+// TODO #768 — enforce canApprovePayment / canViewAnalytics / canEditEvent
+// once collaborator-facing payment-approval, analytics, and event-edit
+// surfaces exist; today they have no endpoint to gate, so only the SET lands.
+export interface CollaboratorPermissions {
+  canApprovePayment?: boolean;
+  canViewAnalytics?: boolean;
+  canEditEvent?: boolean;
+  canSeeAttendees?: boolean;
+}
+
+function normalizePermissions(permissions?: CollaboratorPermissions) {
+  return {
+    canApprovePayment: permissions?.canApprovePayment ?? false,
+    canViewAnalytics: permissions?.canViewAnalytics ?? false,
+    canEditEvent: permissions?.canEditEvent ?? false,
+    canSeeAttendees: permissions?.canSeeAttendees ?? false,
+  };
+}
+
 export async function inviteCollaborator(
   planType: PlanType,
   planId: string,
@@ -76,6 +98,7 @@ export async function inviteCollaborator(
   role: string,
   revenueSharePercentage: number,
   invitedById: string,
+  permissions?: CollaboratorPermissions,
 ): Promise<Collaborator | null> {
   // Validate percentage range
   if (revenueSharePercentage <= 0 || revenueSharePercentage > 90) {
@@ -84,6 +107,8 @@ export async function inviteCollaborator(
 
   const planRole = asPlanRole(planType, role);
   if (!planRole) return null;
+
+  const perms = normalizePermissions(permissions);
 
   // Verify the invited consultant profile exists before creating a collaborator record.
   // Without this check, a stale or fabricated consultantProfileId creates an orphaned row.
@@ -125,6 +150,7 @@ export async function inviteCollaborator(
               status: "PENDING",
               invitedById,
               respondedAt: null,
+              ...perms,
             },
           });
         }
@@ -140,6 +166,7 @@ export async function inviteCollaborator(
           revenueShareBps: pctToBps(revenueSharePercentage),
           status: "PENDING",
           invitedById,
+          ...perms,
         },
       });
     },

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -1,9 +1,12 @@
 /**
- * DPDP (Digital Personal Data Protection Act, 2023) — INDIA COMPLIANCE STUB.
+ * DPDP (Digital Personal Data Protection Act, 2023) — INDIA COMPLIANCE.
  *
- * STATUS: stub. `recordConsent` creates a ConsentArtifact row with a mock
- * hash; `checkConsent` returns `true` unconditionally. Live impl lands in
- * a follow-up PR.
+ * STATUS: consent primitives are LIVE. `recordConsent` writes a ConsentArtifact
+ * row with a real SHA-256 payload hash; `checkConsent` is fail-closed — it
+ * returns `true` only when a non-withdrawn, non-expired artifact exists for the
+ * (user, purpose) pair, else `false`. The substantive operator obligations
+ * below (Consent Manager registration, breach reporting, rights fulfilment)
+ * remain follow-up work.
  *
  * ─────────────────────────────────────────────────────────────────────────
  * LIVE IMPLEMENTATION REQUIREMENTS (follow-up PR)

--- a/lib/novu/service.ts
+++ b/lib/novu/service.ts
@@ -4,6 +4,7 @@
  * Non-throwing: logs errors and returns success/failure status.
  * Pattern follows lib/email.ts (graceful degradation).
  */
+import { createHash } from "node:crypto";
 import * as Sentry from "@sentry/nextjs";
 import { getNovuClient, isNovuConfigured } from "./client";
 import {
@@ -51,13 +52,51 @@ interface TriggerResult {
   error?: Error | string;
 }
 
+// Unconfigured Novu in a deployed env means notifications silently vanish —
+// a console.warn nobody reads is not enough. Local dev stays console-only.
+function reportNotConfigured(workflowId: string): void {
+  console.warn(`[Novu] Not configured. Skipped workflow: ${workflowId}`);
+  if (process.env.NODE_ENV === "production") {
+    Sentry.captureMessage(`[Novu] Not configured — dropped ${workflowId}`, {
+      level: "warning",
+      tags: { subsystem: "novu" },
+    });
+  }
+}
+
+// Deterministic transactionId so app-level retries can't double-notify: Novu
+// rejects a repeated transactionId. Derived from recipient(s) + workflow +
+// canonical payload (the payloads carry the entity ids). `dedupeKey` lets a
+// caller that legitimately re-sends an identical payload (e.g. 24h vs 1h
+// appointment reminders) disambiguate the sends.
+function deriveTransactionId(
+  workflowId: string,
+  recipients: string | string[],
+  payload: NovuPayload,
+  dedupeKey?: string,
+): string {
+  const canonicalPayload = JSON.stringify(
+    Object.fromEntries(
+      Object.entries(payload).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+  );
+  const recipientKey = Array.isArray(recipients)
+    ? [...recipients].sort().join(",")
+    : recipients;
+  const hash = createHash("sha256")
+    .update(`${workflowId}|${recipientKey}|${dedupeKey ?? canonicalPayload}`)
+    .digest("hex");
+  return `${workflowId}:${hash.slice(0, 32)}`;
+}
+
 async function triggerWorkflow<T extends NovuPayload>(
   workflowId: string,
   subscriberId: string,
   payload: T,
+  dedupeKey?: string,
 ): Promise<TriggerResult> {
   if (!isNovuConfigured()) {
-    console.warn(`[Novu] Not configured. Skipped workflow: ${workflowId}`);
+    reportNotConfigured(workflowId);
     return { success: false, error: "Novu not configured" };
   }
 
@@ -67,6 +106,12 @@ async function triggerWorkflow<T extends NovuPayload>(
       workflowId,
       to: subscriberId,
       payload,
+      transactionId: deriveTransactionId(
+        workflowId,
+        subscriberId,
+        payload,
+        dedupeKey,
+      ),
     });
     console.log(`[Novu] Triggered ${workflowId} for ${subscriberId}`);
     return { success: true };
@@ -91,9 +136,10 @@ async function triggerForMultiple<T extends NovuPayload>(
   workflowId: string,
   userIds: string[],
   payload: T,
+  dedupeKey?: string,
 ): Promise<TriggerResult[]> {
   if (!isNovuConfigured()) {
-    console.warn(`[Novu] Not configured. Skipped workflow: ${workflowId}`);
+    reportNotConfigured(workflowId);
     return userIds.map(() => ({
       success: false,
       error: "Novu not configured" as const,
@@ -102,7 +148,7 @@ async function triggerForMultiple<T extends NovuPayload>(
 
   if (userIds.length === 0) return [];
   if (userIds.length === 1)
-    return [await triggerWorkflow(workflowId, userIds[0], payload)];
+    return [await triggerWorkflow(workflowId, userIds[0], payload, dedupeKey)];
 
   const BATCH_SIZE = 100;
   const results: TriggerResult[] = [];
@@ -115,6 +161,12 @@ async function triggerForMultiple<T extends NovuPayload>(
         workflowId,
         to: batch,
         payload,
+        transactionId: deriveTransactionId(
+          workflowId,
+          batch,
+          payload,
+          dedupeKey,
+        ),
       });
       console.log(
         `[Novu] Triggered ${workflowId} for ${batch.length} subscribers`,
@@ -142,7 +194,7 @@ async function triggerBroadcastWorkflow<T extends NovuPayload>(
   payload: T,
 ): Promise<TriggerResult> {
   if (!isNovuConfigured()) {
-    console.warn(`[Novu] Not configured. Skipped broadcast: ${workflowId}`);
+    reportNotConfigured(workflowId);
     return { success: false, error: "Novu not configured" };
   }
 
@@ -211,14 +263,18 @@ export async function notifyAppointmentCompleted(
   );
 }
 
+// `dedupeKey` (appointment + window) keeps the 1h reminder from being
+// swallowed as a duplicate of the 24h one — their payloads are identical.
 export async function notifyAppointmentReminder(
   userIds: string[],
   payload: AppointmentPayload,
+  dedupeKey?: string,
 ) {
   return triggerForMultiple(
     NOVU_WORKFLOWS.APPOINTMENT_REMINDER,
     userIds,
     payload,
+    dedupeKey,
   );
 }
 

--- a/prisma/sql/check-constraints.sql
+++ b/prisma/sql/check-constraints.sql
@@ -162,3 +162,13 @@ ALTER TABLE "ConsultantPayout" DROP CONSTRAINT IF EXISTS "consultant_payout_tds_
 -- SPLIT
 ALTER TABLE "ConsultantPayout" ADD CONSTRAINT "consultant_payout_tds_fy_format"
   CHECK ("tdsFinancialYear" IS NULL OR "tdsFinancialYear" ~ '^[0-9]{4}-[0-9]{2}$');
+
+-- SPLIT
+-- #784 — a Collaborator references exactly one plan: a webinar XOR a class.
+-- The app-level backstop is assertCollaboratorPlanXor in
+-- lib/collaborators/service.ts; this DB CHECK is the last line. Exactly one of
+-- the two FKs is non-NULL <=> exactly one IS NULL, which `<>` expresses.
+ALTER TABLE "Collaborator" DROP CONSTRAINT IF EXISTS "collaborator_plan_xor";
+-- SPLIT
+ALTER TABLE "Collaborator" ADD CONSTRAINT "collaborator_plan_xor"
+  CHECK (("webinarPlanId" IS NULL) <> ("classPlanId" IS NULL));

--- a/schemas/collaborators.ts
+++ b/schemas/collaborators.ts
@@ -20,13 +20,28 @@ export const CLASS_COLLABORATOR_ROLES = [
 export const WebinarCollaboratorRoleEnum = z.enum(WEBINAR_COLLABORATOR_ROLES);
 export const ClassCollaboratorRoleEnum = z.enum(CLASS_COLLABORATOR_ROLES);
 
-export const inviteCollaboratorSchema = z.object({
-  consultantProfileId: z.string().min(1, "Consultant profile ID is required"),
-  revenueSharePercentage: z
-    .number({ required_error: "Revenue share percentage is required" })
-    .gt(0, "Revenue share percentage must be greater than 0")
-    .lte(90, "Revenue share percentage cannot exceed 90"),
+// #768 lockdown #12 — typed permission booleans set at invite time. Default
+// false (least privilege); the owner opts each capability in per collaborator.
+export const collaboratorPermissionsSchema = z.object({
+  canApprovePayment: z.boolean().optional().default(false),
+  canViewAnalytics: z.boolean().optional().default(false),
+  canEditEvent: z.boolean().optional().default(false),
+  canSeeAttendees: z.boolean().optional().default(false),
 });
+
+export type CollaboratorPermissions = z.infer<
+  typeof collaboratorPermissionsSchema
+>;
+
+export const inviteCollaboratorSchema = z
+  .object({
+    consultantProfileId: z.string().min(1, "Consultant profile ID is required"),
+    revenueSharePercentage: z
+      .number({ required_error: "Revenue share percentage is required" })
+      .gt(0, "Revenue share percentage must be greater than 0")
+      .lte(90, "Revenue share percentage cannot exceed 90"),
+  })
+  .merge(collaboratorPermissionsSchema);
 
 export const inviteWebinarCollaboratorSchema = inviteCollaboratorSchema.extend({
   role: WebinarCollaboratorRoleEnum,

--- a/scripts/appointments/send-appointment-reminders.ts
+++ b/scripts/appointments/send-appointment-reminders.ts
@@ -210,14 +210,20 @@ async function sendRemindersForWindow(window: {
 
       const baseUrl = getAppUrl();
 
-      await notifyAppointmentReminder(uniqueUserIds, {
-        appointmentType,
-        consultantName,
-        consulteeName,
-        planTitle,
-        dateTime: slot.startsAt.toISOString(),
-        dashboardUrl: `${baseUrl}/dashboard`,
-      });
+      await notifyAppointmentReminder(
+        uniqueUserIds,
+        {
+          appointmentType,
+          consultantName,
+          consulteeName,
+          planTitle,
+          dateTime: slot.startsAt.toISOString(),
+          dashboardUrl: `${baseUrl}/dashboard`,
+        },
+        // 24h and 1h payloads are identical — key the Novu transactionId by
+        // window so the second reminder isn't deduped away.
+        `${apt.id}:${window.label}`,
+      );
 
       sent++;
     } catch (error) {


### PR DESCRIPTION
Trust & safety sweep — seven scoped correctness/compliance fixes.

## Fixes
1. **Referral stash wipe (#891)** — `app/auth/signup/page.tsx:92`. Landing without `?ref=` no longer clears a previously stashed referral code; only an explicit different code overwrites it. `clearPendingReferral` import dropped.
2. **Novu idempotency + fail-loud** — `lib/novu/service.ts`. Every trigger now carries a deterministic `transactionId` derived from workflow + recipient(s) + payload (or an explicit `dedupeKey`), so app-level retries can't double-notify. Unconfigured Novu in production emits a Sentry `captureMessage` instead of a silent `console.warn`. `scripts/appointments/send-appointment-reminders.ts` passes a per-window `dedupeKey` so the 1h reminder isn't swallowed as a duplicate of the 24h one.
3. **Support dedup + status CAS** — `app/api/user/support-tickets/route.ts:172` reuses an existing open (`status NOT IN RESOLVED/CLOSED`) ticket for the same `paymentId`+user instead of creating a duplicate (runtime check, no schema unique). `app/api/staff/support-tickets/[ticketId]/responses/route.ts:70` OPEN→IN_PROGRESS is now a status-guarded `updateMany` CAS so concurrent staff edits don't clobber.
4. **Collaborator permissions + XOR CHECK** — permission booleans are set at invite time from invite input (`schemas/collaborators.ts`, `lib/collaborators/service.ts`, both `app/api/collaborations/{webinar,class}/[planId]/route.ts`). **Enforced:** `canSeeAttendees` at the participant-roster GETs (`app/api/participants/{webinar,class}/[id]/route.ts`) — an accepted collaborator sees the roster only if granted. **Set-but-not-enforced (no surface yet, terse TODO):** `canApprovePayment`, `canViewAnalytics`, `canEditEvent`. Added the webinar/class XOR to `prisma/sql/check-constraints.sql` (raw-SQL sidecar, mirrors app-level `assertCollaboratorPlanXor`).
5. **Legal constants (supersedes #434)** — `app/(pages)/constants.ts` sets `name: "Practitionist"`, removes the `[ADDRESS]` placeholder and its rendered Registered-Address blocks (about/privacy/terms/contactus/refund; unused `MapPin` import dropped). `email`/`supportEmail` kept as placeholders with a loud `// TODO: real contact email before launch`.
6. **DPDP doc drift** — `lib/compliance/dpdp.ts` header corrected: `checkConsent` is live fail-closed (not "returns true unconditionally") and `recordConsent` writes a real SHA-256 artifact.
7. **Phone Zod** — investigated. Mitigation already exists at both DB write boundaries (`app/form/onboarding/page.tsx` trims to `undefined`; `app/api/user/[id]/route.ts` uses `emptyToUndefined`). The shared `PersonalInfoAndRoleSchema` is unused. No change needed.

## Notes
- `prisma/sql/check-constraints.sql` needs the central migration apply (`npm run db:constraints`) after the next push/reset — it does not self-apply.
- No `prisma/schema.prisma` change; support dedup is a runtime check by design.
- Supersedes (does not close) #434.
- Type-check via CI (local tsc OOM-contended).

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)