### PR TITLE
fix(payments): make checkout earnings + BOOKING journal atomic (C-01)

### DIFF
--- a/app/api/organizations/[orgId]/billing-account/route.ts
+++ b/app/api/organizations/[orgId]/billing-account/route.ts
@@ -26,6 +26,7 @@ import { requireOrgAccess } from "@/lib/auth-helpers";
 // description in `lib/labels/org-labels.ts`.
 import { requireOrgBillingAdminOrOwner } from "@/lib/auth/billing-admin-gate";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { assertVerifiedDomainOrThrow } from "@/lib/enterprise/governance";
 
 // PROJECT is reserved in the Prisma enum for v2 project-billing; the
 // API layer rejects it so callers can't quietly land a BillingAccount
@@ -200,6 +201,13 @@ export async function PATCH(
               { httpStatus: 409 },
             );
           }
+        }
+        // K-02 / #687 — enabling INVOICE funding requires a verified domain
+        // (governance.ts documents this gate for the fundingSource→INVOICE
+        // transition). tx-scoped read: TOCTOU-safe against a concurrent
+        // verification rollback.
+        if (body.fundingSource === "INVOICE") {
+          await assertVerifiedDomainOrThrow(tx, orgId, "INVOICE_FUNDING");
         }
       }
 

--- a/app/api/organizations/[orgId]/earnings/route.ts
+++ b/app/api/organizations/[orgId]/earnings/route.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { sumPaise } from "@/lib/payments/utils/money";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
 const EarningStatusSchema = z.enum([
   "PENDING",
@@ -48,7 +49,10 @@ export async function GET(
   const access = await requireOrgAccess(orgId, "MANAGER");
   if (access.error) return access.error;
 
-  if (!access.org.canHost) {
+  // Honesty gate: an org's canHost column can be true from when the flag was
+  // on, but with ENABLE_HOST_ORGS off resolveOrgSplit returns null so NO new
+  // OrganizationEarnings accrue — surfacing a split dashboard would lie.
+  if (!ENABLE_HOST_ORGS || !access.org.canHost) {
     return NextResponse.json(
       { error: "Organization does not host — no earnings to list" },
       { status: 404 },

--- a/app/api/organizations/[orgId]/earnings/route.ts
+++ b/app/api/organizations/[orgId]/earnings/route.ts
@@ -28,6 +28,7 @@ const EarningStatusSchema = z.enum([
   "PENDING",
   "HELD",
   "READY",
+  "BATCHED", // #837 — batched, cash not yet disbursed; filterable + distinct from PAID
   "PAID",
   "REFUNDED",
 ]);

--- a/app/api/organizations/[orgId]/payouts/route.ts
+++ b/app/api/organizations/[orgId]/payouts/route.ts
@@ -6,7 +6,8 @@
  * row. The creation path is deliberately admin-gated and narrow:
  *   1. Pick all READY earnings in [periodStart, periodEnd).
  *   2. Create the payout with aggregated totals (gross/fee/refunds/net).
- *   3. Attach those earnings to the payout + flip their status to PAID.
+ *   3. Attach those earnings to the payout + flip their status to BATCHED
+ *      (#837 — not PAID; PAID happens only at payout COMPLETED + UTR).
  *
  * Actual fund-movement (RazorpayX / Cashfree) happens asynchronously in
  * jobs/payouts/** — this endpoint only records the intent and reserves the
@@ -168,7 +169,7 @@ export async function POST(
       //       earning.
       //   (3) Re-read the claimed rows (authoritatively scoped by orgPayoutId),
       //       compute totals, and patch the payout row with the real numbers.
-      //   (4) Flip the claimed rows READY → PAID in the same tx.
+      //   (4) Flip the claimed rows READY → BATCHED in the same tx (#837).
       // If no rows are claimed, throw to abort the tx so the placeholder
       // payout row is rolled back too.
       const created = await tx.organizationPayout.create({
@@ -268,11 +269,12 @@ export async function POST(
         },
       });
 
-      // Flip the claimed earnings READY → PAID. The cron that flips the
-      // payout to COMPLETED does not touch earnings.status.
+      // #837 E-03/E-04 — batch creation only STAGES the earnings; cash has not
+      // left. Flip READY → BATCHED, not PAID. markOrgPayoutCompleted performs
+      // the BATCHED → PAID flip when the payout reaches COMPLETED (+ UTR).
       await tx.organizationEarnings.updateMany({
         where: { orgPayoutId: created.id, status: "READY" },
-        data: { status: "PAID" },
+        data: { status: "BATCHED" },
       });
 
       await tx.orgAuditLog.create({

--- a/app/api/organizations/[orgId]/route.ts
+++ b/app/api/organizations/[orgId]/route.ts
@@ -570,7 +570,10 @@ export async function DELETE(
               purchaseOrders: { where: { remainingAmountPaise: { gt: 0 } } },
               earnings: {
                 where: {
-                  status: { in: ["PENDING_TRUST", "PENDING", "HELD", "READY"] },
+                  // #837 — BATCHED is unsettled (payout in flight, cash not moved yet).
+                  status: {
+                    in: ["PENDING_TRUST", "PENDING", "HELD", "READY", "BATCHED"],
+                  },
                 },
               },
               payouts: {

--- a/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/earnings/page.tsx
@@ -163,6 +163,7 @@ export default function EarningsPage({
     { label: "All", value: "ALL" },
     { label: "Pending", value: "PENDING" },
     { label: "Ready", value: "READY" },
+    { label: "Processing", value: "BATCHED" }, // #837 — batched, cash not yet disbursed
     { label: "Paid", value: "PAID" },
     { label: "On Hold", value: "HELD" },
     { label: "Org Trust", value: "PENDING_TRUST" },

--- a/app/dashboard/organization/[orgId]/my-arrangement/page.tsx
+++ b/app/dashboard/organization/[orgId]/my-arrangement/page.tsx
@@ -37,6 +37,7 @@ const EARNING_STATUS_LABEL: Record<string, string> = {
   HELD: "On hold",
   PENDING: "Pending (hold window)",
   PENDING_TRUST: "Pending (trust window)",
+  BATCHED: "Processing payout", // #837 — batched, cash not yet disbursed
   PAID: "Paid",
   REFUNDED: "Refunded",
 };

--- a/jobs/cleanup/release-pending-trust-earnings.ts
+++ b/jobs/cleanup/release-pending-trust-earnings.ts
@@ -1,8 +1,8 @@
 /**
  * Release PENDING_TRUST earnings — invoice-fraud guard release valve (#687).
  *
- * Promotes OrganizationEarnings rows from PENDING_TRUST → PENDING when
- * the sponsoring org has either:
+ * Promotes both OrganizationEarnings AND ConsultantEarnings rows (#687 E-02)
+ * from PENDING_TRUST → PENDING when the sponsoring org has either:
  *   1. transitioned to status=ACTIVE (admin verification), or
  *   2. paid at least one OrganizationInvoice.
  *
@@ -79,28 +79,55 @@ async function runReleasePendingTrustEarningsUnlocked(): Promise<ReleasePendingT
     return result;
   }
 
-  const candidates = await prisma.organizationEarnings.findMany({
-    where: {
-      status: EarningStatus.PENDING_TRUST,
-      organizationId: { in: unlockedOrgIds },
-    },
-    select: { id: true },
-  });
-  result.scanned = candidates.length;
+  // Org rows carry organizationId directly. Consultant rows (#687 E-02) do
+  // NOT — the sponsor lives on the Payment, so join through it. Both are
+  // parked/released as one booking, so an unlocked sponsor promotes both.
+  const [orgCandidates, consultantCandidates] = await Promise.all([
+    prisma.organizationEarnings.findMany({
+      where: {
+        status: EarningStatus.PENDING_TRUST,
+        organizationId: { in: unlockedOrgIds },
+      },
+      select: { id: true },
+    }),
+    prisma.consultantEarnings.findMany({
+      where: {
+        status: EarningStatus.PENDING_TRUST,
+        payment: { organizationId: { in: unlockedOrgIds } },
+      },
+      select: { id: true },
+    }),
+  ]);
+  result.scanned = orgCandidates.length + consultantCandidates.length;
 
-  if (candidates.length === 0) {
+  if (result.scanned === 0) {
     return result;
   }
 
+  // CAS on status inside each updateMany so a concurrent refund/hold that
+  // moved a row out of PENDING_TRUST between the scan and the write is not
+  // clobbered back to PENDING.
   try {
-    const update = await prisma.organizationEarnings.updateMany({
-      where: {
-        id: { in: candidates.map((c) => c.id) },
-        status: EarningStatus.PENDING_TRUST,
-      },
-      data: { status: EarningStatus.PENDING },
-    });
-    result.released = update.count;
+    if (orgCandidates.length > 0) {
+      const orgUpdate = await prisma.organizationEarnings.updateMany({
+        where: {
+          id: { in: orgCandidates.map((c) => c.id) },
+          status: EarningStatus.PENDING_TRUST,
+        },
+        data: { status: EarningStatus.PENDING },
+      });
+      result.released += orgUpdate.count;
+    }
+    if (consultantCandidates.length > 0) {
+      const consultantUpdate = await prisma.consultantEarnings.updateMany({
+        where: {
+          id: { in: consultantCandidates.map((c) => c.id) },
+          status: EarningStatus.PENDING_TRUST,
+        },
+        data: { status: EarningStatus.PENDING },
+      });
+      result.released += consultantUpdate.count;
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     result.errors.push(message);

--- a/jobs/reconcile/reconcile-ledgers.ts
+++ b/jobs/reconcile/reconcile-ledgers.ts
@@ -24,6 +24,7 @@ import {
   recordSystemError,
 } from "../../lib/enterprise/system-events";
 import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+import { freezeWalletSpend } from "../../lib/payments/wallet-freeze";
 import * as Sentry from "@sentry/nextjs";
 
 async function main(): Promise<void> {
@@ -102,6 +103,41 @@ async function main(): Promise<void> {
           },
         },
       );
+
+      // #837 — a wallet cache/journal drift means the balance can't be trusted,
+      // so freeze spend on each drifted account (scoped, not platform-wide) and
+      // page P0. Only WALLET_BALANCE_DRIFT freezes; other finding kinds page via
+      // the captureException above but don't gate spend.
+      const walletDrift = report.findings.filter(
+        (f) => f.kind === "WALLET_BALANCE_DRIFT" && f.billingAccountId,
+      );
+      for (const f of walletDrift) {
+        const froze = await freezeWalletSpend({
+          billingAccountId: f.billingAccountId!,
+          organizationId: f.organizationId ?? null,
+          reason: `ledger reconcile ${report.id}: wallet cache ${f.actualPaise}p ≠ journal ${f.expectedPaise}p (Δ${f.deltaPaise}p)`,
+        });
+        Sentry.captureException(
+          new Error(
+            `WALLET_BALANCE_DRIFT — wallet spend frozen for billing account ${f.billingAccountId}`,
+          ),
+          {
+            level: "fatal",
+            tags: { subsystem: "jobs", job: "reconcile-ledgers" },
+            contexts: {
+              wallet: {
+                billingAccountId: f.billingAccountId,
+                organizationId: f.organizationId ?? null,
+                expectedPaise: f.expectedPaise,
+                actualPaise: f.actualPaise,
+                deltaPaise: f.deltaPaise,
+                reportId: report.id,
+                newlyFrozen: froze,
+              },
+            },
+          },
+        );
+      }
       process.exit(2);
     }
   } catch (error) {

--- a/lib/data/org-analytics.ts
+++ b/lib/data/org-analytics.ts
@@ -17,6 +17,7 @@ import prisma from "@/lib/prisma";
 import { ledgerAccountId } from "@/lib/payments/ledger/post";
 import { sumPaise } from "@/lib/payments/utils/money";
 import { resolveActivationSignals } from "@/lib/enterprise/org-activation-signals";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -204,7 +205,9 @@ export async function getOrgAnalytics(
           },
         })
       : Promise.resolve(0),
-    org.canHost
+    // Honesty gate (#687): with ENABLE_HOST_ORGS off no new splits accrue, so
+    // don't surface host earnings even if canHost is still set on the row.
+    ENABLE_HOST_ORGS && org.canHost
       ? prisma.organizationEarnings.groupBy({
           by: ["status"],
           where: { organizationId: orgId },

--- a/lib/labels/session-labels.ts
+++ b/lib/labels/session-labels.ts
@@ -424,6 +424,11 @@ export const EARNING_STATUS_BADGE: Record<EarningStatus, StatusBadgeStyle> = {
     label: "Ready for payout",
     className: "bg-emerald-100 text-emerald-900 border-emerald-200",
   },
+  // #837 — in a payout batch but cash hasn't left yet; honestly distinct from Paid.
+  BATCHED: {
+    label: "Processing payout",
+    className: "bg-sky-100 text-sky-900 border-sky-200",
+  },
   PAID: {
     label: "Paid",
     className: "bg-green-100 text-green-900 border-green-200",

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -66,7 +66,10 @@ import {
 } from "@/lib/payments/validation/currency-guards";
 import { checkPaymentLegsSumToAmount } from "@/lib/payments/payment-legs";
 import { recordOverageAtCheckout } from "@/lib/payments/billing/overage-settlement";
-import { getInvoiceCreditLimitPaise } from "@/lib/enterprise/governance";
+import {
+  getInvoiceCreditLimitPaise,
+  assertVerifiedDomainOrThrow,
+} from "@/lib/enterprise/governance";
 import {
   notifyOrgProgramExhausted,
   notifyOrgProgramCapNear,
@@ -1939,6 +1942,12 @@ export async function handleCheckout(
     // book-everything-then-ghost abuse pattern. The cap auto-lifts
     // once the org is verified OR pays its first invoice.
     if (fundingSource === "INVOICE") {
+      // K-02 / #687 — an org may not accrue INVOICE debt without a verified
+      // domain. The credit-limit gate below caps unverified-STATUS orgs; this
+      // asserts the orthogonal domain-ownership proof (OrgDomainClaim), the
+      // gate governance.ts documents for INVOICE funding but had no caller.
+      await assertVerifiedDomainOrThrow(prisma, org.id, "INVOICE_FUNDING");
+
       const explicitLimit = org.billingAccount?.creditLimit ?? null;
       const isVerified = org.status === "ACTIVE";
       const governanceLimit = isVerified ? null : getInvoiceCreditLimitPaise();

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -52,6 +52,7 @@ import {
 } from "@/lib/payments/payouts";
 import { walletDebit } from "@/lib/api/organizations/wallet";
 import { isWalletFrozen, WalletFrozenError } from "@/lib/payments/wallet-freeze";
+import { recordSystemError } from "@/lib/enterprise/system-events";
 import {
   recordBookingUtilization,
   ProgramAssignmentLimitError,
@@ -2900,15 +2901,29 @@ export async function handleCheckout(
             }
           }
         } catch (earningsError) {
-          // Log but don't fail — sync-payment-earnings job will pick up the gap
+          // C-01 #837 — payment + booking are committed but earnings + the
+          // BOOKING journal are not. Real money moved, so we don't roll back
+          // and we don't pretend success with a silent warning: page (ERROR)
+          // and durably record the ledger gap. The healer is the data-state
+          // sync-payment-earnings scan (SUCCEEDED payment + earnings:none),
+          // keyed on row state — not on this marker — so it's guaranteed and
+          // idempotent even if this alert is lost.
+          await recordSystemError({
+            category: "PAYOUT",
+            summary: `Earnings + booking journal not written for committed payment ${paymentResponse!.id} (checkout mock/zero/sponsored path)`,
+            err: earningsError,
+            correlationId: paymentResponse!.id,
+            context: {
+              paymentIntent: paymentResponse!.id,
+              userId,
+              appointmentType: validatedData.appointmentType,
+              path: "checkout",
+            },
+          });
           console.error(
             `⚠️ Failed to create earnings for mock payment:`,
             earningsError,
           );
-          Sentry.captureException(earningsError instanceof Error ? earningsError : new Error(String(earningsError)), {
-            tags: { subsystem: "payments" },
-            level: "warning",
-          });
         }
 
         // FIX #437: Consultant qualifying action (receiving first paid booking)

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -51,6 +51,7 @@ import {
   type AppointmentType,
 } from "@/lib/payments/payouts";
 import { walletDebit } from "@/lib/api/organizations/wallet";
+import { isWalletFrozen, WalletFrozenError } from "@/lib/payments/wallet-freeze";
 import {
   recordBookingUtilization,
   ProgramAssignmentLimitError,
@@ -2366,6 +2367,13 @@ export async function handleCheckout(
           // Triggered only when we also have a resolved program assignment,
           // which guarantees the booking is actually sponsored.
           if (isOrgWalletPayment && billingAccountId) {
+            // #837 — refuse to spend a wallet whose cache drifted from the
+            // journal (frozen by the ledger-reconcile job): the balance can't
+            // be trusted until ops reconciles. Chargeback recovery is NOT gated
+            // (see wallet-freeze.ts).
+            if (await isWalletFrozen(tx, billingAccountId)) {
+              throw new WalletFrozenError(billingAccountId);
+            }
             await walletDebit(tx, {
               billingAccountId,
               amountPaise: amount,

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -40,6 +40,8 @@ export interface EarningsSummary {
   totalEarnings: number;
   pendingEarnings: number;
   readyEarnings: number;
+  /** #837 — in a payout batch, cash not yet disbursed (distinct from PAID). */
+  batchedEarnings: number;
   paidEarnings: number;
   heldEarnings: number;
   /**
@@ -70,6 +72,8 @@ interface OrgEarningsSummary {
   totalEarnings: number;
   pendingEarnings: number;
   readyEarnings: number;
+  /** #837 — in a payout batch, cash not yet disbursed (distinct from PAID). */
+  batchedEarnings: number;
   paidEarnings: number;
   heldEarnings: number;
 }
@@ -837,31 +841,37 @@ export async function releaseEarningsFromHold(): Promise<number> {
 export async function getConsultantEarningsSummary(
   consultantProfileId: string,
 ): Promise<EarningsSummary> {
-  const [pending, ready, paid, held, pendingTrust] = await Promise.all([
-    prisma.consultantEarnings.aggregate({
-      where: { consultantProfileId, status: EarningStatus.PENDING },
-      _sum: { consultantSharePaise: true },
-    }),
-    prisma.consultantEarnings.aggregate({
-      where: { consultantProfileId, status: EarningStatus.READY },
-      _sum: { consultantSharePaise: true },
-    }),
-    prisma.consultantEarnings.aggregate({
-      where: { consultantProfileId, status: EarningStatus.PAID },
-      _sum: { consultantSharePaise: true },
-    }),
-    prisma.consultantEarnings.aggregate({
-      where: { consultantProfileId, status: EarningStatus.HELD },
-      _sum: { consultantSharePaise: true },
-    }),
-    prisma.consultantEarnings.aggregate({
-      where: { consultantProfileId, status: EarningStatus.PENDING_TRUST },
-      _sum: { consultantSharePaise: true },
-    }),
-  ]);
+  const [pending, ready, batched, paid, held, pendingTrust] =
+    await Promise.all([
+      prisma.consultantEarnings.aggregate({
+        where: { consultantProfileId, status: EarningStatus.PENDING },
+        _sum: { consultantSharePaise: true },
+      }),
+      prisma.consultantEarnings.aggregate({
+        where: { consultantProfileId, status: EarningStatus.READY },
+        _sum: { consultantSharePaise: true },
+      }),
+      prisma.consultantEarnings.aggregate({
+        where: { consultantProfileId, status: EarningStatus.BATCHED },
+        _sum: { consultantSharePaise: true },
+      }),
+      prisma.consultantEarnings.aggregate({
+        where: { consultantProfileId, status: EarningStatus.PAID },
+        _sum: { consultantSharePaise: true },
+      }),
+      prisma.consultantEarnings.aggregate({
+        where: { consultantProfileId, status: EarningStatus.HELD },
+        _sum: { consultantSharePaise: true },
+      }),
+      prisma.consultantEarnings.aggregate({
+        where: { consultantProfileId, status: EarningStatus.PENDING_TRUST },
+        _sum: { consultantSharePaise: true },
+      }),
+    ]);
 
   const pendingEarnings = sumPaise(pending._sum.consultantSharePaise);
   const readyEarnings = sumPaise(ready._sum.consultantSharePaise);
+  const batchedEarnings = sumPaise(batched._sum.consultantSharePaise);
   const paidEarnings = sumPaise(paid._sum.consultantSharePaise);
   const heldEarnings = sumPaise(held._sum.consultantSharePaise);
   const pendingTrustEarnings = sumPaise(
@@ -870,10 +880,16 @@ export async function getConsultantEarningsSummary(
 
   return {
     consultantProfileId,
+    // #837 — batched money is real cleared earnings in transit; keep it in the total.
     totalEarnings:
-      pendingEarnings + readyEarnings + paidEarnings + heldEarnings,
+      pendingEarnings +
+      readyEarnings +
+      batchedEarnings +
+      paidEarnings +
+      heldEarnings,
     pendingEarnings,
     readyEarnings,
+    batchedEarnings,
     paidEarnings,
     heldEarnings,
     pendingTrustEarnings,
@@ -1208,7 +1224,7 @@ export async function releaseHeldEarnings(
  * Get earnings statistics for admin dashboard
  */
 export async function getEarningsStats() {
-  const [pending, ready, paid, held, refunded] = await Promise.all([
+  const [pending, ready, batched, paid, held, refunded] = await Promise.all([
     prisma.consultantEarnings.aggregate({
       where: { status: EarningStatus.PENDING },
       _sum: { consultantSharePaise: true, platformFeePaise: true },
@@ -1216,6 +1232,11 @@ export async function getEarningsStats() {
     }),
     prisma.consultantEarnings.aggregate({
       where: { status: EarningStatus.READY },
+      _sum: { consultantSharePaise: true, platformFeePaise: true },
+      _count: true,
+    }),
+    prisma.consultantEarnings.aggregate({
+      where: { status: EarningStatus.BATCHED },
       _sum: { consultantSharePaise: true, platformFeePaise: true },
       _count: true,
     }),
@@ -1247,6 +1268,12 @@ export async function getEarningsStats() {
       consultantSharePaise: sumPaise(ready._sum.consultantSharePaise),
       platformFeePaise: sumPaise(ready._sum.platformFeePaise),
     },
+    // #837 — batched, cash not yet disbursed (was previously counted under ready).
+    batched: {
+      count: batched._count,
+      consultantSharePaise: sumPaise(batched._sum.consultantSharePaise),
+      platformFeePaise: sumPaise(batched._sum.platformFeePaise),
+    },
     paid: {
       count: paid._count,
       consultantSharePaise: sumPaise(paid._sum.consultantSharePaise),
@@ -1262,8 +1289,11 @@ export async function getEarningsStats() {
       consultantSharePaise: sumPaise(refunded._sum.consultantSharePaise),
       platformFeePaise: sumPaise(refunded._sum.platformFeePaise),
     },
+    // #837 — platform fee is earned once the sale settles (READY); batched/paid
+    // are downstream of READY, so include all three to keep recognized revenue whole.
     totalPlatformRevenue:
       sumPaise(paid._sum.platformFeePaise) +
+      sumPaise(batched._sum.platformFeePaise) +
       sumPaise(ready._sum.platformFeePaise),
   };
 }
@@ -1278,13 +1308,17 @@ export async function getEarningsStats() {
 export async function getOrgEarningsSummary(
   organizationId: string,
 ): Promise<OrgEarningsSummary> {
-  const [pending, ready, paid, held] = await Promise.all([
+  const [pending, ready, batched, paid, held] = await Promise.all([
     prisma.organizationEarnings.aggregate({
       where: { organizationId, status: EarningStatus.PENDING },
       _sum: { orgSharePaise: true },
     }),
     prisma.organizationEarnings.aggregate({
       where: { organizationId, status: EarningStatus.READY },
+      _sum: { orgSharePaise: true },
+    }),
+    prisma.organizationEarnings.aggregate({
+      where: { organizationId, status: EarningStatus.BATCHED },
       _sum: { orgSharePaise: true },
     }),
     prisma.organizationEarnings.aggregate({
@@ -1299,15 +1333,22 @@ export async function getOrgEarningsSummary(
 
   const pendingEarnings = sumPaise(pending._sum.orgSharePaise);
   const readyEarnings = sumPaise(ready._sum.orgSharePaise);
+  const batchedEarnings = sumPaise(batched._sum.orgSharePaise);
   const paidEarnings = sumPaise(paid._sum.orgSharePaise);
   const heldEarnings = sumPaise(held._sum.orgSharePaise);
 
   return {
     organizationId,
+    // #837 — batched money is real cleared earnings in transit; keep it in the total.
     totalEarnings:
-      pendingEarnings + readyEarnings + paidEarnings + heldEarnings,
+      pendingEarnings +
+      readyEarnings +
+      batchedEarnings +
+      paidEarnings +
+      heldEarnings,
     pendingEarnings,
     readyEarnings,
+    batchedEarnings,
     paidEarnings,
     heldEarnings,
   };

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -310,6 +310,30 @@ export async function createEarningsFromPayment({
             payment.createdAt,
           );
 
+          // #687 E-01/E-02 — the PENDING_TRUST park keys on the SPONSORING org
+          // (the org that OWES the invoice = payment.organizationId), NOT the
+          // expert's HOST org from resolveOrgSplit. An unverified sponsor that
+          // may never pay its invoice must not let consultant OR org earnings
+          // clear. Decide ONCE here and apply to every row this booking writes
+          // (consultant, primary-org, collaborator-org).
+          const sponsorOrgId = payment.organizationId;
+          let parkForTrust = false;
+          if (sponsorOrgId) {
+            const sponsorOrg = await tx.organization.findUnique({
+              where: { id: sponsorOrgId },
+              select: { status: true },
+            });
+            if (sponsorOrg?.status === "PENDING_VERIFICATION") {
+              const paidInvoiceCount = await tx.organizationInvoice.count({
+                where: { organizationId: sponsorOrgId, status: "PAID" },
+              });
+              parkForTrust = paidInvoiceCount === 0;
+            }
+          }
+          const initialEarningStatus: EarningStatus = parkForTrust
+            ? EarningStatus.PENDING_TRUST
+            : EarningStatus.PENDING;
+
           // Determine platform fee and consultant pool based on whether org split applies.
           // #778 §C-2 — floor the marketplace fee (was Math.round); the shaved paisa
           // stays in the consultant pool (gross − fee), the pool's residual party.
@@ -427,7 +451,10 @@ export async function createEarningsFromPayment({
                   consultantSharePaise: creditedShare,
                   role: isOwner ? EarningRole.OWNER : EarningRole.COLLABORATOR,
                   shareBps,
-                  status: EarningStatus.PENDING,
+                  // #687 E-02 — park consultant payables too when the sponsor
+                  // is an unverified INVOICE org; else the platform owes real
+                  // money for a ghost sponsor's booking.
+                  status: initialEarningStatus,
                   holdUntil,
                   currency: "INR",
                 },
@@ -450,7 +477,8 @@ export async function createEarningsFromPayment({
                 grossAmount,
                 platformFeePaise,
                 consultantSharePaise: totalConsultantPool,
-                status: EarningStatus.PENDING,
+                // #687 E-02 — see multi-party branch above.
+                status: initialEarningStatus,
                 holdUntil,
                 currency: "INR",
               },
@@ -463,28 +491,12 @@ export async function createEarningsFromPayment({
           // Skip when orgShare is 0 (Platform-only mode: platformCommissionRate = 1.0)
           // — creating 0-value rows adds noise without value.
           //
-          // PR-1d / #687: if the sponsoring org is still PENDING_VERIFICATION
+          // PR-1d / #687: if the SPONSORING org (payment.organizationId, resolved
+          // above into initialEarningStatus — E-01) is still PENDING_VERIFICATION
           // and has never paid an invoice, accruals start in PENDING_TRUST
           // instead of PENDING. The `release-pending-trust-earnings` cron
           // promotes them once the org is verified or first invoice clears.
           if (orgSplit && orgSplit.orgShare > 0) {
-            const sponsorOrg = await tx.organization.findUnique({
-              where: { id: orgSplit.organizationId },
-              select: { status: true },
-            });
-            let initialStatus: EarningStatus = EarningStatus.PENDING;
-            if (sponsorOrg?.status === "PENDING_VERIFICATION") {
-              const paidInvoiceCount = await tx.organizationInvoice.count({
-                where: {
-                  organizationId: orgSplit.organizationId,
-                  status: "PAID",
-                },
-              });
-              if (paidInvoiceCount === 0) {
-                initialStatus = EarningStatus.PENDING_TRUST;
-              }
-            }
-
             await tx.organizationEarnings.create({
               data: {
                 organizationId: orgSplit.organizationId,
@@ -494,7 +506,7 @@ export async function createEarningsFromPayment({
                 orgSharePaise: orgSplit.orgShare,
                 consultantSharePaise: orgSplit.consultantSharePaise,
                 refundedAmountPaise: 0,
-                status: initialStatus,
+                status: initialEarningStatus,
                 holdUntil,
                 currency: "INR",
                 // Rate-card snapshot: persist the exact split applied so
@@ -538,24 +550,9 @@ export async function createEarningsFromPayment({
               continue;
             }
 
-            // PR-1d / #687 — same PENDING_TRUST gate as the primary org above.
-            const collabSponsorOrg = await tx.organization.findUnique({
-              where: { id: s.orgSplit.organizationId },
-              select: { status: true },
-            });
-            let collabInitialStatus: EarningStatus = EarningStatus.PENDING;
-            if (collabSponsorOrg?.status === "PENDING_VERIFICATION") {
-              const paidInvoiceCount = await tx.organizationInvoice.count({
-                where: {
-                  organizationId: s.orgSplit.organizationId,
-                  status: "PAID",
-                },
-              });
-              if (paidInvoiceCount === 0) {
-                collabInitialStatus = EarningStatus.PENDING_TRUST;
-              }
-            }
-
+            // #687 E-01 — same sponsor-scoped PENDING_TRUST gate as the primary
+            // org above; the park keys on the SPONSOR (payment.organizationId,
+            // via initialEarningStatus), not this collaborator's host org.
             await tx.organizationEarnings.create({
               data: {
                 organizationId: s.orgSplit.organizationId,
@@ -568,7 +565,7 @@ export async function createEarningsFromPayment({
                 orgSharePaise: s.orgSplit.orgShare,
                 consultantSharePaise: s.orgSplit.consultantSharePaise,
                 refundedAmountPaise: 0,
-                status: collabInitialStatus,
+                status: initialEarningStatus,
                 holdUntil,
                 currency: "INR",
                 rateCardIdApplied: s.orgSplit.rateCardIdApplied,

--- a/lib/payments/payouts/org-payout-service.ts
+++ b/lib/payments/payouts/org-payout-service.ts
@@ -13,9 +13,10 @@
  *   - createOrgPayoutBatch(orgId, periodStart, periodEnd, opts?)
  *       Atomic batch creation: claim READY earnings, compute aggregated
  *       totals, write the OrganizationPayout (status DRAFT/PENDING),
- *       flip the claimed earnings to PAID, write SettlementLedgerEntry
- *       + audit log. Optionally accepts an `idempotencyKey` so cron
- *       retries become no-ops via the unique constraint.
+ *       flip the claimed earnings to BATCHED (#837 — NOT PAID; cash has
+ *       not moved yet), write SettlementLedgerEntry + audit log. Optionally
+ *       accepts an `idempotencyKey` so cron retries become no-ops via the
+ *       unique constraint.
  *
  *   - processOrgPayout(payoutId)
  *       State machine progression: PENDING → PROCESSING → COMPLETED |
@@ -413,9 +414,13 @@ export async function createOrgPayoutBatch(
           },
         });
 
+        // #837 E-03/E-04 — batch creation only STAGES the earnings; cash has
+        // not left. Mark BATCHED, not PAID. The PAID flip moves to
+        // markOrgPayoutCompleted (PROCESSING → COMPLETED), so a batch built
+        // with ENABLE_LIVE_PAYOUTS off never reads as paid to auditors.
         await tx.organizationEarnings.updateMany({
           where: { orgPayoutId: created.id, status: "READY" },
-          data: { status: "PAID" },
+          data: { status: "BATCHED" },
         });
 
         await tx.orgAuditLog.create({
@@ -773,8 +778,10 @@ async function markPayoutFailedFromSubmission(
     if (claim.count === 0) return;
 
     // Release earnings back to READY so they're eligible for the next batch.
+    // #837 — a submission-rejected payout is pre-COMPLETED, so its earnings are
+    // BATCHED (never reached PAID).
     await tx.organizationEarnings.updateMany({
-      where: { orgPayoutId: payoutId, status: "PAID" },
+      where: { orgPayoutId: payoutId, status: "BATCHED" },
       data: { status: "READY", orgPayoutId: null },
     });
 
@@ -884,6 +891,14 @@ export async function markOrgPayoutCompleted(payoutId: string): Promise<{
         currency: true,
         organization: { select: { name: true } },
       },
+    });
+
+    // #837 E-03/E-04 — cash has now actually moved (COMPLETED + UTR). This is
+    // the ONLY place org earnings become PAID; createOrgPayoutBatch staged them
+    // as BATCHED.
+    await tx.organizationEarnings.updateMany({
+      where: { orgPayoutId: payoutId, status: "BATCHED" },
+      data: { status: "PAID" },
     });
 
     await tx.orgAuditLog.create({
@@ -1000,8 +1015,9 @@ async function markOrgPayoutFailedInternal(
 
     // Release the underlying earnings back to READY so the next batch
     // sees them. This is the inverse of the createOrgPayoutBatch claim.
+    // #837 — a PROCESSING→FAILED payout's earnings are BATCHED (never PAID).
     await tx.organizationEarnings.updateMany({
-      where: { orgPayoutId: payoutId, status: "PAID" },
+      where: { orgPayoutId: payoutId, status: "BATCHED" },
       data: { status: "READY", orgPayoutId: null },
     });
 

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -332,7 +332,11 @@ export async function createPayoutBatch(
           },
         });
 
-        // Link the exact earnings we summed, with guards against concurrent state changes
+        // Link the exact earnings we summed, with guards against concurrent state changes.
+        // #837 E-03/E-04 — mark BATCHED (not left READY): the earning is now in a
+        // batch and must NOT be re-picked by the next batch. Cash hasn't moved yet;
+        // the PAID flip happens only at COMPLETED in handlePayoutWebhook. The CAS
+        // re-asserts the pre-batch state (READY + payoutId null).
         const linkResult = await tx.consultantEarnings.updateMany({
           where: {
             id: { in: readyEarnings.map((e) => e.id) },
@@ -341,6 +345,7 @@ export async function createPayoutBatch(
           },
           data: {
             payoutId: payout.id,
+            status: EarningStatus.BATCHED,
           },
         });
 
@@ -420,11 +425,13 @@ export async function rejectPayout(
     );
   }
 
-  // Unlink earnings and set them back to READY
+  // Unlink earnings and set them back to READY. #837 — a rejectable payout is
+  // PENDING, so its earnings are BATCHED (never PAID); release only those.
   await prisma.consultantEarnings.updateMany({
-    where: { payoutId },
+    where: { payoutId, status: EarningStatus.BATCHED },
     data: {
       payoutId: null,
+      status: EarningStatus.READY,
     },
   });
 
@@ -741,9 +748,11 @@ async function processSinglePayout(payout: {
     // picked up by the next batch. Without this, earnings linked to a
     // payout that failed before the gateway call (e.g., "No payout account")
     // would remain orphaned since no webhook fires to unlink them.
+    // #837 — pre-gateway failure means cash never moved; earnings are BATCHED
+    // (never PAID) so release them back to READY.
     await prisma.consultantEarnings.updateMany({
-      where: { payoutId: payout.id },
-      data: { payoutId: null },
+      where: { payoutId: payout.id, status: EarningStatus.BATCHED },
+      data: { payoutId: null, status: EarningStatus.READY },
     });
 
     return {
@@ -945,9 +954,11 @@ export async function handlePayoutWebhook(
       const cumulativeCreditedPayments =
         sumPaise(previousCompletedPayouts._sum.amount) + payout.amount;
 
-      // Update earnings to PAID
+      // Update earnings to PAID. #837 E-03/E-04 — this COMPLETED webhook (with
+      // gatewayUtr above) is the ONLY place consultant earnings become PAID;
+      // createPayoutBatch staged them as BATCHED.
       await tx.consultantEarnings.updateMany({
-        where: { payoutId: payout.id },
+        where: { payoutId: payout.id, status: EarningStatus.BATCHED },
         data: {
           status: EarningStatus.PAID,
           paidAt: new Date(),
@@ -1014,10 +1025,13 @@ export async function handlePayoutWebhook(
       payoutStatus === PayoutStatus.FAILED ||
       payoutStatus === PayoutStatus.CANCELLED
     ) {
+      // #837 — a FAILED/CANCELLED payout never disbursed; its earnings are
+      // BATCHED (never PAID) so release them back to READY for the next batch.
       await tx.consultantEarnings.updateMany({
-        where: { payoutId: payout.id },
+        where: { payoutId: payout.id, status: EarningStatus.BATCHED },
         data: {
           payoutId: null,
+          status: EarningStatus.READY,
         },
       });
 

--- a/lib/payments/wallet-freeze.ts
+++ b/lib/payments/wallet-freeze.ts
@@ -28,6 +28,7 @@ const UNFREEZE_CATEGORY = "WALLET_UNFREEZE";
 const freezeKey = (billingAccountId: string) => `wallet-freeze:${billingAccountId}`;
 
 export class WalletFrozenError extends Error {
+  public readonly httpStatus = 409;
   constructor(public billingAccountId: string) {
     super(
       `Wallet spend frozen on billing account ${billingAccountId} pending ledger-drift resolution`,

--- a/lib/payments/wallet-freeze.ts
+++ b/lib/payments/wallet-freeze.ts
@@ -1,0 +1,73 @@
+/**
+ * #837 — wallet-spend freeze, scoped to a single drifted BillingAccount.
+ *
+ * When the ledger-reconcile job finds WALLET_BALANCE_DRIFT (cached
+ * `BillingAccount.walletBalance` ≠ the journal's WALLET account) the balance is
+ * no longer trustworthy, so we must stop spending it until ops reconciles.
+ *
+ * There is no schema column for a per-wallet freeze and the launch schema is
+ * frozen, so the freeze rides the existing append-only `SystemEvent` log rather
+ * than a new column/table:
+ *   - the freeze KEY is the indexed `correlationId` = `wallet-freeze:<billingAccountId>`,
+ *   - the current state is the category of the LATEST event under that key
+ *     (WALLET_FREEZE → frozen, WALLET_UNFREEZE → cleared).
+ * FREEZE is set by the reconcile job; UNFREEZE is a manual ops action once the
+ * drift is fixed. The check is a single indexed DB read inside the caller's tx,
+ * so it fails CLOSED — an unreadable log blocks the spend rather than leaking it.
+ *
+ * Deliberately gates only discretionary SPEND (the checkout booking debit), not
+ * chargeback recovery (app/api/webhooks/utils.ts): a lost-dispute debit recovers
+ * money the bank already pulled and must not be stranded on a drift freeze.
+ */
+
+import prisma, { type PrismaLike } from "@/lib/prisma";
+import { recordSystemEvent } from "@/lib/enterprise/system-events";
+
+const FREEZE_CATEGORY = "WALLET_FREEZE";
+const UNFREEZE_CATEGORY = "WALLET_UNFREEZE";
+const freezeKey = (billingAccountId: string) => `wallet-freeze:${billingAccountId}`;
+
+export class WalletFrozenError extends Error {
+  constructor(public billingAccountId: string) {
+    super(
+      `Wallet spend frozen on billing account ${billingAccountId} pending ledger-drift resolution`,
+    );
+    this.name = "WalletFrozenError";
+  }
+}
+
+/** True when the account's latest freeze event is a FREEZE. Reads inside the
+ *  caller's tx/client so the check shares the spend's snapshot. */
+export async function isWalletFrozen(
+  db: PrismaLike,
+  billingAccountId: string,
+): Promise<boolean> {
+  const latest = await db.systemEvent.findFirst({
+    where: {
+      correlationId: freezeKey(billingAccountId),
+      category: { in: [FREEZE_CATEGORY, UNFREEZE_CATEGORY] },
+    },
+    orderBy: { createdAt: "desc" },
+    select: { category: true },
+  });
+  return latest?.category === FREEZE_CATEGORY;
+}
+
+/** Freeze wallet spend for one account. Idempotent — no-op if already frozen.
+ *  Returns true when it wrote a new freeze event. */
+export async function freezeWalletSpend(params: {
+  billingAccountId: string;
+  organizationId?: string | null;
+  reason: string;
+}): Promise<boolean> {
+  if (await isWalletFrozen(prisma, params.billingAccountId)) return false;
+  await recordSystemEvent({
+    organizationId: params.organizationId ?? null,
+    category: FREEZE_CATEGORY,
+    severity: "ERROR",
+    message: `Wallet spend FROZEN for billing account ${params.billingAccountId}: ${params.reason}`,
+    context: { billingAccountId: params.billingAccountId, reason: params.reason },
+    correlationId: freezeKey(params.billingAccountId),
+  });
+  return true;
+}

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -131,6 +131,29 @@ interface EventData {
  *
  * Used by both webhook handlers and mock payment flows
  */
+// #837 — discriminated Phase-1 outcomes so Phase 2 can auto-refund the two
+// captured-but-blocked cases (amount mismatch, double-booking loser) instead of
+// parking the funds on manual ops. `null` = already-processed / metadata-fail.
+type PaymentSuccessTxResult =
+  | {
+      outcome: "amount_mismatch";
+      paymentId: string;
+      gatewayAmountPaise: number;
+      expectedAmount: number;
+    }
+  | {
+      outcome: "confirmed";
+      paymentId: string;
+      appointmentId: string;
+      appointmentType: string;
+      userId: string;
+      userName: string | null;
+      amount: number;
+      currency: string;
+      capturedAfterTerminal: boolean;
+      doubleBookingBlocked: boolean;
+    };
+
 export async function handlePaymentSuccess(
   paymentIntentId: string,
   rawMetadata: Record<string, string>,
@@ -159,7 +182,7 @@ export async function handlePaymentSuccess(
   // winner confirmed and blocks. The SUCCEEDED early-return keeps the retry
   // idempotent.
   const txResult = await withSerializableRetry(() =>
-    prisma.$transaction(async (tx) => {
+    prisma.$transaction(async (tx): Promise<PaymentSuccessTxResult | null> => {
     const payment = await tx.payment.findUnique({
       where: { paymentIntent: paymentIntentId },
       include: { user: { include: { consulteeProfile: true } } },
@@ -202,11 +225,14 @@ export async function handlePaymentSuccess(
           },
         },
       );
+      // #837 — mark SUCCEEDED (gateway truth) + stamp REQUIRES_MANUAL_RECOVERY as
+      // the FALLBACK. Phase 2 auto-refunds the wrong-amount capture; the manual
+      // marker only survives if that refund call itself throws.
       await tx.payment.update({
         where: { id: payment.id },
         data: {
           paymentStatus: PaymentStatus.SUCCEEDED,
-          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed.`,
+          description: `REQUIRES_MANUAL_RECOVERY: capture amount ${gatewayAmountPaise}p ≠ expected ${payment.amount}p. Booking NOT confirmed; auto-refund attempted.`,
         },
       });
       console.error(
@@ -218,12 +244,18 @@ export async function handlePaymentSuccess(
           user_id: payment.userId,
           gateway_amount_paise: gatewayAmountPaise,
           expected_amount_paise: payment.amount,
-          action_required:
-            "IMMEDIATE: reconcile captured funds; confirm or refund manually",
+          action_required: "auto-refund attempted; reconcile only if it failed",
           timestamp: new Date().toISOString(),
         }),
       );
-      return null; // Skip confirmation + Phase 2 — requires manual intervention
+      // Signal Phase 2 to auto-refund post-commit — the gateway refund call must
+      // not run inside this Serializable tx.
+      return {
+        outcome: "amount_mismatch",
+        paymentId: payment.id,
+        gatewayAmountPaise,
+        expectedAmount: payment.amount,
+      };
     }
 
     // VALIDATION: Check metadata before processing
@@ -350,6 +382,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
     // Return data needed for Phase 2
     return {
+      outcome: "confirmed",
       paymentId: payment.id,
       appointmentId: appointment.id,
       appointmentType: metadata.appointmentType,
@@ -360,6 +393,9 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       // #855 — a capture that landed after the booking was cancelled; Phase 2
       // auto-refunds it instead of treating it as a confirmed booking.
       capturedAfterTerminal: confirmResult.capturedAfterTerminal,
+      // #837 — the #827 first-confirmed-wins guard blocked this booking; Phase 2
+      // auto-refunds the loser and releases its tentative hold.
+      doubleBookingBlocked: confirmResult.doubleBookingBlocked ?? false,
     };
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
@@ -368,6 +404,42 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
 
   // If transaction returned null, the payment was already processed or had a metadata error
   if (!txResult) return;
+
+  // #837 — the gateway captured a different amount than we ordered. Auto-refund
+  // the whole capture (never confirm a booking for the wrong money) and skip
+  // Phase 2. REQUIRES_MANUAL_RECOVERY stays stamped as the fallback if the
+  // refund throws. Idempotent: on webhook replay the payment is already
+  // SUCCEEDED so the SUCCEEDED early-return fires before this path is reached,
+  // and refundPayment's refundable-balance guard blocks any double-refund.
+  if (txResult.outcome === "amount_mismatch") {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "capture amount mismatch",
+        initiatedByUserId: null,
+      });
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            payment: {
+              paymentId: txResult.paymentId,
+              gatewayAmountPaise: txResult.gatewayAmountPaise,
+              expectedAmount: txResult.expectedAmount,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund amount-mismatch capture; REQUIRES_MANUAL_RECOVERY (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
 
   // #855 — the capture landed after the booking was cancelled. The payment is
   // SUCCEEDED (gateway truth) but the booking is dead, so auto-refund and skip
@@ -387,6 +459,51 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       );
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
+        refundError,
+      );
+    }
+    return;
+  }
+
+  // #837 — the #827 first-confirmed-wins guard blocked this booking: the payment
+  // is SUCCEEDED but the slots lost to an overlapping confirmed booking, so
+  // auto-refund and release the tentative hold (otherwise a paid customer holds
+  // no booking and their slots block rebooking). Skip the rest of Phase 2 — no
+  // earnings/invoice/notifications for a booking that never confirmed.
+  // Idempotent: webhook replay hits the SUCCEEDED early-return before here;
+  // refundPayment's refundable-balance guard blocks a double-refund; the slot
+  // release runs after a successful refund so a refund failure leaves the hold
+  // for the #830 orphan sweep + manual recovery rather than freeing it unpaid.
+  if (txResult.doubleBookingBlocked) {
+    try {
+      await refundPayment({
+        paymentId: txResult.paymentId,
+        reason: "double-booking blocked at confirmation",
+        initiatedByUserId: null,
+      });
+      // Release the tentative hold only once the money is back.
+      await withSerializableRetry(() =>
+        prisma.$transaction(
+          (tx) => cleanupFailedPaymentAppointment(tx, txResult.appointmentId),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        ),
+      );
+    } catch (refundError) {
+      Sentry.captureException(
+        refundError instanceof Error ? refundError : new Error(String(refundError)),
+        {
+          tags: { subsystem: "payments" },
+          level: "error",
+          contexts: {
+            booking: {
+              paymentId: txResult.paymentId,
+              appointmentId: txResult.appointmentId,
+            },
+          },
+        },
+      );
+      console.error(
+        "Failed to auto-refund double-booking loser; slots left for #830 sweep (Phase 2):",
         refundError,
       );
     }
@@ -1277,7 +1394,7 @@ export async function confirmExistingAppointment(
   tx: Tx,
   appointmentId: string,
   userId?: string,
-): Promise<{ capturedAfterTerminal: boolean }> {
+): Promise<{ capturedAfterTerminal: boolean; doubleBookingBlocked?: boolean }> {
   // First fetch appointment to determine type
   const appointment = await tx.appointment.findUnique({
     where: { id: appointmentId },
@@ -1355,8 +1472,11 @@ export async function confirmExistingAppointment(
             slotId: slot.id,
           },
         }).catch(() => {});
-        // slots stay tentative; do not confirm over the winner
-        return { capturedAfterTerminal: false };
+        // #837 — slots stay tentative here; the webhook's Phase 2 auto-refunds
+        // the loser and releases the hold. The #830 sweep re-drives via this
+        // same guard and reports (doesn't refund), so signalling the block up is
+        // what routes the refund without fighting the guard.
+        return { capturedAfterTerminal: false, doubleBookingBlocked: true };
       }
     }
   }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -641,11 +641,19 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       }
     }
   } catch (earningsError) {
-    Sentry.captureException(
-      earningsError instanceof Error ? earningsError : new Error(String(earningsError)),
-      { tags: { subsystem: "payments" }, level: "warning" },
-    );
-    // Log but don't fail — sync-payment-earnings job will pick up the gap
+    // C-01 #837 — payment + booking are committed but earnings + the BOOKING
+    // journal are not. Real money moved, so we don't roll back and we don't
+    // pretend success with a silent warning: page (ERROR) and durably record
+    // the ledger gap. The healer is the data-state sync-payment-earnings scan
+    // (SUCCEEDED payment + earnings:none), keyed on row state — not on this
+    // marker — so it's guaranteed and idempotent even if this alert is lost.
+    await recordSystemError({
+      category: "PAYOUT",
+      summary: `Earnings + booking journal not written for committed payment ${paymentId} (webhook path)`,
+      err: earningsError,
+      correlationId: paymentId,
+      context: { paymentId, appointmentId, userId, path: "webhook" },
+    });
     console.error(
       `⚠️ Failed to create earnings for payment ${paymentId}:`,
       earningsError,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3895,7 +3895,12 @@ enum EarningStatus {
   PENDING // In hold period
   HELD // Extended hold (dispute)
   READY // Ready for payout
-  PAID // Successfully paid
+  /// #837 E-03/E-04 — rolled into a payout batch but cash has NOT left yet
+  /// (batch exists / gateway not wired / ENABLE_LIVE_PAYOUTS off). Distinct
+  /// from PAID so finance exports + dashboards don't claim money moved before
+  /// the payout reaches COMPLETED with a UTR. Excluded from batch-eligibility.
+  BATCHED
+  PAID // Cash actually disbursed (payout COMPLETED + UTR)
   REFUNDED // Refunded to consultee
   /// Earnings accrued from a PENDING_VERIFICATION INVOICE-funded org
   /// before the org has been verified or paid its first invoice. The


### PR DESCRIPTION
## C-01 — the audit's P0 CFO-trust bug

`createEarningsFromPayment` + the double-entry BOOKING journal run in a try/catch **after** the checkout transaction commits, at `lib/payments/operations/checkout.ts:2904` (mock/zero/org-sponsored path) and the live/webhook path at `lib/payments/webhooks/handlers.ts:643`. Both swallowed the failure at `level: "warning"` with "sync-payment-earnings job will pick up the gap" and returned success — so a payment+booking could be committed while earnings + the BOOKING journal were silently missing, with nobody paged.

## Option chosen: B (compensating-write with hard alert), NOT A (tx-fold)

I chose **B** because folding into the transaction is **unsafe** here:

1. **`createEarningsFromPayment` opens its OWN transaction** — `withSerializableRetry(prisma.$transaction(…, Serializable))` at `earnings-service.ts:290`. It does **not** accept a `tx`. The `#896` waiver-race guard depends on Serializable + P2034 retry, which requires aborting and re-running the *whole* tx — impossible if nested inside the checkout tx's already-open interactive transaction.
2. **The BOOKING journal lives inside that same internal tx** (the `paymentLeg.findMany` + balanced posting at `earnings-service.ts:597+`), so it can't be folded independently either.
3. **Lock-footprint blowup** — folding drags rate-card reads, org/invoice-count lookups, the paymentLeg scan, and multiple `ConsultantEarnings`/`OrganizationEarnings` creates + ledger postings into the checkout tx, ballooning its lock duration/contention. That's the explicit disqualifier.
4. It's called from **3 sites** (checkout, webhook, sync-job); refactoring it to accept a tx and drop its retry would regress `#896`.

No external gateway/HTTP I/O sits in the earnings/journal path (only fire-and-forget Sentry telemetry), so I/O isn't the blocker — the retry semantics + lock blowup are.

## What B does (both paths, consistently)

Replaced the silent `level: "warning"` swallow with `recordSystemError({ category: "PAYOUT", … })`, which:
- writes a **durable append-only `SystemEvent`** row (severity `ERROR`) — the same durable-marker mechanism B1 used for wallet-freeze; auditable by finance/eng, keyed by `correlationId = paymentId`, and
- **escalates to Sentry at ERROR (P0)** — no more silent warning.

We deliberately do **not** roll back: the money moved and the booking is real, so returning the booking success to the customer is correct — we just stop pretending the *internal* ledger is fine.

**Durability is already guaranteed, no new schema needed.** The healer — `scripts/earnings/sync-payment-earnings.ts` — is a **data-state scan**: it finds every `SUCCEEDED` payment within 30 days with `earnings: { none: {} }` and calls the idempotent `createEarningsFromPayment`. It keys on **row state, not on a marker/outbox**, so the gap is closed even if this alert is lost. No outbox table added (no `schema.prisma` change); `SystemEvent` is reused as the durable audit record.

## B1/B2/B3 behavior preserved

Untouched — all the earnings-status logic stays inside `createEarningsFromPayment`, which this PR does not modify: B1 auto-refund/wallet-freeze, B2 `PENDING_TRUST` sponsor-scoped park, B3 `BATCHED` status, and the `initialEarningStatus` decision all continue to apply on both the inline call and the sync-job heal.

## Stacking / merge order

Stacked on **B3 #993 → B2 #991 → B1 #990** — merge in that order.

## Verification

Type-check + race-suite via CI (local OOM-contended, so `tsc`/`jest`/`prisma generate` were intentionally skipped; types hand-verified by reading).

Part of #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)