### PR TITLE
fix(payments): auto-refund captured-but-blocked funds + wallet-drift freeze

### DIFF
--- a/jobs/reconcile/reconcile-ledgers.ts
+++ b/jobs/reconcile/reconcile-ledgers.ts
@@ -24,6 +24,7 @@ import {
   recordSystemError,
 } from "../../lib/enterprise/system-events";
 import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+import { freezeWalletSpend } from "../../lib/payments/wallet-freeze";
 import * as Sentry from "@sentry/nextjs";
 
 async function main(): Promise<void> {
@@ -102,6 +103,41 @@ async function main(): Promise<void> {
           },
         },
       );
+
+      // #837 — a wallet cache/journal drift means the balance can't be trusted,
+      // so freeze spend on each drifted account (scoped, not platform-wide) and
+      // page P0. Only WALLET_BALANCE_DRIFT freezes; other finding kinds page via
+      // the captureException above but don't gate spend.
+      const walletDrift = report.findings.filter(
+        (f) => f.kind === "WALLET_BALANCE_DRIFT" && f.billingAccountId,
+      );
+      for (const f of walletDrift) {
+        const froze = await freezeWalletSpend({
+          billingAccountId: f.billingAccountId!,
+          organizationId: f.organizationId ?? null,
+          reason: `ledger reconcile ${report.id}: wallet cache ${f.actualPaise}p ≠ journal ${f.expectedPaise}p (Δ${f.deltaPaise}p)`,
+        });
+        Sentry.captureException(
+          new Error(
+            `WALLET_BALANCE_DRIFT — wallet spend frozen for billing account ${f.billingAccountId}`,
+          ),
+          {
+            level: "fatal",
+            tags: { subsystem: "jobs", job: "reconcile-ledgers" },
+            contexts: {
+              wallet: {
+                billingAccountId: f.billingAccountId,
+                organizationId: f.organizationId ?? null,
+                expectedPaise: f.expectedPaise,
+                actualPaise: f.actualPaise,
+                deltaPaise: f.deltaPaise,
+                reportId: report.id,
+                newlyFrozen: froze,
+              },
+            },
+          },
+        );
+      }
       process.exit(2);
     }
   } catch (error) {

--- a/jobs/reconcile/reconcile-ledgers.ts
+++ b/jobs/reconcile/reconcile-ledgers.ts
@@ -128,9 +128,10 @@ async function main(): Promise<void> {
               wallet: {
                 billingAccountId: f.billingAccountId,
                 organizationId: f.organizationId ?? null,
-                expectedPaise: f.expectedPaise,
-                actualPaise: f.actualPaise,
-                deltaPaise: f.deltaPaise,
+                // JSON can't serialize BigInt; walletBalance is BigInt at runtime.
+                expectedPaise: Number(f.expectedPaise),
+                actualPaise: Number(f.actualPaise),
+                deltaPaise: Number(f.deltaPaise),
                 reportId: report.id,
                 newlyFrozen: froze,
               },

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -51,6 +51,7 @@ import {
   type AppointmentType,
 } from "@/lib/payments/payouts";
 import { walletDebit } from "@/lib/api/organizations/wallet";
+import { isWalletFrozen, WalletFrozenError } from "@/lib/payments/wallet-freeze";
 import {
   recordBookingUtilization,
   ProgramAssignmentLimitError,
@@ -2366,6 +2367,13 @@ export async function handleCheckout(
           // Triggered only when we also have a resolved program assignment,
           // which guarantees the booking is actually sponsored.
           if (isOrgWalletPayment && billingAccountId) {
+            // #837 — refuse to spend a wallet whose cache drifted from the
+            // journal (frozen by the ledger-reconcile job): the balance can't
+            // be trusted until ops reconciles. Chargeback recovery is NOT gated
+            // (see wallet-freeze.ts).
+            if (await isWalletFrozen(tx, billingAccountId)) {
+              throw new WalletFrozenError(billingAccountId);
+            }
             await walletDebit(tx, {
               billingAccountId,
               amountPaise: amount,

--- a/lib/payments/wallet-freeze.ts
+++ b/lib/payments/wallet-freeze.ts
@@ -1,0 +1,73 @@
+/**
+ * #837 — wallet-spend freeze, scoped to a single drifted BillingAccount.
+ *
+ * When the ledger-reconcile job finds WALLET_BALANCE_DRIFT (cached
+ * `BillingAccount.walletBalance` ≠ the journal's WALLET account) the balance is
+ * no longer trustworthy, so we must stop spending it until ops reconciles.
+ *
+ * There is no schema column for a per-wallet freeze and the launch schema is
+ * frozen, so the freeze rides the existing append-only `SystemEvent` log rather
+ * than a new column/table:
+ *   - the freeze KEY is the indexed `correlationId` = `wallet-freeze:<billingAccountId>`,
+ *   - the current state is the category of the LATEST event under that key
+ *     (WALLET_FREEZE → frozen, WALLET_UNFREEZE → cleared).
+ * FREEZE is set by the reconcile job; UNFREEZE is a manual ops action once the
+ * drift is fixed. The check is a single indexed DB read inside the caller's tx,
+ * so it fails CLOSED — an unreadable log blocks the spend rather than leaking it.
+ *
+ * Deliberately gates only discretionary SPEND (the checkout booking debit), not
+ * chargeback recovery (app/api/webhooks/utils.ts): a lost-dispute debit recovers
+ * money the bank already pulled and must not be stranded on a drift freeze.
+ */
+
+import prisma, { type PrismaLike } from "@/lib/prisma";
+import { recordSystemEvent } from "@/lib/enterprise/system-events";
+
+const FREEZE_CATEGORY = "WALLET_FREEZE";
+const UNFREEZE_CATEGORY = "WALLET_UNFREEZE";
+const freezeKey = (billingAccountId: string) => `wallet-freeze:${billingAccountId}`;
+
+export class WalletFrozenError extends Error {
+  constructor(public billingAccountId: string) {
+    super(
+      `Wallet spend frozen on billing account ${billingAccountId} pending ledger-drift resolution`,
+    );
+    this.name = "WalletFrozenError";
+  }
+}
+
+/** True when the account's latest freeze event is a FREEZE. Reads inside the
+ *  caller's tx/client so the check shares the spend's snapshot. */
+export async function isWalletFrozen(
+  db: PrismaLike,
+  billingAccountId: string,
+): Promise<boolean> {
+  const latest = await db.systemEvent.findFirst({
+    where: {
+      correlationId: freezeKey(billingAccountId),
+      category: { in: [FREEZE_CATEGORY, UNFREEZE_CATEGORY] },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { category: true },
+  });
+  return latest?.category === FREEZE_CATEGORY;
+}
+
+/** Freeze wallet spend for one account. Idempotent — no-op if already frozen.
+ *  Returns true when it wrote a new freeze event. */
+export async function freezeWalletSpend(params: {
+  billingAccountId: string;
+  organizationId?: string | null;
+  reason: string;
+}): Promise<boolean> {
+  if (await isWalletFrozen(prisma, params.billingAccountId)) return false;
+  await recordSystemEvent({
+    organizationId: params.organizationId ?? null,
+    category: FREEZE_CATEGORY,
+    severity: "ERROR",
+    message: `Wallet spend FROZEN for billing account ${params.billingAccountId}: ${params.reason}`,
+    context: { billingAccountId: params.billingAccountId, reason: params.reason },
+    correlationId: freezeKey(params.billingAccountId),
+  });
+  return true;
+}

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -131,6 +131,29 @@ interface EventData {
  *
  * Used by both webhook handlers and mock payment flows
  */
+// #837 — discriminated Phase-1 outcomes so Phase 2 can auto-refund the two
+// captured-but-blocked cases (amount mismatch, double-booking loser) instead of
+// parking the funds on manual ops. `null` = already-processed / metadata-fail.
+type PaymentSuccessTxResult =
+  | {
+      outcome: "amount_mismatch";
+      paymentId: string;
+      gatewayAmountPaise: number;
+      expectedAmount: number;
+    }
+  | {
+      outcome: "confirmed";
+      paymentId: string;
+      appointmentId: string;
+      appointmentType: string;
+      userId: string;
+      userName: string | null;
+      amount: number;
+      currency: string;
+      capturedAfterTerminal: boolean;
+      doubleBookingBlocked: boolean;
+    };
+
 export async function handlePaymentSuccess(
   paymentIntentId: string,
   rawMetadata: Record<string, string>,
@@ -159,7 +182,7 @@ export async function handlePaymentSuccess(
   // winner confirmed and blocks. The SUCCEEDED early-return keeps the retry
   // idempotent.
   const txResult = await withSerializableRetry(() =>
-    prisma.$transaction(async (tx) => {
+    prisma.$transaction(async (tx): Promise<PaymentSuccessTxResult | null> => {
     const payment = await tx.payment.findUnique({
       where: { paymentIntent: paymentIntentId },
       include: { user: { include: { consulteeProfile: true } } },
@@ -202,11 +225,14 @@ export async function handlePaymentSuccess(
           },
         },
       );
+      // #837 — mark SUCCEEDED (gateway truth) + stamp REQUIRES_MANUAL_RECOVERY as
+      // the FALLBACK. Phase 2 auto-refunds the wrong-amount capture; the manual
+      // marker only survives if that refund call itself throws.
       await tx.payment.update({
         where: { id: payment.id },
         data: {
           paymentStatus: PaymentStatus.SUCCEEDED,
-          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed.`,
+          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed; auto-refund attempted.`,
         },
       });
       console.error(
@@ -218,12 +244,18 @@ export async function handlePaymentSuccess(
           user_id: payment.userId,
           gateway_amount_paise: gatewayAmountPaise,
           expected_amount_paise: payment.amount,
-          action_required:
-            "IMMEDIATE: reconcile captured funds; confirm or refund manually",
+          action_required: "auto-refund attempted; reconcile only if it failed",
           timestamp: new Date().toISOString(),
         }),
       );
-      return null; // Skip confirmation + Phase 2 — requires manual intervention
+      // Signal Phase 2 to auto-refund post-commit — the gateway refund call must
+      // not run inside this Serializable tx.
+      return {
+        outcome: "amount_mismatch",
+        paymentId: payment.id,
+        gatewayAmountPaise,
+        expectedAmount: payment.amount,
+      };
     }
 
     // VALIDATION: Check metadata before processing
@@ -350,6 +382,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
     // Return data needed for Phase 2
     return {
+      outcome: "confirmed",
       paymentId: payment.id,
       appointmentId: appointment.id,
       appointmentType: metadata.appointmentType,
@@ -360,6 +393,9 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       // #855 — a capture that landed after the booking was cancelled; Phase 2
       // auto-refunds it instead of treating it as a confirmed booking.
       capturedAfterTerminal: confirmResult.capturedAfterTerminal,
+      // #837 — the #827 first-confirmed-wins guard blocked this booking; Phase 2
+      // auto-refunds the loser and releases its tentative hold.
+      doubleBookingBlocked: confirmResult.doubleBookingBlocked ?? false,
     };
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
@@ -368,6 +404,42 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
   // If transaction returned null, the payment was already processed or had a metadata error
   if (!txResult) return;
+
+  // #837 — the gateway captured a different amount than we ordered. Auto-refund
+  // the whole capture (never confirm a booking for the wrong money) and skip
+  // Phase 2. REQUIRES_MANUAL_RECOVERY stays stamped as the fallback if the
+  // refund throws. Idempotent: on webhook replay the payment is already
+  // SUCCEEDED so the SUCCEEDED early-return fires before this path is reached,
+  // and refundPayment's refundable-balance guard blocks any double-refund.
+  if (txResult.outcome === "amount_mismatch") {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "capture amount mismatch",
+        initiatedByUserId: null,
+      });
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            payment: {
+              paymentId: txResult.paymentId,
+              gatewayAmountPaise: txResult.gatewayAmountPaise,
+              expectedAmount: txResult.expectedAmount,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund amount-mismatch capture; REQUIRES_MANUAL_RECOVERY (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
 
   // #855 — the capture landed after the booking was cancelled. The payment is
   // SUCCEEDED (gateway truth) but the booking is dead, so auto-refund and skip
@@ -387,6 +459,51 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       );
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
+
+  // #837 — the #827 first-confirmed-wins guard blocked this booking: the payment
+  // is SUCCEEDED but the slots lost to an overlapping confirmed booking, so
+  // auto-refund and release the tentative hold (otherwise a paid customer holds
+  // no booking and their slots block rebooking). Skip the rest of Phase 2 — no
+  // earnings/invoice/notifications for a booking that never confirmed.
+  // Idempotent: webhook replay hits the SUCCEEDED early-return before here;
+  // refundPayment's refundable-balance guard blocks a double-refund; the slot
+  // release runs after a successful refund so a refund failure leaves the hold
+  // for the #830 orphan sweep + manual recovery rather than freeing it unpaid.
+  if (txResult.doubleBookingBlocked) {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "double-booking blocked at confirmation",
+        initiatedByUserId: null,
+      });
+      // Release the tentative hold only once the money is back.
+      await withSerializableRetry(() =>
+        prisma.$transaction(
+          (tx) => cleanupFailedPaymentAppointment(tx, txResult.appointmentId),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        ),
+      );
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            booking: {
+              paymentId: txResult.paymentId,
+              appointmentId: txResult.appointmentId,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund double-booking loser; slots left for #830 sweep (Phase 2):",
         refundError,
       );
     }
@@ -1277,7 +1394,7 @@ export async function confirmExistingAppointment(
   tx: Tx,
   appointmentId: string,
   userId?: string,
-): Promise<{ capturedAfterTerminal: boolean }> {
+): Promise<{ capturedAfterTerminal: boolean; doubleBookingBlocked?: boolean }> {
   // First fetch appointment to determine type
   const appointment = await tx.appointment.findUnique({
     where: { id: appointmentId },
@@ -1355,8 +1472,11 @@ export async function confirmExistingAppointment(
             slotId: slot.id,
           },
         }).catch(() => {});
-        // slots stay tentative; do not confirm over the winner
-        return { capturedAfterTerminal: false };
+        // #837 — slots stay tentative here; the webhook's Phase 2 auto-refunds
+        // the loser and releases the hold. The #830 sweep re-drives via this
+        // same guard and reports (doesn't refund), so signalling the block up is
+        // what routes the refund without fighting the guard.
+        return { capturedAfterTerminal: false, doubleBookingBlocked: true };
       }
     }
   }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -418,6 +418,14 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         reason: "capture amount mismatch",
         initiatedByUserId: null,
       });
+      // Refund succeeded — clear the Phase 1 REQUIRES_MANUAL_RECOVERY marker so
+      // ops dashboards don't flag a payment that no longer needs manual recovery.
+      await prisma.payment.update({
+        where: { id: txResult.paymentId },
+        data: {
+          description: `Auto-refunded: capture amount ${txResult.gatewayAmountPaise}p ≠ expected ${txResult.expectedAmount}p. Booking NOT confirmed.`,
+        },
+      });
     } catch (refundError) {
       Sentry.captureException(
         refundError instanceof Error ? refundError : new Error(String(refundError)),


### PR DESCRIPTION
Two verified webhook paths captured funds but blocked the booking and parked the money on manual ops; a third path detected a wallet cache/journal drift and only reported it. All three now act. The existing `refundPayment` infra (`lib/payments/operations/refund.ts`) is reused for the two refund paths — the same pattern already used by the capture-after-cancellation path (#855). Manual recovery is preserved as the FALLBACK wherever an auto-refund could fail.

## Fix 1 — Capture amount-mismatch auto-refund
`lib/payments/webhooks/handlers.ts` (amount-parity block, was `return null`). When the gateway captures an amount ≠ `Payment.amount`, the code marked `REQUIRES_MANUAL_RECOVERY` and returned, leaving captured funds with no refund. Now Phase 1 marks the payment SUCCEEDED (gateway truth) + stamps `REQUIRES_MANUAL_RECOVERY` as the fallback, and signals Phase 2 (`outcome: "amount_mismatch"`) to auto-refund the whole capture via `refundPayment` post-commit (the gateway call must not run inside the Serializable tx). A fatal Sentry alert already fired inside the tx with the payment id + both amounts; a second `error`-level `captureException` fires only if the refund throws, in which case the manual marker stands.
- **Idempotency**: on webhook replay the payment is already SUCCEEDED, so the existing SUCCEEDED early-return fires before this path is reached; `refundPayment`'s refundable-balance guard independently blocks any double-refund.

## Fix 2 — Double-booking loser auto-refund + slot release
`lib/payments/webhooks/handlers.ts` (`confirmExistingAppointment`, the #827 `CONFIRMATION_BLOCKED_DOUBLE_BOOKING` block). Previously it logged "needs a refund" but never refunded, leaving a SUCCEEDED payment + tentative slots for ops. The guard now returns `doubleBookingBlocked: true`, propagated to Phase 2, which auto-refunds via `refundPayment` and then releases the tentative hold via the existing `cleanupFailedPaymentAppointment` (in a fresh Serializable tx, mirroring the #830 sweep discipline). Slots are released only AFTER a successful refund, so a refund failure leaves the hold for the #830 orphan sweep + manual recovery rather than freeing it unpaid.
- **Idempotency**: same SUCCEEDED early-return on replay + `refundPayment`'s refundable-balance guard.

## Fix 3 — Wallet-drift freeze
`jobs/reconcile/reconcile-ledgers.ts` detected `WALLET_BALANCE_DRIFT` but only reported. On `!report.ok` the job now freezes wallet spend on each drifted `BillingAccount` (scoped, not platform-wide) and pages a P0 (`fatal` Sentry). Spend is gated at the checkout wallet-debit site in `lib/payments/operations/checkout.ts` via a new `isWalletFrozen`/`WalletFrozenError` (`lib/payments/wallet-freeze.ts`).

**Freeze design (no schema change).** There is no per-wallet freeze column and the launch schema is frozen, so the freeze rides the existing append-only `SystemEvent` log: the freeze KEY is the indexed `correlationId` = `wallet-freeze:<billingAccountId>`, and the current state is the category of the latest event under that key (`WALLET_FREEZE` vs `WALLET_UNFREEZE`). The check is a single indexed read inside the caller's tx, so it fails CLOSED. FREEZE is set by the reconcile job; UNFREEZE is a manual ops action after the drift is reconciled. The freeze deliberately gates only discretionary spend (the checkout booking debit), NOT the chargeback-recovery debit in `app/api/webhooks/utils.ts` — that path only catches `WalletInsufficientFundsError` and rethrows everything else, and a lost-dispute recovery must not be stranded on a freeze.

## Uncertainty flags (money code — read carefully)
- **No schema change was made or needed** (per the STOP-and-report instruction).
- **Type-check + race-suite via CI (local OOM-contended).** tsc/jest were not run locally (machine OOM-thrashing); relying on CI. I reviewed the discriminated-union narrowing (`PaymentSuccessTxResult`) and the `PrismaLike` freeze reads by hand but could not compile-verify.
- **Freeze semantics via `SystemEvent`/`correlationId`** is a pragmatic reuse of a telemetry log as a state flag; it works and is indexed, but a reviewer may prefer a dedicated table/column (schema-frozen, so deferred). Flagging for a decision.
- **Admin-trigger parity**: the freeze reaction lives in the cron job wrapper only; the on-demand admin reconcile route (`POST /api/admin/reconcile-ledgers`) calls the same read-only auditor but does not yet freeze. Left out to keep scope tight — worth a follow-up.
- **Manual UNFREEZE path** is not built here (no writer for `WALLET_UNFREEZE`); ops would clear a freeze by writing that event after reconciling. Flagging.

Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)