### PR TITLE
perf(bookings): narrow PENDING request queries + server-side Auto Allocate

### DIFF
--- a/app/api/bookings/consultations/route.ts
+++ b/app/api/bookings/consultations/route.ts
@@ -1,5 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
+import {
+  PROFILE_WITH_USER_SELECT,
+  APPOINTMENT_LIST_SELECT,
+} from "@/lib/booking/list-selects";
 import { AppointmentStatus } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { transitionConsultationRequest } from "@/lib/booking/transitions";
@@ -119,43 +123,11 @@ export async function GET(request: NextRequest) {
               title: true,
               durationInHours: true,
               consultantProfileId: true,
-              consultantProfile: {
-                select: {
-                  id: true,
-                  user: { select: { id: true, name: true, image: true } },
-                },
-              },
+              consultantProfile: PROFILE_WITH_USER_SELECT,
             },
           },
-          requestedBy: {
-            select: {
-              id: true,
-              user: { select: { id: true, name: true, image: true } },
-            },
-          },
-          appointment: {
-            select: {
-              id: true,
-              organizationId: true,
-              slotsOfAppointment: {
-                select: {
-                  id: true,
-                  startsAt: true,
-                  endsAt: true,
-                  isTentative: true,
-                },
-                orderBy: { startsAt: "asc" },
-              },
-              payment: {
-                select: {
-                  id: true,
-                  paymentStatus: true,
-                  amount: true,
-                  currency: true,
-                },
-              },
-            },
-          },
+          requestedBy: PROFILE_WITH_USER_SELECT,
+          appointment: APPOINTMENT_LIST_SELECT,
         },
         orderBy: {
           requestedAt: "desc",

--- a/app/api/bookings/consultations/route.ts
+++ b/app/api/bookings/consultations/route.ts
@@ -35,11 +35,10 @@ export async function GET(request: NextRequest) {
     // ownership filter and serving every consultant's consultations.
     if (!isPrivileged(session.user.role)) {
       if (session.user.role === "CONSULTANT") {
-        // Consultants can only see their own consultations
+        // Consultants can only see their own consultations. Filter on the
+        // plan's scalar FK (indexed) instead of joining consultantProfile.
         whereClause.consultationPlan = {
-          consultantProfile: {
-            id: session.user.consultantProfileId ?? "__none__",
-          },
+          consultantProfileId: session.user.consultantProfileId ?? "__none__",
         };
       } else if (session.user.role === "CONSULTEE") {
         // Consultees can only see their own consultations
@@ -106,34 +105,55 @@ export async function GET(request: NextRequest) {
     }
 
     const [consultations, total] = await Promise.all([
+      // #997 Phase 0 — narrow SELECT (see subscriptions route for rationale).
       prisma.consultation.findMany({
         where: whereClause,
-        include: {
+        select: {
+          id: true,
+          status: true,
+          requestedAt: true,
+          bookingSource: true,
           consultationPlan: {
-            include: {
+            select: {
+              id: true,
+              title: true,
+              durationInHours: true,
+              consultantProfileId: true,
               consultantProfile: {
-                include: {
-                  user: { select: { id: true, name: true, email: true, image: true, role: true, phone: true } },
+                select: {
+                  id: true,
+                  user: { select: { id: true, name: true, image: true } },
                 },
               },
             },
           },
           requestedBy: {
-            include: {
-              user: { select: { id: true, name: true, email: true, image: true, role: true, phone: true } },
+            select: {
+              id: true,
+              user: { select: { id: true, name: true, image: true } },
             },
           },
           appointment: {
-            include: {
+            select: {
+              id: true,
+              organizationId: true,
               slotsOfAppointment: {
-                include: {
-                  user: { select: { id: true, name: true, email: true, image: true, role: true, phone: true } },
+                select: {
+                  id: true,
+                  startsAt: true,
+                  endsAt: true,
+                  isTentative: true,
                 },
-                orderBy: {
-                  startsAt: "asc",
+                orderBy: { startsAt: "asc" },
+              },
+              payment: {
+                select: {
+                  id: true,
+                  paymentStatus: true,
+                  amount: true,
+                  currency: true,
                 },
               },
-              payment: { select: { id: true, paymentStatus: true, amount: true, currency: true } },
             },
           },
         },

--- a/app/api/bookings/subscriptions/route.ts
+++ b/app/api/bookings/subscriptions/route.ts
@@ -1,5 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
+import {
+  PROFILE_WITH_USER_SELECT,
+  APPOINTMENT_LIST_SELECT,
+} from "@/lib/booking/list-selects";
 import { Prisma, AppointmentStatus } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { addMonths } from "date-fns";
@@ -135,43 +139,11 @@ export async function GET(request: NextRequest) {
               sessionDurationInHours: true,
               totalSessions: true,
               consultantProfileId: true,
-              consultantProfile: {
-                select: {
-                  id: true,
-                  user: { select: { id: true, name: true, image: true } },
-                },
-              },
+              consultantProfile: PROFILE_WITH_USER_SELECT,
             },
           },
-          requestedBy: {
-            select: {
-              id: true,
-              user: { select: { id: true, name: true, image: true } },
-            },
-          },
-          appointments: {
-            select: {
-              id: true,
-              organizationId: true,
-              slotsOfAppointment: {
-                select: {
-                  id: true,
-                  startsAt: true,
-                  endsAt: true,
-                  isTentative: true,
-                },
-                orderBy: { startsAt: "asc" },
-              },
-              payment: {
-                select: {
-                  id: true,
-                  paymentStatus: true,
-                  amount: true,
-                  currency: true,
-                },
-              },
-            },
-          },
+          requestedBy: PROFILE_WITH_USER_SELECT,
+          appointments: APPOINTMENT_LIST_SELECT,
         },
         orderBy: {
           requestedAt: "desc",

--- a/app/api/bookings/subscriptions/route.ts
+++ b/app/api/bookings/subscriptions/route.ts
@@ -42,11 +42,10 @@ export async function GET(request: NextRequest) {
     // ownership filter and serving every consultant's subscriptions.
     if (!isPrivileged(session.user.role)) {
       if (session.user.role === "CONSULTANT") {
-        // Consultants can only see their own subscriptions
+        // Consultants can only see their own subscriptions. Filter on the
+        // plan's scalar FK (indexed) instead of joining consultantProfile.
         whereClause.subscriptionPlan = {
-          consultantProfile: {
-            id: session.user.consultantProfileId ?? "__none__",
-          },
+          consultantProfileId: session.user.consultantProfileId ?? "__none__",
         };
       } else if (session.user.role === "CONSULTEE") {
         // Consultees can only see their own subscriptions
@@ -110,42 +109,67 @@ export async function GET(request: NextRequest) {
       // kind === "all": no additional filter
     }
 
+    // #997 Phase 0 — narrow SELECTs replace the old include tree. The deep
+    // includes joined consultantProfile.domain/subDomains/tags (M2M) and a
+    // per-slot user M2M that no list consumer reads, and over-shared user
+    // PII (email/role/phone) against the #946 allowlist direction. Field
+    // superset verified across RequestSlotAllocationTab, the Mini tab,
+    // fetchApprovals, and useEvents consumers.
     const [subscriptions, total] = await Promise.all([
       prisma.subscription.findMany({
         where: whereClause,
-        include: {
+        select: {
+          id: true,
+          status: true,
+          requestedAt: true,
+          bookingSource: true,
+          schedulingPeriodStartsAt: true,
+          schedulingPeriodEndsAt: true,
+          schedulingTimezone: true,
           subscriptionPlan: {
-            include: {
+            select: {
+              id: true,
+              title: true,
+              callsPerWeek: true,
+              durationInMonths: true,
+              sessionDurationInHours: true,
+              totalSessions: true,
+              consultantProfileId: true,
               consultantProfile: {
-                include: {
-                  user: { select: { id: true, name: true, email: true, image: true, role: true, phone: true } },
-                  domain: true,
-                  subDomains: true,
-                  tags: true,
+                select: {
+                  id: true,
+                  user: { select: { id: true, name: true, image: true } },
                 },
               },
             },
           },
           requestedBy: {
-            include: {
-              user: {
-                select: {
-                  id: true,
-                  name: true,
-                  email: true,
-                  image: true,
-                },
-              },
+            select: {
+              id: true,
+              user: { select: { id: true, name: true, image: true } },
             },
           },
           appointments: {
-            include: {
+            select: {
+              id: true,
+              organizationId: true,
               slotsOfAppointment: {
-                include: {
-                  user: { select: { id: true, name: true, email: true, image: true, role: true, phone: true } },
+                select: {
+                  id: true,
+                  startsAt: true,
+                  endsAt: true,
+                  isTentative: true,
+                },
+                orderBy: { startsAt: "asc" },
+              },
+              payment: {
+                select: {
+                  id: true,
+                  paymentStatus: true,
+                  amount: true,
+                  currency: true,
                 },
               },
-              payment: { select: { id: true, paymentStatus: true, amount: true, currency: true } },
             },
           },
         },

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useSlotAllocation.ts
@@ -8,7 +8,6 @@ import {
   AllocationResult,
 } from "../utils/allocationAlgorithms";
 import { AllocationService } from "../utils/allocationService";
-import type { RawSlotData } from "./useCalendarData";
 import { isRecurringEventType } from "@/utils/slotAllocation/types";
 import {
   ValidationResult,
@@ -980,18 +979,18 @@ export function useEventSlotAllocation(
    * Auto-allocate using available slots
    */
   const autoAllocate = useCallback(
-    async (availableSlots: TimeSlot[]) => {
+    // #997 Phase 1 — auto-allocation runs SERVER-side (isAuto mode: Redis
+    // locks, tz-aware caps, initialAllocation guard, idempotent replay).
+    // The old path fetched the consultant's entire scheduling period of
+    // availability into the browser and ran AllocationAlgorithms here.
+    // The parameter is kept for interface stability with UnifiedCalendar.
+    async (_availableSlots: TimeSlot[]) => {
       setIsAllocating(true);
       setAllocationError(null);
 
       try {
-        const sessionDuration =
-          eventType === "consultation" || eventType === "webinar"
-            ? options.durationInHours
-            : options.sessionDurationInHours;
-
-        // Slots are picked inside the algorithm, so the fingerprint covers
-        // mode + event only: a double-click replays, a later re-run (after a
+        // Slots are picked server-side, so the fingerprint covers mode +
+        // event only: a double-click replays, a later re-run (after a
         // failure changed nothing) also replays, which is safe either way.
         const attempt = resolveAttemptKey(
           attemptKeyRef.current,
@@ -999,66 +998,52 @@ export function useEventSlotAllocation(
         );
         attemptKeyRef.current = attempt;
 
-        const allocationOptions: AllocationOptions = {
+        const response = await AllocationService.allocateSlots(
           eventType,
           eventId,
-          durationInMonths: options.durationInMonths,
-          callsPerWeek: options.callsPerWeek,
-          durationInHours: sessionDuration,
-          sessionDurationInHours: sessionDuration,
-          startDate: options.startDate,
-          endDate: options.endDate,
-          totalSessions: options.maxTotalCalls, // maxTotalCalls is already totalSessions-aware
-          pastConfirmedSlotCount: options.pastConfirmedSlotCount,
-          // Per-day caps so auto-allocate respects the same limit as the manual
-          // path (subscription 1/day, class 2/day).
-          maxCallsPerDay: options.maxCallsPerDay,
-          maxSessionsPerDay: options.maxSessionsPerDay,
-          schedulingTimezone: options.schedulingTimezone,
-          idempotencyKey: attempt.key,
-          initialAllocation: options.initialAllocation || undefined,
-        };
-
-        // For recurring events (subscription/class), the calendar UI only
-        // provides slots for the currently viewed week, but the algorithm
-        // needs slots spanning the entire scheduling period. Fetch them.
-        let slotsForAllocation = availableSlots;
-        if (
-          isRecurringEventType(eventType) &&
-          options.startDate &&
-          options.endDate &&
-          options.consultantId
-        ) {
-          const fullPeriodData = await AllocationService.fetchAvailabilitySlots(
-            options.consultantId,
-            options.startDate,
-            options.endDate,
-          );
-          const allRawSlots = [
-            ...(fullPeriodData.weekly || []),
-            ...(fullPeriodData.custom || []),
-          ];
-          slotsForAllocation = allRawSlots.map((slot: RawSlotData) => ({
-            startTime: new Date(slot.startsAt),
-            endTime: new Date(slot.endsAt),
-            isAvailable:
-              slot.bookingStatus === "available" ||
-              slot.bookingStatus === "partially-booked",
-            isBooked: slot.bookingStatus === "fully-booked",
-          }));
-        }
-
-        const result = await AllocationAlgorithms.autoAllocate(
-          slotsForAllocation,
-          allocationOptions,
+          [],
+          {
+            isAuto: true,
+            idempotencyKey: attempt.key,
+            initialAllocation: options.initialAllocation || undefined,
+          },
         );
 
-        if (result.success) {
-          setSelectedSlots(result.selectedSlots);
+        if (response.success) {
+          // Reflect the server's picks on the grid (best-effort — the host
+          // closes the dialog via onSuccess either way).
+          const pickedSlots: TimeSlot[] = (response.data ?? [])
+            .flatMap(
+              (appointment) =>
+                (appointment.slotsOfAppointment as
+                  | { startsAt: string; endsAt: string }[]
+                  | undefined) ?? [],
+            )
+            .map((slot) => ({
+              startTime: new Date(slot.startsAt),
+              endTime: new Date(slot.endsAt),
+              isAvailable: true,
+              isBooked: false,
+            }));
+          if (pickedSlots.length > 0) {
+            setSelectedSlots(pickedSlots);
+          }
           toast(autoScheduled());
-          onSuccess?.(result);
+          onSuccess?.({
+            success: true,
+            selectedSlots: pickedSlots,
+            strategy: "server-auto",
+          });
         } else {
-          handleAllocationFailure(result, "Auto allocation failed");
+          handleAllocationFailure(
+            {
+              success: false,
+              selectedSlots: [],
+              error: response.error,
+              httpStatus: response.httpStatus,
+            },
+            "Auto allocation failed",
+          );
         }
       } catch (error) {
         const errorMessage =

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationAlgorithms.ts
@@ -267,6 +267,10 @@ export class AllocationAlgorithms {
    * 3. Smart scoring system for optimal slot selection
    * 4. Intelligent spacing for recurring events
    */
+  // #997 Phase 1 — product code now calls the SERVER's isAuto mode; this
+  // client implementation is retained as the test oracle that pins parity
+  // between auto-picked schedules and the manual validators (see
+  // mode-parity.test.ts) until phases 2-3 retire the client engine.
   static async autoAllocate(
     availableSlots: TimeSlot[],
     options: AllocationOptions,

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationService.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationService.ts
@@ -232,10 +232,11 @@ export class AllocationService {
   ): Promise<AllocationResponse> {
     const slotStrings = slots.map((slot) => slot.startTime.toISOString());
 
-    // Build the request object consistently for all event types
+    // Build the request object consistently for all event types. Auto mode
+    // omits `slots` entirely — the server discovers them (#997 Phase 1).
     const request: AllocationRequest = {
       isAuto: allocationOptions?.isAuto || false,
-      slots: slotStrings,
+      slots: allocationOptions?.isAuto ? undefined : slotStrings,
       useRequestedSlots: allocationOptions?.useRequestedSlots,
       initialAllocation: allocationOptions?.initialAllocation,
     };

--- a/lib/booking/list-selects.ts
+++ b/lib/booking/list-selects.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared Prisma SELECT fragments for the booking list endpoints (#997
+ * Phase 0). The narrow selects replaced the old include trees, which joined
+ * consultant domain/subdomain/tag M2Ms and a per-slot user M2M that no list
+ * consumer reads, and over-shared user PII (email/role/phone) against the
+ * #946 allowlist direction. Both list routes must stay field-identical for
+ * their shared consumers, so the fragments live here rather than being
+ * repeated per route.
+ */
+
+/** Public-safe user identity for list rows (#946 allowlist). */
+export const PUBLIC_USER_SELECT = {
+  select: { id: true, name: true, image: true },
+} as const;
+
+/** A profile row reduced to its id and public user identity. Used for both
+ * the requesting consultee and the plan's consultant profile. */
+export const PROFILE_WITH_USER_SELECT = {
+  select: {
+    id: true,
+    user: PUBLIC_USER_SELECT,
+  },
+} as const;
+
+/** Appointment payload for list rows: org tag, ordered slot atoms, and the
+ * payment identity fields the requests/approvals tables render. */
+export const APPOINTMENT_LIST_SELECT = {
+  select: {
+    id: true,
+    organizationId: true,
+    slotsOfAppointment: {
+      select: {
+        id: true,
+        startsAt: true,
+        endsAt: true,
+        isTentative: true,
+      },
+      orderBy: { startsAt: "asc" },
+    },
+    payment: {
+      select: {
+        id: true,
+        paymentStatus: true,
+        amount: true,
+        currency: true,
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
## Problem

Issue #997's Problem A: `GET /api/bookings/subscriptions?status=PENDING` took 30–40 seconds on production for a consultant with a single pending request, and the consultations list shares the same shape. Issue #997's Problem B: the Allocate Slots dialog's **Auto Allocate** button downloaded the consultant's entire scheduling period of availability into the browser and ran the ~850-line client allocation algorithm there, then submitted the result as manual slots.

## Phase 0 — narrow the PENDING list queries

The real cost was the include tree, not a missing index: the subscriptions GET joined `consultantProfile.domain`, `subDomains`, and `tags` (all many-to-many), plus a per-slot `slotsOfAppointment.user` M2M that **no list consumer reads** — and both routes over-shared user PII (`email`, `role`, `phone`) against the #946 select-allowlist direction. Both GETs now use explicit narrow `select`s of the verified field superset (checked against `RequestSlotAllocationTab`, the Mini tab, `fetchApprovals`, and every `useEvents` consumer), and the ownership filter uses the plan's indexed scalar FK (`consultantProfileId`) instead of joining through `consultantProfile`. The existing composite indexes (`[subscriptionPlanId, status, requestedAt]` / `[consultationPlanId, status, requestedAt]` + plan `[consultantProfileId]`) already cover the hot path, so **there is no schema change and no db push needed**.

## Phase 1 — Auto Allocate moves server-side

The server's `SlotAllocationService` already has the hardened auto mode (`isAuto: true`: Redis locks, scheduling-timezone weekly/day caps, the ADR B10 `initialAllocation` guard, idempotent replay). The client hook now calls it directly — no availability download, no client-side search — and reflects the returned appointment slots on the grid. `isAuto` requests omit the `slots` array (the Zod schema already models this). `AllocationAlgorithms.autoAllocate` is deliberately **retained as the mode-parity test oracle** (`mode-parity.test.ts` pins that auto-picked schedules satisfy the manual validators) until phases 2–3 retire the client engine entirely.

## Testing

631 tests green (`__tests__/booking-algorithm` + `__tests__/schedule`) under both `TZ=UTC` and `TZ=Asia/Kolkata`; full `tsc --noEmit` clean; eslint clean on changed files. Response-shape compatibility verified against every consumer of the two list endpoints.

Part of #997 (phases 2–3 — precomputed status grid and thin validation hook — remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
