### PR TITLE
fix(enterprise): INVOICE-sponsor trust — rescope PENDING_TRUST (E-01), park consultant earnings (E-02), domain gate (K-02)

### DIFF
--- a/app/api/organizations/[orgId]/billing-account/route.ts
+++ b/app/api/organizations/[orgId]/billing-account/route.ts
@@ -26,6 +26,7 @@ import { requireOrgAccess } from "@/lib/auth-helpers";
 // description in `lib/labels/org-labels.ts`.
 import { requireOrgBillingAdminOrOwner } from "@/lib/auth/billing-admin-gate";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { assertVerifiedDomainOrThrow } from "@/lib/enterprise/governance";
 
 // PROJECT is reserved in the Prisma enum for v2 project-billing; the
 // API layer rejects it so callers can't quietly land a BillingAccount
@@ -200,6 +201,13 @@ export async function PATCH(
               { httpStatus: 409 },
             );
           }
+        }
+        // K-02 / #687 — enabling INVOICE funding requires a verified domain
+        // (governance.ts documents this gate for the fundingSource→INVOICE
+        // transition). tx-scoped read: TOCTOU-safe against a concurrent
+        // verification rollback.
+        if (body.fundingSource === "INVOICE") {
+          await assertVerifiedDomainOrThrow(tx, orgId, "INVOICE_FUNDING");
         }
       }
 

