### PR TITLE
fix(payments): merge refund metadata + normalize empty gateway ids (release #1014 review)

### DIFF
--- a/__tests__/payments/refund-operation.test.ts
+++ b/__tests__/payments/refund-operation.test.ts
@@ -828,6 +828,54 @@ describe("refundPayment — M1 gateway wiring", () => {
     expect(state.refunds[0]?.cascadedAt).toBeTruthy();
   });
 
+  it("release #1014 review — gateway metadata MERGES into the row, preserving Phase-1 audit keys", async () => {
+    seedSinglePartyWalletPayment({});
+    // Razorpay always returns notes (reason at minimum), so this is the
+    // every-refund path, not an edge case.
+    mockCreateGatewayRefund.mockResolvedValueOnce({
+      refundId: "rfnd_gw_meta",
+      amount: 10000,
+      currency: "INR",
+      status: "SUCCEEDED",
+      metadata: { reason: "customer request", gw_key: "gw_val" },
+    });
+
+    await refundPayment({
+      paymentId: "pay-1",
+      reason: "customer request",
+      initiatedByUserId: "admin-1",
+    });
+
+    const meta = state.refunds[0]?.metadata as Record<string, unknown>;
+    // Phase-1 keys survive the gateway-id binding...
+    expect(meta.initiatedByUserId).toBe("admin-1");
+    expect(meta.source).toBe("app");
+    // ...and the gateway keys land alongside them.
+    expect(meta.gw_key).toBe("gw_val");
+    expect(meta.reason).toBe("customer request");
+  });
+
+  it("release #1014 review — falsy gateway id keeps the pending_ placeholder and omits gatewayRefundId", async () => {
+    seedSinglePartyWalletPayment({});
+    mockCreateGatewayRefund.mockResolvedValueOnce({
+      refundId: "",
+      amount: 10000,
+      currency: "INR",
+      status: "PENDING",
+    });
+
+    const result = await refundPayment({
+      paymentId: "pay-1",
+      reason: "id-less gateway ack",
+    });
+
+    expect(result.status).toBe("PENDING");
+    // Contract: absent, never "".
+    expect(result.gatewayRefundId).toBeUndefined();
+    // Row keeps the placeholder the reconcile cron matches on.
+    expect(String(state.refunds[0]?.refundId)).toMatch(/^pending_/);
+  });
+
   it("gateway throw keeps a pending_ placeholder, runs NO cascade, and surfaces RefundGatewayError", async () => {
     seedSinglePartyWalletPayment({});
     mockCreateGatewayRefund.mockRejectedValueOnce(

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -83,8 +83,11 @@ export type RefundResult = {
    * gateway accepted the refund but hasn't settled it — the refund webhook
    * (or the cascadedAt backstop cron) completes it. */
   status: "SUCCEEDED" | "PENDING";
-  /** Real gateway refund id (re_xxx / rfnd_xxx / mock_re_xxx). */
-  gatewayRefundId: string;
+  /** Real gateway refund id (re_xxx / rfnd_xxx / mock_re_xxx). Absent when
+   * the gateway accepted but returned no id — the Refund row then keeps its
+   * `pending_` placeholder and the reconcile cron owns recovery (release
+   * #1014 review: never surface "" as a gateway id). */
+  gatewayRefundId?: string;
 };
 
 export class RefundValidationError extends Error {
@@ -335,9 +338,24 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
   await prisma.refund.update({
     where: { id: reserved.id },
     data: {
-      refundId: gateway.refundId,
+      // Falsy gateway id keeps the pending_ placeholder (mirrors the FAILED
+      // branch) so the reconcile cron still matches the row — and the
+      // non-nullable unique column never gets "".
+      refundId: gateway.refundId || reserved.refundId,
+      // Merge, not replace: Phase 1's audit keys (initiatedByUserId, source)
+      // must survive gateway-id binding — the Razorpay path always returns
+      // notes, so a bare assign wiped them (release #1014 review).
       ...(gateway.metadata
-        ? { metadata: gateway.metadata as Prisma.InputJsonValue }
+        ? {
+            metadata: {
+              ...(reserved.metadata &&
+              typeof reserved.metadata === "object" &&
+              !Array.isArray(reserved.metadata)
+                ? reserved.metadata
+                : {}),
+              ...(gateway.metadata as Record<string, unknown>),
+            } as Prisma.InputJsonValue,
+          }
         : {}),
     },
   });
@@ -353,7 +371,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
       organizationEarningsReversed: 0,
       clawbackInitiated: false,
       status: "PENDING" as const,
-      gatewayRefundId: gateway.refundId,
+      gatewayRefundId: gateway.refundId || undefined,
     };
   }
 
@@ -380,7 +398,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         amountRefundedPaise: requested,
         ...cascade,
         status: "SUCCEEDED" as const,
-        gatewayRefundId: gateway.refundId,
+        gatewayRefundId: gateway.refundId || undefined,
       };
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },


### PR DESCRIPTION
Addresses the three inline review comments on release PR #1014, all targeting `lib/payments/operations/refund.ts` (introduced by #1001).

## Comment verdicts

**1. CRITICAL — Phase-3a metadata assignment replaces the Refund row's metadata: FIXED (valid).**
`metadata: gateway.metadata` overwrote the JSON written in Phase 1, destroying the `initiatedByUserId` and `source: "app"` audit keys. This was not an edge case: the Razorpay gateway always returns `notes` (it carries the refund reason), so the wipe happened on every Razorpay refund. The update now spreads the reserved row's existing metadata beneath the gateway keys, so every previously-written key survives; the gateway wins on a key collision. The same update also gains the `gateway.refundId || reserved.refundId` falsy-guard the FAILED branch already had, so the non-nullable unique `refundId` column can never be bound to `""` and the `pending_` placeholder stays matchable by `scripts/refunds/reconcile-pending-refunds.ts`.

**2 + 3. MEDIUM — falsy `gateway.refundId` returned directly as `gatewayRefundId`: FIXED (valid in substance).**
The gateway SDK typings declare `refundId: string`, so there was no compile-time violation — but the Stripe/Razorpay client typings are loose enough that a malformed response yields `""` at runtime, which the result would then present as a "real gateway refund id". Both return sites now normalize with `|| undefined`, and `RefundResult.gatewayRefundId` is declared optional with a doc comment explaining the absent-not-empty contract. This is safe to loosen: no caller consumes `result.gatewayRefundId` (grep confirms only the test reads it), and the reconcile cron matches on the DB column's `pending_` prefix, not on this result. I deliberately did not adopt the reviewer's suggested `|| reserved.refundId` fallback for the returned value — that would report the internal `pending_` placeholder as a gateway id, which is exactly the confusion the field's contract exists to prevent.

## Tests
Two pins added to `__tests__/payments/refund-operation.test.ts`: existing metadata keys survive gateway-id binding (with gateway keys merged alongside), and a falsy gateway id keeps the `pending_` placeholder on the row while omitting `gatewayRefundId` from the result.

## Validation
- `npx jest __tests__/payments --coverage=false`: 14 suites, 107 tests, all green (run in a sibling worktree at this commit).
- `NODE_OPTIONS="--max-old-space-size=12288" npx tsc --noEmit`: clean (cold run, no cache).
- `npx eslint` on both changed files: 0 errors (only the pre-existing `no-explicit-any` warnings in the test stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)