### PR TITLE
perf(dashboards): server-side stats and pagination for client-computed lists (#997 secondary findings)

### DIFF
--- a/__tests__/dashboards/admin-disputes-stats.test.ts
+++ b/__tests__/dashboards/admin-disputes-stats.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #997 secondary findings — the Disputes dashboard's "Under Review"/"Won"
+ * stat cards used to `.filter()` the current *page* of disputes (≤20 rows)
+ * instead of counting the whole table, so they silently undercounted at
+ * scale. Pins that the route now returns a server-computed `stats` block
+ * that ignores the current page/search/gateway filter, mirroring how
+ * `urgentDisputes` was already computed.
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "../../app/api/admin/disputes/route";
+import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+import prisma from "@/lib/prisma";
+
+jest.mock("../../lib/auth-helpers", () => ({
+  __esModule: true,
+  requirePrivilegedAuth: jest.fn(),
+}));
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    dispute: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}));
+
+const mockedAuth = requirePrivilegedAuth as jest.Mock;
+const mockedFindMany = prisma.dispute.findMany as jest.Mock;
+const mockedCount = prisma.dispute.count as jest.Mock;
+
+function req(url: string) {
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAuth.mockResolvedValue({ session: { user: { id: "staff-1", role: "STAFF" } } });
+  mockedFindMany.mockResolvedValue([]);
+});
+
+describe("GET /api/admin/disputes — stats", () => {
+  it("returns dashboard-wide underReviewCount/wonCount independent of the page size", async () => {
+    // Page 1 of a filtered search only returns 2 rows, but the platform
+    // has far more UNDER_REVIEW/WON disputes overall.
+    mockedCount
+      .mockResolvedValueOnce(2) // total (filtered)
+      .mockResolvedValueOnce(1) // urgentDisputes
+      .mockResolvedValueOnce(37) // underReviewCount (unfiltered)
+      .mockResolvedValueOnce(112); // wonCount (unfiltered)
+
+    const res = await GET(
+      req("http://localhost/api/admin/disputes?search=acme&limit=20"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats).toEqual({ underReviewCount: 37, wonCount: 112 });
+  });
+
+  it("computes underReviewCount/wonCount with a status-only where (no search/gateway leakage)", async () => {
+    mockedCount.mockResolvedValue(0);
+
+    await GET(req("http://localhost/api/admin/disputes?search=acme&gateway=STRIPE"));
+
+    // Calls 3 and 4 (0-indexed 2, 3) are the underReviewCount/wonCount counts.
+    const underReviewCall = mockedCount.mock.calls[2][0];
+    const wonCall = mockedCount.mock.calls[3][0];
+    expect(underReviewCall).toEqual({ where: { status: "UNDER_REVIEW" } });
+    expect(wonCall).toEqual({ where: { status: "WON" } });
+  });
+
+  it("403s when the caller isn't privileged", async () => {
+    mockedAuth.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+    });
+    const res = await GET(req("http://localhost/api/admin/disputes"));
+    expect(res.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/dashboards/admin-payouts-trend.test.ts
+++ b/__tests__/dashboards/admin-payouts-trend.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #997 secondary findings — the admin Payouts "Last 7 Days" chart used to
+ * fetch `/api/admin/payouts?limit=100` and bucket the raw rows into days in
+ * the browser (not 7-day-safe at scale, per the client's own TODO). Pins
+ * that the new trend endpoint bounds the query to the 7-day window and
+ * buckets server-side.
+ */
+
+import { GET } from "../../app/api/admin/payouts/trend/route";
+import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+import prisma from "@/lib/prisma";
+
+jest.mock("../../lib/auth-helpers", () => ({
+  __esModule: true,
+  requirePrivilegedAuth: jest.fn(),
+}));
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    consultantPayout: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockedAuth = requirePrivilegedAuth as jest.Mock;
+const mockedFindMany = prisma.consultantPayout.findMany as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAuth.mockResolvedValue({ session: { user: { id: "admin-1", role: "ADMIN" } } });
+});
+
+describe("GET /api/admin/payouts/trend", () => {
+  it("bounds the query to the 7-day window (not an arbitrary row limit)", async () => {
+    mockedFindMany.mockResolvedValue([]);
+    await GET();
+
+    const call = mockedFindMany.mock.calls[0][0];
+    expect(call.select).toEqual({ createdAt: true, amount: true });
+    const since = call.where.createdAt.gte as Date;
+    const daysAgo = (Date.now() - since.getTime()) / (1000 * 60 * 60 * 24);
+    // 6 full days back from the start of today, so this should land between
+    // 6 and 7 days depending on time-of-day.
+    expect(daysAgo).toBeGreaterThanOrEqual(6);
+    expect(daysAgo).toBeLessThan(8);
+  });
+
+  it("returns exactly 7 buckets summed by calendar day (UTC)", async () => {
+    const today = new Date();
+    const todayUtc = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    mockedFindMany.mockResolvedValue([
+      { createdAt: todayUtc, amount: 10_000 },
+      { createdAt: todayUtc, amount: 5_000 },
+    ]);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.series).toHaveLength(7);
+
+    const todayKey = todayUtc.toISOString().slice(0, 10);
+    const todayBucket = body.series.find(
+      (d: { day: string }) => d.day === todayKey,
+    );
+    expect(todayBucket.totalPaise).toBe(15_000);
+
+    // Every other bucket is untouched (0).
+    const otherTotal = body.series
+      .filter((d: { day: string }) => d.day !== todayKey)
+      .reduce((s: number, d: { totalPaise: number }) => s + d.totalPaise, 0);
+    expect(otherTotal).toBe(0);
+  });
+
+  it("403s when the caller isn't privileged", async () => {
+    mockedAuth.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+    });
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/dashboards/admin-refunds-stats.test.ts
+++ b/__tests__/dashboards/admin-refunds-stats.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #997 secondary findings — the Refunds dashboard's Pending/Succeeded/Failed
+ * stat cards used to `.filter()` the current *page* of refunds (≤20 rows)
+ * instead of the whole table. Pins that the route now returns a
+ * server-computed `stats` block independent of the current page.
+ */
+
+import { NextRequest } from "next/server";
+import { GET } from "../../app/api/admin/refunds/route";
+import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+import prisma from "@/lib/prisma";
+
+jest.mock("../../lib/auth-helpers", () => ({
+  __esModule: true,
+  requirePrivilegedAuth: jest.fn(),
+}));
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    refund: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}));
+
+const mockedAuth = requirePrivilegedAuth as jest.Mock;
+const mockedFindMany = prisma.refund.findMany as jest.Mock;
+const mockedCount = prisma.refund.count as jest.Mock;
+
+function req(url: string) {
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAuth.mockResolvedValue({ session: { user: { id: "staff-1", role: "STAFF" } } });
+  mockedFindMany.mockResolvedValue([]);
+});
+
+describe("GET /api/admin/refunds — stats", () => {
+  it("returns dashboard-wide pending/succeeded/failed counts independent of the page size", async () => {
+    mockedCount
+      .mockResolvedValueOnce(3) // total (filtered)
+      .mockResolvedValueOnce(9) // pendingCount (unfiltered)
+      .mockResolvedValueOnce(240) // succeededCount (unfiltered)
+      .mockResolvedValueOnce(5); // failedCount (unfiltered)
+
+    const res = await GET(req("http://localhost/api/admin/refunds?search=re_123"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats).toEqual({
+      pendingCount: 9,
+      succeededCount: 240,
+      failedCount: 5,
+    });
+  });
+
+  it("scopes the status-breakdown counts by status only (not the request's search/gateway)", async () => {
+    mockedCount.mockResolvedValue(0);
+    await GET(req("http://localhost/api/admin/refunds?gateway=RAZORPAY&search=x"));
+
+    expect(mockedCount.mock.calls[1][0]).toEqual({ where: { status: "PENDING" } });
+    expect(mockedCount.mock.calls[2][0]).toEqual({ where: { status: "SUCCEEDED" } });
+    expect(mockedCount.mock.calls[3][0]).toEqual({ where: { status: "FAILED" } });
+  });
+
+  it("403s when the caller isn't privileged", async () => {
+    mockedAuth.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+    });
+    const res = await GET(req("http://localhost/api/admin/refunds"));
+    expect(res.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/dashboards/moderation-reports-search.test.ts
+++ b/__tests__/dashboards/moderation-reports-search.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #997 secondary findings — the staff moderation queue used to fetch every
+ * PENDING report and substring-search on every keystroke client-side. Pins
+ * that the route now accepts a `search` param and filters server-side over
+ * the same fields (report id, reason, reporter name, target user name) the
+ * old client-side filter checked.
+ */
+
+import { GET } from "../../app/api/staff/moderation/reports/route";
+import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+import prisma from "@/lib/prisma";
+
+jest.mock("../../lib/auth-helpers", () => ({
+  __esModule: true,
+  requirePrivilegedAuth: jest.fn(),
+}));
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    moderationReport: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      groupBy: jest.fn(),
+    },
+  },
+}));
+
+const mockedAuth = requirePrivilegedAuth as jest.Mock;
+const mockedFindMany = prisma.moderationReport.findMany as jest.Mock;
+const mockedCount = prisma.moderationReport.count as jest.Mock;
+const mockedGroupBy = prisma.moderationReport.groupBy as jest.Mock;
+
+function req(url: string) {
+  return new Request(url) as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAuth.mockResolvedValue({ session: { user: { id: "staff-1", role: "STAFF" } } });
+  mockedFindMany.mockResolvedValue([]);
+  mockedCount.mockResolvedValue(0);
+  mockedGroupBy.mockResolvedValue([]);
+});
+
+describe("GET /api/staff/moderation/reports — search", () => {
+  it("omits the OR clause when no search term is given", async () => {
+    await GET(req("http://localhost/api/staff/moderation/reports?status=PENDING"));
+    const where = mockedFindMany.mock.calls[0][0].where;
+    expect(where.OR).toBeUndefined();
+  });
+
+  it("filters server-side over id/reason/reporter-name/target-name", async () => {
+    await GET(
+      req(
+        "http://localhost/api/staff/moderation/reports?status=PENDING&search=spam",
+      ),
+    );
+    const where = mockedFindMany.mock.calls[0][0].where;
+    expect(where.status).toBe("PENDING");
+    expect(where.OR).toEqual([
+      { id: { contains: "spam", mode: "insensitive" } },
+      { reason: { contains: "spam", mode: "insensitive" } },
+      { reportedBy: { name: { contains: "spam", mode: "insensitive" } } },
+      { targetUser: { name: { contains: "spam", mode: "insensitive" } } },
+    ]);
+  });
+
+  it("403s when the caller isn't privileged", async () => {
+    mockedAuth.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+    });
+    const res = await GET(req("http://localhost/api/staff/moderation/reports"));
+    expect(res.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/dashboards/org-payouts-pagination.test.ts
+++ b/__tests__/dashboards/org-payouts-pagination.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #997 secondary findings — org Payouts used to fetch every payout for the
+ * org (bounded only by a `limit=25` default with no `offset`) and reduce
+ * `totalPaid`/`pendingAmount` client-side every render. Pins that the route
+ * now (a) accepts `offset` so the list is truly paginated and (b) returns a
+ * server-aggregated `stats` block (`totalPaidPaise`/`pendingPaise`/`counts`)
+ * computed org-wide, independent of the current page/status filter.
+ */
+
+import { GET } from "../../app/api/organizations/[orgId]/payouts/route";
+import { requireOrgAccess } from "@/lib/auth-helpers";
+import prisma from "@/lib/prisma";
+
+jest.mock("../../lib/auth-helpers", () => ({
+  __esModule: true,
+  requireOrgAccess: jest.fn(),
+  requireOrgOwner: jest.fn(),
+}));
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    organizationPayout: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      aggregate: jest.fn(),
+      groupBy: jest.fn(),
+    },
+  },
+}));
+
+const mockedAccess = requireOrgAccess as jest.Mock;
+const mockedFindMany = prisma.organizationPayout.findMany as jest.Mock;
+const mockedCount = prisma.organizationPayout.count as jest.Mock;
+const mockedAggregate = prisma.organizationPayout.aggregate as jest.Mock;
+const mockedGroupBy = prisma.organizationPayout.groupBy as jest.Mock;
+
+function req(url: string) {
+  return new Request(url) as never;
+}
+
+function params(orgId: string) {
+  return { params: Promise.resolve({ orgId }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAccess.mockResolvedValue({ org: { canHost: true } });
+  mockedFindMany.mockResolvedValue([]);
+  mockedCount.mockResolvedValue(0);
+  mockedAggregate.mockResolvedValue({ _sum: { netPayoutPaise: null } });
+  mockedGroupBy.mockResolvedValue([]);
+});
+
+describe("GET /api/organizations/[orgId]/payouts — pagination + stats", () => {
+  it("passes offset/limit through to the paginated findMany", async () => {
+    const res = await GET(
+      req("http://localhost/api/organizations/org1/payouts?limit=10&offset=20"),
+      params("org1"),
+    );
+    expect(res.status).toBe(200);
+    const call = mockedFindMany.mock.calls[0][0];
+    expect(call.take).toBe(10);
+    expect(call.skip).toBe(20);
+
+    const body = await res.json();
+    expect(body.pagination).toEqual({
+      total: 0,
+      limit: 10,
+      offset: 20,
+      hasMore: false,
+    });
+  });
+
+  it("returns org-wide totalPaidPaise/pendingPaise/counts unaffected by the status filter", async () => {
+    mockedAggregate
+      .mockResolvedValueOnce({ _sum: { netPayoutPaise: BigInt(50_000) } }) // COMPLETED
+      .mockResolvedValueOnce({ _sum: { netPayoutPaise: BigInt(12_000) } }); // in-flight
+    mockedGroupBy.mockResolvedValue([
+      { status: "COMPLETED", _count: { id: 4 } },
+      { status: "PENDING", _count: { id: 2 } },
+    ]);
+    mockedCount.mockResolvedValue(1); // filtered total for the page being viewed
+
+    const res = await GET(
+      req("http://localhost/api/organizations/org1/payouts?status=PENDING"),
+      params("org1"),
+    );
+    const body = await res.json();
+
+    expect(body.stats.totalPaidPaise).toBe(50000);
+    expect(body.stats.pendingPaise).toBe(12000);
+    expect(body.stats.counts).toEqual({ COMPLETED: 4, PENDING: 2, total: 6 });
+
+    // The status filter narrows the *list* query, not the org-wide aggregates.
+    const aggregateCall = mockedAggregate.mock.calls[0][0];
+    expect(aggregateCall.where).toEqual({
+      organizationId: "org1",
+      status: "COMPLETED",
+    });
+  });
+
+  it("404s when the org doesn't host (no payouts to list)", async () => {
+    mockedAccess.mockResolvedValue({ org: { canHost: false } });
+    const res = await GET(
+      req("http://localhost/api/organizations/org1/payouts"),
+      params("org1"),
+    );
+    expect(res.status).toBe(404);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("400s on an out-of-range limit", async () => {
+    const res = await GET(
+      req("http://localhost/api/organizations/org1/payouts?limit=1000"),
+      params("org1"),
+    );
+    expect(res.status).toBe(400);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/disputes/route.ts
+++ b/app/api/admin/disputes/route.ts
@@ -42,41 +42,49 @@ export async function GET(req: NextRequest) {
       where.payment = { is: { organizationId: orgId } };
     }
 
-    // Fetch disputes with pagination
-    const [disputes, total, urgentDisputes] = await Promise.all([
-      prisma.dispute.findMany({
-        where,
-        skip: (page - 1) * limit,
-        take: limit,
-        orderBy: { createdAt: "desc" },
-        include: {
-          payment: {
-            select: {
-              id: true,
-              paymentIntent: true,
+    // Fetch disputes with pagination. underReviewCount/wonCount are
+    // dashboard-wide (unfiltered by search/gateway, like urgentDisputes below)
+    // — #997 secondary findings: the stat cards used to `.filter()` the
+    // current page's `disputes` array, so they silently showed ≤`limit` (20)
+    // instead of the true platform-wide count.
+    const [disputes, total, urgentDisputes, underReviewCount, wonCount] =
+      await Promise.all([
+        prisma.dispute.findMany({
+          where,
+          skip: (page - 1) * limit,
+          take: limit,
+          orderBy: { createdAt: "desc" },
+          include: {
+            payment: {
+              select: {
+                id: true,
+                paymentIntent: true,
+              },
             },
           },
-        },
-      }),
-      prisma.dispute.count({ where }),
-      // Count urgent disputes (due within 3 days)
-      prisma.dispute.count({
-        where: {
-          dueBy: {
-            lte: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
-            gte: new Date(),
+        }),
+        prisma.dispute.count({ where }),
+        // Count urgent disputes (due within 3 days)
+        prisma.dispute.count({
+          where: {
+            dueBy: {
+              lte: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+              gte: new Date(),
+            },
+            status: {
+              in: ["WARNING_NEEDS_RESPONSE", "NEEDS_RESPONSE", "UNDER_REVIEW"],
+            },
           },
-          status: {
-            in: ["WARNING_NEEDS_RESPONSE", "NEEDS_RESPONSE", "UNDER_REVIEW"],
-          },
-        },
-      }),
-    ]);
+        }),
+        prisma.dispute.count({ where: { status: "UNDER_REVIEW" } }),
+        prisma.dispute.count({ where: { status: "WON" } }),
+      ]);
 
     return NextResponse.json({
       disputes,
       total,
       urgentDisputes,
+      stats: { underReviewCount, wonCount },
       page,
       limit,
       totalPages: Math.ceil(total / limit),

--- a/app/api/admin/payouts/trend/route.ts
+++ b/app/api/admin/payouts/trend/route.ts
@@ -1,0 +1,84 @@
+/**
+ * GET /api/admin/payouts/trend
+ *
+ * #997 secondary findings — the "Payouts - Last 7 Days" chart used to fetch
+ * `/api/admin/payouts?limit=100` and bucket the raw rows into days in the
+ * browser (a TODO in the client flagged `limit=100` as not 7-day-safe at
+ * scale). This endpoint bounds the query to the actual 7-day window and does
+ * the bucketing server-side.
+ *
+ * Prisma's `groupBy` can't truncate a timestamp to a calendar day (no
+ * expression support without raw SQL, which this repo avoids), so we select
+ * only `{createdAt, amount}` inside the window — far narrower than the old
+ * ≤100-row/all-columns fetch — and bucket in JS.
+ */
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+
+const TREND_DAYS = 7;
+
+function dayKey(d: Date): string {
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function dayLabel(d: Date): string {
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export async function GET() {
+  try {
+    const auth = await requirePrivilegedAuth();
+    if (auth.error) return auth.error;
+
+    const now = new Date();
+    const todayUtc = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    const since = new Date(todayUtc);
+    since.setUTCDate(since.getUTCDate() - (TREND_DAYS - 1));
+
+    const rows = await prisma.consultantPayout.findMany({
+      where: { createdAt: { gte: since } },
+      select: { createdAt: true, amount: true },
+    });
+
+    const buckets = new Map<string, { label: string; totalPaise: number }>();
+    for (let i = 0; i < TREND_DAYS; i++) {
+      const d = new Date(since);
+      d.setUTCDate(d.getUTCDate() + i);
+      buckets.set(dayKey(d), { label: dayLabel(d), totalPaise: 0 });
+    }
+
+    for (const row of rows) {
+      const bucket = buckets.get(dayKey(row.createdAt));
+      if (bucket) bucket.totalPaise += row.amount;
+    }
+
+    const series = Array.from(buckets.entries()).map(([day, v]) => ({
+      day,
+      label: v.label,
+      totalPaise: v.totalPaise,
+    }));
+
+    return NextResponse.json({ series });
+  } catch (error) {
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "admin" } },
+    );
+    console.error("Error fetching payout trend:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch payout trend" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/admin/refunds/route.ts
+++ b/app/api/admin/refunds/route.ts
@@ -35,28 +35,37 @@ export async function GET(req: NextRequest) {
       };
     }
 
-    // Fetch refunds with pagination
-    const [refunds, total] = await Promise.all([
-      prisma.refund.findMany({
-        where,
-        skip: (page - 1) * limit,
-        take: limit,
-        orderBy: { createdAt: "desc" },
-        include: {
-          payment: {
-            select: {
-              id: true,
-              paymentIntent: true,
+    // Fetch refunds with pagination. pending/succeeded/failed counts are
+    // dashboard-wide (unfiltered by search/gateway) — #997 secondary
+    // findings: the stat cards used to `.filter()` the current page's
+    // `refunds` array, so they silently showed ≤`limit` (20) instead of the
+    // true platform-wide count.
+    const [refunds, total, pendingCount, succeededCount, failedCount] =
+      await Promise.all([
+        prisma.refund.findMany({
+          where,
+          skip: (page - 1) * limit,
+          take: limit,
+          orderBy: { createdAt: "desc" },
+          include: {
+            payment: {
+              select: {
+                id: true,
+                paymentIntent: true,
+              },
             },
           },
-        },
-      }),
-      prisma.refund.count({ where }),
-    ]);
+        }),
+        prisma.refund.count({ where }),
+        prisma.refund.count({ where: { status: "PENDING" } }),
+        prisma.refund.count({ where: { status: "SUCCEEDED" } }),
+        prisma.refund.count({ where: { status: "FAILED" } }),
+      ]);
 
     return NextResponse.json({
       refunds,
       total,
+      stats: { pendingCount, succeededCount, failedCount },
       page,
       limit,
       totalPages: Math.ceil(total / limit),

--- a/app/api/organizations/[orgId]/payouts/route.ts
+++ b/app/api/organizations/[orgId]/payouts/route.ts
@@ -27,6 +27,8 @@ import { requireOrgAccess, requireOrgOwner } from "@/lib/auth-helpers";
 // requireOrgOwner so BILLING_ADMIN can trigger payouts without escalation.
 import { requireOrgBillingAdminOrOwner } from "@/lib/auth/billing-admin-gate";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
+import { sumPaise } from "@/lib/payments/utils/money";
+import type { PayoutStatus } from "@prisma/client";
 
 const PayoutStatusSchema = z.enum([
   "PENDING",
@@ -59,7 +61,12 @@ const QuerySchema = z.object({
   from: z.coerce.date().optional(),
   to: z.coerce.date().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(25),
+  offset: z.coerce.number().int().min(0).default(0),
 });
+
+// In-flight = held/reserved but not yet disbursed (mirrors the client's
+// former "Pending" card definition).
+const IN_FLIGHT_STATUSES: PayoutStatus[] = ["PENDING", "APPROVED", "PROCESSING"];
 
 export async function GET(
   req: NextRequest,
@@ -88,27 +95,71 @@ export async function GET(
   }
   const q = parsedQuery.data;
 
-  const payouts = await prisma.organizationPayout.findMany({
-    where: {
-      organizationId: orgId,
-      ...(q.status && { status: q.status }),
-      ...(q.from || q.to
-        ? {
-            createdAt: {
-              ...(q.from && { gte: q.from }),
-              ...(q.to && { lt: q.to }),
-            },
-          }
-        : {}),
+  const where = {
+    organizationId: orgId,
+    ...(q.status && { status: q.status }),
+    ...(q.from || q.to
+      ? {
+          createdAt: {
+            ...(q.from && { gte: q.from }),
+            ...(q.to && { lt: q.to }),
+          },
+        }
+      : {}),
+  };
+
+  // #997 secondary findings: this used to fetch every payout for the org
+  // (no offset) and reduce totals client-side every render. Pagination now
+  // bounds the list; `stats` below is server-aggregated and org-wide
+  // (ignores status/date filters) so the summary cards don't shift as the
+  // table is filtered/paged — matching the client's original "stay on the
+  // full set" intent.
+  const [payouts, total, paidAgg, pendingAgg, statusCounts] =
+    await Promise.all([
+      prisma.organizationPayout.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: q.limit,
+        skip: q.offset,
+        include: {
+          _count: { select: { earnings: true } },
+        },
+      }),
+      prisma.organizationPayout.count({ where }),
+      prisma.organizationPayout.aggregate({
+        where: { organizationId: orgId, status: "COMPLETED" },
+        _sum: { netPayoutPaise: true },
+      }),
+      prisma.organizationPayout.aggregate({
+        where: { organizationId: orgId, status: { in: IN_FLIGHT_STATUSES } },
+        _sum: { netPayoutPaise: true },
+      }),
+      prisma.organizationPayout.groupBy({
+        by: ["status"],
+        where: { organizationId: orgId },
+        _count: { id: true },
+      }),
+    ]);
+
+  const counts = Object.fromEntries(
+    statusCounts.map((s) => [s.status, s._count.id]),
+  ) as Partial<Record<PayoutStatus, number>>;
+  const totalCount = statusCounts.reduce((sum, s) => sum + s._count.id, 0);
+
+  return NextResponse.json({
+    data: payouts,
+    pagination: {
+      total,
+      limit: q.limit,
+      offset: q.offset,
+      hasMore: q.offset + q.limit < total,
     },
-    orderBy: { createdAt: "desc" },
-    take: q.limit,
-    include: {
-      _count: { select: { earnings: true } },
+    stats: {
+      totalPaidPaise: sumPaise(paidAgg._sum.netPayoutPaise),
+      pendingPaise: sumPaise(pendingAgg._sum.netPayoutPaise),
+      counts: { ...counts, total: totalCount },
     },
   });
-
-  return NextResponse.json({ data: payouts });
 }
 
 export async function POST(

--- a/app/api/staff/moderation/reports/route.ts
+++ b/app/api/staff/moderation/reports/route.ts
@@ -26,6 +26,7 @@ export async function GET(req: NextRequest) {
     const type = searchParams.get("type") as ModerationReportType | null;
     const status = searchParams.get("status") as ModerationReportStatus | null;
     const assignedToId = searchParams.get("assignedToId");
+    const search = searchParams.get("search");
     const page = parseInt(searchParams.get("page") || "1");
     const limit = parseInt(searchParams.get("limit") || "20");
     const offset = (page - 1) * limit;
@@ -36,6 +37,17 @@ export async function GET(req: NextRequest) {
     if (status) where.status = status;
     if (assignedToId) {
       where.assignedToId = assignedToId === "unassigned" ? null : assignedToId;
+    }
+    // #997 secondary findings — the client used to fetch every PENDING
+    // report and substring-search on every keystroke. Search server-side
+    // over the same fields the old client filter checked.
+    if (search) {
+      where.OR = [
+        { id: { contains: search, mode: "insensitive" } },
+        { reason: { contains: search, mode: "insensitive" } },
+        { reportedBy: { name: { contains: search, mode: "insensitive" } } },
+        { targetUser: { name: { contains: search, mode: "insensitive" } } },
+      ];
     }
 
     const [reports, total] = await Promise.all([

--- a/app/dashboard/admin/payouts/page.tsx
+++ b/app/dashboard/admin/payouts/page.tsx
@@ -36,72 +36,25 @@ const VALID_TABS: readonly TabKey[] = [
   "earnings",
 ] as const;
 
-interface PayoutTrendDatum {
-  createdAt: string;
-  amount: number;
+interface PayoutTrendSeriesDatum {
+  day: string;
+  label: string;
+  totalPaise: number;
 }
 
 interface PayoutTrendResponse {
-  payouts: PayoutTrendDatum[];
-  pagination?: {
-    total: number;
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-  };
+  series: PayoutTrendSeriesDatum[];
 }
 
+// #997 secondary findings — the 7-day bucketing used to run client-side over
+// a `?limit=100` guess (not 7-day-safe at scale). The server now returns an
+// already-bucketed, bounded 7-day series via /api/admin/payouts/trend.
 async function fetchPayoutTrend(): Promise<PayoutTrendResponse> {
-  // TODO: If /api/admin/payouts?limit=100 doesn't return enough history for a
-  // meaningful trend (e.g. paginated past the 7-day window), introduce a
-  // dedicated trend endpoint rather than fetching more client-side.
-  const response = await fetch("/api/admin/payouts?limit=100");
+  const response = await fetch("/api/admin/payouts/trend");
   if (!response.ok) {
     throw new Error("Failed to fetch payout trend");
   }
   return response.json() as Promise<PayoutTrendResponse>;
-}
-
-function formatDayKey(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-function formatDayLabel(date: Date): string {
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
-
-function buildLast7DaysSeries(
-  payouts: PayoutTrendDatum[] | undefined,
-): Array<{ day: string; label: string; total: number }> {
-  const now = new Date();
-  const days: Array<{ day: string; label: string; total: number }> = [];
-  for (let i = 6; i >= 0; i--) {
-    const d = new Date(now);
-    d.setHours(0, 0, 0, 0);
-    d.setDate(d.getDate() - i);
-    days.push({ day: formatDayKey(d), label: formatDayLabel(d), total: 0 });
-  }
-  if (!payouts?.length) return days;
-
-  const index = new Map(days.map((d, i) => [d.day, i]));
-  for (const p of payouts) {
-    if (!p?.createdAt) continue;
-    const d = new Date(p.createdAt);
-    if (Number.isNaN(d.getTime())) continue;
-    const key = formatDayKey(d);
-    const idx = index.get(key);
-    if (idx !== undefined) {
-      // amounts are stored in minor units (paise/cents) — normalize to major
-      days[idx].total += (p.amount || 0) / 100;
-    }
-  }
-  return days;
 }
 
 export default function AdminPayoutsPage() {
@@ -130,8 +83,14 @@ export default function AdminPayoutsPage() {
   });
 
   const chartData = useMemo(
-    () => buildLast7DaysSeries(trendData?.payouts),
-    [trendData?.payouts],
+    () =>
+      (trendData?.series ?? []).map((d) => ({
+        day: d.day,
+        label: d.label,
+        // amounts are paise server-side — normalize to major units for display.
+        total: d.totalPaise / 100,
+      })),
+    [trendData?.series],
   );
 
   const hasAnyTrendData = chartData.some((d) => d.total > 0);

--- a/app/dashboard/organization/[orgId]/payouts/PayoutsPageClient.tsx
+++ b/app/dashboard/organization/[orgId]/payouts/PayoutsPageClient.tsx
@@ -57,10 +57,32 @@ interface PayoutItem {
   createdAt: string;
 }
 
+interface PayoutsResponse {
+  data: PayoutItem[];
+  pagination: { total: number; limit: number; offset: number; hasMore: boolean };
+  // #997 secondary findings — server-aggregated, org-wide (ignores the
+  // status filter/page) so the summary cards don't shift as the table is
+  // narrowed/paged.
+  stats: {
+    totalPaidPaise: number;
+    pendingPaise: number;
+    counts: Record<string, number>;
+  };
+}
+
+const PAGE_SIZE = 25;
+
 async function fetchPayouts(
   orgId: string,
-): Promise<{ data: PayoutItem[] }> {
-  const res = await fetch(`/api/organizations/${orgId}/payouts`);
+  offset: number,
+  status: StatusFilter,
+): Promise<PayoutsResponse> {
+  const params = new URLSearchParams({
+    limit: String(PAGE_SIZE),
+    offset: String(offset),
+  });
+  if (status !== "ALL") params.set("status", status);
+  const res = await fetch(`/api/organizations/${orgId}/payouts?${params}`);
   if (!res.ok) throw new Error("Failed to load payouts");
   return res.json();
 }
@@ -130,10 +152,11 @@ export function PayoutsPageClient({
   const queryClient = useQueryClient();
   const [createError, setCreateError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
+  const [page, setPage] = useState(1);
 
   const { data, isPending } = useQuery({
-    queryKey: ["org-payouts", orgId],
-    queryFn: () => fetchPayouts(orgId),
+    queryKey: ["org-payouts", orgId, page, statusFilter],
+    queryFn: () => fetchPayouts(orgId, (page - 1) * PAGE_SIZE, statusFilter),
     enabled: allowed,
   });
 
@@ -164,33 +187,25 @@ export function PayoutsPageClient({
   });
 
   const payouts = data?.data ?? [];
+  const pagination = data?.pagination;
+  const totalPages = pagination ? Math.max(1, Math.ceil(pagination.total / PAGE_SIZE)) : 1;
 
-  // Statuses come from prisma `enum PayoutStatus`: PENDING / APPROVED /
-  // PROCESSING / COMPLETED / FAILED / CANCELLED. "Total paid out"
-  // counts only fully-disbursed COMPLETED payouts; "Pending" rolls up
-  // everything in flight (PENDING approval, APPROVED but not sent,
-  // and PROCESSING).
-  const completedPayouts = payouts.filter((p) => p.status === "COMPLETED");
-  const totalPaid = completedPayouts.reduce(
-    (s, p) => s + p.netPayoutPaise,
-    0,
-  );
-  const pendingAmount = payouts
-    .filter(
-      (p) =>
-        p.status === "PENDING" ||
-        p.status === "APPROVED" ||
-        p.status === "PROCESSING",
-    )
-    .reduce((s, p) => s + p.netPayoutPaise, 0);
+  // #997 secondary findings — server-aggregated org-wide totals (was an
+  // unbounded fetch-all + per-render reduce). Statuses come from prisma
+  // `enum PayoutStatus`: PENDING / APPROVED / PROCESSING / COMPLETED /
+  // FAILED / CANCELLED. "Total paid out" counts only fully-disbursed
+  // COMPLETED payouts; "Pending" rolls up everything in flight.
+  const stats = data?.stats;
+  const totalPaid = stats?.totalPaidPaise ?? 0;
+  const pendingAmount = stats?.pendingPaise ?? 0;
+  const completedCount = stats?.counts.COMPLETED ?? 0;
+  const totalPayoutsCount = stats?.counts.total ?? 0;
+  const hasProcessingPayouts = (stats?.counts.PROCESSING ?? 0) > 0;
 
-  // Client-side filter over the already-fetched rows (#777 §B). Summary
-  // cards above stay on the full set so the totals don't shift as you
-  // narrow the table.
-  const visiblePayouts =
-    statusFilter === "ALL"
-      ? payouts
-      : payouts.filter((p) => p.status === statusFilter);
+  // The list itself is now server-paginated + server-filtered (`status`
+  // query param), so `payouts` is already the page to render — no more
+  // client-side re-filtering over an unbounded fetch (#777 §B superseded).
+  const visiblePayouts = payouts;
 
   if (!allowed) return null;
 
@@ -214,7 +229,7 @@ export function PayoutsPageClient({
               <StatCard
                 title="Total paid out"
                 value={formatCurrencyAmount(totalPaid, "INR")}
-                subtitle={`${completedPayouts.length} payouts`}
+                subtitle={`${completedCount} payouts`}
                 icon={Wallet}
                 variant="success"
               />
@@ -226,7 +241,7 @@ export function PayoutsPageClient({
               />
               <StatCard
                 title="Total payouts"
-                value={payouts.length}
+                value={totalPayoutsCount}
                 icon={CheckCircle2}
               />
             </DashboardGrid>
@@ -234,8 +249,7 @@ export function PayoutsPageClient({
             {/* #776 §B: disbursement is gated until live payouts go-live;
                 say so honestly rather than letting PROCESSING rows imply
                 money is moving. */}
-            {!livePayoutsEnabled &&
-              payouts.some((p) => p.status === "PROCESSING") && (
+            {!livePayoutsEnabled && hasProcessingPayouts && (
                 <div className="mt-4 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
                   <PauseCircle className="mt-0.5 h-4 w-4 shrink-0" />
                   <p>
@@ -269,10 +283,13 @@ export function PayoutsPageClient({
             <Card className="mt-6">
               <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
                 <CardTitle className="text-base">Payout History</CardTitle>
-                {payouts.length > 0 && (
+                {totalPayoutsCount > 0 && (
                   <Select
                     value={statusFilter}
-                    onValueChange={(v) => setStatusFilter(v as StatusFilter)}
+                    onValueChange={(v) => {
+                      setStatusFilter(v as StatusFilter);
+                      setPage(1);
+                    }}
                   >
                     <SelectTrigger className="h-8 w-[180px]">
                       <SelectValue />
@@ -288,7 +305,7 @@ export function PayoutsPageClient({
                 )}
               </CardHeader>
               <CardContent>
-                {payouts.length === 0 ? (
+                {totalPayoutsCount === 0 ? (
                   <p className="text-sm text-zinc-500 text-center py-8">
                     No payouts yet. Earnings will accumulate and you can create a
                     payout batch when ready.
@@ -425,6 +442,32 @@ export function PayoutsPageClient({
                 )}
               </CardContent>
             </Card>
+
+            {/* Pagination — the list is now server-paginated (#997 secondary
+                findings), so paging is a real fetch, not a client slice. */}
+            {totalPages > 1 && (
+              <div className="mt-4 flex justify-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                >
+                  Previous
+                </Button>
+                <span className="flex items-center px-4 text-sm text-zinc-500">
+                  Page {page} of {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
           </>
         )}
       </DashboardContent>

--- a/app/dashboard/staff/[staffId]/(features)/moderation/page.tsx
+++ b/app/dashboard/staff/[staffId]/(features)/moderation/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   keepPreviousData,
   useMutation,
@@ -99,6 +99,10 @@ const formatDate = (dateString: string) => {
 export default function ContentModerationPage() {
   const [activeTab, setActiveTab] = useState("reports");
   const [searchQuery, setSearchQuery] = useState("");
+  // #997 secondary findings — the reports list used to fetch all PENDING
+  // reports and substring-search every keystroke client-side. Debounce and
+  // send the query to the server instead.
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [selectedReport, setSelectedReport] = useState<ModerationReport | null>(
     null,
   );
@@ -109,6 +113,11 @@ export default function ContentModerationPage() {
 
   const { toast } = useToast();
   const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
   // Fetch moderation stats
   const {
@@ -133,10 +142,12 @@ export default function ContentModerationPage() {
     isError: reportsError,
     refetch: refetchReports,
   } = useQuery({
-    queryKey: ["staff-moderation-reports", "PENDING"],
+    queryKey: ["staff-moderation-reports", "PENDING", debouncedSearch],
     queryFn: async (): Promise<{ reports: ModerationReport[] }> => {
+      const params = new URLSearchParams({ status: "PENDING" });
+      if (debouncedSearch) params.set("search", debouncedSearch);
       const response = await fetch(
-        "/api/staff/moderation/reports?status=PENDING",
+        `/api/staff/moderation/reports?${params}`,
       );
       if (!response.ok) throw new Error("Failed to fetch reports");
       return response.json();
@@ -372,18 +383,8 @@ export default function ContentModerationPage() {
   const handleDeleteReview = (reviewId: string) =>
     deleteReviewMutation.mutate(reviewId);
 
-  // Filter reports by search
-  const filteredReports = searchQuery
-    ? reports.filter(
-        (r) =>
-          r.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          r.reason.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          r.reporter.name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          r.reportedUser.name
-            ?.toLowerCase()
-            .includes(searchQuery.toLowerCase()),
-      )
-    : reports;
+  // #997 secondary findings — search now happens server-side (debounced
+  // above); `reports` is already the filtered set.
 
   return (
     <div className="space-y-6">
@@ -539,13 +540,13 @@ export default function ContentModerationPage() {
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
-          ) : filteredReports.length === 0 ? (
+          ) : reports.length === 0 ? (
             <p className="text-center text-muted-foreground py-8">
               No pending reports
             </p>
           ) : (
             <div className="space-y-3">
-              {filteredReports.map((report) => (
+              {reports.map((report) => (
                 <Card
                   key={report.id}
                   className="cursor-pointer hover:shadow-md transition-shadow"

--- a/components/admin/VerificationQueue.tsx
+++ b/components/admin/VerificationQueue.tsx
@@ -70,41 +70,68 @@ const formatRelativeTime = (dateString: string) => {
   return formatDate(dateString);
 };
 
+// #997 secondary findings — this queue used to fetch every PENDING
+// verification in one unbounded call. The API (`getVerificationQueue`) was
+// already paginated (default limit 20) — the client just never asked for
+// page 2, silently hiding anything past the first page. Page through it
+// with "Load more" instead.
+const PAGE_SIZE = 20;
+
 export function VerificationQueue({
   apiBasePath = "/api/staff/moderation/profiles",
 }: VerificationQueueProps) {
   const [verifications, setVerifications] = useState<ProfileVerification[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [total, setTotal] = useState(0);
   const [selectedVerification, setSelectedVerification] =
     useState<ProfileVerification | null>(null);
   const { toast } = useToast();
 
-  const fetchVerifications = useCallback(async () => {
-    try {
-      setLoading(true);
-      const response = await fetch(`${apiBasePath}?status=PENDING`);
-      if (!response.ok) throw new Error("Failed to fetch verifications");
-      const data: { verifications?: ProfileVerification[] } =
-        await response.json();
-      setVerifications(data.verifications || []);
-    } catch (error) {
-      console.error("Error fetching verifications:", error);
-      toast({
-        title: "Error",
-        description: "Failed to load pending verifications",
-        variant: "destructive",
-      });
-    } finally {
-      setLoading(false);
-    }
-  }, [apiBasePath, toast]);
+  const fetchVerifications = useCallback(
+    async (targetPage: number, append: boolean) => {
+      try {
+        if (append) setLoadingMore(true);
+        else setLoading(true);
+        const response = await fetch(
+          `${apiBasePath}?status=PENDING&page=${targetPage}&limit=${PAGE_SIZE}`,
+        );
+        if (!response.ok) throw new Error("Failed to fetch verifications");
+        const data: {
+          verifications?: ProfileVerification[];
+          pagination?: { total: number; hasMore: boolean };
+        } = await response.json();
+        const fetched = data.verifications ?? [];
+        setVerifications((prev) => (append ? [...prev, ...fetched] : fetched));
+        setTotal(data.pagination?.total ?? fetched.length);
+        setHasMore(data.pagination?.hasMore ?? false);
+        setPage(targetPage);
+      } catch (error) {
+        console.error("Error fetching verifications:", error);
+        toast({
+          title: "Error",
+          description: "Failed to load pending verifications",
+          variant: "destructive",
+        });
+      } finally {
+        if (append) setLoadingMore(false);
+        else setLoading(false);
+      }
+    },
+    [apiBasePath, toast],
+  );
 
   useEffect(() => {
-    fetchVerifications();
+    fetchVerifications(1, false);
   }, [fetchVerifications]);
 
+  const handleRefresh = () => fetchVerifications(1, false);
+  const handleLoadMore = () => fetchVerifications(page + 1, true);
+
   const handleVerificationComplete = () => {
-    fetchVerifications();
+    fetchVerifications(1, false);
     setSelectedVerification(null);
   };
 
@@ -141,7 +168,7 @@ export function VerificationQueue({
           <Button
             variant="outline"
             size="sm"
-            onClick={fetchVerifications}
+            onClick={handleRefresh}
             className="mt-4"
           >
             <RefreshCw className="h-4 w-4 mr-2" />
@@ -157,13 +184,13 @@ export function VerificationQueue({
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <p className="text-sm text-zinc-500">
-            {verifications.length} pending verification
-            {verifications.length !== 1 ? "s" : ""}
+            {verifications.length} of {total} pending verification
+            {total !== 1 ? "s" : ""}
           </p>
           <Button
             variant="ghost"
             size="sm"
-            onClick={fetchVerifications}
+            onClick={handleRefresh}
             disabled={loading}
           >
             <RefreshCw
@@ -248,6 +275,22 @@ export function VerificationQueue({
             </Card>
           );
         })}
+
+        {hasMore && (
+          <div className="flex justify-center pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+            >
+              {loadingMore ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : null}
+              Load more
+            </Button>
+          </div>
+        )}
       </div>
 
       <VerificationReviewModal

--- a/components/appointments/AppointmentCalendar.tsx
+++ b/components/appointments/AppointmentCalendar.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from "react";
 import {
   addMonths,
   format,
-  isSameDay,
   isSameMonth,
   isToday,
   startOfMonth,
@@ -79,10 +78,25 @@ export function AppointmentCalendar({
     });
   }, [month]);
 
+  // #997 secondary findings — `eventsOf` used to re-filter+sort the whole
+  // `events` array once per grid cell (42x per render). Pre-index once into
+  // a Map keyed by local day, so each cell is an O(1) lookup.
+  const eventsByDay = useMemo(() => {
+    const map = new Map<string, CalendarEvent[]>();
+    for (const event of events) {
+      const key = format(event.start, "yyyy-MM-dd");
+      const bucket = map.get(key);
+      if (bucket) bucket.push(event);
+      else map.set(key, [event]);
+    }
+    map.forEach((bucket) => {
+      bucket.sort((a, b) => a.start.getTime() - b.start.getTime());
+    });
+    return map;
+  }, [events]);
+
   const eventsOf = (date: Date) =>
-    events
-      .filter((e) => isSameDay(e.start, date))
-      .sort((a, b) => a.start.getTime() - b.start.getTime());
+    eventsByDay.get(format(date, "yyyy-MM-dd")) ?? [];
 
   return (
     <div className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden">

--- a/components/dashboard/shared/DisputesPage.tsx
+++ b/components/dashboard/shared/DisputesPage.tsx
@@ -155,6 +155,10 @@ export function DisputesPage({
   const totalPages = data?.totalPages ?? 1;
   const total = data?.total ?? 0;
   const urgentCount = data?.urgentDisputes ?? 0;
+  // #997 secondary findings — server-computed, dashboard-wide (not the
+  // current page's rows via .filter()).
+  const underReviewCount = data?.stats?.underReviewCount ?? 0;
+  const wonCount = data?.stats?.wonCount ?? 0;
 
   const handleViewDispute = (disputeId: string) => {
     router.push(`${basePath}/disputes/${disputeId}`);
@@ -319,9 +323,7 @@ export function DisputesPage({
               <Clock className="h-5 w-5 text-yellow-600" />
             </div>
             <div>
-              <p className="text-2xl font-bold">
-                {disputes.filter((d) => d.status === "UNDER_REVIEW").length}
-              </p>
+              <p className="text-2xl font-bold">{underReviewCount}</p>
               <p className="text-sm text-muted-foreground">Under Review</p>
             </div>
           </CardContent>
@@ -332,9 +334,7 @@ export function DisputesPage({
               <CheckCircle className="h-5 w-5 text-green-600" />
             </div>
             <div>
-              <p className="text-2xl font-bold">
-                {disputes.filter((d) => d.status === "WON").length}
-              </p>
+              <p className="text-2xl font-bold">{wonCount}</p>
               <p className="text-sm text-muted-foreground">Won</p>
             </div>
           </CardContent>

--- a/components/dashboard/shared/RefundsPage.tsx
+++ b/components/dashboard/shared/RefundsPage.tsx
@@ -151,12 +151,13 @@ export function RefundsPage({
   const totalPages = refundsData?.totalPages ?? 1;
   const total = refundsData?.total ?? 0;
 
-  // Calculate stats
+  // #997 secondary findings — server-computed, dashboard-wide (previously
+  // `.filter()` over the current page's ≤20 rows, which undercounted).
   const stats = {
-    total: total,
-    pending: refunds.filter((r) => r.status === "PENDING").length,
-    succeeded: refunds.filter((r) => r.status === "SUCCEEDED").length,
-    failed: refunds.filter((r) => r.status === "FAILED").length,
+    total,
+    pending: refundsData?.stats?.pendingCount ?? 0,
+    succeeded: refundsData?.stats?.succeededCount ?? 0,
+    failed: refundsData?.stats?.failedCount ?? 0,
   };
 
   const renderRowActions = (refund: Refund) =>

--- a/types/disputes.ts
+++ b/types/disputes.ts
@@ -35,6 +35,12 @@ export interface DisputeListResponse {
   disputes: Dispute[];
   total: number;
   urgentDisputes: number;
+  // #997 secondary findings — dashboard-wide counts (unfiltered by the
+  // current search/status/gateway), like `urgentDisputes` above.
+  stats: {
+    underReviewCount: number;
+    wonCount: number;
+  };
   page: number;
   limit: number;
   totalPages: number;

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -101,6 +101,13 @@ export interface Refund {
 export interface RefundListResponse {
   refunds: Refund[];
   total: number;
+  // #997 secondary findings — dashboard-wide counts (unfiltered by the
+  // current search/gateway), not a client-side .filter() over the page.
+  stats: {
+    pendingCount: number;
+    succeededCount: number;
+    failedCount: number;
+  };
   page: number;
   limit?: number;
   totalPages: number;


### PR DESCRIPTION
## Summary

Sweep of the "Secondary findings" section of #997 (misplaced client-side compute outside the Request Calendar). Verified each item against current code first — one had already drifted (staff moderation was already paginated server-side; the gap was narrower than the issue described).

| # | Item | Outcome |
|---|---|---|
| 1 | Disputes/Refunds stat cards (`DisputesPage.tsx`, `RefundsPage.tsx`) | **Fixed.** "Under Review"/"Won" and Pending/Succeeded/Failed cards were `.filter()`-ing the current paginated page (≤20 rows) and presenting it as a dashboard-wide total — a correctness bug. Added a server-computed `stats` block to `/api/admin/disputes` and `/api/admin/refunds` (modeled on `SubscriptionsPage`'s `data.stats`), computed independent of the current search/status/gateway filter (same pattern as the existing `urgentDisputes` count). |
| 2 | Org payouts (`PayoutsPageClient.tsx`) | **Fixed.** `GET /api/organizations/[orgId]/payouts` fetched every payout for the org (only a `limit` cap, no `offset`) and the client reduced `totalPaid`/`pendingAmount` every render. Added `offset` pagination plus a server-aggregated `{totalPaidPaise, pendingPaise, counts}` stats block (org-wide, ignoring the status filter — matches the client's original "stay on the full set" intent for the summary cards). Client now pages through the list and the status filter is a real server-side query param instead of a client-side re-filter over an unbounded fetch. |
| 3 | Admin payouts trend (`admin/payouts/page.tsx`) | **Fixed.** New `GET /api/admin/payouts/trend` bounds the query to the actual 7-day window (`select {createdAt, amount}`) and buckets by calendar day server-side, replacing the client's `?limit=100` guess + browser-side bucketing (which had a TODO flagging it as not 7-day-safe at scale). Note: literal Prisma `groupBy` can't truncate a timestamp to a day without raw SQL, which this repo avoids — the endpoint instead narrows the fetch to the 7-day window and does the (now server-side, no longer client-side) bucketing in the route handler. |
| 4 | Staff moderation queue (`moderation/page.tsx`) | **Fixed.** `limit` already existed server-side (default 20) — the actual gap was no `search` param, so the client fetched the first page and substring-filtered only those rows. Added `search` to `/api/staff/moderation/reports` (matches report id/reason/reporter name/target name) and wired the client to debounce (300ms) and query the server instead of filtering client-side. |
| 5 | Admin verification queue (`VerificationQueue.tsx`) | **Fixed, narrower than described.** The API (`getVerificationQueue`, shared by `/api/admin/verification` and `/api/staff/moderation/profiles`) was already paginated server-side (default limit 20) — it was never truly unbounded. The client just never requested page 2, silently capping the queue at 20. Added page state + a "Load more" control. |
| 6 | Shared `AppointmentCalendar` | **Fixed.** `eventsOf(date)` re-filtered + sorted the whole `events` array once per grid cell (42x per render). Pre-indexed into a `Map<dateKey, CalendarEvent[]>` via `useMemo`; `eventsOf` is now an O(1) lookup. Stays client-side by design (interactive month nav) — not moved to the server, per the issue's explicit note. |
| — | Consultee event/appointment reshapers (`event-processor.ts`, `map-consultee.ts`) | **Skipped** — explicitly out of scope per the issue ("low priority"). |

## Notes

- Money fields follow the repo's BigInt-paise convention: aggregate `_sum` values go through `sumPaise()` (Prisma's BigInt→number extension doesn't apply to `aggregate`/`groupBy`); plain row reads are already number via the Prisma result extension.
- All routes keep their existing `requireApiAuth`/`requirePrivilegedAuth`/`requireOrgAccess` gates; only query/response shapes changed.
- Response shapes are additive (`stats`, `pagination` fields added) except the org payouts route, whose sole consumer (`PayoutsPageClient.tsx`) was updated in the same commit — verified via grep that nothing else calls it.

## Test plan

- [x] 5 new jest suites (16 tests) under `__tests__/dashboards/` covering the disputes/refunds stats correctness, org-payouts pagination + stats, the payouts trend bucketing, and moderation search — run in a sibling worktree (jest can't run under `.claude/worktrees`).
- [x] Full existing jest suite: 132 suites / 1544 tests pass, no regressions.
- [x] `NODE_OPTIONS="--max-old-space-size=12288" npx tsc --noEmit` — clean, zero errors.
- [x] `eslint` on all changed files — zero errors (one pre-existing, unrelated `unused-imports` warning on `requireOrgOwner` in the org payouts route, not introduced by this change).
- No dev server used per repo convention.

Part of #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a seven-day payout trend view for administrators.
  - Added server-side pagination, filtering, and summary statistics to organization payouts.
  - Added server-side search for moderation reports.
  - Added “Load more” pagination for the verification queue.

- **Bug Fixes**
  - Dashboard dispute and refund statistics now reflect all records, not just the current page.
  - Payout and moderation views now provide more accurate filtering and summaries.
  - Improved calendar event rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->