### PR TITLE
fix(booking): lifecycle correctness — cancelled-event CAS, class partial reschedule, cleanup guards, utilization re-key, reminder scheduler

### DIFF
--- a/.github/workflows/send-appointment-reminders.yml
+++ b/.github/workflows/send-appointment-reminders.yml
@@ -1,0 +1,49 @@
+name: Send Appointment Reminders
+
+on:
+  schedule:
+    # Hourly — the 1-hour reminder window (45–75 min before start) assumes
+    # at-least-hourly firing; Redis SET-NX in the script dedupes overlaps.
+    - cron: "12 * * * *"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  send-appointment-reminders:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      # Database connection (required for Prisma)
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+      DIRECT_URL: ${{ secrets.DIRECT_URL }}
+      # Reminder notifications fan out through Novu; links built via getAppUrl
+      NOVU_SECRET_KEY: ${{ secrets.NOVU_SECRET_KEY }}
+      NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Send appointment reminders
+        run: npx tsx jobs/appointments/send-appointment-reminders.ts
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          SLACK_OPS_WEBHOOK_URL: ${{ secrets.SLACK_OPS_WEBHOOK_URL }}
+        run: bash scripts/ci/notify-ops-failure.sh "send-appointment-reminders"

--- a/__tests__/booking-algorithm/rescheduleCancel.test.ts
+++ b/__tests__/booking-algorithm/rescheduleCancel.test.ts
@@ -1170,6 +1170,7 @@ describe("cleanupTentativeSlots", () => {
         endsAt: new Date("2025-01-01T10:30:00.000Z"),
         isTentative: true,
         createdAt: new Date("2024-12-01T00:00:00.000Z"),
+        updatedAt: new Date("2024-12-01T00:00:00.000Z"),
         appointment: {
           payment: [],
           consultation: {
@@ -1205,6 +1206,7 @@ describe("cleanupTentativeSlots", () => {
         endsAt: new Date(),
         isTentative: true,
         createdAt: new Date("2024-12-01"),
+        updatedAt: new Date("2024-12-01"),
         appointment: { payment: [], consultation: null, subscription: null },
       },
       {
@@ -1214,6 +1216,7 @@ describe("cleanupTentativeSlots", () => {
         endsAt: new Date(),
         isTentative: true,
         createdAt: new Date("2024-12-01"),
+        updatedAt: new Date("2024-12-01"),
         appointment: { payment: [], consultation: null, subscription: null },
       },
       {
@@ -1223,6 +1226,7 @@ describe("cleanupTentativeSlots", () => {
         endsAt: new Date(),
         isTentative: true,
         createdAt: new Date("2024-12-01"),
+        updatedAt: new Date("2024-12-01"),
         appointment: { payment: [], consultation: null, subscription: null },
       },
     ];

--- a/__tests__/booking-algorithm/slotAllocationService.test.ts
+++ b/__tests__/booking-algorithm/slotAllocationService.test.ts
@@ -91,8 +91,17 @@ function makeMockTx() {
       update: jest.fn(),
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
-    webinar: { findUnique: jest.fn(), update: jest.fn() },
-    class: { findUnique: jest.fn(), update: jest.fn() },
+    webinar: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      // Guarded transitions (transitionWebinarEvent) use WHERE-guarded updateMany
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+    class: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
     // #440 — createAppointments denormalizes the consultant onto each slot.
     consultantProfile: {
       findFirst: jest.fn().mockResolvedValue({ id: "consultant-profile-1" }),
@@ -1128,9 +1137,14 @@ describe("Auto allocation", () => {
       mode: "auto",
     });
 
-    expect(mockTx.webinar.update).toHaveBeenCalledWith(
+    // Guarded transition: WHERE-guarded updateMany (EVENT_ALLOWED_FROM),
+    // so a CANCELLED/COMPLETED webinar can no longer be resurrected.
+    expect(mockTx.webinar.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "webinar-1" },
+        where: expect.objectContaining({
+          id: "webinar-1",
+          status: expect.objectContaining({ in: expect.any(Array) }),
+        }),
         data: expect.objectContaining({ status: "SCHEDULED" }),
       }),
     );
@@ -1382,7 +1396,7 @@ describe("updateEventStatus", () => {
       slots: ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"],
     });
 
-    const updateData = mockTx.webinar.update.mock.calls[0][0].data;
+    const updateData = mockTx.webinar.updateMany.mock.calls[0][0].data;
     expect(updateData.status).toBe("SCHEDULED");
     // Webinar should NOT have scheduling period fields
     expect(updateData.schedulingPeriodStartsAt).toBeUndefined();
@@ -1406,10 +1420,11 @@ describe("updateEventStatus", () => {
       slots: ["2025-01-06T10:00:00Z", "2025-01-06T10:30:00Z"],
     });
 
-    const updateData = mockTx.class.update.mock.calls[0][0].data;
-    expect(updateData.status).toBe("SCHEDULED");
-    expect(updateData.schedulingPeriodStartsAt).toBeDefined();
-    expect(updateData.schedulingPeriodEndsAt).toBeDefined();
+    // Guarded transition: status rides transitionClassEvent's updateMany
+    const updateCall = mockTx.class.updateMany.mock.calls[0][0];
+    expect(updateCall.data.status).toBe("SCHEDULED");
+    expect(updateCall.data.schedulingPeriodStartsAt).toBeDefined();
+    expect(updateCall.data.schedulingPeriodEndsAt).toBeDefined();
   });
 });
 
@@ -2183,14 +2198,10 @@ describe("Edge cases", () => {
 
       // Correct model was queried (read runs on the base client now)
       expect((prisma as any)[eventType].findUnique).toHaveBeenCalled();
-      // Correct model was updated — consultation/subscription go through
-      // the #836 CAS transition helpers (updateMany); webinar/class still
-      // use a plain update in updateEventStatus.
-      const mutator =
-        eventType === "consultation" || eventType === "subscription"
-          ? freshTx[eventType].updateMany
-          : freshTx[eventType].update;
-      expect(mutator).toHaveBeenCalled();
+      // Correct model was updated — ALL four types now go through
+      // WHERE-guarded CAS transitions (updateMany): #836 for
+      // consultation/subscription, EVENT_ALLOWED_FROM for webinar/class.
+      expect(freshTx[eventType].updateMany).toHaveBeenCalled();
     }
   });
 });

--- a/__tests__/booking/cleanup-tentative-guard.test.ts
+++ b/__tests__/booking/cleanup-tentative-guard.test.ts
@@ -43,6 +43,7 @@ describe("#829 — cleanup delete re-states the tentative + unpaid guards", () =
         id: "slot-1",
         appointmentId: "appt-1",
         createdAt: new Date("2026-05-01T00:00:00Z"),
+        updatedAt: new Date("2026-05-01T00:00:00Z"),
         startsAt: new Date("2026-05-02T10:00:00Z"),
         endsAt: new Date("2026-05-02T11:00:00Z"),
         appointment: { payment: [], consultation: null, subscription: null },

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -206,12 +206,14 @@ export async function POST(
             ? allSubscriptionSlots
             : appointment.slotsOfAppointment;
 
-        // For SUBSCRIPTION with slotIds, only reschedule the specific slots
+        // For SUBSCRIPTION/CLASS with slotIds, only reschedule the specific
+        // slots. CLASS previously fell through to the whole-class branch, so
+        // a per-session class reschedule silently escalated to every session.
         if (
-          derivedType === "SUBSCRIPTION" &&
           slotIds &&
           slotIds.length > 0 &&
-          appointment.subscription
+          ((derivedType === "SUBSCRIPTION" && appointment.subscription) ||
+            (derivedType === "CLASS" && appointment.class))
         ) {
           // Filter to only the requested slots from ALL subscription slots
           slotsToReschedule = allSubscriptionSlots.filter((s) =>
@@ -243,10 +245,10 @@ export async function POST(
 
         // Mark the appropriate slots as tentative
         if (
-          derivedType === "SUBSCRIPTION" &&
           slotIds &&
           slotIds.length > 0 &&
-          appointment.subscription
+          ((derivedType === "SUBSCRIPTION" && appointment.subscription) ||
+            (derivedType === "CLASS" && appointment.class))
         ) {
           // Individual/multiple session reschedule - mark ALL slots of the affected appointments
           // (e.g. a 1.5h session has 3 consecutive slots; all must be marked tentative together)

--- a/lib/booking/transitions.ts
+++ b/lib/booking/transitions.ts
@@ -117,6 +117,44 @@ export const EVENT_ALLOWED_FROM: Record<WebinarStatus, WebinarStatus[]> = {
 export const CLASS_EVENT_ALLOWED_FROM: Record<ClassStatus, ClassStatus[]> =
   EVENT_ALLOWED_FROM;
 
+export async function transitionWebinarEvent(
+  tx: Pick<Tx, "webinar">,
+  args: {
+    where: { id: string };
+    to: WebinarStatus;
+    data?: Omit<Prisma.WebinarUncheckedUpdateManyInput, "status">;
+    fromIn?: WebinarStatus[];
+  },
+): Promise<void> {
+  const res = await tx.webinar.updateMany({
+    where: {
+      ...args.where,
+      status: { in: args.fromIn ?? EVENT_ALLOWED_FROM[args.to] },
+    },
+    data: { status: args.to, ...args.data },
+  });
+  if (res.count === 0) throw new IllegalTransitionError("Webinar", args.to);
+}
+
+export async function transitionClassEvent(
+  tx: Pick<Tx, "class">,
+  args: {
+    where: { id: string };
+    to: ClassStatus;
+    data?: Omit<Prisma.ClassUncheckedUpdateManyInput, "status">;
+    fromIn?: ClassStatus[];
+  },
+): Promise<void> {
+  const res = await tx.class.updateMany({
+    where: {
+      ...args.where,
+      status: { in: args.fromIn ?? CLASS_EVENT_ALLOWED_FROM[args.to] },
+    },
+    data: { status: args.to, ...args.data },
+  });
+  if (res.count === 0) throw new IllegalTransitionError("Class", args.to);
+}
+
 //////////////////////////////////////////////// SlotOfAppointment ////////////////////////////////////////////////
 
 // A reschedule may re-mark a SCHEDULED or already-RESCHEDULED slot tentative,

--- a/scripts/appointments/cleanup-tentative-slots.ts
+++ b/scripts/appointments/cleanup-tentative-slots.ts
@@ -65,7 +65,10 @@ async function cleanupTentativeSlotsUnlocked(): Promise<TentativeSlotCleanupResu
     const staleTentativeSlots = await prisma.slotOfAppointment.findMany({
       where: {
         isTentative: true,
-        createdAt: { lt: expirationDate },
+        // Grace runs from the LAST write, not creation: a reschedule flips
+        // isTentative on an old row, and measuring from createdAt gave those
+        // slots zero grace before deletion.
+        updatedAt: { lt: expirationDate },
         appointment: {
           payment: {
             none: {
@@ -94,6 +97,31 @@ async function cleanupTentativeSlotsUnlocked(): Promise<TentativeSlotCleanupResu
                     status: {
                       notIn: ["PENDING", "APPROVED_PENDING_PAYMENT"],
                     },
+                  },
+                },
+              ],
+            },
+            // Group events: a SCHEDULED/IN_PROGRESS webinar or class with
+            // tentative slots is mid-reschedule awaiting a new time — the
+            // guard set above only covered request-status event types, so
+            // these were swept (dropping attendee links) within the grace
+            // window of any unpaid event.
+            {
+              OR: [
+                { webinar: null },
+                {
+                  webinar: {
+                    status: { notIn: ["SCHEDULED", "IN_PROGRESS"] },
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                { class: null },
+                {
+                  class: {
+                    status: { notIn: ["SCHEDULED", "IN_PROGRESS"] },
                   },
                 },
               ],
@@ -133,7 +161,9 @@ async function cleanupTentativeSlotsUnlocked(): Promise<TentativeSlotCleanupResu
     for (const slot of staleTentativeSlots) {
       console.log(`\nProcessing tentative slot ${slot.id}`);
       console.log(`   Appointment ID: ${slot.appointmentId}`);
-      console.log(`   Created: ${slot.createdAt.toISOString()}`);
+      console.log(
+        `   Created: ${slot.createdAt.toISOString()} (last write ${slot.updatedAt.toISOString()})`,
+      );
       console.log(
         `   Slot time: ${slot.startsAt.toISOString()} - ${slot.endsAt.toISOString()}`,
       );

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -47,6 +47,8 @@ import {
   ALLOCATION_APPROVABLE_FROM,
   transitionConsultationRequest,
   transitionSubscriptionRequest,
+  transitionWebinarEvent,
+  transitionClassEvent,
 } from "@/lib/booking/transitions";
 import { IllegalTransitionError } from "@/lib/enterprise/transitions";
 import {
@@ -2070,22 +2072,49 @@ export class SlotAllocationService {
     // helper's upsert preserves the first-create priceAtBookingPaise.
     const existingUtil = await tx.bookingUtilization.findUnique({
       where: { paymentId: orgPayment.id },
-      select: { id: true },
+      select: { id: true, appointmentIds: true },
     });
     const priceAtBookingPaise = existingUtil ? 0 : orgPayment.amount;
+
+    // Re-allocation deletes counted appointments and recreates them with
+    // fresh ids, so an id-set diff alone re-debits every replaced session.
+    // Substitute stale tracked ids (no longer live on this subscription)
+    // with incoming ids 1:1 WITHOUT debiting; only ids beyond the
+    // substitution budget are genuinely additional sessions.
+    let idsToDebit = newAppointmentIds;
+    if (existingUtil) {
+      const liveIds = new Set(subscription!.appointments.map((a) => a.id));
+      const trackedLive = existingUtil.appointmentIds.filter((id) =>
+        liveIds.has(id),
+      );
+      const staleCount = existingUtil.appointmentIds.length - trackedLive.length;
+      if (staleCount > 0) {
+        const alreadyTracked = new Set(trackedLive);
+        const incomingNew = newAppointmentIds.filter(
+          (id) => !alreadyTracked.has(id),
+        );
+        const substituted = incomingNew.slice(0, staleCount);
+        idsToDebit = incomingNew.slice(staleCount);
+        await tx.bookingUtilization.update({
+          where: { id: existingUtil.id },
+          data: { appointmentIds: [...trackedLive, ...substituted] },
+        });
+        if (idsToDebit.length === 0) return;
+      }
+    }
 
     try {
       await recordBookingUtilization(tx, {
         programAssignmentId: assignment.id,
         paymentId: orgPayment.id,
-        engagementsConsumed: newAppointmentIds.length,
+        engagementsConsumed: idsToDebit.length,
         priceAtBookingPaise,
         // PR-1e (G3): pass the appointment ids so re-allocation
         // (delete+recreate of the same slot) can't double-debit. The
         // helper computes the set diff against
         // BookingUtilization.appointmentIds and increments only by the
         // genuinely-new ids.
-        appointmentIds: newAppointmentIds,
+        appointmentIds: idsToDebit,
       });
     } catch (err) {
       if (err instanceof ProgramAssignmentLimitError) {
@@ -2432,10 +2461,12 @@ export class SlotAllocationService {
 
       case "webinar":
         // Webinar model does NOT have startDate/endDate fields
-        // Start date is stored in the Appointment's slots
-        await tx.webinar.update({
+        // Start date is stored in the Appointment's slots.
+        // Guarded transition — an unguarded update let allocation racing a
+        // cancel resurrect a CANCELLED (or re-open a COMPLETED) webinar.
+        await transitionWebinarEvent(tx, {
           where: { id: eventId },
-          data: { status: "SCHEDULED" },
+          to: "SCHEDULED",
         });
         break;
 
@@ -2444,10 +2475,11 @@ export class SlotAllocationService {
         // FIX: Only set schedulingPeriod if not already configured — same guard as SUBSCRIPTION.
         // Overwriting an explicitly-set period on re-allocation shifts the window, allowing
         // slots outside the original range to pass the scheduling-period validation check.
-        await tx.class.update({
+        // Guarded transition — same resurrection hazard as WEBINAR above.
+        await transitionClassEvent(tx, {
           where: { id: eventId },
+          to: "SCHEDULED",
           data: {
-            status: "SCHEDULED",
             ...(!config.schedulingPeriodStartsAt ||
             !config.schedulingPeriodEndsAt
               ? {


### PR DESCRIPTION
## Problem

The 2026-07-17 booking-lifecycle audit (run alongside PR #998) verified five defects in the reschedule/cancel/cleanup path with file-level evidence. This PR fixes the ones that are independent of the refund-gateway work.

## Fixes (audit ids)

- **C2 — cancelled-event resurrection.** `SlotAllocationService.updateEventStatus` used unguarded `tx.webinar.update` / `tx.class.update` to stamp `SCHEDULED`, so an allocation racing a cancel could resurrect a CANCELLED (or re-open a COMPLETED) webinar or class. The `EVENT_ALLOWED_FROM` map existed in `lib/booking/transitions.ts` but was never applied; new `transitionWebinarEvent` / `transitionClassEvent` helpers bake it into the UPDATE's WHERE clause, and a zero-row match throws `IllegalTransitionError`, rolling back the allocation — exactly the #836 doctrine the request-status types already follow.
- **R1 — class partial reschedule silently escalated.** The `slotIds[]` branch of the reschedule route was SUBSCRIPTION-only, so a per-session class reschedule fell through to the whole-class branch: the 24-hour policy validated the wrong slot set and every session in the class was marked tentative. The `slotIds` filter and tentative-marking branches now cover CLASS identically to SUBSCRIPTION.
- **R3 — rescheduled slots got zero cleanup grace.** `cleanup-tentative-slots` measured its grace window from `slot.createdAt`, but a reschedule flips `isTentative` on an old row — so rescheduled slots were already "stale" at the next sweep. Grace now runs from `updatedAt` (the tentative-marking write). The active-review guard also only covered consultation/subscription statuses; SCHEDULED/IN_PROGRESS webinars and classes mid-reschedule are now skipped instead of having their slots (and attendee links) deleted.
- **M4 — org utilization double-debit on re-allocation.** Re-allocation deletes counted appointments and recreates them under fresh ids, so the `BookingUtilization.appointmentIds` dedup saw every replaced session as new and debited the program cap again. Stale tracked ids are now substituted one-for-one with the incoming ids without debiting; only genuinely additional sessions debit.
- **Reminder scheduler was missing entirely.** `send-appointment-reminders` existed at all three layers (script, job wrapper, HTTP route) but nothing scheduled it — reminders never sent. Added the hourly GitHub Actions workflow mirroring the repo's cron pattern (the 45–75-minute reminder window assumes at-least-hourly firing; Redis SET-NX in the script dedupes overlaps).

## Testing

657 tests green across `__tests__/booking-algorithm`, `__tests__/schedule`, and the enterprise cap suites, including updated assertions that pin the new WHERE-guarded transitions. Full `tsc --noEmit` clean. `__tests__/payments/razorpay-refund-target.test.ts` fails identically on clean dev in this environment (pre-existing, unrelated).

## Related

Follow-up issues for the audit's remaining findings (refund-dependent flows, UI kind-gates, proration, dispute freeze, QStash, terminology) are filed separately and linked from the audit umbrella. The refund-gateway fix (M1/M8) ships in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appointment reminders now run automatically every hour, with an option for manual triggering and operational failure alerts.
  * Rescheduling class bookings with selected sessions now affects only those sessions.

* **Bug Fixes**
  * Tentative slots now remain protected based on their last update, reducing premature cleanup.
  * Improved event status transition safety for webinars and classes.
  * Prevented duplicate subscription-cap deductions during slot reallocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->