### PR TITLE
feat(booking): consultant no-show auto-refund + notification (#471)

### DIFF
--- a/.github/workflows/detect-consultant-no-shows.yml
+++ b/.github/workflows/detect-consultant-no-shows.yml
@@ -1,0 +1,53 @@
+name: Detect Consultant No-Shows
+
+on:
+  schedule:
+    # Run hourly (offset to avoid colliding with other :00/:07 crons)
+    - cron: "17 * * * *"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  detect-consultant-no-shows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      # Database connection (required for Prisma)
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+      # #471 auto-refund reuses refundPayment (#990) — gateway creds for parity
+      # with the other money jobs (reconcile-pending-refunds).
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      RAZORPAY_KEY_ID: ${{ secrets.RAZORPAY_KEY_ID }}
+      RAZORPAY_SECRET: ${{ secrets.RAZORPAY_SECRET }}
+      # Both-party no-show + refund notifications
+      NOVU_SECRET_KEY: ${{ secrets.NOVU_SECRET_KEY }}
+      NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Detect consultant no-shows
+        run: npx tsx jobs/appointments/detect-consultant-no-shows.ts
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          SLACK_OPS_WEBHOOK_URL: ${{ secrets.SLACK_OPS_WEBHOOK_URL }}
+        run: bash scripts/ci/notify-ops-failure.sh "detect-consultant-no-shows"

--- a/jobs/appointments/detect-consultant-no-shows.ts
+++ b/jobs/appointments/detect-consultant-no-shows.ts
@@ -1,0 +1,87 @@
+/**
+ * Consultant No-Show Detection Job (GitHub Actions Wrapper) — #471
+ *
+ * Thin wrapper around scripts/appointments/detect-consultant-no-shows.ts.
+ * Adds GitHub Actions outputs + error handling. Runs hourly.
+ */
+
+import {
+  detectConsultantNoShows,
+  disconnectDatabase,
+  type NoShowResult,
+} from "../../scripts/appointments/detect-consultant-no-shows";
+import fs from "fs";
+import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+import * as Sentry from "@sentry/nextjs";
+
+function outputToGitHubActions(result: NoShowResult): void {
+  if (!process.env.GITHUB_ACTIONS) return;
+
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    const outputs = [
+      `detected=${result.detected}`,
+      `refunded=${result.refunded}`,
+      `success=${result.success}`,
+    ].join("\n");
+    fs.appendFileSync(outputFile, outputs + "\n");
+  }
+
+  if (result.detected > 0) {
+    console.log(
+      `::notice::Consultant no-shows: ${result.detected} detected, ${result.refunded} refunded`,
+    );
+  }
+  if (!result.success) {
+    console.log(`::warning::No-show job had errors: ${result.errors.join("; ")}`);
+  }
+}
+
+async function main(): Promise<void> {
+  await abortIfMaintenance("detect-consultant-no-shows");
+  Sentry.logger.info("job:detect-consultant-no-shows started");
+  console.log("⏰ Starting consultant no-show detection job...");
+  console.log(`Timestamp: ${new Date().toISOString()}`);
+
+  try {
+    const result = await detectConsultantNoShows();
+
+    console.log("\n📊 Job Results:");
+    console.log(`   Detected: ${result.detected}`);
+    console.log(`   Refunded: ${result.refunded}`);
+    console.log(`   Success: ${result.success}`);
+
+    if (result.errors.length > 0) {
+      console.log("\n⚠️ Errors:");
+      result.errors.forEach((e) => console.log(`   - ${e}`));
+    }
+
+    outputToGitHubActions(result);
+
+    Sentry.logger.info("job:detect-consultant-no-shows finished", {
+      detected: result.detected,
+      refunded: result.refunded,
+    });
+
+    if (!result.success) {
+      process.exit(1);
+    }
+  } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      Sentry.logger.info("job:detect-consultant-no-shows skipped — lock held");
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
+    Sentry.captureException(error, {
+      tags: { subsystem: "jobs", job: "detect-consultant-no-shows" },
+    });
+    console.error("❌ Fatal error in consultant no-show detection:", error);
+    process.exit(1);
+  } finally {
+    await disconnectDatabase();
+  }
+}
+
+main();

--- a/jobs/reconcile/reconcile-ledgers.ts
+++ b/jobs/reconcile/reconcile-ledgers.ts
@@ -24,6 +24,7 @@ import {
   recordSystemError,
 } from "../../lib/enterprise/system-events";
 import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+import { freezeWalletSpend } from "../../lib/payments/wallet-freeze";
 import * as Sentry from "@sentry/nextjs";
 
 async function main(): Promise<void> {
@@ -102,6 +103,41 @@ async function main(): Promise<void> {
           },
         },
       );