--- a/app/api/organizations/[orgId]/earnings/route.ts
+++ b/app/api/organizations/[orgId]/earnings/route.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { sumPaise } from "@/lib/payments/utils/money";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
 const EarningStatusSchema = z.enum([
   "PENDING",
@@ -48,7 +49,10 @@ export async function GET(
   const access = await requireOrgAccess(orgId, "MANAGER");
   if (access.error) return access.error;
 
-  if (!access.org.canHost) {
+  // Honesty gate: an org's canHost column can be true from when the flag was
+  // on, but with ENABLE_HOST_ORGS off resolveOrgSplit returns null so NO new
+  // OrganizationEarnings accrue — surfacing a split dashboard would lie.
+  if (!ENABLE_HOST_ORGS || !access.org.canHost) {
     return NextResponse.json(
       { error: "Organization does not host — no earnings to list" },
       { status: 404 },

--- a/jobs/cleanup/release-pending-trust-earnings.ts
+++ b/jobs/cleanup/release-pending-trust-earnings.ts
@@ -1,8 +1,8 @@
 /**
  * Release PENDING_TRUST earnings — invoice-fraud guard release valve (#687).
  *
- * Promotes OrganizationEarnings rows from PENDING_TRUST → PENDING when
- * the sponsoring org has either:
+ * Promotes both OrganizationEarnings AND ConsultantEarnings rows (#687 E-02)
+ * from PENDING_TRUST → PENDING when the sponsoring org has either:
  *   1. transitioned to status=ACTIVE (admin verification), or
  *   2. paid at least one OrganizationInvoice.
  *
@@ -79,28 +79,55 @@ async function runReleasePendingTrustEarningsUnlocked(): Promise<ReleasePendingT
     return result;
   }
 
-  const candidates = await prisma.organizationEarnings.findMany({
-    where: {
-      status: EarningStatus.PENDING_TRUST,
-      organizationId: { in: unlockedOrgIds },
-    },
-    select: { id: true },
-  });
-  result.scanned = candidates.length;
+  // Org rows carry organizationId directly. Consultant rows (#687 E-02) do
+  // NOT — the sponsor lives on the Payment, so join through it. Both are
+  // parked/released as one booking, so an unlocked sponsor promotes both.
+  const [orgCandidates, consultantCandidates] = await Promise.all([
+    prisma.organizationEarnings.findMany({
+      where: {
+        status: EarningStatus.PENDING_TRUST,
+        organizationId: { in: unlockedOrgIds },
+      },
+      select: { id: true },
+    }),
+    prisma.consultantEarnings.findMany({
+      where: {
+        status: EarningStatus.PENDING_TRUST,
+        payment: { organizationId: { in: unlockedOrgIds } },
+      },
+      select: { id: true },
+    }),
+  ]);
+  result.scanned = orgCandidates.length + consultantCandidates.length;
 
-  if (candidates.length === 0) {
+  if (result.scanned === 0) {
     return result;
   }
 
+  // CAS on status inside each updateMany so a concurrent refund/hold that
+  // moved a row out of PENDING_TRUST between the scan and the write is not
+  // clobbered back to PENDING.
   try {
-    const update = await prisma.organizationEarnings.updateMany({
-      where: {
-        id: { in: candidates.map((c) => c.id) },
-        status: EarningStatus.PENDING_TRUST,
-      },
-      data: { status: EarningStatus.PENDING },
-    });
-    result.released = update.count;
+    if (orgCandidates.length > 0) {
+      const orgUpdate = await prisma.organizationEarnings.updateMany({
+        where: {
+          id: { in: orgCandidates.map((c) => c.id) },
+          status: EarningStatus.PENDING_TRUST,
+        },
+        data: { status: EarningStatus.PENDING },
+      });
+      result.released += orgUpdate.count;
+    }
+    if (consultantCandidates.length > 0) {
+      const consultantUpdate = await prisma.consultantEarnings.updateMany({
+        where: {
+          id: { in: consultantCandidates.map((c) => c.id) },
+          status: EarningStatus.PENDING_TRUST,
+        },
+        data: { status: EarningStatus.PENDING },
+      });
+      result.released += consultantUpdate.count;
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     result.errors.push(message);

--- a/jobs/reconcile/reconcile-ledgers.ts
+++ b/jobs/reconcile/reconcile-ledgers.ts
@@ -24,6 +24,7 @@ import {
   recordSystemError,
 } from "../../lib/enterprise/system-events";
 import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+import { freezeWalletSpend } from "../../lib/payments/wallet-freeze";
 import * as Sentry from "@sentry/nextjs";
 
 async function main(): Promise<void> {
@@ -102,6 +103,41 @@ async function main(): Promise<void> {
           },
         },
       );
+
+      // #837 — a wallet cache/journal drift means the balance can't be trusted,
+      // so freeze spend on each drifted account (scoped, not platform-wide) and
+      // page P0. Only WALLET_BALANCE_DRIFT freezes; other finding kinds page via
+      // the captureException above but don't gate spend.
+      const walletDrift = report.findings.filter(
+        (f) => f.kind === "WALLET_BALANCE_DRIFT" && f.billingAccountId,
+      );
+      for (const f of walletDrift) {
+        const froze = await freezeWalletSpend({
+          billingAccountId: f.billingAccountId!,
+          organizationId: f.organizationId ?? null,
+          reason: `ledger reconcile ${report.id}: wallet cache ${f.actualPaise}p ≠ journal ${f.expectedPaise}p (Δ${f.deltaPaise}p)`,
+        });
+        Sentry.captureException(
+          new Error(
+            `WALLET_BALANCE_DRIFT — wallet spend frozen for billing account ${f.billingAccountId}`,
+          ),
+          {
+            level: "fatal",
+            tags: { subsystem: "jobs", job: "reconcile-ledgers" },
+            contexts: {
+              wallet: {
+                billingAccountId: f.billingAccountId,
+                organizationId: f.organizationId ?? null,
+                expectedPaise: f.expectedPaise,
+                actualPaise: f.actualPaise,
+                deltaPaise: f.deltaPaise,
+                reportId: report.id,
+                newlyFrozen: froze,
+              },
+            },
+          },
+        );
+      }
       process.exit(2);
     }
   } catch (error) {

--- a/lib/data/org-analytics.ts
+++ b/lib/data/org-analytics.ts
@@ -17,6 +17,7 @@ import prisma from "@/lib/prisma";
 import { ledgerAccountId } from "@/lib/payments/ledger/post";
 import { sumPaise } from "@/lib/payments/utils/money";
 import { resolveActivationSignals } from "@/lib/enterprise/org-activation-signals";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -204,7 +205,9 @@ export async function getOrgAnalytics(
           },
         })
       : Promise.resolve(0),
-    org.canHost
+    // Honesty gate (#687): with ENABLE_HOST_ORGS off no new splits accrue, so
+    // don't surface host earnings even if canHost is still set on the row.
+    ENABLE_HOST_ORGS && org.canHost
       ? prisma.organizationEarnings.groupBy({
           by: ["status"],
           where: { organizationId: orgId },

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -66,7 +66,10 @@ import {
 } from "@/lib/payments/validation/currency-guards";
 import { checkPaymentLegsSumToAmount } from "@/lib/payments/payment-legs";
 import { recordOverageAtCheckout } from "@/lib/payments/billing/overage-settlement";
-import { getInvoiceCreditLimitPaise } from "@/lib/enterprise/governance";
+import {
+  getInvoiceCreditLimitPaise,
+  assertVerifiedDomainOrThrow,
+} from "@/lib/enterprise/governance";
 import {
   notifyOrgProgramExhausted,
   notifyOrgProgramCapNear,
@@ -1939,6 +1942,12 @@ export async function handleCheckout(
     // book-everything-then-ghost abuse pattern. The cap auto-lifts
     // once the org is verified OR pays its first invoice.
     if (fundingSource === "INVOICE") {
+      // K-02 / #687 — an org may not accrue INVOICE debt without a verified
+      // domain. The credit-limit gate below caps unverified-STATUS orgs; this
+      // asserts the orthogonal domain-ownership proof (OrgDomainClaim), the
+      // gate governance.ts documents for INVOICE funding but had no caller.
+      await assertVerifiedDomainOrThrow(prisma, org.id, "INVOICE_FUNDING");
+
       const explicitLimit = org.billingAccount?.creditLimit ?? null;
       const isVerified = org.status === "ACTIVE";
       const governanceLimit = isVerified ? null : getInvoiceCreditLimitPaise();

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -51,6 +51,7 @@ import {
   type AppointmentType,
 } from "@/lib/payments/payouts";
 import { walletDebit } from "@/lib/api/organizations/wallet";
+import { isWalletFrozen, WalletFrozenError } from "@/lib/payments/wallet-freeze";
 import {
   recordBookingUtilization,
   ProgramAssignmentLimitError,
@@ -2366,6 +2367,13 @@ export async function handleCheckout(
           // Triggered only when we also have a resolved program assignment,
           // which guarantees the booking is actually sponsored.
           if (isOrgWalletPayment && billingAccountId) {
+            // #837 — refuse to spend a wallet whose cache drifted from the
+            // journal (frozen by the ledger-reconcile job): the balance can't
+            // be trusted until ops reconciles. Chargeback recovery is NOT gated
+            // (see wallet-freeze.ts).
+            if (await isWalletFrozen(tx, billingAccountId)) {
+              throw new WalletFrozenError(billingAccountId);
+            }
             await walletDebit(tx, {
               billingAccountId,
               amountPaise: amount,

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -310,6 +310,30 @@ export async function createEarningsFromPayment({
             payment.createdAt,
           );
 
+          // #687 E-01/E-02 — the PENDING_TRUST park keys on the SPONSORING org
+          // (the org that OWES the invoice = payment.organizationId), NOT the
+          // expert's HOST org from resolveOrgSplit. An unverified sponsor that
+          // may never pay its invoice must not let consultant OR org earnings
+          // clear. Decide ONCE here and apply to every row this booking writes
+          // (consultant, primary-org, collaborator-org).
+          const sponsorOrgId = payment.organizationId;
+          let parkForTrust = false;
+          if (sponsorOrgId) {
+            const sponsorOrg = await tx.organization.findUnique({
+              where: { id: sponsorOrgId },
+              select: { status: true },
+            });
+            if (sponsorOrg?.status === "PENDING_VERIFICATION") {
+              const paidInvoiceCount = await tx.organizationInvoice.count({
+                where: { organizationId: sponsorOrgId, status: "PAID" },
+              });
+              parkForTrust = paidInvoiceCount === 0;
+            }
+          }
+          const initialEarningStatus: EarningStatus = parkForTrust
+            ? EarningStatus.PENDING_TRUST
+            : EarningStatus.PENDING;
+
           // Determine platform fee and consultant pool based on whether org split applies.
           // #778 §C-2 — floor the marketplace fee (was Math.round); the shaved paisa
           // stays in the consultant pool (gross − fee), the pool's residual party.
@@ -427,7 +451,10 @@ export async function createEarningsFromPayment({
                   consultantSharePaise: creditedShare,
                   role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
                   shareBps,
-                  status: EarningStatus.PENDING,
+                  // #687 E-02 — park consultant payables too when the sponsor
+                  // is an unverified INVOICE org; else the platform owes real
+                  // money for a ghost sponsor's booking.
+                  status: initialEarningStatus,
                   holdUntil,
                   currency: "INR",
                 },
@@ -450,7 +477,8 @@ export async function createEarningsFromPayment({
                 grossAmount,
                 platformFeePaise,
                 consultantSharePaise: totalConsultantPool,
-                status: EarningStatus.PENDING,
+                // #687 E-02 — see multi-party branch above.
+                status: initialEarningStatus,
                 holdUntil,
                 currency: "INR",
               },
@@ -463,28 +491,12 @@ export async function createEarningsFromPayment({
           // Skip when orgShare is 0 (Platform-only mode: platformCommissionRate = 1.0)
           // — creating 0-value rows adds noise without value.
           //
-          // PR-1d / #687: if the sponsoring org is still PENDING_VERIFICATION
+          // PR-1d / #687: if the SPONSORING org (payment.organizationId, resolved
+          // above into initialEarningStatus — E-01) is still PENDING_VERIFICATION
           // and has never paid an invoice, accruals start in PENDING_TRUST
           // instead of PENDING. The `release-pending-trust-earnings` cron
           // promotes them once the org is verified or first invoice clears.
           if (orgSplit && orgSplit.orgShare > 0) {
-            const sponsorOrg = await tx.organization.findUnique({
-              where: { id: orgSplit.organizationId },
-              select: { status: true },
-            });
-            let initialStatus: EarningStatus = EarningStatus.PENDING;
-            if (sponsorOrg?.status === "PENDING_VERIFICATION") {
-              const paidInvoiceCount = await tx.organizationInvoice.count({
-                where: {
-                  organizationId: orgSplit.organizationId,
-                  status: "PAID",
-                },
-              });
-              if (paidInvoiceCount === 0) {
-                initialStatus = EarningStatus.PENDING_TRUST;
-              }
-            }
-
             await tx.organizationEarnings.create({
               data: {
                 organizationId: orgSplit.organizationId,
@@ -494,7 +506,7 @@ export async function createEarningsFromPayment({
                 orgSharePaise: orgSplit.orgShare,
                 consultantSharePaise: orgSplit.consultantSharePaise,
                 refundedAmountPaise: 0,
-                status: initialStatus,
+                status: initialEarningStatus,
                 holdUntil,
                 currency: "INR",
                 // Rate-card snapshot: persist the exact split applied so
@@ -538,24 +550,9 @@ export async function createEarningsFromPayment({
               continue;
             }
 
-            // PR-1d / #687 — same PENDING_TRUST gate as the primary org above.
-            const collabSponsorOrg = await tx.organization.findUnique({
-              where: { id: s.orgSplit.organizationId },
-              select: { status: true },
-            });
-            let collabInitialStatus: EarningStatus = EarningStatus.PENDING;
-            if (collabSponsorOrg?.status === "PENDING_VERIFICATION") {
-              const paidInvoiceCount = await tx.organizationInvoice.count({
-                where: {
-                  organizationId: s.orgSplit.organizationId,
-                  status: "PAID",
-                },
-              });
-              if (paidInvoiceCount === 0) {
-                collabInitialStatus = EarningStatus.PENDING_TRUST;
-              }
-            }
-
+            // #687 E-01 — same sponsor-scoped PENDING_TRUST gate as the primary
+            // org above; the park keys on the SPONSOR (payment.organizationId,
+            // via initialEarningStatus), not this collaborator's host org.
             await tx.organizationEarnings.create({
               data: {
                 organizationId: s.orgSplit.organizationId,
@@ -568,7 +565,7 @@ export async function createEarningsFromPayment({
                 orgSharePaise: s.orgSplit.orgShare,
                 consultantSharePaise: s.orgSplit.consultantSharePaise,
                 refundedAmountPaise: 0,
-                status: collabInitialStatus,
+                status: initialEarningStatus,
                 holdUntil,
                 currency: "INR",
                 rateCardIdApplied: s.orgSplit.rateCardIdApplied,

--- a/lib/payments/wallet-freeze.ts
+++ b/lib/payments/wallet-freeze.ts
@@ -1,0 +1,73 @@
+/**
+ * #837 — wallet-spend freeze, scoped to a single drifted BillingAccount.
+ *
+ * When the ledger-reconcile job finds WALLET_BALANCE_DRIFT (cached
+ * `BillingAccount.walletBalance` ≠ the journal's WALLET account) the balance is
+ * no longer trustworthy, so we must stop spending it until ops reconciles.
+ *
+ * There is no schema column for a per-wallet freeze and the launch schema is
+ * frozen, so the freeze rides the existing append-only `SystemEvent` log rather
+ * than a new column/table:
+ *   - the freeze KEY is the indexed `correlationId` = `wallet-freeze:<billingAccountId>`,
+ *   - the current state is the category of the LATEST event under that key
+ *     (WALLET_FREEZE → frozen, WALLET_UNFREEZE → cleared).
+ * FREEZE is set by the reconcile job; UNFREEZE is a manual ops action once the
+ * drift is fixed. The check is a single indexed DB read inside the caller's tx,
+ * so it fails CLOSED — an unreadable log blocks the spend rather than leaking it.
+ *
+ * Deliberately gates only discretionary SPEND (the checkout booking debit), not
+ * chargeback recovery (app/api/webhooks/utils.ts): a lost-dispute debit recovers
+ * money the bank already pulled and must not be stranded on a drift freeze.
+ */
+
+import prisma, { type PrismaLike } from "@/lib/prisma";
+import { recordSystemEvent } from "@/lib/enterprise/system-events";
+
+const FREEZE_CATEGORY = "WALLET_FREEZE";
+const UNFREEZE_CATEGORY = "WALLET_UNFREEZE";
+const freezeKey = (billingAccountId: string) => `wallet-freeze:${billingAccountId}`;
+
+export class WalletFrozenError extends Error {
+  constructor(public billingAccountId: string) {
+    super(
+      `Wallet spend frozen on billing account ${billingAccountId} pending ledger-drift resolution`,
+    );
+    this.name = "WalletFrozenError";
+  }
+}
+
+/** True when the account's latest freeze event is a FREEZE. Reads inside the
+ *  caller's tx/client so the check shares the spend's snapshot. */
+export async function isWalletFrozen(
+  db: PrismaLike,
+  billingAccountId: string,
+): Promise<boolean> {
+  const latest = await db.systemEvent.findFirst({
+    where: {
+      correlationId: freezeKey(billingAccountId),
+      category: { in: [FREEZE_CATEGORY, UNFREEZE_CATEGORY] },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { category: true },
+  });
+  return latest?.category === FREEZE_CATEGORY;
+}
+
+/** Freeze wallet spend for one account. Idempotent — no-op if already frozen.
+ *  Returns true when it wrote a new freeze event. */
+export async function freezeWalletSpend(params: {
+  billingAccountId: string;
+  organizationId?: string | null;
+  reason: string;
+}): Promise<boolean> {
+  if (await isWalletFrozen(prisma, params.billingAccountId)) return false;
+  await recordSystemEvent({
+    organizationId: params.organizationId ?? null,
+    category: FREEZE_CATEGORY,
+    severity: "ERROR",
+    message: `Wallet spend FROZEN for billing account ${params.billingAccountId}: ${params.reason}`,
+    context: { billingAccountId: params.billingAccountId, reason: params.reason },
+    correlationId: freezeKey(params.billingAccountId),
+  });
+  return true;
+}

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -131,6 +131,29 @@ interface EventData {
  *
  * Used by both webhook handlers and mock payment flows
  */
+// #837 — discriminated Phase-1 outcomes so Phase 2 can auto-refund the two
+// captured-but-blocked cases (amount mismatch, double-booking loser) instead of
+// parking the funds on manual ops. `null` = already-processed / metadata-fail.
+type PaymentSuccessTxResult =
+  | {
+      outcome: "amount_mismatch";
+      paymentId: string;
+      gatewayAmountPaise: number;
+      expectedAmount: number;
+    }
+  | {
+      outcome: "confirmed";
+      paymentId: string;
+      appointmentId: string;
+      appointmentType: string;
+      userId: string;
+      userName: string | null;
+      amount: number;
+      currency: string;
+      capturedAfterTerminal: boolean;
+      doubleBookingBlocked: boolean;
+    };
+
 export async function handlePaymentSuccess(
   paymentIntentId: string,
   rawMetadata: Record<string, string>,
@@ -159,7 +182,7 @@ export async function handlePaymentSuccess(
   // winner confirmed and blocks. The SUCCEEDED early-return keeps the retry
   // idempotent.
   const txResult = await withSerializableRetry(() =>
-    prisma.$transaction(async (tx) => {
+    prisma.$transaction(async (tx): Promise<PaymentSuccessTxResult | null> => {
     const payment = await tx.payment.findUnique({
       where: { paymentIntent: paymentIntentId },
       include: { user: { include: { consulteeProfile: true } } },
@@ -202,11 +225,14 @@ export async function handlePaymentSuccess(
           },
         },
       );
+      // #837 — mark SUCCEEDED (gateway truth) + stamp REQUIRES_MANUAL_RECOVERY as
+      // the FALLBACK. Phase 2 auto-refunds the wrong-amount capture; the manual
+      // marker only survives if that refund call itself throws.
       await tx.payment.update({
         where: { id: payment.id },
         data: {
           paymentStatus: PaymentStatus.SUCCEEDED,
-          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed.`,
+          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed; auto-refund attempted.`,
         },
       });
       console.error(
@@ -218,12 +244,18 @@ export async function handlePaymentSuccess(
           user_id: payment.userId,
           gateway_amount_paise: gatewayAmountPaise,
           expected_amount_paise: payment.amount,
-          action_required:
-            "IMMEDIATE: reconcile captured funds; confirm or refund manually",
+          action_required: "auto-refund attempted; reconcile only if it failed",
           timestamp: new Date().toISOString(),
         }),
       );
-      return null; // Skip confirmation + Phase 2 — requires manual intervention
+      // Signal Phase 2 to auto-refund post-commit — the gateway refund call must
+      // not run inside this Serializable tx.
+      return {
+        outcome: "amount_mismatch",
+        paymentId: payment.id,
+        gatewayAmountPaise,
+        expectedAmount: payment.amount,
+      };
     }
 
     // VALIDATION: Check metadata before processing
@@ -350,6 +382,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
     // Return data needed for Phase 2
     return {
+      outcome: "confirmed",
       paymentId: payment.id,
       appointmentId: appointment.id,
       appointmentType: metadata.appointmentType,
@@ -360,6 +393,9 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       // #855 — a capture that landed after the booking was cancelled; Phase 2
       // auto-refunds it instead of treating it as a confirmed booking.
       capturedAfterTerminal: confirmResult.capturedAfterTerminal,
+      // #837 — the #827 first-confirmed-wins guard blocked this booking; Phase 2
+      // auto-refunds the loser and releases its tentative hold.
+      doubleBookingBlocked: confirmResult.doubleBookingBlocked ?? false,
     };
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
@@ -368,6 +404,42 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
   // If transaction returned null, the payment was already processed or had a metadata error
   if (!txResult) return;
+
+  // #837 — the gateway captured a different amount than we ordered. Auto-refund
+  // the whole capture (never confirm a booking for the wrong money) and skip
+  // Phase 2. REQUIRES_MANUAL_RECOVERY stays stamped as the fallback if the
+  // refund throws. Idempotent: on webhook replay the payment is already
+  // SUCCEEDED so the SUCCEEDED early-return fires before this path is reached,
+  // and refundPayment's refundable-balance guard blocks any double-refund.
+  if (txResult.outcome === "amount_mismatch") {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "capture amount mismatch",
+        initiatedByUserId: null,
+      });
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            payment: {
+              paymentId: txResult.paymentId,
+              gatewayAmountPaise: txResult.gatewayAmountPaise,
+              expectedAmount: txResult.expectedAmount,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund amount-mismatch capture; REQUIRES_MANUAL_RECOVERY (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
 
   // #855 — the capture landed after the booking was cancelled. The payment is
   // SUCCEEDED (gateway truth) but the booking is dead, so auto-refund and skip
@@ -387,6 +459,51 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       );
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
+
+  // #837 — the #827 first-confirmed-wins guard blocked this booking: the payment
+  // is SUCCEEDED but the slots lost to an overlapping confirmed booking, so
+  // auto-refund and release the tentative hold (otherwise a paid customer holds
+  // no booking and their slots block rebooking). Skip the rest of Phase 2 — no
+  // earnings/invoice/notifications for a booking that never confirmed.
+  // Idempotent: webhook replay hits the SUCCEEDED early-return before here;
+  // refundPayment's refundable-balance guard blocks a double-refund; the slot
+  // release runs after a successful refund so a refund failure leaves the hold
+  // for the #830 orphan sweep + manual recovery rather than freeing it unpaid.
+  if (txResult.doubleBookingBlocked) {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "double-booking blocked at confirmation",
+        initiatedByUserId: null,
+      });
+      // Release the tentative hold only once the money is back.
+      await withSerializableRetry(() =>
+        prisma.$transaction(
+          (tx) => cleanupFailedPaymentAppointment(tx, txResult.appointmentId),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        ),
+      );
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            booking: {
+              paymentId: txResult.paymentId,
+              appointmentId: txResult.appointmentId,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund double-booking loser; slots left for #830 sweep (Phase 2):",
         refundError,
       );
     }
@@ -1277,7 +1394,7 @@ export async function confirmExistingAppointment(
   tx: Tx,
   appointmentId: string,
   userId?: string,
-): Promise<{ capturedAfterTerminal: boolean }> {
+): Promise<{ capturedAfterTerminal: boolean; doubleBookingBlocked?: boolean }> {
   // First fetch appointment to determine type
   const appointment = await tx.appointment.findUnique({
     where: { id: appointmentId },
@@ -1355,8 +1472,11 @@ export async function confirmExistingAppointment(
             slotId: slot.id,
           },
         }).catch(() => {});
-        // slots stay tentative; do not confirm over the winner
-        return { capturedAfterTerminal: false };
+        // #837 — slots stay tentative here; the webhook's Phase 2 auto-refunds
+        // the loser and releases the hold. The #830 sweep re-drives via this
+        // same guard and reports (doesn't refund), so signalling the block up is
+        // what routes the refund without fighting the guard.
+        return { capturedAfterTerminal: false, doubleBookingBlocked: true };
       }
     }
   }


### PR DESCRIPTION
## Why

Enterprise INVOICE-funded bookings let an unverified sponsoring org book, accrue real consultant/org payables, and never pay the invoice ("book everything, delete, run" — #687). `PENDING_TRUST` was meant to PARK payables until the sponsor is verified/pays, but it was mis-wired. This PR fixes the money-trust holes.

> **Stacks on B1 (#990).** This branch is cut from the money-auto-refund branch, so its diff includes B1's auto-refund + wallet-freeze commit. **Review/merge B1 (#990) first**; only the top commit here is this PR's work.

## Fixes

### E-01 (P0) — PENDING_TRUST scoped to the wrong org
`lib/payments/payouts/earnings-service.ts` gated the trust-park on `orgSplit.organizationId` — the EXPERT's HOST org (oldest EXPERT membership from `resolveOrgSplit`), not the org that owes the invoice. The sponsor is `payment.organizationId`. The park decision now keys on the sponsor: computed once (`sponsorOrg.status === PENDING_VERIFICATION` && zero PAID invoices → `PENDING_TRUST`, else `PENDING`) and applied to the primary-org, collaborator-org, and consultant rows alike. The two inline host-org lookups (primary + collaborator) are removed in favour of the single sponsor-scoped `initialEarningStatus`.

### E-02 (P0) — consultant earnings never parked
`ConsultantEarnings` rows were always created `PENDING`, so the platform could owe experts real money for a ghost sponsor. Both create paths (single-owner + multi-party collaborator) now use the sponsor-scoped `initialEarningStatus`. The release valve `jobs/cleanup/release-pending-trust-earnings.ts` now also promotes parked consultant rows: since `ConsultantEarnings` has no `organizationId`, it joins to the sponsor through the `Payment` relation (`payment: { organizationId: { in: unlockedOrgIds } }`). Both updates remain CAS-safe (updateMany re-checks `status = PENDING_TRUST`) and idempotent.

### K-02 (P1) — domain-verification gate unwired
`lib/enterprise/governance.ts:68` `assertVerifiedDomainOrThrow` had zero callers. Now wired into the two INVOICE debt-accrual entry points:
- `lib/payments/operations/checkout.ts` — top of the `fundingSource === "INVOICE"` branch (before the credit-limit exposure check).
- `app/api/organizations/[orgId]/billing-account/route.ts` — the `fundingSource → INVOICE` transition (tx-scoped, TOCTOU-safe).

This is orthogonal to the existing credit-limit gate (which caps unverified-STATUS orgs): domain verification proves domain ownership before any INVOICE debt can accrue.

### Host-dashboard honesty
When `ENABLE_HOST_ORGS` is off, `resolveOrgSplit` returns null so no `OrganizationEarnings` accrue, yet an org's `canHost` column can still be set from when the flag was on. The host-earnings query in `lib/data/org-analytics.ts` and the `GET .../earnings` route (`app/api/organizations/[orgId]/earnings/route.ts`) now require `ENABLE_HOST_ORGS` alongside `canHost`, so the dashboard reflects the flag-off reality instead of surfacing a split that no longer accrues.

## Notes
- No `schema.prisma` change — `PENDING_TRUST` already exists; the BATCHED status is a separate downstream PR.
- **Behavioral tightening:** INVOICE bookings/transitions now hard-require a verified `OrgDomainClaim`. Test/seed sponsor orgs without a verified domain will start getting `DOMAIN_VERIFICATION_REQUIRED` (403).
- Type-check via CI (local tsc OOM-contended).

Part of #687, #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)