### PR TITLE
fix(payments): wire app-initiated refunds to the Razorpay gateway

### DIFF
--- a/__tests__/payments/refund-operation.test.ts
+++ b/__tests__/payments/refund-operation.test.ts
@@ -457,6 +457,19 @@ function restoreState(snapshot: Store): void {
 // Audit-actions module is pure constants; no mock needed.
 
 // ---------------------------------------------------------------------------
+// Mock the gateway layer — refundPayment now calls the REAL gateway (M1). The
+// default resolves an immediately-processed Razorpay refund so the existing
+// cascade tests exercise the same synchronous path as before; individual
+// tests override per-case (pending / declined / thrown).
+// ---------------------------------------------------------------------------
+
+const mockCreateGatewayRefund = jest.fn();
+jest.mock("../../lib/payments", () => ({
+  __esModule: true,
+  createRefund: (...args: unknown[]) => mockCreateGatewayRefund(...args),
+}));
+
+// ---------------------------------------------------------------------------
 // Imports under test (after the prisma mock is registered).
 // ---------------------------------------------------------------------------
 
@@ -464,6 +477,7 @@ import {
   refundPayment,
   applyRefundCascade,
   RefundValidationError,
+  RefundGatewayError,
 } from "@/lib/payments/operations/refund";
 import prisma from "@/lib/prisma";
 
@@ -510,6 +524,7 @@ function seedSinglePartyWalletPayment({
     currency: "INR",
     paymentStatus: "SUCCEEDED",
     paymentGateway: "RAZORPAY",
+    paymentIntent: "pay_intent_seed",
     displayCurrencyAtCheckout: null,
     exchangeRateAtCheckout: null,
     organizationId,
@@ -560,6 +575,12 @@ beforeEach(() => {
   state = newStore();
   uuidCounter = 0;
   jest.clearAllMocks();
+  mockCreateGatewayRefund.mockResolvedValue({
+    refundId: "rfnd_gw_1",
+    amount: 0,
+    currency: "INR",
+    status: "SUCCEEDED",
+  });
 });
 
 // ===========================================================================
@@ -665,6 +686,7 @@ describe("refundPayment — multi-collaborator refund balances the ledger (#813 
       currency: "INR",
       paymentStatus: "SUCCEEDED",
       paymentGateway: "RAZORPAY",
+      paymentIntent: "pay_intent_seed",
       displayCurrencyAtCheckout: null,
       exchangeRateAtCheckout: null,
       organizationId: null,
@@ -769,10 +791,132 @@ describe("refundPayment — multi-collaborator refund balances the ledger (#813 
     // No leg reversal persisted — only the original WALLET leg remains.
     expect(state.paymentLegs).toHaveLength(1);
     expect(state.paymentLegs[0]?.id).toBe("leg-mc");
-    // No refund row persisted (created PENDING inside the tx, then rolled back).
-    expect(state.refunds).toHaveLength(0);
+    // M1 three-phase semantics: the gateway ALREADY moved the money, so the
+    // Refund row must SURVIVE the cascade rollback — PENDING, bound to the
+    // real gateway id, cascadedAt reverted — so the webhook redelivery /
+    // backstop cron re-drive the cascade durably.
+    expect(state.refunds).toHaveLength(1);
+    expect(state.refunds[0]?.status).toBe("PENDING");
+    expect(state.refunds[0]?.refundId).toBe("rfnd_gw_1");
+    expect(state.refunds[0]?.cascadedAt ?? null).toBeNull();
     // Payment row untouched (no amountRefundedPaise written by the cascade).
     expect(state.payments.get("pay-mc")?.amountRefundedPaise).toBeUndefined();
+  });
+});
+
+describe("refundPayment — M1 gateway wiring", () => {
+  it("calls the gateway before marking SUCCEEDED and binds the gateway refund id", async () => {
+    seedSinglePartyWalletPayment({});
+
+    const result = await refundPayment({
+      paymentId: "pay-1",
+      reason: "customer request",
+      initiatedByUserId: "admin-1",
+    });
+
+    expect(mockCreateGatewayRefund).toHaveBeenCalledTimes(1);
+    expect(mockCreateGatewayRefund).toHaveBeenCalledWith({
+      paymentIntentId: "pay_intent_seed",
+      amount: 10000,
+      reason: "customer request",
+    });
+    expect(result.status).toBe("SUCCEEDED");
+    expect(result.gatewayRefundId).toBe("rfnd_gw_1");
+    expect(state.refunds).toHaveLength(1);
+    expect(state.refunds[0]?.refundId).toBe("rfnd_gw_1");
+    expect(state.refunds[0]?.status).toBe("SUCCEEDED");
+    expect(state.refunds[0]?.cascadedAt).toBeTruthy();
+  });
+
+  it("gateway throw keeps a pending_ placeholder, runs NO cascade, and surfaces RefundGatewayError", async () => {
+    seedSinglePartyWalletPayment({});
+    mockCreateGatewayRefund.mockRejectedValueOnce(
+      new Error("gateway unreachable"),
+    );
+
+    await expect(
+      refundPayment({ paymentId: "pay-1", reason: "net-down" }),
+    ).rejects.toThrow(RefundGatewayError);
+
+    expect(state.refunds).toHaveLength(1);
+    const row = state.refunds[0];
+    // Placeholder id is what reconcile-pending-refunds matches on.
+    expect(String(row?.refundId)).toMatch(/^pending_/);
+    expect(row?.status).toBe("PENDING");
+    expect(row?.cascadedAt ?? null).toBeNull();
+    // No money-side effects ran.
+    expect(state.consultantEarnings.get("ce-1")?.refundedShareAmount).toBe(0);
+    expect(state.billingAccounts.get("ba-1")?.walletBalance).toBe(50000);
+    expect(state.paymentLegs).toHaveLength(1);
+  });
+
+  it("gateway-PENDING refund defers the cascade to the webhook path (no double-post)", async () => {
+    seedSinglePartyWalletPayment({});
+    mockCreateGatewayRefund.mockResolvedValueOnce({
+      refundId: "rfnd_gw_slow",
+      amount: 10000,
+      currency: "INR",
+      status: "PENDING",
+    });
+
+    const result = await refundPayment({
+      paymentId: "pay-1",
+      reason: "slow gateway",
+    });
+
+    expect(result.status).toBe("PENDING");
+    expect(result.legsReversed).toBe(0);
+    const row = state.refunds[0];
+    expect(row?.refundId).toBe("rfnd_gw_slow"); // webhook finds it by THIS id
+    expect(row?.status).toBe("PENDING");
+    expect(row?.cascadedAt ?? null).toBeNull();
+    expect(state.consultantEarnings.get("ce-1")?.refundedShareAmount).toBe(0);
+
+    // Webhook-style completion: the cascade applies exactly once against the
+    // SAME row — and a second application no-ops on the cascadedAt claim.
+    const first = await applyRefundCascade(tx, {
+      paymentId: "pay-1",
+      refundId: String(row?.id),
+      amountPaise: 10000,
+      reason: "Gateway refund",
+      initiatedByUserId: null,
+    });
+    expect(first.legsReversed).toBeGreaterThan(0);
+    const second = await applyRefundCascade(tx, {
+      paymentId: "pay-1",
+      refundId: String(row?.id),
+      amountPaise: 10000,
+      reason: "Gateway refund",
+      initiatedByUserId: null,
+    });
+    expect(second.legsReversed).toBe(0);
+  });
+
+  it("gateway-declined refund marks the row FAILED and restores the refundable balance", async () => {
+    seedSinglePartyWalletPayment({});
+    mockCreateGatewayRefund.mockResolvedValueOnce({
+      refundId: "rfnd_gw_declined",
+      amount: 10000,
+      currency: "INR",
+      status: "FAILED",
+    });
+
+    await expect(
+      refundPayment({ paymentId: "pay-1", reason: "declined" }),
+    ).rejects.toMatchObject({
+      name: "RefundGatewayError",
+      code: "GATEWAY_REFUND_DECLINED",
+    });
+
+    const row = state.refunds[0];
+    expect(row?.status).toBe("FAILED");
+    expect(row?.failureReason).toBeTruthy();
+    expect(row?.failedAt).toBeTruthy();
+    expect(state.consultantEarnings.get("ce-1")?.refundedShareAmount).toBe(0);
+
+    // FAILED rows don't consume the refundable balance — a retry succeeds.
+    const retry = await refundPayment({ paymentId: "pay-1", reason: "retry" });
+    expect(retry.status).toBe("SUCCEEDED");
   });
 });
 
@@ -814,6 +958,7 @@ describe("refundPayment — multi-leg WALLET + REFERRAL_CREDIT", () => {
       currency: "INR",
       paymentStatus: "SUCCEEDED",
       paymentGateway: "RAZORPAY",
+      paymentIntent: "pay_intent_seed",
       displayCurrencyAtCheckout: null,
       exchangeRateAtCheckout: null,
       organizationId: null,
@@ -1016,6 +1161,7 @@ describe("refundPayment — #778 §C-1 negative platform plug posts, never skips
       currency: "INR",
       paymentStatus: "SUCCEEDED",
       paymentGateway: "RAZORPAY",
+      paymentIntent: "pay_intent_seed",
       displayCurrencyAtCheckout: null,
       exchangeRateAtCheckout: null,
       organizationId: null,
@@ -1088,6 +1234,7 @@ describe("applyRefundCascade — #786 reversal legs for unbilled accruals", () =
       currency: "INR",
       paymentStatus: "SUCCEEDED",
       paymentGateway: "RAZORPAY",
+      paymentIntent: "pay_intent_seed",
       displayCurrencyAtCheckout: null,
       exchangeRateAtCheckout: null,
       organizationId: "org-1",

--- a/actions/maintenance/freeze-appointments.ts
+++ b/actions/maintenance/freeze-appointments.ts
@@ -370,7 +370,11 @@ export async function freezeAppointments(
 
   // Issue refunds AFTER the transaction commits.
   // The Payment records still exist (appointments with payments were not deleted).
-  // On gateway failure a PENDING placeholder is created for the reconcile cron to retry.
+  // On gateway failure a PENDING placeholder is created for the
+  // reconcile-pending-refunds cron, which RECONCILES (matches an existing
+  // gateway refund by amount + time window) or marks the row FAILED after
+  // 24h and notifies the payer (#779) — it does NOT re-initiate the gateway
+  // call, so a throw here means no money moved until an operator retries.
   for (const payment of pendingRefunds) {
     try {
       const result = await createRefund({

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -47,6 +47,7 @@ import {
   RefundStatus,
 } from "@prisma/client";
 
+import { createRefund as createGatewayRefund } from "@/lib/payments";
 import { walletCredit } from "@/lib/api/organizations/wallet";
 import { reverseBookingUtilization } from "@/lib/api/organizations/program-helpers";
 import { assertEarningStatusTransitionLegal } from "@/lib/payments/payouts/earning-status";
@@ -78,6 +79,12 @@ export type RefundResult = {
   consultantEarningsReversed: number;
   organizationEarningsReversed: number;
   clawbackInitiated: boolean;
+  /** SUCCEEDED = gateway confirmed and the cascade ran; PENDING = the
+   * gateway accepted the refund but hasn't settled it — the refund webhook
+   * (or the cascadedAt backstop cron) completes it. */
+  status: "SUCCEEDED" | "PENDING";
+  /** Real gateway refund id (re_xxx / rfnd_xxx / mock_re_xxx). */
+  gatewayRefundId: string;
 };
 
 export class RefundValidationError extends Error {
@@ -87,6 +94,21 @@ export class RefundValidationError extends Error {
   ) {
     super(message);
     this.name = "RefundValidationError";
+  }
+}
+
+/** Gateway rejected or errored on the refund call. The Refund row is kept
+ * (PENDING with a `pending_` placeholder, or FAILED when the gateway
+ * definitively declined) so the reconcile cron / failed-refund notifier own
+ * recovery — callers must NOT retry the gateway themselves. */
+export class RefundGatewayError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public refundRowId: string,
+  ) {
+    super(message);
+    this.name = "RefundGatewayError";
   }
 }
 
@@ -114,6 +136,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
       currency: true,
       paymentStatus: true,
       paymentGateway: true,
+      paymentIntent: true,
       displayCurrencyAtCheckout: true,
       exchangeRateAtCheckout: true,
       refunds: { select: { amountPaise: true, status: true } },
@@ -186,7 +209,13 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
     );
   }
 
-  return prisma.$transaction(
+  // PHASE 1 — reserve. Create the Refund row in PENDING with a `pending_`
+  // placeholder id inside a Serializable tx: the balance re-check and the
+  // reservation are atomic, so racing refunds can't oversubscribe, and the
+  // placeholder is exactly what `reconcile-pending-refunds` recovers if we
+  // crash between the gateway call and Phase 3 (the "two-phase refund
+  // pattern" that cron documents).
+  const reserved = await prisma.$transaction(
     async (tx) => {
       // Re-derive `refundable` inside the Serializable tx — defends
       // against two refunds racing through the outer read. Must mirror the
@@ -222,21 +251,14 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         );
       }
 
-      // Create the Refund row in PENDING (the schema's pre-success
-      // state — there is no PROCESSING enum value). We use a synthetic
-      // `refundId` keyed `app_<uuid>` so it's distinguishable from
-      // gateway IDs (`re_xxx`/`rfnd_xxx`) and from the
-      // reconciliation-script placeholders (`pending_xxx`). Callers
-      // that bind to a real gateway refund (Stripe `re_xxx`) should
-      // update this row's `refundId` after the gateway call returns.
-      const created = await tx.refund.create({
+      return tx.refund.create({
         data: {
           paymentId: input.paymentId,
           amountPaise: requested,
           currency: payment.currency,
           reason: input.reason,
           status: RefundStatus.PENDING,
-          refundId: `app_${globalThis.crypto.randomUUID()}`,
+          refundId: `pending_${globalThis.crypto.randomUUID()}`,
           paymentGateway: payment.paymentGateway,
           exchangeRateAtRefund: payment.exchangeRateAtCheckout,
           displayCurrency: payment.displayCurrencyAtCheckout,
@@ -246,24 +268,119 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
           } as Prisma.InputJsonValue,
         },
       });
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
 
+  // PHASE 2 — the actual gateway refund (M1: this call was previously
+  // missing entirely — refunds were marked SUCCEEDED without the customer's
+  // card ever being credited). Runs OUTSIDE any transaction: external I/O
+  // must not sit inside a Serializable tx, and an SSI retry must not re-hit
+  // the gateway. Mirrors actions/maintenance/freeze-appointments.ts.
+  let gateway: Awaited<ReturnType<typeof createGatewayRefund>>;
+  try {
+    gateway = await createGatewayRefund({
+      paymentIntentId: payment.paymentIntent,
+      amount: requested,
+      reason: input.reason,
+    });
+  } catch (err) {
+    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
+      tags: { subsystem: "payments", feature: "refund" },
+      extra: { paymentId: input.paymentId, refundRowId: reserved.id },
+    });
+    // Keep the PENDING placeholder: the reconcile cron matches it against
+    // the gateway (covers "call actually landed but we never heard back")
+    // or FAILs it after 24h, which triggers the payer notification (#779).
+    await prisma.refund
+      .update({
+        where: { id: reserved.id },
+        data: {
+          metadata: {
+            initiatedByUserId: input.initiatedByUserId ?? null,
+            source: "app",
+            gateway_error: err instanceof Error ? err.message : String(err),
+          } as Prisma.InputJsonValue,
+        },
+      })
+      .catch(() => undefined); // best-effort annotation only
+    throw new RefundGatewayError(
+      `Gateway refund failed for payment ${input.paymentId}: ${err instanceof Error ? err.message : String(err)}`,
+      "GATEWAY_REFUND_FAILED",
+      reserved.id,
+    );
+  }
+
+  // PHASE 3a — bind the outcome OUTSIDE the cascade tx. If the cascade
+  // below fails and rolls back, the row still points at the real gateway
+  // refund, so the refund webhook / cascadedAt backstop cron complete it by
+  // id — no heuristic amount+time matching needed.
+  if (gateway.status === "FAILED") {
+    await prisma.refund.update({
+      where: { id: reserved.id },
+      data: {
+        refundId: gateway.refundId || reserved.refundId,
+        status: RefundStatus.FAILED,
+        failureReason: "Gateway declined the refund",
+        failedAt: new Date(),
+      },
+    });
+    throw new RefundGatewayError(
+      `Gateway declined refund for payment ${input.paymentId}`,
+      "GATEWAY_REFUND_DECLINED",
+      reserved.id,
+    );
+  }
+
+  await prisma.refund.update({
+    where: { id: reserved.id },
+    data: {
+      refundId: gateway.refundId,
+      ...(gateway.metadata
+        ? { metadata: gateway.metadata as Prisma.InputJsonValue }
+        : {}),
+    },
+  });
+
+  if (gateway.status !== "SUCCEEDED") {
+    // Money not settled yet — no cascade, row stays PENDING under its real
+    // gateway id so the webhook reconciles instead of duplicating.
+    return {
+      refundId: reserved.id,
+      amountRefundedPaise: requested,
+      legsReversed: 0,
+      consultantEarningsReversed: 0,
+      organizationEarningsReversed: 0,
+      clawbackInitiated: false,
+      status: "PENDING" as const,
+      gatewayRefundId: gateway.refundId,
+    };
+  }
+
+  // PHASE 3b — settle: cascade + SUCCEEDED atomically. A throw here rolls
+  // back the cascade AND the cascadedAt claim, leaving the row PENDING under
+  // its gateway id for the webhook redelivery / backstop cron to re-drive.
+  return prisma.$transaction(
+    async (tx) => {
       const cascade = await applyRefundCascade(tx, {
         paymentId: input.paymentId,
-        refundId: created.id,
+        refundId: reserved.id,
         amountPaise: requested,
         reason: input.reason,
         initiatedByUserId: input.initiatedByUserId ?? null,
       });
 
       await tx.refund.update({
-        where: { id: created.id },
+        where: { id: reserved.id },
         data: { status: RefundStatus.SUCCEEDED },
       });
 
       return {
-        refundId: created.id,
+        refundId: reserved.id,
         amountRefundedPaise: requested,
         ...cascade,
+        status: "SUCCEEDED" as const,
+        gatewayRefundId: gateway.refundId,
       };
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },


### PR DESCRIPTION
## Problem (audit finding M1 — CRITICAL)

`refundPayment` — the single entry point for every app-initiated refund (appointment cancellation, moderation engagement cancels, consultant no-show detection, payment-webhook compensation) — created an `app_`-keyed `Refund` row, ran the full money cascade (legs, wallet, earnings, ledger, booking utilization, credit notes), and marked the refund **SUCCEEDED without ever calling the payment gateway**. The customer was told they were refunded; their card was never credited. Worse, when an operator later issued the refund manually from the Razorpay dashboard, the refund webhook could not match our `app_` row and **minted a second `Refund` row, double-posting the cascade** (earnings are capped, but the REFUND ledger posting and wallet credit applied twice).

## Fix — three-phase refund, mirroring the `freeze-appointments` precedent

1. **Reserve** (Serializable tx): the refundable-balance re-check (refunds + lost-chargeback netting, unchanged) and the creation of a PENDING `Refund` row with a `pending_` placeholder id are atomic, so racing refunds can't oversubscribe, and a crash after the gateway call is exactly the case `reconcile-pending-refunds` recovers.
2. **Gateway call** (outside any transaction): the previously-missing `createRefund` call against Razorpay/Stripe/mock. A thrown gateway error keeps the placeholder (reconcile-or-24h-FAIL, payer notified per #779) and surfaces a typed `RefundGatewayError`; a gateway **decline** marks the row FAILED without consuming refundable balance, so a retry works.
3. **Bind + settle**: the real gateway refund id is written in its own commit *before* the cascade, so any later failure leaves a row the refund webhook finds **by id** — the webhook now reconciles our row instead of duplicating it. The cascade + SUCCEEDED flip stay atomic and idempotent on `cascadedAt`; gateway-PENDING refunds defer the cascade to the webhook/backstop cron entirely.

`RefundResult` gains `status` (`SUCCEEDED`/`PENDING`) and `gatewayRefundId`; existing callers are unaffected.

Also fixes **M8**: the `freeze-appointments` comment claimed the reconcile cron "retries" failed gateway refunds — it only matches existing ones and FAILs after 24h. The comment now states the truth. Automatic re-initiation was deliberately **not** added: `createRefund` has no gateway-side idempotency key, and the reconcile matcher's 5-minute window means a re-initiation could double-refund a landed-but-unmatched refund.

## Tests

`__tests__/payments/refund-operation.test.ts`: gateway layer mocked; 4 new cases pin — gateway called before SUCCEEDED with the real id bound; gateway throw ⇒ `pending_` placeholder, zero cascade side-effects; gateway-PENDING ⇒ cascade deferred and later applied exactly once via `cascadedAt` (webhook simulation); gateway decline ⇒ FAILED row + refundable balance restored. The ledger-throw atomicity test now pins the new invariant: cascade writes roll back but the Refund row **survives** under its gateway id (money moved — the row must track it). Suites: payments 105/105, enterprise/ledger 530/530, full `tsc --noEmit` clean.

## Flagged, out of scope

- `lib/payments/operations/reversal-engine.ts:190` still mints `app_` child refunds in its CLASS_MULTI fan-out — currently **no production callers** (scaffolding); needs the same gateway decision when wired up.
- M3 (auto-refund on consultant REJECT), M2/C3 (group-event attendee refunds), M6/C7 (proration) — follow-ups now unblocked by this PR.

Part of the 2026-07-17 booking-subsystem audit follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