+
+      // #837 — a wallet cache/journal drift means the balance can't be trusted,
+      // so freeze spend on each drifted account (scoped, not platform-wide) and
+      // page P0. Only WALLET_BALANCE_DRIFT freezes; other finding kinds page via
+      // the captureException above but don't gate spend.
+      const walletDrift = report.findings.filter(
+        (f) => f.kind === "WALLET_BALANCE_DRIFT" && f.billingAccountId,
+      );
+      for (const f of walletDrift) {
+        const froze = await freezeWalletSpend({
+          billingAccountId: f.billingAccountId!,
+          organizationId: f.organizationId ?? null,
+          reason: `ledger reconcile ${report.id}: wallet cache ${f.actualPaise}p ≠ journal ${f.expectedPaise}p (Δ${f.deltaPaise}p)`,
+        });
+        Sentry.captureException(
+          new Error(
+            `WALLET_BALANCE_DRIFT — wallet spend frozen for billing account ${f.billingAccountId}`,
+          ),
+          {
+            level: "fatal",
+            tags: { subsystem: "jobs", job: "reconcile-ledgers" },
+            contexts: {
+              wallet: {
+                billingAccountId: f.billingAccountId,
+                organizationId: f.organizationId ?? null,
+                expectedPaise: f.expectedPaise,
+                actualPaise: f.actualPaise,
+                deltaPaise: f.deltaPaise,
+                reportId: report.id,
+                newlyFrozen: froze,
+              },
+            },
+          },
+        );
+      }
       process.exit(2);
     }
   } catch (error) {

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -51,6 +51,7 @@ import {
   type AppointmentType,
 } from "@/lib/payments/payouts";
 import { walletDebit } from "@/lib/api/organizations/wallet";
+import { isWalletFrozen, WalletFrozenError } from "@/lib/payments/wallet-freeze";
 import {
   recordBookingUtilization,
   ProgramAssignmentLimitError,
@@ -2366,6 +2367,13 @@ export async function handleCheckout(
           // Triggered only when we also have a resolved program assignment,
           // which guarantees the booking is actually sponsored.
           if (isOrgWalletPayment && billingAccountId) {
+            // #837 — refuse to spend a wallet whose cache drifted from the
+            // journal (frozen by the ledger-reconcile job): the balance can't
+            // be trusted until ops reconciles. Chargeback recovery is NOT gated
+            // (see wallet-freeze.ts).
+            if (await isWalletFrozen(tx, billingAccountId)) {
+              throw new WalletFrozenError(billingAccountId);
+            }
             await walletDebit(tx, {
               billingAccountId,
               amountPaise: amount,

--- a/lib/payments/wallet-freeze.ts
+++ b/lib/payments/wallet-freeze.ts
@@ -1,0 +1,73 @@
+/**
+ * #837 — wallet-spend freeze, scoped to a single drifted BillingAccount.
+ *
+ * When the ledger-reconcile job finds WALLET_BALANCE_DRIFT (cached
+ * `BillingAccount.walletBalance` ≠ the journal's WALLET account) the balance is
+ * no longer trustworthy, so we must stop spending it until ops reconciles.
+ *
+ * There is no schema column for a per-wallet freeze and the launch schema is
+ * frozen, so the freeze rides the existing append-only `SystemEvent` log rather
+ * than a new column/table:
+ *   - the freeze KEY is the indexed `correlationId` = `wallet-freeze:<billingAccountId>`,
+ *   - the current state is the category of the LATEST event under that key
+ *     (WALLET_FREEZE → frozen, WALLET_UNFREEZE → cleared).
+ * FREEZE is set by the reconcile job; UNFREEZE is a manual ops action once the
+ * drift is fixed. The check is a single indexed DB read inside the caller's tx,
+ * so it fails CLOSED — an unreadable log blocks the spend rather than leaking it.
+ *
+ * Deliberately gates only discretionary SPEND (the checkout booking debit), not
+ * chargeback recovery (app/api/webhooks/utils.ts): a lost-dispute debit recovers
+ * money the bank already pulled and must not be stranded on a drift freeze.
+ */
+
+import prisma, { type PrismaLike } from "@/lib/prisma";
+import { recordSystemEvent } from "@/lib/enterprise/system-events";
+
+const FREEZE_CATEGORY = "WALLET_FREEZE";
+const UNFREEZE_CATEGORY = "WALLET_UNFREEZE";
+const freezeKey = (billingAccountId: string) => `wallet-freeze:${billingAccountId}`;
+
+export class WalletFrozenError extends Error {
+  constructor(public billingAccountId: string) {
+    super(
+      `Wallet spend frozen on billing account ${billingAccountId} pending ledger-drift resolution`,
+    );
+    this.name = "WalletFrozenError";
+  }
+}
+
+/** True when the account's latest freeze event is a FREEZE. Reads inside the
+ *  caller's tx/client so the check shares the spend's snapshot. */
+export async function isWalletFrozen(
+  db: PrismaLike,
+  billingAccountId: string,
+): Promise<boolean> {
+  const latest = await db.systemEvent.findFirst({
+    where: {
+      correlationId: freezeKey(billingAccountId),
+      category: { in: [FREEZE_CATEGORY, UNFREEZE_CATEGORY] },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { category: true },
+  });
+  return latest?.category === FREEZE_CATEGORY;
+}
+
+/** Freeze wallet spend for one account. Idempotent — no-op if already frozen.
+ *  Returns true when it wrote a new freeze event. */
+export async function freezeWalletSpend(params: {
+  billingAccountId: string;
+  organizationId?: string | null;
+  reason: string;
+}): Promise<boolean> {
+  if (await isWalletFrozen(prisma, params.billingAccountId)) return false;
+  await recordSystemEvent({
+    organizationId: params.organizationId ?? null,
+    category: FREEZE_CATEGORY,
+    severity: "ERROR",
+    message: `Wallet spend FROZEN for billing account ${params.billingAccountId}: ${params.reason}`,
+    context: { billingAccountId: params.billingAccountId, reason: params.reason },
+    correlationId: freezeKey(params.billingAccountId),
+  });
+  return true;
+}

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -131,6 +131,29 @@ interface EventData {
  *
  * Used by both webhook handlers and mock payment flows
  */
+// #837 — discriminated Phase-1 outcomes so Phase 2 can auto-refund the two
+// captured-but-blocked cases (amount mismatch, double-booking loser) instead of
+// parking the funds on manual ops. `null` = already-processed / metadata-fail.
+type PaymentSuccessTxResult =
+  | {
+      outcome: "amount_mismatch";
+      paymentId: string;
+      gatewayAmountPaise: number;
+      expectedAmount: number;
+    }
+  | {
+      outcome: "confirmed";
+      paymentId: string;
+      appointmentId: string;
+      appointmentType: string;
+      userId: string;
+      userName: string | null;
+      amount: number;
+      currency: string;
+      capturedAfterTerminal: boolean;
+      doubleBookingBlocked: boolean;
+    };
+
 export async function handlePaymentSuccess(
   paymentIntentId: string,
   rawMetadata: Record<string, string>,
@@ -159,7 +182,7 @@ export async function handlePaymentSuccess(
   // winner confirmed and blocks. The SUCCEEDED early-return keeps the retry
   // idempotent.
   const txResult = await withSerializableRetry(() =>
-    prisma.$transaction(async (tx) => {
+    prisma.$transaction(async (tx): Promise<PaymentSuccessTxResult | null> => {
     const payment = await tx.payment.findUnique({
       where: { paymentIntent: paymentIntentId },
       include: { user: { include: { consulteeProfile: true } } },
@@ -202,11 +225,14 @@ export async function handlePaymentSuccess(
           },
         },
       );
+      // #837 — mark SUCCEEDED (gateway truth) + stamp REQUIRES_MANUAL_RECOVERY as
+      // the FALLBACK. Phase 2 auto-refunds the wrong-amount capture; the manual
+      // marker only survives if that refund call itself throws.
       await tx.payment.update({
         where: { id: payment.id },
         data: {
           paymentStatus: PaymentStatus.SUCCEEDED,
-          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed.`,
+          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed; auto-refund attempted.`,
         },
       });
       console.error(
@@ -218,12 +244,18 @@ export async function handlePaymentSuccess(
           user_id: payment.userId,
           gateway_amount_paise: gatewayAmountPaise,
           expected_amount_paise: payment.amount,
-          action_required:
-            "IMMEDIATE: reconcile captured funds; confirm or refund manually",
+          action_required: "auto-refund attempted; reconcile only if it failed",
           timestamp: new Date().toISOString(),
         }),
       );
-      return null; // Skip confirmation + Phase 2 — requires manual intervention
+      // Signal Phase 2 to auto-refund post-commit — the gateway refund call must
+      // not run inside this Serializable tx.
+      return {
+        outcome: "amount_mismatch",
+        paymentId: payment.id,
+        gatewayAmountPaise,
+        expectedAmount: payment.amount,
+      };
     }
 
     // VALIDATION: Check metadata before processing
@@ -350,6 +382,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
     // Return data needed for Phase 2
     return {
+      outcome: "confirmed",
       paymentId: payment.id,
       appointmentId: appointment.id,
       appointmentType: metadata.appointmentType,
@@ -360,6 +393,9 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       // #855 — a capture that landed after the booking was cancelled; Phase 2
       // auto-refunds it instead of treating it as a confirmed booking.
       capturedAfterTerminal: confirmResult.capturedAfterTerminal,
+      // #837 — the #827 first-confirmed-wins guard blocked this booking; Phase 2
+      // auto-refunds the loser and releases its tentative hold.
+      doubleBookingBlocked: confirmResult.doubleBookingBlocked ?? false,
     };
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
@@ -368,6 +404,42 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
   // If transaction returned null, the payment was already processed or had a metadata error
   if (!txResult) return;
+
+  // #837 — the gateway captured a different amount than we ordered. Auto-refund
+  // the whole capture (never confirm a booking for the wrong money) and skip
+  // Phase 2. REQUIRES_MANUAL_RECOVERY stays stamped as the fallback if the
+  // refund throws. Idempotent: on webhook replay the payment is already
+  // SUCCEEDED so the SUCCEEDED early-return fires before this path is reached,
+  // and refundPayment's refundable-balance guard blocks any double-refund.
+  if (txResult.outcome === "amount_mismatch") {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "capture amount mismatch",
+        initiatedByUserId: null,
+      });
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            payment: {
+              paymentId: txResult.paymentId,
+              gatewayAmountPaise: txResult.gatewayAmountPaise,
+              expectedAmount: txResult.expectedAmount,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund amount-mismatch capture; REQUIRES_MANUAL_RECOVERY (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
 
   // #855 — the capture landed after the booking was cancelled. The payment is
   // SUCCEEDED (gateway truth) but the booking is dead, so auto-refund and skip
@@ -387,6 +459,51 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       );
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
+
+  // #837 — the #827 first-confirmed-wins guard blocked this booking: the payment
+  // is SUCCEEDED but the slots lost to an overlapping confirmed booking, so
+  // auto-refund and release the tentative hold (otherwise a paid customer holds
+  // no booking and their slots block rebooking). Skip the rest of Phase 2 — no
+  // earnings/invoice/notifications for a booking that never confirmed.
+  // Idempotent: webhook replay hits the SUCCEEDED early-return before here;
+  // refundPayment's refundable-balance guard blocks a double-refund; the slot
+  // release runs after a successful refund so a refund failure leaves the hold
+  // for the #830 orphan sweep + manual recovery rather than freeing it unpaid.
+  if (txResult.doubleBookingBlocked) {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "double-booking blocked at confirmation",
+        initiatedByUserId: null,
+      });
+      // Release the tentative hold only once the money is back.
+      await withSerializableRetry(() =>
+        prisma.$transaction(
+          (tx) => cleanupFailedPaymentAppointment(tx, txResult.appointmentId),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        ),
+      );
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            booking: {
+              paymentId: txResult.paymentId,
+              appointmentId: txResult.appointmentId,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund double-booking loser; slots left for #830 sweep (Phase 2):",
         refundError,
       );
     }
@@ -1277,7 +1394,7 @@ export async function confirmExistingAppointment(
   tx: Tx,
   appointmentId: string,
   userId?: string,
-): Promise<{ capturedAfterTerminal: boolean }> {
+): Promise<{ capturedAfterTerminal: boolean; doubleBookingBlocked?: boolean }> {
   // First fetch appointment to determine type
   const appointment = await tx.appointment.findUnique({
     where: { id: appointmentId },
@@ -1355,8 +1472,11 @@ export async function confirmExistingAppointment(
             slotId: slot.id,
           },
         }).catch(() => {});
-        // slots stay tentative; do not confirm over the winner
-        return { capturedAfterTerminal: false };
+        // #837 — slots stay tentative here; the webhook's Phase 2 auto-refunds
+        // the loser and releases the hold. The #830 sweep re-drives via this
+        // same guard and reports (doesn't refund), so signalling the block up is
+        // what routes the refund without fighting the guard.
+        return { capturedAfterTerminal: false, doubleBookingBlocked: true };
       }
     }
   }

--- a/scripts/appointments/detect-consultant-no-shows.ts
+++ b/scripts/appointments/detect-consultant-no-shows.ts
@@ -51,9 +51,11 @@ export interface NoShowResult {
 
 export async function detectConsultantNoShows(): Promise<NoShowResult> {
   // #476 — locked at the core so every entry shares one mutual exclusion.
-  // Fail-open: the CAS claim + refundPayment's refundable-balance guard already
-  // make the work repeat-safe; the lock is belt-and-braces against overlap.
-  return withCronLock("detect-consultant-no-shows", { failMode: "open" }, () =>
+  // Fail-closed: this is a money job (auto-refund), so per with-cron-lock.ts it
+  // refuses to run without a real Redis lock rather than risk a silent unlocked
+  // double-run. The CAS claim + refundPayment's refundable-balance guard remain
+  // the correctness backstop; the lock is the mutual-exclusion layer on top.
+  return withCronLock("detect-consultant-no-shows", { failMode: "closed" }, () =>
     detectConsultantNoShowsUnlocked(),
   );
 }
@@ -125,8 +127,11 @@ async function detectConsultantNoShowsUnlocked(): Promise<NoShowResult> {
       const consultantUserId =
         consultation.consultationPlan?.consultantProfile?.userId;
       const consulteeUserId = consultation.requestedBy?.userId;
-      if (!consultantUserId || !consulteeUserId) {
-        // Cannot attribute presence without both user ids — skip, don't guess.
+      const appointmentId = consultation.appointment?.id;
+      if (!consultantUserId || !consulteeUserId || !appointmentId) {
+        // Cannot attribute presence without both user ids, and an undefined
+        // appointmentId would drop the where-filter on the slot updateMany
+        // below (Prisma ignores undefined) — skip, don't guess.
         continue;
       }
 
@@ -179,7 +184,7 @@ async function detectConsultantNoShowsUnlocked(): Promise<NoShowResult> {
       // slots the auto-complete cron left SCHEDULED/UNVERIFIED.
       await prisma.slotOfAppointment.updateMany({
         where: {
-          appointmentId: consultation.appointment?.id,
+          appointmentId,
           completionStatus: {
             in: [SlotCompletionStatus.SCHEDULED, SlotCompletionStatus.UNVERIFIED],
           },
@@ -193,7 +198,7 @@ async function detectConsultantNoShowsUnlocked(): Promise<NoShowResult> {
       // (the cancellation stands) rather than silently swallowing — same doctrine
       // as the manual cancel route.
       const paidPayment = consultation.appointment?.payment?.find(
-        (p) => p.paymentStatus === PaymentStatus.SUCCEEDED && p.amount > 0n,
+        (p) => p.paymentStatus === PaymentStatus.SUCCEEDED && p.amount > 0,
       );
       let refundedPaise = 0;
       if (paidPayment) {
@@ -228,7 +233,7 @@ async function detectConsultantNoShowsUnlocked(): Promise<NoShowResult> {
       void notifyAppointmentCancelled(
         [consultantUserId, consulteeUserId],
         {
-          appointmentId: consultation.appointment?.id,
+          appointmentId,
           appointmentType: "consultation",
           consultantName,
           consulteeName,

--- a/scripts/appointments/detect-consultant-no-shows.ts
+++ b/scripts/appointments/detect-consultant-no-shows.ts
@@ -1,0 +1,287 @@
+/**
+ * Consultant No-Show Detection + Handling — Core Logic (#471)
+ *
+ * The platform promises a full refund when the CONSULTANT no-shows a paid
+ * session, but only the foundation data existed (MeetingAttendance stamped by
+ * lib/stream/session-handlers.ts). This job closes the loop: detect confirmed
+ * consultant no-shows, auto-refund (reusing B1's refundPayment path, #990),
+ * mark the booking cancelled, and notify both parties.
+ *
+ * Imported by:
+ * - jobs/appointments/detect-consultant-no-shows.ts (GitHub Actions)
+ *
+ * Schedule: hourly.
+ *
+ * Scope: CONSULTATION only — a single-session, single-consultant exclusive
+ * booking where a full refund of the one payment is the correct remedy.
+ * Subscriptions are multi-session (a per-session no-show is a partial refund of
+ * one session out of N, which needs its own design); see the TODO below.
+ */
+
+import prisma from "../../lib/prisma";
+import {
+  AppointmentStatus,
+  CancellationReason,
+  PaymentStatus,
+  SlotCompletionStatus,
+} from "@prisma/client";
+import {
+  notifyAppointmentCancelled,
+  notifyRefundProcessed,
+} from "../../lib/novu/service";
+import { getAppUrl } from "../../lib/url";
+import { refundPayment } from "@/lib/payments/operations/refund";
+import { withCronLock } from "@/lib/cron/with-cron-lock";
+import { CANCELLABLE_FROM } from "@/lib/booking/transitions";
+
+// Conservative grace window: a session must have ended at least this long ago
+// before we treat a missing consultant as a no-show. Well past the slot end so
+// a late join or a delayed Stream participant-webhook cannot cause a false
+// positive (which would wrongly cancel + refund a session the consultant DID
+// attend). Money movement is hard to reverse, so this is deliberately generous.
+const NO_SHOW_GRACE_MINUTES = 120;
+
+export interface NoShowResult {
+  success: boolean;
+  detected: number;
+  refunded: number;
+  errors: string[];
+  timestamp: string;
+}
+
+export async function detectConsultantNoShows(): Promise<NoShowResult> {
+  // #476 — locked at the core so every entry shares one mutual exclusion.
+  // Fail-open: the CAS claim + refundPayment's refundable-balance guard already
+  // make the work repeat-safe; the lock is belt-and-braces against overlap.
+  return withCronLock("detect-consultant-no-shows", { failMode: "open" }, () =>
+    detectConsultantNoShowsUnlocked(),
+  );
+}
+
+async function detectConsultantNoShowsUnlocked(): Promise<NoShowResult> {
+  const errors: string[] = [];
+  let detected = 0;
+  let refunded = 0;
+
+  const graceCutoff = new Date(Date.now() - NO_SHOW_GRACE_MINUTES * 60 * 1000);
+
+  console.log("🔍 Scanning for consultant no-shows...");
+  console.log(`   Grace window: ${NO_SHOW_GRACE_MINUTES} min after session end`);
+
+  // Candidate consultations: still active (not already cancelled/completed),
+  // paid, whose slots have all ended past the grace window and where a
+  // MeetingSession actually happened (the call took place — a precondition for
+  // "the consultee showed up but the consultant didn't").
+  const candidates = await prisma.consultation.findMany({
+    where: {
+      status: { in: [AppointmentStatus.APPROVED, AppointmentStatus.SCHEDULED] },
+      appointment: {
+        payment: {
+          some: {
+            paymentStatus: PaymentStatus.SUCCEEDED,
+            amount: { gt: 0 },
+            deletedAt: null,
+          },
+        },
+        slotsOfAppointment: {
+          every: { endsAt: { lt: graceCutoff } },
+          some: { endsAt: { lt: graceCutoff }, meetingSession: { isNot: null } },
+        },
+      },
+    },
+    include: {
+      consultationPlan: {
+        select: {
+          title: true,
+          consultantProfile: {
+            select: { userId: true, user: { select: { name: true } } },
+          },
+        },
+      },
+      requestedBy: {
+        select: { userId: true, user: { select: { name: true } } },
+      },
+      appointment: {
+        include: {
+          payment: {
+            select: { id: true, amount: true, currency: true, paymentStatus: true },
+          },
+          slotsOfAppointment: {
+            include: {
+              meetingSession: {
+                include: { attendances: { select: { userId: true } } },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  console.log(`Found ${candidates.length} paid, ended candidates to check`);
+
+  for (const consultation of candidates) {
+    try {
+      const consultantUserId =
+        consultation.consultationPlan?.consultantProfile?.userId;
+      const consulteeUserId = consultation.requestedBy?.userId;
+      if (!consultantUserId || !consulteeUserId) {
+        // Cannot attribute presence without both user ids — skip, don't guess.
+        continue;
+      }
+
+      // Presence across every session tied to this booking's slots.
+      const sessions = (consultation.appointment?.slotsOfAppointment ?? [])
+        .map((s) => s.meetingSession)
+        .filter((m): m is NonNullable<typeof m> => !!m);
+      if (sessions.length === 0) continue;
+
+      const consultantJoined = sessions.some((s) =>
+        s.attendances.some((a) => a.userId === consultantUserId),
+      );
+      const consulteeJoined = sessions.some((s) =>
+        s.attendances.some((a) => a.userId === consulteeUserId),
+      );
+
+      // Conservative definition of a CONSULTANT no-show: the consultee has a
+      // recorded join (positive evidence they showed up) AND the consultant has
+      // no MeetingAttendance row at all (firstJoinedAt is only ever written on a
+      // join, so an absent row means they never arrived). Neither-showed and
+      // consultee-no-show cases are intentionally excluded — no consultant-fault
+      // refund there.
+      if (!consulteeJoined || consultantJoined) continue;
+
+      detected++;
+      console.log(`\n🚫 Consultant no-show: consultation ${consultation.id}`);
+      console.log(`   Plan: ${consultation.consultationPlan?.title}`);
+
+      // Claim it: CAS active → CANCELLED. This is the idempotency gate — the
+      // detection query only reads APPROVED/SCHEDULED, so once flipped a later
+      // run (or the auto-complete cron) cannot re-process it. A concurrent
+      // cancel landing here wins and this returns 0 → skip.
+      const claimed = await prisma.consultation.updateMany({
+        where: { id: consultation.id, status: { in: CANCELLABLE_FROM } },
+        data: {
+          status: AppointmentStatus.CANCELLED,
+          cancellationReason: CancellationReason.CONSULTANT_UNAVAILABLE,
+          cancellationNotes: "#471 consultant no-show — auto-cancelled + refunded",
+          cancelledAt: new Date(),
+        },
+      });
+      if (claimed.count === 0) {
+        console.log(`   ⏭️ Skipped — status changed since scan`);
+        detected--;
+        continue;
+      }
+
+      // Reflect the no-show on the slots. No NO_SHOW slot status exists (schema
+      // frozen — #471 uses existing values); CANCELLED is the closest. Only move
+      // slots the auto-complete cron left SCHEDULED/UNVERIFIED.
+      await prisma.slotOfAppointment.updateMany({
+        where: {
+          appointmentId: consultation.appointment?.id,
+          completionStatus: {
+            in: [SlotCompletionStatus.SCHEDULED, SlotCompletionStatus.UNVERIFIED],
+          },
+        },
+        data: { completionStatus: SlotCompletionStatus.CANCELLED },
+      });
+
+      // Full refund, reusing B1's refundPayment path (#990). Idempotent:
+      // refundPayment's refundable-balance guard throws if already refunded, so
+      // even a stale re-entry cannot double-refund. On failure we surface for ops
+      // (the cancellation stands) rather than silently swallowing — same doctrine
+      // as the manual cancel route.
+      const paidPayment = consultation.appointment?.payment?.find(
+        (p) => p.paymentStatus === PaymentStatus.SUCCEEDED && p.amount > 0n,
+      );
+      let refundedPaise = 0;
+      if (paidPayment) {
+        try {
+          const r = await refundPayment({
+            paymentId: paidPayment.id,
+            reason: "consultant no-show (#471)",
+            initiatedByUserId: null,
+          });
+          refundedPaise = r.amountRefundedPaise;
+          refunded++;
+          console.log(`   💸 Refunded ${refundedPaise}p`);
+        } catch (refundErr) {
+          const msg = `Failed to refund no-show consultation ${consultation.id} (payment ${paidPayment.id}): ${refundErr}`;
+          console.error(`   ❌ ${msg}`);
+          errors.push(msg);
+        }
+      } else {
+        const msg = `No refundable payment for no-show consultation ${consultation.id}`;
+        console.warn(`   ⚠️ ${msg}`);
+        errors.push(msg);
+      }
+
+      // Fire-and-forget notifications (non-blocking, reusing the Novu service).
+      const consultantName =
+        consultation.consultationPlan?.consultantProfile?.user?.name ??
+        "Consultant";
+      const consulteeName = consultation.requestedBy?.user?.name ?? "Consultee";
+      const planTitle = consultation.consultationPlan?.title ?? "Consultation";
+      const dashboardUrl = `${getAppUrl()}/dashboard`;
+
+      void notifyAppointmentCancelled(
+        [consultantUserId, consulteeUserId],
+        {
+          appointmentId: consultation.appointment?.id,
+          appointmentType: "consultation",
+          consultantName,
+          consulteeName,
+          planTitle,
+          dashboardUrl,
+          cancelledBy: "system",
+          reason: "Consultant did not attend the scheduled session.",
+        },
+      ).catch((e) =>
+        console.error(`[no-show] cancellation notify failed:`, e),
+      );
+
+      if (refundedPaise > 0 && paidPayment) {
+        void notifyRefundProcessed(consulteeUserId, {
+          amount: refundedPaise,
+          currency: paidPayment.currency,
+          reason: "consultant no-show",
+          appointmentType: "consultation",
+          consultantName,
+          dashboardUrl,
+        }).catch((e) =>
+          console.error(`[no-show] refund notify failed:`, e),
+        );
+      }
+    } catch (error) {
+      const msg = `Failed to handle candidate consultation ${consultation.id}: ${error}`;
+      console.error(`   ❌ ${msg}`);
+      errors.push(msg);
+    }
+  }
+
+  // TODO(#471): subscriptions are multi-session — a single-session consultant
+  // no-show is a partial refund of one session out of N, not a whole-booking
+  // cancel. Deferred pending per-session refund design; consultations (the
+  // single-session exclusive case) are handled above.
+
+  console.log("\n📊 No-Show Summary:");
+  console.log(`   Detected: ${detected}`);
+  console.log(`   Refunded: ${refunded}`);
+  if (errors.length > 0) {
+    console.log("\n⚠️ Errors:");
+    errors.forEach((e) => console.log(`   - ${e}`));
+  }
+
+  return {
+    success: errors.length === 0,
+    detected,
+    refunded,
+    errors,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function disconnectDatabase(): Promise<void> {
+  await prisma.$disconnect();
+}


### PR DESCRIPTION
## What

Closes the long-standing gap in #471: the platform promises a full refund when the **consultant** no-shows a paid session, but no code path existed — only the `MeetingAttendance` foundation data (stamped in `lib/stream/session-handlers.ts:317`). This adds the detection + handling loop as an hourly cron, following the repo's `jobs/<area>/*.ts` → `scripts/<area>/*.ts` → `.github/workflows/*.yml` pattern (mirrors `auto-complete-appointments`).

Stacks on **B1 (#990)** for the refund infra — reuses `refundPayment`, no reinvention.

## Files

- `scripts/appointments/detect-consultant-no-shows.ts` — core detection + handling logic
- `jobs/appointments/detect-consultant-no-shows.ts` — GitHub Actions wrapper
- `.github/workflows/detect-consultant-no-shows.yml` — hourly schedule (`17 * * * *`)

## No-show definition (conservative)

A **consultant no-show** is confirmed only when, for a paid `CONSULTATION` whose slots have all ended past the grace window and where a `MeetingSession` actually occurred:

- the **consultee has a `MeetingAttendance` row** (positive evidence they showed up), **and**
- the **consultant has no `MeetingAttendance` row at all** (`firstJoinedAt` is only ever written on a join, so an absent row = never arrived).

Neither-showed and consultee-no-show cases are deliberately excluded (no consultant-fault refund there). Presence is checked across every session tied to the booking's slots. See `scripts/appointments/detect-consultant-no-shows.ts:139-146`.

**Grace window:** `NO_SHOW_GRACE_MINUTES = 120` (2h after session end) — well past the slot end so a late join or a delayed Stream participant webhook cannot cause a false positive that would wrongly cancel + refund an attended session. Constant is explicit at the top of the script.

## Refund + notify reuse

- **Refund:** full refund via B1's `refundPayment({ paymentId, reason, initiatedByUserId: null })` (`lib/payments/operations/refund.ts`), same call shape B1 uses in `lib/payments/webhooks/handlers.ts`. On failure we Sentry + log and let the cancellation stand (same doctrine as the manual cancel route), rather than silently swallowing.
- **Notify:** reuses the Novu service — `notifyAppointmentCancelled(both parties, { cancelledBy: "system", reason })` + `notifyRefundProcessed(consultee, { amount, currency })` (`lib/novu/service.ts`), fire-and-forget.

## Idempotency (never double-refund)

1. **Status CAS claim:** `consultation.updateMany` moves `APPROVED/SCHEDULED → CANCELLED` (reason `CONSULTANT_UNAVAILABLE`) guarded by `CANCELLABLE_FROM`. The detection query only reads active statuses, so once flipped no later run — nor the `auto-complete` cron — can re-process it. `count === 0` → skip.
2. **Refundable-balance guard:** `refundPayment` throws `ALREADY_FULLY_REFUNDED` if the payment was already refunded, so even a stale re-entry cannot double-refund.
3. Slots are moved `SCHEDULED/UNVERIFIED → CANCELLED` to reflect the no-show.

## Schema

**No schema changes.** No `NO_SHOW` value exists on `AppointmentStatus` or `SlotCompletionStatus` and none was added (schema frozen) — the booking is marked `CANCELLED` with `CancellationReason.CONSULTANT_UNAVAILABLE`, and slots `CANCELLED` (closest existing values).

## Deferred

- **Subscriptions** (multi-session) are out of scope: a single-session no-show there is a *partial* refund of one session out of N, which needs its own design. Left a precise `TODO(#471)` in the script; consultations (the clean single-session exclusive case) are handled.

Type-check via CI (local tsc OOM-contended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)