### PR TITLE
perf(bookings): server-computed calendar status grid (#997 phases 2-3)

### DIFF
--- a/__tests__/booking-algorithm/server-status-grid.test.ts
+++ b/__tests__/booking-algorithm/server-status-grid.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #997 Phases 2-3 — server-computed calendar status grid.
+ *
+ * Covers the PURE aggregation helpers extracted for the consultant
+ * Allocate-Slots calendar's server-side move:
+ *
+ *  - computeWeeklyConfirmedCallCounts (app/api/slots/appointments/route.ts):
+ *    Phase 3's per-week confirmed-call aggregate, parity-checked against
+ *    SlotCalculationService.weekKey — the SAME key the interactive weekly-
+ *    limit guard and the server validator (SubscriptionValidationService) use.
+ *  - buildOverlapMetaIndex / overlapMetaCandidatesFor / extractOverlapTitleAndParticipant
+ *    (availability-with-allocation route): Phase 2's per-interval tooltip
+ *    metadata, bucketed the same way isSlotAllocated/getSlotBookingStatus
+ *    bucket appointment overlap.
+ *
+ * Route modules import prisma/auth-server at top level for their GET
+ * handlers; both are mocked here purely so importing the pure helpers
+ * doesn't require a live DB/session (mirrors authorization.test.ts).
+ */
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock("../../lib/auth-server", () => ({
+  getSession: jest.fn(),
+}));
+
+import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+import { computeWeeklyConfirmedCallCounts } from "@/app/api/slots/appointments/route";
+import {
+  buildOverlapMetaIndex,
+  overlapMetaCandidatesFor,
+  extractOverlapTitleAndParticipant,
+  type OverlapAppointmentMeta,
+} from "@/app/api/slots/availability-with-allocation/[consultantId]/route";
+
+// ─── computeWeeklyConfirmedCallCounts (Phase 3) ─────────────────────────────
+
+describe("computeWeeklyConfirmedCallCounts", () => {
+  const SUB_ID = "sub-1";
+  const SLOTS_PER_CALL = 2; // 1-hour session
+
+  function confirmedAppt(startsAtIso: string, opts?: { tz?: string }) {
+    const start = new Date(startsAtIso);
+    return {
+      appointmentType: "SUBSCRIPTION",
+      subscription: { id: SUB_ID, schedulingTimezone: opts?.tz },
+      slotsOfAppointment: [
+        { startsAt: start, isTentative: false },
+        { startsAt: new Date(start.getTime() + 30 * 60 * 1000), isTentative: false },
+      ],
+    };
+  }
+
+  it("counts one confirmed call per matching week key", () => {
+    const appts = [
+      confirmedAppt("2025-01-06T10:00:00.000Z"), // Monday
+      confirmedAppt("2025-01-08T10:00:00.000Z"), // Wednesday, same week
+    ];
+    const counts = computeWeeklyConfirmedCallCounts(appts, SUB_ID, SLOTS_PER_CALL);
+    const weekKey = SlotCalculationService.weekKey(new Date("2025-01-06T10:00:00.000Z"));
+    expect(counts[weekKey]).toBe(2);
+  });
+
+  it("parity: buckets by the SAME key as SlotCalculationService.weekKey per appointment's own schedulingTimezone", () => {
+    const tz = "America/Los_Angeles";
+    const startIso = "2025-01-06T10:00:00.000Z";
+    const appts = [confirmedAppt(startIso, { tz })];
+    const counts = computeWeeklyConfirmedCallCounts(appts, SUB_ID, SLOTS_PER_CALL);
+    const expectedKey = SlotCalculationService.weekKey(new Date(startIso), tz);
+    expect(counts[expectedKey]).toBe(1);
+    expect(Object.keys(counts)).toEqual([expectedKey]);
+  });
+
+  it("excludes tentative slots (mid-reschedule, not a completed call)", () => {
+    const appt = confirmedAppt("2025-01-06T10:00:00.000Z");
+    appt.slotsOfAppointment[0].isTentative = true;
+    const counts = computeWeeklyConfirmedCallCounts([appt], SUB_ID, SLOTS_PER_CALL);
+    expect(counts).toEqual({});
+  });
+
+  it("excludes appointments whose slot count doesn't match slotsPerCall", () => {
+    const appt = confirmedAppt("2025-01-06T10:00:00.000Z");
+    appt.slotsOfAppointment.pop(); // now 1 slot, slotsPerCall expects 2
+    const counts = computeWeeklyConfirmedCallCounts([appt], SUB_ID, SLOTS_PER_CALL);
+    expect(counts).toEqual({});
+  });
+
+  it("excludes other subscriptions and other appointment types", () => {
+    const otherSub = confirmedAppt("2025-01-06T10:00:00.000Z");
+    otherSub.subscription = { id: "sub-other", schedulingTimezone: undefined };
+    const consultation = {
+      appointmentType: "CONSULTATION",
+      subscription: undefined,
+      slotsOfAppointment: [{ startsAt: new Date("2025-01-06T10:00:00.000Z") }],
+    };
+    const counts = computeWeeklyConfirmedCallCounts(
+      [otherSub, consultation],
+      SUB_ID,
+      SLOTS_PER_CALL,
+    );
+    expect(counts).toEqual({});
+  });
+
+  it("returns {} for an empty appointment list", () => {
+    expect(computeWeeklyConfirmedCallCounts([], SUB_ID, SLOTS_PER_CALL)).toEqual({});
+  });
+});
+
+// ─── Overlap metadata index (Phase 2) ───────────────────────────────────────
+
+describe("extractOverlapTitleAndParticipant", () => {
+  it("extracts consultation title + requester name", () => {
+    const result = extractOverlapTitleAndParticipant({
+      id: "a1",
+      appointmentType: "CONSULTATION",
+      slotsOfAppointment: [],
+      consultation: {
+        consultationPlan: { title: "Career Coaching" },
+        requestedBy: { user: { name: "Jane Doe" } },
+      },
+    });
+    expect(result).toEqual({ title: "Career Coaching", with: "Jane Doe" });
+  });
+
+  it("extracts subscription title + requester name", () => {
+    const result = extractOverlapTitleAndParticipant({
+      id: "a2",
+      appointmentType: "SUBSCRIPTION",
+      slotsOfAppointment: [],
+      subscription: {
+        subscriptionPlan: { title: "Monthly Mentorship" },
+        requestedBy: { user: { name: "John Smith" } },
+      },
+    });
+    expect(result).toEqual({ title: "Monthly Mentorship", with: "John Smith" });
+  });
+
+  it("falls back to a generic label when plan title is missing", () => {
+    const result = extractOverlapTitleAndParticipant({
+      id: "a3",
+      appointmentType: "WEBINAR",
+      slotsOfAppointment: [],
+      webinar: { webinarPlan: { title: null } },
+    });
+    expect(result).toEqual({ title: "Webinar" });
+  });
+
+  it("never returns a participant name for webinar/class (no requestedBy on those types)", () => {
+    const webinar = extractOverlapTitleAndParticipant({
+      id: "a4",
+      appointmentType: "WEBINAR",
+      slotsOfAppointment: [],
+      webinar: { webinarPlan: { title: "Group Session" } },
+    });
+    expect(webinar.with).toBeUndefined();
+  });
+});
+
+describe("buildOverlapMetaIndex + overlapMetaCandidatesFor", () => {
+  const baseAppt = (id: string, startIso: string, endIso: string) => ({
+    id,
+    appointmentType: "CONSULTATION" as const,
+    slotsOfAppointment: [
+      { id: `${id}-slot`, startsAt: new Date(startIso), endsAt: new Date(endIso) },
+    ],
+    consultation: {
+      consultationPlan: { title: "Basic Consultation" },
+      requestedBy: { user: { name: "Alice" } },
+    },
+  });
+
+  it("finds an appointment overlapping an exact 30-min bucket", () => {
+    const index = buildOverlapMetaIndex([
+      baseAppt("appt-1", "2025-01-06T10:00:00.000Z", "2025-01-06T10:30:00.000Z"),
+    ]);
+    const found = overlapMetaCandidatesFor(
+      index,
+      new Date("2025-01-06T10:00:00.000Z").getTime(),
+      new Date("2025-01-06T10:30:00.000Z").getTime(),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      id: "appt-1",
+      title: "Basic Consultation",
+      with: "Alice",
+    });
+  });
+
+  it("spans multiple 30-min buckets for a longer appointment slot", () => {
+    const index = buildOverlapMetaIndex([
+      baseAppt("appt-2", "2025-01-06T10:00:00.000Z", "2025-01-06T11:00:00.000Z"), // 2 buckets
+    ]);
+    const secondBucket = overlapMetaCandidatesFor(
+      index,
+      new Date("2025-01-06T10:30:00.000Z").getTime(),
+      new Date("2025-01-06T11:00:00.000Z").getTime(),
+    );
+    expect(secondBucket.map((m) => m.id)).toEqual(["appt-2"]);
+  });
+
+  it("returns no candidates for a non-overlapping window", () => {
+    const index = buildOverlapMetaIndex([
+      baseAppt("appt-3", "2025-01-06T10:00:00.000Z", "2025-01-06T10:30:00.000Z"),
+    ]);
+    const found = overlapMetaCandidatesFor(
+      index,
+      new Date("2025-01-06T14:00:00.000Z").getTime(),
+      new Date("2025-01-06T14:30:00.000Z").getTime(),
+    );
+    expect(found).toHaveLength(0);
+  });
+
+  it("dedupes by appointment id when a slot spans buckets already scanned", () => {
+    const index = buildOverlapMetaIndex([
+      baseAppt("appt-4", "2025-01-06T10:00:00.000Z", "2025-01-06T11:00:00.000Z"),
+    ]);
+    // Query window spans BOTH of appt-4's buckets — must appear once, not twice.
+    const found = overlapMetaCandidatesFor(
+      index,
+      new Date("2025-01-06T10:00:00.000Z").getTime(),
+      new Date("2025-01-06T11:00:00.000Z").getTime(),
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it("keeps two different appointments in the same bucket separate", () => {
+    const index = buildOverlapMetaIndex([
+      baseAppt("appt-5", "2025-01-06T10:00:00.000Z", "2025-01-06T10:30:00.000Z"),
+      {
+        ...baseAppt("appt-6", "2025-01-06T10:00:00.000Z", "2025-01-06T10:30:00.000Z"),
+        consultation: {
+          consultationPlan: { title: "Overlap Two" },
+          requestedBy: { user: { name: "Bob" } },
+        },
+      },
+    ]);
+    const found = overlapMetaCandidatesFor(
+      index,
+      new Date("2025-01-06T10:00:00.000Z").getTime(),
+      new Date("2025-01-06T10:30:00.000Z").getTime(),
+    );
+    const ids = found.map((m: OverlapAppointmentMeta) => m.id).sort();
+    expect(ids).toEqual(["appt-5", "appt-6"]);
+  });
+});

--- a/__tests__/booking-algorithm/server-status-grid.test.ts
+++ b/__tests__/booking-algorithm/server-status-grid.test.ts
@@ -8,7 +8,7 @@
  * Covers the PURE aggregation helpers extracted for the consultant
  * Allocate-Slots calendar's server-side move:
  *
- *  - computeWeeklyConfirmedCallCounts (app/api/slots/appointments/route.ts):
+ *  - computeWeeklyConfirmedCallCounts (lib/booking/weekly-call-counts.ts):
  *    Phase 3's per-week confirmed-call aggregate, parity-checked against
  *    SlotCalculationService.weekKey — the SAME key the interactive weekly-
  *    limit guard and the server validator (SubscriptionValidationService) use.
@@ -32,7 +32,7 @@ jest.mock("../../lib/auth-server", () => ({
 }));
 
 import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
-import { computeWeeklyConfirmedCallCounts } from "@/app/api/slots/appointments/route";
+import { computeWeeklyConfirmedCallCounts } from "@/lib/booking/weekly-call-counts";
 import {
   buildOverlapMetaIndex,
   overlapMetaCandidatesFor,

--- a/__tests__/booking-algorithm/server-status-grid.test.ts
+++ b/__tests__/booking-algorithm/server-status-grid.test.ts
@@ -38,7 +38,7 @@ import {
   overlapMetaCandidatesFor,
   extractOverlapTitleAndParticipant,
   type OverlapAppointmentMeta,
-} from "@/app/api/slots/availability-with-allocation/[consultantId]/route";
+} from "@/lib/booking/overlap-meta";
 
 // ─── computeWeeklyConfirmedCallCounts (Phase 3) ─────────────────────────────
 

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -4,6 +4,43 @@ import { AppointmentsType, Prisma } from "@prisma/client";
 import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 import { resolveOrgScope } from "@/lib/api/scope/parse";
 import { getConsultantAppointments } from "@/lib/data/consultant-appointments";
+import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+
+/**
+ * #997 Phase 3 — one confirmed (non-tentative) appointment whose slot count
+ * matches slotsPerCall = one completed call. Bucketed by the SAME
+ * scheduling-timezone week key (ADR B9) the server validator uses, so the
+ * interactive weekly-limit guard can do an O(1) lookup instead of
+ * re-deriving this from a separate whole-window appointment fetch on every
+ * slot click (previously UnifiedCalendar's countCompletedCallsForWeek).
+ */
+export function computeWeeklyConfirmedCallCounts(
+  appointments: Array<{
+    appointmentType: string;
+    subscription?: { id?: string; schedulingTimezone?: string | null } | null;
+    slotsOfAppointment?: Array<{ startsAt: Date | string; isTentative?: boolean }>;
+  }>,
+  subscriptionId: string,
+  slotsPerCall: number,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const appt of appointments) {
+    if (appt.appointmentType !== "SUBSCRIPTION") continue;
+    if (appt.subscription?.id !== subscriptionId) continue;
+    const slots = appt.slotsOfAppointment || [];
+    // Tentative slots are the OLD slots mid-reschedule — never a completed call.
+    if (slots.some((s) => s.isTentative)) continue;
+    if (slots.length !== slotsPerCall) continue;
+    const firstSlot = slots[0];
+    if (!firstSlot?.startsAt) continue;
+    const weekKey = SlotCalculationService.weekKey(
+      new Date(firstSlot.startsAt),
+      appt.subscription?.schedulingTimezone || undefined,
+    );
+    counts[weekKey] = (counts[weekKey] || 0) + 1;
+  }
+  return counts;
+}
 
 export async function GET(request: NextRequest) {
   const authResult = await requireApiAuth();
@@ -160,7 +197,26 @@ export async function GET(request: NextRequest) {
       orgScopeFilter: apptOrgFilter,
     });
 
-    return NextResponse.json({ data: appointments });
+    // #997 Phase 3 — opt-in aggregate, only computed when the caller scopes
+    // to a single subscription and states its per-call slot count (both
+    // already known client-side from the plan config — no extra DB read).
+    const slotsPerCallParam = searchParams.get("slotsPerCall");
+    const slotsPerCall = slotsPerCallParam
+      ? parseInt(slotsPerCallParam, 10)
+      : NaN;
+    const weeklyConfirmedCallCounts =
+      subscriptionId && Number.isFinite(slotsPerCall) && slotsPerCall > 0
+        ? computeWeeklyConfirmedCallCounts(
+            appointments,
+            subscriptionId,
+            slotsPerCall,
+          )
+        : undefined;
+
+    return NextResponse.json({
+      data: appointments,
+      ...(weeklyConfirmedCallCounts ? { weeklyConfirmedCallCounts } : {}),
+    });
   } catch (error) {
     console.error("Error fetching appointments:", error);
     return NextResponse.json(

--- a/app/api/slots/appointments/route.ts
+++ b/app/api/slots/appointments/route.ts
@@ -4,43 +4,7 @@ import { AppointmentsType, Prisma } from "@prisma/client";
 import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 import { resolveOrgScope } from "@/lib/api/scope/parse";
 import { getConsultantAppointments } from "@/lib/data/consultant-appointments";
-import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
-
-/**
- * #997 Phase 3 — one confirmed (non-tentative) appointment whose slot count
- * matches slotsPerCall = one completed call. Bucketed by the SAME
- * scheduling-timezone week key (ADR B9) the server validator uses, so the
- * interactive weekly-limit guard can do an O(1) lookup instead of
- * re-deriving this from a separate whole-window appointment fetch on every
- * slot click (previously UnifiedCalendar's countCompletedCallsForWeek).
- */
-export function computeWeeklyConfirmedCallCounts(
-  appointments: Array<{
-    appointmentType: string;
-    subscription?: { id?: string; schedulingTimezone?: string | null } | null;
-    slotsOfAppointment?: Array<{ startsAt: Date | string; isTentative?: boolean }>;
-  }>,
-  subscriptionId: string,
-  slotsPerCall: number,
-): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const appt of appointments) {
-    if (appt.appointmentType !== "SUBSCRIPTION") continue;
-    if (appt.subscription?.id !== subscriptionId) continue;
-    const slots = appt.slotsOfAppointment || [];
-    // Tentative slots are the OLD slots mid-reschedule — never a completed call.
-    if (slots.some((s) => s.isTentative)) continue;
-    if (slots.length !== slotsPerCall) continue;
-    const firstSlot = slots[0];
-    if (!firstSlot?.startsAt) continue;
-    const weekKey = SlotCalculationService.weekKey(
-      new Date(firstSlot.startsAt),
-      appt.subscription?.schedulingTimezone || undefined,
-    );
-    counts[weekKey] = (counts[weekKey] || 0) + 1;
-  }
-  return counts;
-}
+import { computeWeeklyConfirmedCallCounts } from "@/lib/booking/weekly-call-counts";
 
 export async function GET(request: NextRequest) {
   const authResult = await requireApiAuth();

--- a/app/api/slots/availability-with-allocation/[consultantId]/route.ts
+++ b/app/api/slots/availability-with-allocation/[consultantId]/route.ts
@@ -3,12 +3,134 @@ import prisma from "@/lib/prisma";
 import {
   AppointmentSlot,
   CustomSlot,
+  dayMap,
+  makeLocalizer,
   processAvailabilitySlots,
+  THIRTY_MIN_MS,
   WeeklySlot,
 } from "@/utils/timeSlotsProcessing";
 import { NextRequest, NextResponse } from "next/server";
 import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
 import { minuteUtcToDate } from "@/utils/slotAllocation/slotTimeUtils";
+import { getSession } from "@/lib/auth-server";
+import { isPrivileged } from "@/lib/auth-helpers";
+import type { TSlotTiming } from "@/types/slots";
+import type { BookingStatus } from "@/utils/timeSlotsProcessing";
+
+/** #997 Phase 2 — tooltip display metadata for a booked slot. Only computed
+ * (and only ever returned) when the caller is the owning consultant/staff —
+ * this route is otherwise PUBLIC/unauthenticated (consultee browsing), so
+ * participant names must never leak onto that path. */
+export interface OverlapAppointmentMeta {
+  id: string;
+  type: string;
+  title: string;
+  with?: string;
+}
+
+type SlotTimingWithOverlap = TSlotTiming & {
+  isAllocated: boolean;
+  bookingStatus: BookingStatus;
+  overlappingAppointments?: OverlapAppointmentMeta[];
+};
+
+/** Minimal shape the overlap-metadata builder needs — a subset of the
+ * detail-mode Prisma appointment include. */
+interface AppointmentForOverlapMeta {
+  id: string;
+  appointmentType: string;
+  slotsOfAppointment: { id: string; startsAt: Date; endsAt: Date }[];
+  consultation?: {
+    consultationPlan?: { title?: string | null } | null;
+    requestedBy?: { user?: { name?: string | null } | null } | null;
+  } | null;
+  subscription?: {
+    subscriptionPlan?: { title?: string | null } | null;
+    requestedBy?: { user?: { name?: string | null } | null } | null;
+  } | null;
+  webinar?: { webinarPlan?: { title?: string | null } | null } | null;
+  class?: { classPlan?: { title?: string | null } | null } | null;
+}
+
+export function extractOverlapTitleAndParticipant(
+  appt: AppointmentForOverlapMeta,
+): { title: string; with?: string } {
+  switch (appt.appointmentType) {
+    case "CONSULTATION":
+      return {
+        title: appt.consultation?.consultationPlan?.title || "Consultation",
+        with: appt.consultation?.requestedBy?.user?.name || undefined,
+      };
+    case "SUBSCRIPTION":
+      return {
+        title: appt.subscription?.subscriptionPlan?.title || "Subscription",
+        with: appt.subscription?.requestedBy?.user?.name || undefined,
+      };
+    case "WEBINAR":
+      return { title: appt.webinar?.webinarPlan?.title || "Webinar" };
+    case "CLASS":
+      return { title: appt.class?.classPlan?.title || "Class" };
+    default:
+      return { title: appt.appointmentType || "Unknown" };
+  }
+}
+
+/** Buckets each appointment's display metadata by every 30-min epoch bucket
+ * its slot spans — mirrors buildAppointmentIndex's alignment so a lookup with
+ * {@link overlapMetaCandidatesFor} finds the same overlaps getSlotBookingStatus
+ * would. */
+export function buildOverlapMetaIndex(
+  appointments: AppointmentForOverlapMeta[],
+): Map<number, OverlapAppointmentMeta[]> {
+  const index = new Map<number, OverlapAppointmentMeta[]>();
+  for (const appt of appointments) {
+    const { title, with: withUser } = extractOverlapTitleAndParticipant(appt);
+    const meta: OverlapAppointmentMeta = {
+      id: appt.id,
+      type: appt.appointmentType,
+      title,
+      with: withUser,
+    };
+    for (const slot of appt.slotsOfAppointment) {
+      if (!slot.startsAt || !slot.endsAt) continue;
+      const startMs = new Date(slot.startsAt).getTime();
+      const endMs = new Date(slot.endsAt).getTime();
+      if (isNaN(startMs) || isNaN(endMs) || endMs <= startMs) continue;
+      const firstBucket = Math.floor(startMs / THIRTY_MIN_MS);
+      const lastBucket = Math.floor((endMs - 1) / THIRTY_MIN_MS);
+      for (let b = firstBucket; b <= lastBucket; b++) {
+        const bucket = index.get(b);
+        if (bucket) bucket.push(meta);
+        else index.set(b, [meta]);
+      }
+    }
+  }
+  return index;
+}
+
+/** Dedupe-by-id overlap lookup spanning every 30-min bucket [startMs, endMs)
+ * touches — safe even if the interval isn't itself epoch-aligned. */
+export function overlapMetaCandidatesFor(
+  index: Map<number, OverlapAppointmentMeta[]>,
+  startMs: number,
+  endMs: number,
+): OverlapAppointmentMeta[] {
+  const firstBucket = Math.floor(startMs / THIRTY_MIN_MS);
+  const lastBucket = Math.floor((endMs - 1) / THIRTY_MIN_MS);
+  const seen = new Set<string>();
+  const out: OverlapAppointmentMeta[] = [];
+  for (let b = firstBucket; b <= lastBucket; b++) {
+    const bucket = index.get(b);
+    if (!bucket) continue;
+    for (const m of bucket) {
+      if (!seen.has(m.id)) {
+        seen.add(m.id);
+        out.push(m);
+      }
+    }
+  }
+  return out;
+}
 
 // Helper function to check if a slot is a legitimate overnight slot
 function isValidOvernightSlot(startTime: Date, endTime: Date): boolean {
@@ -58,6 +180,27 @@ export async function GET(
     const endDateInUtc =
       searchParams.get("endDateInUtc") || searchParams.get("endDate");
     const timezone = searchParams.get("timezone") || "UTC";
+
+    // #997 Phase 2 — explicit opt-in for the consultant Allocate-Slots
+    // calendar's per-interval tooltip metadata (title/participant name).
+    // This route is otherwise PUBLIC (consultee/trials browsing, see
+    // middleware.ts) so the richer include is gated behind BOTH the flag
+    // AND session ownership — a consultee's request never satisfies the
+    // ownership check, so their response is byte-identical to before.
+    const includeAppointmentDetailsRequested =
+      searchParams.get("includeAppointmentDetails") === "true";
+    let includeAppointmentDetails = false;
+    if (includeAppointmentDetailsRequested) {
+      const session = await getSession(true);
+      const isOwner = session?.user?.consultantProfileId === consultantId;
+      if (!session?.user?.id || (!isOwner && !isPrivileged(session.user.role))) {
+        return NextResponse.json(
+          { error: "Forbidden: appointment details require consultant ownership" },
+          { status: 403 },
+        );
+      }
+      includeAppointmentDetails = true;
+    }
 
     if (!startDateInUtc || !endDateInUtc) {
       return NextResponse.json(
@@ -121,42 +264,77 @@ export async function GET(
 
     // 2. Fetch all appointments to find allocated slots
     // FIX Bug #15: Use centralized occupancy policy for consistent conflict detection
-    const appointments = await prisma.appointment.findMany({
-      where: {
-        OR: buildOccupiedAppointmentFilter(consultantId),
-        slotsOfAppointment: {
-          some: {
-            OR: [
-              {
-                startsAt: {
-                  gte: startDate,
-                  lt: endDate,
-                },
+    const occupiedAppointmentWhere = {
+      OR: buildOccupiedAppointmentFilter(consultantId),
+      slotsOfAppointment: {
+        some: {
+          OR: [
+            {
+              startsAt: {
+                gte: startDate,
+                lt: endDate,
               },
-              {
-                endsAt: {
-                  gt: startDate,
-                  lte: endDate,
-                },
+            },
+            {
+              endsAt: {
+                gt: startDate,
+                lte: endDate,
               },
-              {
-                startsAt: { lte: startDate },
-                endsAt: { gte: endDate },
-              },
-            ],
-          },
+            },
+            {
+              startsAt: { lte: startDate },
+              endsAt: { gte: endDate },
+            },
+          ],
         },
       },
-      include: {
-        slotsOfAppointment: true,
-      },
-    });
+    };
+
+    // #997 Phase 2 — two separate queries (rather than one conditionally-built
+    // `include`) so the PUBLIC path (majority of traffic — consultee/trials
+    // browsing) never pays for the extra plan-title/participant-name joins.
+    let rawSlotsOfAppointment: { id: string; startsAt: Date; endsAt: Date }[];
+    let overlapMetaIndex: Map<number, OverlapAppointmentMeta[]> = new Map();
+    let detailAppointments: AppointmentForOverlapMeta[] = [];
+    if (includeAppointmentDetails) {
+      detailAppointments = await prisma.appointment.findMany({
+        where: occupiedAppointmentWhere,
+        include: {
+          slotsOfAppointment: true,
+          consultation: {
+            select: {
+              consultationPlan: { select: { title: true } },
+              requestedBy: { select: { user: { select: { name: true } } } },
+            },
+          },
+          subscription: {
+            select: {
+              subscriptionPlan: { select: { title: true } },
+              requestedBy: { select: { user: { select: { name: true } } } },
+            },
+          },
+          webinar: { select: { webinarPlan: { select: { title: true } } } },
+          class: { select: { classPlan: { select: { title: true } } } },
+        },
+      });
+      rawSlotsOfAppointment = detailAppointments.flatMap(
+        (appt) => appt.slotsOfAppointment,
+      );
+      overlapMetaIndex = buildOverlapMetaIndex(detailAppointments);
+    } else {
+      const appointments = await prisma.appointment.findMany({
+        where: occupiedAppointmentWhere,
+        include: { slotsOfAppointment: true },
+      });
+      rawSlotsOfAppointment = appointments.flatMap(
+        (appt) => appt.slotsOfAppointment,
+      );
+    }
 
     // Extract appointment slots using flatMap with defensive filtering
     // Defensive Programming: Filter out corrupt appointment slots
-    const appointmentSlots: AppointmentSlot[] = appointments.flatMap((appt) =>
-      appt.slotsOfAppointment
-        .filter((slot) => {
+    const appointmentSlots: AppointmentSlot[] = rawSlotsOfAppointment
+      .filter((slot) => {
           // Validate slot has required fields
           if (!slot.startsAt || !slot.endsAt) {
             console.warn(
@@ -215,13 +393,12 @@ export async function GET(
             return false;
           }
 
-          return true;
-        })
-        .map((slot) => ({
-          startsAt: slot.startsAt,
-          endsAt: slot.endsAt,
-        })),
-    );
+        return true;
+      })
+      .map((slot) => ({
+        startsAt: slot.startsAt,
+        endsAt: slot.endsAt,
+      }));
 
     // Convert to utility interfaces with defensive validation
     // Weekly slots now use Int (minutes since midnight UTC 0-1439) instead of DateTime
@@ -361,14 +538,78 @@ export async function GET(
       consultant.scheduleType === "CUSTOM" ? customSlots : [];
 
     // Process slots using the unified utility with filtered slots
-    const slotsByDate = processAvailabilitySlots(
-      filteredWeeklySlots,
-      filteredCustomSlots,
-      appointmentSlots,
-      startDate,
-      endDate,
-      timezone,
-    );
+    const slotsByDate: Record<string, SlotTimingWithOverlap[]> =
+      processAvailabilitySlots(
+        filteredWeeklySlots,
+        filteredCustomSlots,
+        appointmentSlots,
+        startDate,
+        endDate,
+        timezone,
+      );
+
+    // #997 Phase 2 — attach per-interval tooltip metadata AND synthesize
+    // "orphan" cells: a booked appointment slot whose availability row was
+    // edited/removed after booking has no availability-derived entry above,
+    // so without this the consultant calendar would silently show it as
+    // pickable. This mirrors the client patch it replaces (previously in
+    // useCalendarData.ts's slotStatusMap: "ensure appointments without
+    // availability slots still show as booked").
+    if (includeAppointmentDetails) {
+      const coveredStartsMs = new Set<number>();
+      for (const dateKey of Object.keys(slotsByDate)) {
+        for (const slot of slotsByDate[dateKey]) {
+          const startMs = new Date(slot.startsAt).getTime();
+          coveredStartsMs.add(startMs);
+          const endMs = new Date(slot.endsAt).getTime();
+          slot.overlappingAppointments = overlapMetaCandidatesFor(
+            overlapMetaIndex,
+            startMs,
+            endMs,
+          );
+        }
+      }
+
+      const loc = makeLocalizer(timezone);
+      for (const apptSlot of rawSlotsOfAppointment) {
+        const start = new Date(apptSlot.startsAt);
+        const end = new Date(apptSlot.endsAt);
+        if (isNaN(start.getTime()) || isNaN(end.getTime())) continue;
+        if (start < startDate || start >= endDate) continue;
+        const startMs = start.getTime();
+        if (coveredStartsMs.has(startMs)) continue;
+        coveredStartsMs.add(startMs); // de-dupe overlapping appointment rows onto one cell
+
+        const dateKey = loc.dateKey(start);
+        const synthetic: SlotTimingWithOverlap = {
+          slotId: `orphan-${startMs}`,
+          dateInISO: start.toISOString(),
+          dayOfWeek: dayMap[loc.dayIndex(start)],
+          startsAt: start.toISOString(),
+          endsAt: end.toISOString(),
+          slotOfAvailabilityId: "",
+          slotOfAppointmentId: "",
+          localStartTime: loc.timeP(start),
+          localEndTime: loc.timeP(end),
+          type: "CUSTOM",
+          isAllocated: true,
+          bookingStatus: "fully-booked",
+          overlappingAppointments: overlapMetaCandidatesFor(
+            overlapMetaIndex,
+            startMs,
+            end.getTime(),
+          ),
+        };
+        (slotsByDate[dateKey] ||= []).push(synthetic);
+      }
+
+      // Re-sort days that received synthetic entries.
+      for (const dateKey of Object.keys(slotsByDate)) {
+        slotsByDate[dateKey].sort(
+          (a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
+        );
+      }
+    }
 
     return NextResponse.json({ data: slotsByDate }, { status: 200 });
   } catch (error) {

--- a/app/api/slots/availability-with-allocation/[consultantId]/route.ts
+++ b/app/api/slots/availability-with-allocation/[consultantId]/route.ts
@@ -13,124 +13,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
 import { minuteUtcToDate } from "@/utils/slotAllocation/slotTimeUtils";
 import { getSession } from "@/lib/auth-server";
+import {
+  buildOverlapMetaIndex,
+  overlapMetaCandidatesFor,
+  type OverlapAppointmentMeta,
+  type AppointmentForOverlapMeta,
+} from "@/lib/booking/overlap-meta";
 import { isPrivileged } from "@/lib/auth-helpers";
 import type { TSlotTiming } from "@/types/slots";
 import type { BookingStatus } from "@/utils/timeSlotsProcessing";
-
-/** #997 Phase 2 — tooltip display metadata for a booked slot. Only computed
- * (and only ever returned) when the caller is the owning consultant/staff —
- * this route is otherwise PUBLIC/unauthenticated (consultee browsing), so
- * participant names must never leak onto that path. */
-export interface OverlapAppointmentMeta {
-  id: string;
-  type: string;
-  title: string;
-  with?: string;
-}
 
 type SlotTimingWithOverlap = TSlotTiming & {
   isAllocated: boolean;
   bookingStatus: BookingStatus;
   overlappingAppointments?: OverlapAppointmentMeta[];
 };
-
-/** Minimal shape the overlap-metadata builder needs — a subset of the
- * detail-mode Prisma appointment include. */
-interface AppointmentForOverlapMeta {
-  id: string;
-  appointmentType: string;
-  slotsOfAppointment: { id: string; startsAt: Date; endsAt: Date }[];
-  consultation?: {
-    consultationPlan?: { title?: string | null } | null;
-    requestedBy?: { user?: { name?: string | null } | null } | null;
-  } | null;
-  subscription?: {
-    subscriptionPlan?: { title?: string | null } | null;
-    requestedBy?: { user?: { name?: string | null } | null } | null;
-  } | null;
-  webinar?: { webinarPlan?: { title?: string | null } | null } | null;
-  class?: { classPlan?: { title?: string | null } | null } | null;
-}
-
-export function extractOverlapTitleAndParticipant(
-  appt: AppointmentForOverlapMeta,
-): { title: string; with?: string } {
-  switch (appt.appointmentType) {
-    case "CONSULTATION":
-      return {
-        title: appt.consultation?.consultationPlan?.title || "Consultation",
-        with: appt.consultation?.requestedBy?.user?.name || undefined,
-      };
-    case "SUBSCRIPTION":
-      return {
-        title: appt.subscription?.subscriptionPlan?.title || "Subscription",
-        with: appt.subscription?.requestedBy?.user?.name || undefined,
-      };
-    case "WEBINAR":
-      return { title: appt.webinar?.webinarPlan?.title || "Webinar" };
-    case "CLASS":
-      return { title: appt.class?.classPlan?.title || "Class" };
-    default:
-      return { title: appt.appointmentType || "Unknown" };
-  }
-}
-
-/** Buckets each appointment's display metadata by every 30-min epoch bucket
- * its slot spans — mirrors buildAppointmentIndex's alignment so a lookup with
- * {@link overlapMetaCandidatesFor} finds the same overlaps getSlotBookingStatus
- * would. */
-export function buildOverlapMetaIndex(
-  appointments: AppointmentForOverlapMeta[],
-): Map<number, OverlapAppointmentMeta[]> {
-  const index = new Map<number, OverlapAppointmentMeta[]>();
-  for (const appt of appointments) {
-    const { title, with: withUser } = extractOverlapTitleAndParticipant(appt);
-    const meta: OverlapAppointmentMeta = {
-      id: appt.id,
-      type: appt.appointmentType,
-      title,
-      with: withUser,
-    };
-    for (const slot of appt.slotsOfAppointment) {
-      if (!slot.startsAt || !slot.endsAt) continue;
-      const startMs = new Date(slot.startsAt).getTime();
-      const endMs = new Date(slot.endsAt).getTime();
-      if (isNaN(startMs) || isNaN(endMs) || endMs <= startMs) continue;
-      const firstBucket = Math.floor(startMs / THIRTY_MIN_MS);
-      const lastBucket = Math.floor((endMs - 1) / THIRTY_MIN_MS);
-      for (let b = firstBucket; b <= lastBucket; b++) {
-        const bucket = index.get(b);
-        if (bucket) bucket.push(meta);
-        else index.set(b, [meta]);
-      }
-    }
-  }
-  return index;
-}
-
-/** Dedupe-by-id overlap lookup spanning every 30-min bucket [startMs, endMs)
- * touches — safe even if the interval isn't itself epoch-aligned. */
-export function overlapMetaCandidatesFor(
-  index: Map<number, OverlapAppointmentMeta[]>,
-  startMs: number,
-  endMs: number,
-): OverlapAppointmentMeta[] {
-  const firstBucket = Math.floor(startMs / THIRTY_MIN_MS);
-  const lastBucket = Math.floor((endMs - 1) / THIRTY_MIN_MS);
-  const seen = new Set<string>();
-  const out: OverlapAppointmentMeta[] = [];
-  for (let b = firstBucket; b <= lastBucket; b++) {
-    const bucket = index.get(b);
-    if (!bucket) continue;
-    for (const m of bucket) {
-      if (!seen.has(m.id)) {
-        seen.add(m.id);
-        out.push(m);
-      }
-    }
-  }
-  return out;
-}
 
 // Helper function to check if a slot is a legitimate overnight slot
 function isValidOvernightSlot(startTime: Date, endTime: Date): boolean {

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/components/UnifiedCalendar.tsx
@@ -142,51 +142,6 @@ function areSlotsEqual(slots1: TimeSlot[], slots2: TimeSlot[]): boolean {
 }
 
 /**
- * Counts completed calls (appointments with a full slot block) for a given
- * subscription inside a specific week window.
- */
-interface CalendarAppointmentSlot {
-  startsAt: string;
-  endsAt: string;
-  isTentative?: boolean;
-}
-
-interface CalendarAppointment {
-  id: string;
-  appointmentType: string;
-  subscription?: { id?: string };
-  slotsOfAppointment?: CalendarAppointmentSlot[];
-}
-
-function countCompletedCallsForWeek(
-  existingAppointments: CalendarAppointment[],
-  subscriptionId: string,
-  slotsPerCall: number,
-  targetWeekKey: string,
-  schedulingTimezone?: string,
-): number {
-  if (!Array.isArray(existingAppointments)) return 0;
-
-  return existingAppointments.filter((appt: CalendarAppointment) => {
-    if (appt.appointmentType !== "SUBSCRIPTION") return false;
-    if (!appt.subscription || appt.subscription.id !== subscriptionId)
-      return false;
-    const slots = appt.slotsOfAppointment || [];
-    // Skip tentative appointments — during rescheduling, tentative slots are the
-    // OLD slots being replaced and should not count toward the weekly limit.
-    if (slots.some((s: CalendarAppointmentSlot) => s.isTentative)) return false;
-    // A completed call is an appointment that has exactly the per-call slot count
-    if (slots.length !== slotsPerCall) return false;
-    return (
-      SlotCalculationService.weekKey(
-        new Date(slots[0].startsAt),
-        schedulingTimezone,
-      ) === targetWeekKey
-    );
-  }).length;
-}
-
-/**
  * Counts completed calls from the user's current selection for a specific week.
  * A completed call is exactly `slotsPerCall` consecutive 30-min slots on the same day.
  */
@@ -428,14 +383,14 @@ export function UnifiedCalendar({
   const {
     consultantDetails,
     availableSlots,
-    existingAppointments,
     eventSlots,
     eventTentativeSlots = [],
+    weeklyConfirmedCallCounts,
     loading,
     error,
     refetch,
     refetchEventSlots,
-    refetchAppointments,
+    refetchAvailability,
     getSlotStatusForInterval,
   } = useCalendarData({
     consultantId,
@@ -446,14 +401,17 @@ export function UnifiedCalendar({
     mode,
     allowedStart,
     allowedEnd,
+    sessionDurationInHours,
   });
 
   // Wrap onAllocationComplete to refetch data before calling parent callback
   const handleAllocationSuccess = useCallback(
     async (result: AllocationResponse) => {
       try {
-        // Refetch event slots and appointments so newly allocated slots appear correctly
-        await Promise.all([refetchEventSlots(), refetchAppointments()]);
+        // Refetch event slots (weeklyConfirmedCallCounts) and availability
+        // (server-computed status grid/tooltips, #997 Phase 2) so newly
+        // allocated slots appear correctly.
+        await Promise.all([refetchEventSlots(), refetchAvailability()]);
       } catch (error) {
         Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "client" } });
         console.error(
@@ -465,7 +423,7 @@ export function UnifiedCalendar({
       // Call parent callback
       onAllocationComplete?.(result);
     },
-    [refetchEventSlots, refetchAppointments, onAllocationComplete],
+    [refetchEventSlots, refetchAvailability, onAllocationComplete],
   );
 
   // Count past confirmed event slots for in-progress recurring events
@@ -749,13 +707,12 @@ export function UnifiedCalendar({
             schedulingTimezone,
           );
           const slotsPerCall = getSlotsPerCall(sessionDurationInHours);
-          const completedCalls = countCompletedCallsForWeek(
-            existingAppointments,
-            eventId,
-            slotsPerCall,
-            targetWeekKey,
-            schedulingTimezone,
-          );
+          // #997 Phase 3 — server-precomputed confirmed-call count for this
+          // week (bucketed with the SAME SlotCalculationService.weekKey the
+          // server validator uses), fetched alongside eventSlots. Replaces
+          // re-deriving this from a separate whole-window appointment fetch
+          // on every slot click.
+          const completedCalls = weeklyConfirmedCallCounts[targetWeekKey] || 0;
 
           // Also include already selected complete calls in this same week
           const selectedCompleted = countCompletedSelectedCallsForWeek(
@@ -860,7 +817,7 @@ export function UnifiedCalendar({
       allowedStart,
       allowedEnd,
       selectedSlots,
-      existingAppointments,
+      weeklyConfirmedCallCounts,
       eventSlotsSet,
       eventTentativeSlotsSet,
       toast,

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useCalendarData.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/hooks/useCalendarData.ts
@@ -39,6 +39,10 @@ export interface UseCalendarDataOptions {
   mode: "view" | "select" | "allocate";
   allowedStart?: Date;
   allowedEnd?: Date;
+  /** #997 Phase 3 — subscription per-call slot count, sent to the event-slots
+   * fetch so the server can bucket `weeklyConfirmedCallCounts` the same way
+   * the interactive weekly-limit guard needs it. Ignored for other event types. */
+  sessionDurationInHours?: number;
 }
 
 export interface TimeSlot {
@@ -113,6 +117,15 @@ export interface RawSlotData {
   dayOfWeek?: string;
   localStartTime?: string;
   localEndTime?: string;
+  /** #997 Phase 2 — server-precomputed tooltip metadata for this interval
+   * (title/participant of any overlapping appointment). Only present because
+   * fetchAvailabilitySlots requests `includeAppointmentDetails`. */
+  overlappingAppointments?: Array<{
+    id: string;
+    type: string;
+    title: string;
+    with?: string;
+  }>;
 }
 
 /**
@@ -142,7 +155,6 @@ interface SlotStatusResult {
 interface CalendarData {
   consultantDetails: ConsultantData | null;
   availableSlots: TimeSlot[];
-  existingAppointments: Appointment[];
   rawAvailabilitySlots: {
     weekly: RawSlotData[];
     custom: RawSlotData[];
@@ -151,6 +163,11 @@ interface CalendarData {
   // This event's OWN tentative slots (being rescheduled) — rendered as a distinct
   // "Rescheduling" state, separate from confirmed eventSlots and foreign bookings.
   eventTentativeSlots: TimeSlot[];
+  // #997 Phase 3 — confirmed (non-tentative) call counts for THIS event,
+  // bucketed by scheduling-timezone week key (ADR B9). Server-computed
+  // alongside eventSlots; replaces re-deriving this from a separate
+  // whole-window appointment fetch on every slot click.
+  weeklyConfirmedCallCounts: Record<string, number>;
   loading: boolean;
   error: string | null;
 }
@@ -159,7 +176,6 @@ export interface UseCalendarDataReturn extends CalendarData {
   refetch: () => Promise<void>;
   refetchConsultant: () => Promise<void>;
   refetchAvailability: () => Promise<void>;
-  refetchAppointments: () => Promise<void>;
   refetchEventSlots: () => Promise<void>;
   getSlotStatusForInterval: (
     interval: { hour: number; minute: number },
@@ -190,6 +206,7 @@ export function useCalendarData(
     currentDate,
     mode,
     allowedEnd,
+    sessionDurationInHours,
   } = options;
   const { toast } = useToast();
 
@@ -200,14 +217,15 @@ export function useCalendarData(
     weekly: RawSlotData[];
     custom: RawSlotData[];
   }>({ weekly: [], custom: [] });
-  const [existingAppointments, setExistingAppointments] = useState<
-    Appointment[]
-  >([]);
   const [eventSlots, setEventSlots] = useState<TimeSlot[]>([]);
   // The current event's OWN tentative slots (being rescheduled). Tracked
   // separately from eventSlots (confirmed) so the calendar can render them as a
   // distinct "Rescheduling" state instead of mislabeling them as foreign "Booked".
   const [eventTentativeSlots, setEventTentativeSlots] = useState<TimeSlot[]>([]);
+  // #997 Phase 3 — see CalendarData.weeklyConfirmedCallCounts.
+  const [weeklyConfirmedCallCounts, setWeeklyConfirmedCallCounts] = useState<
+    Record<string, number>
+  >({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -268,10 +286,16 @@ export function useCalendarData(
             ? endOfWeek(currentDate)
             : endOfMonth(currentDate);
 
+      // #997 Phase 2 — this hook only ever backs the consultant's OWN
+      // Allocate-Slots calendar (never the public consultee/trials one), so
+      // always request the server-computed tooltip/orphan-slot detail. The
+      // route re-verifies ownership server-side regardless of this flag.
       const data = await AllocationService.fetchAvailabilitySlots(
         consultantId,
         startDate,
         endDate,
+        undefined,
+        true,
       );
 
       // Defensive: Validate data structure before using
@@ -323,102 +347,6 @@ export function useCalendarData(
     }
   }, [consultantId, toast, view, currentDate, mode, allowedEnd]);
 
-  // FIXED: Proper date range filtering for appointments to prevent "stray slots"
-  const fetchExistingAppointments = useCallback(async (): Promise<void> => {
-    if (!consultantId) return;
-
-    try {
-      // Always start from the view's natural start so pre-period weeks have
-      // appointment data for conflict detection (mirrors availability fix).
-      const startDate =
-        view === "week" ? startOfWeek(currentDate) : startOfMonth(currentDate);
-      // End at allowedEnd in allocate mode.
-      const endDate =
-        mode === "allocate" && allowedEnd
-          ? allowedEnd
-          : view === "week"
-            ? endOfWeek(currentDate)
-            : endOfMonth(currentDate);
-
-      const data = await AllocationService.fetchAppointments(
-        consultantId,
-        startDate,
-        endDate,
-      );
-
-      // Defensive: Validate data is an array before using
-      if (!Array.isArray(data)) {
-        console.warn("⚠️ fetchExistingAppointments: Data is not an array");
-        setExistingAppointments([]);
-        return;
-      }
-
-      // Defensive: Filter out invalid appointments
-      const validatedAppointments = data.filter((appt: Appointment) => {
-        if (!appt || !appt.id) {
-          console.warn(
-            "⚠️ fetchExistingAppointments: Filtering out appointment without id",
-          );
-          return false;
-        }
-
-        // If appointment has slots, validate them
-        if (appt.slotsOfAppointment && Array.isArray(appt.slotsOfAppointment)) {
-          appt.slotsOfAppointment = appt.slotsOfAppointment.filter(
-            (slot: AppointmentSlotRaw) => {
-              if (!slot || !slot.startsAt || !slot.endsAt) {
-                console.warn(
-                  `⚠️ fetchExistingAppointments: Filtering out invalid slot in appointment ${appt.id}`,
-                  { slot },
-                );
-                return false;
-              }
-              return true;
-            },
-          );
-        }
-
-        return true;
-      });
-
-      // Filter out cancelled/rejected/expired appointments so they don't show as "Booked"
-      const activeAppointments = validatedAppointments.filter((appt: Appointment) => {
-        const inactiveRequestStatuses = ["REJECTED", "CANCELLED", "EXPIRED"];
-        // Check consultation status
-        if (appt.consultation?.status) {
-          if (inactiveRequestStatuses.includes(appt.consultation.status))
-            return false;
-        }
-        // Check subscription status
-        if (appt.subscription?.status) {
-          if (inactiveRequestStatuses.includes(appt.subscription.status))
-            return false;
-        }
-        // Check webinar status
-        if (appt.webinar?.status) {
-          if (appt.webinar.status === "CANCELLED") return false;
-        }
-        // Check class status
-        if (appt.class?.status) {
-          if (appt.class.status === "CANCELLED") return false;
-        }
-        return true;
-      });
-
-      setExistingAppointments(activeAppointments);
-    } catch (error) {
-      console.error("Error fetching appointments:", error);
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to fetch appointments";
-      setError(errorMessage);
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: errorMessage,
-      });
-    }
-  }, [consultantId, toast, view, currentDate, mode, allowedEnd]);
-
   const fetchEventSlots = useCallback(async (): Promise<void> => {
     // Fetch event slots for ALL event types (subscription, consultation, webinar, class)
     // This allows the calendar to show "This Event" (black) instead of "Booked" (gray)
@@ -426,11 +354,25 @@ export function useCalendarData(
     if (!eventType || !eventId) {
       setEventSlots([]);
       setEventTentativeSlots([]);
+      setWeeklyConfirmedCallCounts({});
       return;
     }
 
     try {
-      const data = await AllocationService.fetchEventSlots(eventType, eventId, consultantId);
+      // #997 Phase 3 — pass slotsPerCall (subscriptions only) so the server
+      // can also return weeklyConfirmedCallCounts alongside this event's slots.
+      const slotsPerCall =
+        eventType === "subscription"
+          ? Math.ceil((sessionDurationInHours || 1) / 0.5)
+          : undefined;
+      const { data, weeklyConfirmedCallCounts: weeklyCounts } =
+        await AllocationService.fetchEventSlots(
+          eventType,
+          eventId,
+          consultantId,
+          slotsPerCall,
+        );
+      setWeeklyConfirmedCallCounts(weeklyCounts);
 
       if (data && Array.isArray(data) && data.length > 0) {
         // Filter out cancelled/rejected appointments from event slots
@@ -503,51 +445,9 @@ export function useCalendarData(
       console.error("Error fetching event slots:", error);
       setEventSlots([]);
       setEventTentativeSlots([]);
+      setWeeklyConfirmedCallCounts({});
     }
-  }, [eventType, eventId, consultantId]);
-
-  /**
-   * Helper function to extract appointment plan title
-   */
-  const extractAppointmentTitle = (appointment: Appointment): string => {
-    if (!appointment) return "Unknown";
-
-    switch (appointment.appointmentType) {
-      case "CONSULTATION":
-        return (
-          appointment.consultation?.consultationPlan?.title || "Consultation"
-        );
-      case "SUBSCRIPTION":
-        return (
-          appointment.subscription?.subscriptionPlan?.title || "Subscription"
-        );
-      case "WEBINAR":
-        return appointment.webinar?.webinarPlan?.title || "Webinar";
-      case "CLASS":
-        return appointment.class?.classPlan?.title || "Class";
-      default:
-        return appointment.appointmentType || "Unknown";
-    }
-  };
-
-  /**
-   * Helper function to extract appointment participant name
-   */
-  const extractAppointmentParticipant = (appointment: Appointment): string => {
-    if (!appointment) return "";
-
-    switch (appointment.appointmentType) {
-      case "CONSULTATION":
-        return appointment.consultation?.requestedBy?.user?.name || "";
-      case "SUBSCRIPTION":
-        return appointment.subscription?.requestedBy?.user?.name || "";
-      case "WEBINAR":
-      case "CLASS":
-        return appointment.slotsOfAppointment?.[0]?.user?.[0]?.name || "";
-      default:
-        return "";
-    }
-  };
+  }, [eventType, eventId, consultantId, sessionDurationInHours]);
 
   /**
    * PERFORMANCE: Compute visible dates for the current view so the slotStatusMap
@@ -571,37 +471,72 @@ export function useCalendarData(
   }, [currentDate, view]);
 
   /**
-   * PERFORMANCE: Pre-parse raw slot and appointment times once, then reuse across
-   * all 336+ cell computations instead of re-parsing per cell.
+   * #997 Phase 2 — the server (availability-with-allocation, requested with
+   * includeAppointmentDetails) already returns bookingStatus AND
+   * overlappingAppointments per 30-min interval. Index it ONCE by UTC ISO
+   * start so every cell below is an O(1) lookup instead of the old
+   * O(cells × (availabilitySlots + appointments)) cross-reference join.
    */
-  const parsedRawSlots = useMemo(() => {
+  const serverGridByISO = useMemo(() => {
+    const map = new Map<string, RawSlotData>();
     const allRaw = [
       ...(rawAvailabilitySlots.weekly || []),
       ...(rawAvailabilitySlots.custom || []),
     ];
-    return allRaw.map((slot) => ({
-      start: new Date(slot.startsAt).getTime(),
-      end: new Date(slot.endsAt).getTime(),
-      bookingStatus: slot.bookingStatus || "available",
-    }));
+    for (const slot of allRaw) {
+      map.set(new Date(slot.startsAt).toISOString(), slot);
+    }
+    return map;
   }, [rawAvailabilitySlots]);
 
-  const parsedAppointmentSlots = useMemo(() => {
-    return existingAppointments.flatMap((appointment) =>
-      (appointment.slotsOfAppointment || []).map((slt: AppointmentSlotRaw) => ({
-        start: new Date(slt.startsAt).getTime(),
-        end: new Date(slt.endsAt).getTime(),
-        appointmentId: appointment.id,
-        appointmentType: appointment.appointmentType,
-        title: extractAppointmentTitle(appointment),
-        with: extractAppointmentParticipant(appointment),
-      })),
-    );
-  }, [existingAppointments]);
+  /**
+   * Derives the cell's display status from ONE server grid lookup. The
+   * server already resolved bookingStatus (incl. the "appointment with no
+   * backing availability row" edge case via a synthesized fully-booked
+   * entry, #997 Phase 2) — only past/disabled stay client-computed since
+   * they depend on wall-clock "now", not on server-fetched data.
+   */
+  const deriveStatusFromServerGrid = useCallback(
+    (localStart: Date, localEnd: Date, now: number): SlotStatusResult => {
+      const serverSlot = serverGridByISO.get(localStart.toISOString());
+
+      let isAvailable = false;
+      let isBookedForDisplay = false;
+      let isPartiallyBooked = false;
+      let overlappingAppointments: SlotStatusResult["overlappingAppointments"] =
+        [];
+
+      if (serverSlot) {
+        isAvailable = serverSlot.bookingStatus === "available";
+        isBookedForDisplay = serverSlot.bookingStatus === "fully-booked";
+        isPartiallyBooked = serverSlot.bookingStatus === "partially-booked";
+        overlappingAppointments = serverSlot.overlappingAppointments || [];
+      }
+
+      const endMs = localEnd.getTime();
+      const isInPast = endMs < now;
+      const isDisabled = !isAvailable || isBookedForDisplay || isInPast;
+
+      return {
+        isAvailable,
+        isBooked: isBookedForDisplay || isPartiallyBooked,
+        isBookedForDisplay,
+        isPartiallyBooked,
+        isDisabled,
+        isInPast,
+        intervalStartUTCString: localStart.toISOString(),
+        intervalEndUTCString: localEnd.toISOString(),
+        localStartTime: localStart,
+        localEndTime: localEnd,
+        overlappingAppointments,
+      };
+    },
+    [serverGridByISO],
+  );
 
   /**
    * PERFORMANCE: Precompute slot status for every visible cell.
-   * Converts 336 × O(W+C+A×S) → 1 precomputation + 336 × O(1) Map lookups.
+   * Converts 336 × O(W+C+A×S) → 1 index build + 336 × O(1) Map lookups.
    * Key format: `${year}-${month}-${day}-${hour}-${minute}`
    */
   const slotStatusMap = useMemo((): Map<string, SlotStatusResult> => {
@@ -627,63 +562,13 @@ export function useCalendarData(
           0,
         );
         const localEnd = new Date(localStart.getTime() + 30 * 60 * 1000);
-        const startMs = localStart.getTime();
-        const endMs = localEnd.getTime();
 
-        // Find overlapping raw availability slots
-        const overlappingSlots = parsedRawSlots.filter(
-          (s) => startMs < s.end && s.start < endMs,
-        );
-
-        // Find overlapping appointments for tooltip
-        const overlappingAppointments = parsedAppointmentSlots
-          .filter((s) => startMs < s.end && s.start < endMs)
-          .map((s) => ({
-            id: s.appointmentId,
-            type: s.appointmentType,
-            title: s.title,
-            with: s.with,
-          }));
-
-        // Determine booking status from server-calculated data
-        let isAvailable = false;
-        let isBookedForDisplay = false;
-        let isPartiallyBooked = false;
-
-        if (overlappingSlots.length > 0) {
-          const bookingStatus = overlappingSlots[0].bookingStatus;
-          isAvailable = bookingStatus === "available";
-          isBookedForDisplay = bookingStatus === "fully-booked";
-          isPartiallyBooked = bookingStatus === "partially-booked";
-        }
-
-        // Ensure appointments without availability slots still show as booked
-        if (!isBookedForDisplay && overlappingAppointments.length > 0) {
-          isBookedForDisplay = true;
-          isAvailable = false;
-        }
-
-        const isInPast = endMs < now;
-        const isDisabled = !isAvailable || isBookedForDisplay || isInPast;
-
-        map.set(key, {
-          isAvailable,
-          isBooked: isBookedForDisplay || isPartiallyBooked,
-          isBookedForDisplay,
-          isPartiallyBooked,
-          isDisabled,
-          isInPast,
-          intervalStartUTCString: localStart.toISOString(),
-          intervalEndUTCString: localEnd.toISOString(),
-          localStartTime: localStart,
-          localEndTime: localEnd,
-          overlappingAppointments,
-        });
+        map.set(key, deriveStatusFromServerGrid(localStart, localEnd, now));
       }
     }
 
     return map;
-  }, [visibleDates, parsedRawSlots, parsedAppointmentSlots]);
+  }, [visibleDates, deriveStatusFromServerGrid]);
 
   /**
    * SLOT STATUS LOOKUP — O(1) via precomputed Map.
@@ -706,57 +591,13 @@ export function useCalendarData(
         localIntervalStartDate.getTime() + 30 * 60 * 1000,
       );
 
-      const startMs = localIntervalStartDate.getTime();
-      const endMs = localIntervalEndDate.getTime();
-
-      const overlappingSlots = parsedRawSlots.filter(
-        (s) => startMs < s.end && s.start < endMs,
+      return deriveStatusFromServerGrid(
+        localIntervalStartDate,
+        localIntervalEndDate,
+        Date.now(),
       );
-
-      const overlappingAppointments = parsedAppointmentSlots
-        .filter((s) => startMs < s.end && s.start < endMs)
-        .map((s) => ({
-          id: s.appointmentId,
-          type: s.appointmentType,
-          title: s.title,
-          with: s.with,
-        }));
-
-      let isAvailable = false;
-      let isBookedForDisplay = false;
-      let isPartiallyBooked = false;
-
-      if (overlappingSlots.length > 0) {
-        const bookingStatus = overlappingSlots[0].bookingStatus;
-        isAvailable = bookingStatus === "available";
-        isBookedForDisplay = bookingStatus === "fully-booked";
-        isPartiallyBooked = bookingStatus === "partially-booked";
-      }
-
-      if (!isBookedForDisplay && overlappingAppointments.length > 0) {
-        isBookedForDisplay = true;
-        isAvailable = false;
-      }
-
-      const now = new Date();
-      const isInPast = localIntervalEndDate < now;
-      const isDisabled = !isAvailable || isBookedForDisplay || isInPast;
-
-      return {
-        isAvailable,
-        isBooked: isBookedForDisplay || isPartiallyBooked,
-        isBookedForDisplay,
-        isPartiallyBooked,
-        isDisabled,
-        isInPast,
-        intervalStartUTCString: localIntervalStartDate.toISOString(),
-        intervalEndUTCString: localIntervalEndDate.toISOString(),
-        localStartTime: localIntervalStartDate,
-        localEndTime: localIntervalEndDate,
-        overlappingAppointments,
-      };
     },
-    [slotStatusMap, parsedRawSlots, parsedAppointmentSlots],
+    [slotStatusMap, deriveStatusFromServerGrid],
   );
 
   // PERFORMANCE: Fetch all data function with parallel API calls
@@ -771,7 +612,6 @@ export function useCalendarData(
       await Promise.all([
         fetchConsultantDetails(),
         fetchAvailabilitySlots(),
-        fetchExistingAppointments(),
         fetchEventSlots(),
       ]);
     } catch (error) {
@@ -784,13 +624,7 @@ export function useCalendarData(
     } finally {
       setLoading(false);
     }
-  }, [
-    consultantId,
-    fetchConsultantDetails,
-    fetchAvailabilitySlots,
-    fetchExistingAppointments,
-    fetchEventSlots,
-  ]);
+  }, [consultantId, fetchConsultantDetails, fetchAvailabilitySlots, fetchEventSlots]);
 
   // PERFORMANCE: Split into two effects so date-independent fetches don't re-fire on week navigation.
 
@@ -822,7 +656,7 @@ export function useCalendarData(
       }
       setError(null);
 
-      Promise.all([fetchAvailabilitySlots(), fetchExistingAppointments()])
+      fetchAvailabilitySlots()
         .catch((error) => {
           console.error("Error fetching date-dependent data:", error);
           setError(
@@ -841,7 +675,6 @@ export function useCalendarData(
     consultantDetails,
     weeklySlotCount,
     fetchAvailabilitySlots,
-    fetchExistingAppointments,
   ]);
 
   // ENHANCEMENT: Individual refetch functions for granular control
@@ -863,15 +696,6 @@ export function useCalendarData(
     }
   }, [fetchAvailabilitySlots]);
 
-  const refetchAppointments = useCallback(async (): Promise<void> => {
-    setLoading(true);
-    try {
-      await fetchExistingAppointments();
-    } finally {
-      setLoading(false);
-    }
-  }, [fetchExistingAppointments]);
-
   const refetchEventSlots = useCallback(async (): Promise<void> => {
     setLoading(true);
     try {
@@ -885,10 +709,10 @@ export function useCalendarData(
     // Data
     consultantDetails,
     availableSlots,
-    existingAppointments,
     rawAvailabilitySlots,
     eventSlots,
     eventTentativeSlots,
+    weeklyConfirmedCallCounts,
     loading,
     error,
 
@@ -896,7 +720,6 @@ export function useCalendarData(
     refetch: fetchAllData,
     refetchConsultant,
     refetchAvailability,
-    refetchAppointments,
     refetchEventSlots,
     getSlotStatusForInterval, // KEY: Unified slot status calculation
     slotStatusMap, // PERFORMANCE: Precomputed status map for O(1) lookups

--- a/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationService.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/shared/utils/allocationService.ts
@@ -2,6 +2,15 @@ import * as Sentry from "@sentry/nextjs";
 import { TimeSlot } from "./calendarUtils";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
+/** #997 Phase 2 — tooltip display metadata for a booked slot, computed
+ * server-side (only present when `includeAppointmentDetails` was authorized). */
+export interface OverlappingAppointmentMeta {
+  id: string;
+  type: string;
+  title: string;
+  with?: string;
+}
+
 /** Shape of a raw availability slot returned from the availability-with-allocation API */
 interface RawAvailabilityApiSlot {
   slotId: string;
@@ -12,6 +21,9 @@ interface RawAvailabilityApiSlot {
   dayOfWeek?: string;
   localStartTime?: string;
   localEndTime?: string;
+  /** #997 Phase 2 — server-precomputed status-grid tooltip data; only
+   * populated when the calendar requested `includeAppointmentDetails`. */
+  overlappingAppointments?: OverlappingAppointmentMeta[];
 }
 
 export interface AllocationRequest {
@@ -408,6 +420,15 @@ export class AllocationService {
      * the API response aligned with the user's calendar view.
      */
     timezone?: string,
+    /**
+     * #997 Phase 2 — requests the server-computed status grid's per-interval
+     * `overlappingAppointments` tooltip metadata + "orphan booked slot"
+     * synthesis. The route re-checks ownership server-side regardless of
+     * this flag (it's an opt-in signal, not the authorization itself) — the
+     * consultee/trials calendars never pass it, so their response shape is
+     * unchanged.
+     */
+    includeAppointmentDetails?: boolean,
   ) {
     if (!consultantId) {
       throw new Error("Consultant ID is required");
@@ -430,6 +451,9 @@ export class AllocationService {
         endDateInUtc: endDate.toISOString(),
         timezone: tz,
       });
+      if (includeAppointmentDetails) {
+        params.set("includeAppointmentDetails", "true");
+      }
       const response = await fetch(
         `/api/slots/availability-with-allocation/${consultantId}?${params}`,
       );
@@ -456,44 +480,20 @@ export class AllocationService {
   }
 
   /**
-   * Fetches all appointments for a consultant
-   */
-  static async fetchAppointments(
-    consultantId: string,
-    startDate: Date,
-    endDate: Date,
-  ) {
-    if (!consultantId) {
-      throw new Error("Consultant ID is required");
-    }
-
-    try {
-      const params = new URLSearchParams({
-        consultantProfileId: consultantId,
-        startDate: startDate.toISOString(),
-        endDate: endDate.toISOString(),
-      });
-      const response = await fetch(`/api/slots/appointments?${params}`);
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || "Failed to fetch appointments");
-      }
-      const { data } = await response.json();
-      return data || [];
-    } catch (error) {
-      console.error("Error fetching appointments:", error);
-      throw error;
-    }
-  }
-
-  /**
    * Fetches specific event slots for any event type
    * Used to display "This Event" (black) instead of "Booked" (gray) in calendar
+   *
+   * #997 Phase 3 — when `slotsPerCall` is given for a subscription, the
+   * response also carries `weeklyConfirmedCallCounts` (server-bucketed by
+   * scheduling-timezone week, ADR B9) so the calendar's interactive
+   * weekly-limit guard no longer needs a separate whole-window appointment
+   * fetch to re-derive it.
    */
   static async fetchEventSlots(
     eventType: "consultation" | "subscription" | "webinar" | "class",
     eventId: string,
     consultantProfileId: string,
+    slotsPerCall?: number,
   ) {
     try {
       const params = new URLSearchParams({
@@ -508,6 +508,9 @@ export class AllocationService {
         params.append("classId", eventId);
       } else if (eventType === "subscription") {
         params.append("subscriptionId", eventId);
+        if (slotsPerCall && slotsPerCall > 0) {
+          params.append("slotsPerCall", String(slotsPerCall));
+        }
       } else if (eventType === "consultation") {
         params.append("consultationId", eventId);
       }
@@ -518,8 +521,13 @@ export class AllocationService {
         throw new Error("Failed to fetch event slots");
       }
 
-      const { data } = await response.json();
-      return data || [];
+      const { data, weeklyConfirmedCallCounts } = await response.json();
+      return {
+        data: data || [],
+        weeklyConfirmedCallCounts:
+          (weeklyConfirmedCallCounts as Record<string, number> | undefined) ||
+          {},
+      };
     } catch (error) {
       console.error("Error fetching event slots:", error);
       throw error;

--- a/lib/booking/overlap-meta.ts
+++ b/lib/booking/overlap-meta.ts
@@ -1,0 +1,110 @@
+import { THIRTY_MIN_MS } from "@/utils/timeSlotsProcessing";
+
+/** #997 Phase 2 — tooltip display metadata for a booked slot. Only computed
+ * (and only ever returned) when the caller is the owning consultant/staff —
+ * this route is otherwise PUBLIC/unauthenticated (consultee browsing), so
+ * participant names must never leak onto that path. */
+export interface OverlapAppointmentMeta {
+  id: string;
+  type: string;
+  title: string;
+  with?: string;
+}
+
+/** Minimal shape the overlap-metadata builder needs — a subset of the
+ * detail-mode Prisma appointment include. */
+export interface AppointmentForOverlapMeta {
+  id: string;
+  appointmentType: string;
+  slotsOfAppointment: { id: string; startsAt: Date; endsAt: Date }[];
+  consultation?: {
+    consultationPlan?: { title?: string | null } | null;
+    requestedBy?: { user?: { name?: string | null } | null } | null;
+  } | null;
+  subscription?: {
+    subscriptionPlan?: { title?: string | null } | null;
+    requestedBy?: { user?: { name?: string | null } | null } | null;
+  } | null;
+  webinar?: { webinarPlan?: { title?: string | null } | null } | null;
+  class?: { classPlan?: { title?: string | null } | null } | null;
+}
+
+export function extractOverlapTitleAndParticipant(
+  appt: AppointmentForOverlapMeta,
+): { title: string; with?: string } {
+  switch (appt.appointmentType) {
+    case "CONSULTATION":
+      return {
+        title: appt.consultation?.consultationPlan?.title || "Consultation",
+        with: appt.consultation?.requestedBy?.user?.name || undefined,
+      };
+    case "SUBSCRIPTION":
+      return {
+        title: appt.subscription?.subscriptionPlan?.title || "Subscription",
+        with: appt.subscription?.requestedBy?.user?.name || undefined,
+      };
+    case "WEBINAR":
+      return { title: appt.webinar?.webinarPlan?.title || "Webinar" };
+    case "CLASS":
+      return { title: appt.class?.classPlan?.title || "Class" };
+    default:
+      return { title: appt.appointmentType || "Unknown" };
+  }
+}
+
+/** Buckets each appointment's display metadata by every 30-min epoch bucket
+ * its slot spans — mirrors buildAppointmentIndex's alignment so a lookup with
+ * {@link overlapMetaCandidatesFor} finds the same overlaps getSlotBookingStatus
+ * would. */
+export function buildOverlapMetaIndex(
+  appointments: AppointmentForOverlapMeta[],
+): Map<number, OverlapAppointmentMeta[]> {
+  const index = new Map<number, OverlapAppointmentMeta[]>();
+  for (const appt of appointments) {
+    const { title, with: withUser } = extractOverlapTitleAndParticipant(appt);
+    const meta: OverlapAppointmentMeta = {
+      id: appt.id,
+      type: appt.appointmentType,
+      title,
+      with: withUser,
+    };
+    for (const slot of appt.slotsOfAppointment) {
+      if (!slot.startsAt || !slot.endsAt) continue;
+      const startMs = new Date(slot.startsAt).getTime();
+      const endMs = new Date(slot.endsAt).getTime();
+      if (isNaN(startMs) || isNaN(endMs) || endMs <= startMs) continue;
+      const firstBucket = Math.floor(startMs / THIRTY_MIN_MS);
+      const lastBucket = Math.floor((endMs - 1) / THIRTY_MIN_MS);
+      for (let b = firstBucket; b <= lastBucket; b++) {
+        const bucket = index.get(b);
+        if (bucket) bucket.push(meta);
+        else index.set(b, [meta]);
+      }
+    }
+  }
+  return index;
+}
+
+/** Dedupe-by-id overlap lookup spanning every 30-min bucket [startMs, endMs)
+ * touches — safe even if the interval isn't itself epoch-aligned. */
+export function overlapMetaCandidatesFor(
+  index: Map<number, OverlapAppointmentMeta[]>,
+  startMs: number,
+  endMs: number,
+): OverlapAppointmentMeta[] {
+  const firstBucket = Math.floor(startMs / THIRTY_MIN_MS);
+  const lastBucket = Math.floor((endMs - 1) / THIRTY_MIN_MS);
+  const seen = new Set<string>();
+  const out: OverlapAppointmentMeta[] = [];
+  for (let b = firstBucket; b <= lastBucket; b++) {
+    const bucket = index.get(b);
+    if (!bucket) continue;
+    for (const m of bucket) {
+      if (!seen.has(m.id)) {
+        seen.add(m.id);
+        out.push(m);
+      }
+    }
+  }
+  return out;
+}

--- a/lib/booking/weekly-call-counts.ts
+++ b/lib/booking/weekly-call-counts.ts
@@ -1,0 +1,37 @@
+import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+
+/**
+ * #997 Phase 3 — one confirmed (non-tentative) appointment whose slot count
+ * matches slotsPerCall = one completed call. Bucketed by the SAME
+ * scheduling-timezone week key (ADR B9) the server validator uses, so the
+ * interactive weekly-limit guard can do an O(1) lookup instead of
+ * re-deriving this from a separate whole-window appointment fetch on every
+ * slot click (previously UnifiedCalendar's countCompletedCallsForWeek).
+ */
+export function computeWeeklyConfirmedCallCounts(
+  appointments: Array<{
+    appointmentType: string;
+    subscription?: { id?: string; schedulingTimezone?: string | null } | null;
+    slotsOfAppointment?: Array<{ startsAt: Date | string; isTentative?: boolean }>;
+  }>,
+  subscriptionId: string,
+  slotsPerCall: number,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const appt of appointments) {
+    if (appt.appointmentType !== "SUBSCRIPTION") continue;
+    if (appt.subscription?.id !== subscriptionId) continue;
+    const slots = appt.slotsOfAppointment || [];
+    // Tentative slots are the OLD slots mid-reschedule — never a completed call.
+    if (slots.some((s) => s.isTentative)) continue;
+    if (slots.length !== slotsPerCall) continue;
+    const firstSlot = slots[0];
+    if (!firstSlot?.startsAt) continue;
+    const weekKey = SlotCalculationService.weekKey(
+      new Date(firstSlot.startsAt),
+      appt.subscription?.schedulingTimezone || undefined,
+    );
+    counts[weekKey] = (counts[weekKey] || 0) + 1;
+  }
+  return counts;
+}

--- a/lib/data/consultant-appointments.ts
+++ b/lib/data/consultant-appointments.ts
@@ -303,6 +303,9 @@ export async function getConsultantAppointments(
           },
           schedulingPeriodStartsAt: true,
           schedulingPeriodEndsAt: true,
+          // #997 Phase 3 — the appointments route's weekly-confirmed-call-count
+          // aggregate buckets by THIS column (ADR B9), not a client-passed tz.
+          schedulingTimezone: true,
           status: true,
         },
       },

--- a/types/appointment.ts
+++ b/types/appointment.ts
@@ -170,6 +170,9 @@ export type TAppointment = Prisma.AppointmentGetPayload<{
             user: true;
           };
         };
+        // #997 Phase 3 — weekly-confirmed-call-count aggregate buckets by this
+        // column (ADR B9), read in app/api/slots/appointments/route.ts.
+        schedulingTimezone: true;
       };
     };
     webinar: {

--- a/utils/timeSlotsProcessing.ts
+++ b/utils/timeSlotsProcessing.ts
@@ -63,7 +63,10 @@ export interface AppointmentSlot {
 // actually overlap it. Every SlotOfAppointment is exactly 30 min and 30-min
 // aligned, so a 30-min bucket is exact; the multi-bucket span below keeps it
 // correct even for legacy/longer rows.
-const THIRTY_MIN_MS = 30 * 60 * 1000;
+// #997 Phase 2 — exported so the availability-with-allocation route can bucket
+// its OWN overlap-metadata index (title/participant for tooltips) using the
+// exact same alignment as isSlotAllocated/getSlotBookingStatus below.
+export const THIRTY_MIN_MS = 30 * 60 * 1000;
 export type AppointmentIndex = Map<number, AppointmentSlot[]>;
 
 export function buildAppointmentIndex(
@@ -130,7 +133,9 @@ const WEEKDAY_TO_INDEX: Record<string, number> = {
   Sat: 6,
 };
 
-function makeLocalizer(timezone: string) {
+// #997 Phase 2 — exported so route.ts can localize synthetic (orphan)
+// appointment-only intervals with the exact same dateKey/timeP format used here.
+export function makeLocalizer(timezone: string) {
   const timeFmt = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     hour: "numeric",


### PR DESCRIPTION
## Summary

Phases 2-3 of #997: move the consultant Allocate-Slots calendar's client-side status join and existing-appointment aggregation server-side, by **extending** the already-shared `availability-with-allocation` and `appointments` endpoints (additive, opt-in, auth-gated fields) rather than forking new ones. Phases 0-1 (slow PENDING list endpoints + server-side Auto Allocate) already shipped in #1000.

## What moved server-side

**Phase 2 — status grid.** `GET /api/slots/availability-with-allocation/[consultantId]` now accepts `includeAppointmentDetails=true`. When the caller is authenticated as the owning consultant (or ADMIN/STAFF) it additionally:
- Attaches per-interval `overlappingAppointments` tooltip metadata (id/type/title/participant name) to each slot in the response, computed from the appointments query the endpoint already runs for `bookingStatus` — no new query, just a few extra `select` fields on the existing one.
- Synthesizes "orphan" cells — a booked appointment slot whose availability row was later edited/removed — as `fully-booked`, replacing a client patch that used to require the full appointment array to detect this.

`useCalendarData.ts`'s `slotStatusMap`/`getSlotStatusForInterval` now build ONE `Map` from this server grid (keyed by UTC interval-start ISO — the client already builds `intervalStartUTCString`) instead of a per-cell `O(cells × (availabilitySlots + appointments))` cross-reference join over ~2,000 cells per calendar load.

**Phase 3 — selection-independent aggregates.** `GET /api/slots/appointments` now accepts `slotsPerCall` for a scoped `subscriptionId` and returns `weeklyConfirmedCallCounts`, bucketed with `SlotCalculationService.weekKey` (ADR B9) from confirmed, non-tentative appointments read straight from the DB — the same key the server validator (`SubscriptionValidationService`) already uses. `UnifiedCalendar`'s weekly-limit click guard reads this map instead of re-deriving it from a separate whole-window appointment fetch on every slot click (the removed `countCompletedCallsForWeek`). As a side effect this also fixes a latent correctness gap: the old client derivation only saw appointments within the *currently displayed* week/month range, so it could undercount confirmed calls in a different week near a boundary; the server aggregate scans the whole event.

Since nothing else consumed the whole-window appointment fetch after these two moves, `useCalendarData`'s `fetchExistingAppointments`/`existingAppointments`/`refetchAppointments` and `AllocationService.fetchAppointments` are removed entirely — one full network round-trip (and its client-side filtering/expansion) is gone from every Allocate-Slots calendar load.

## What deliberately stayed client-side (and why)

- **Interactive selection validation** (`slotSelectionValidation.ts`, `useSlotAllocation.ts`'s `toggleSlot`) — these operate on the consultant's *in-session* click selection, not server data. They're cheap (pure functions over a small in-memory array), already unit-tested (631+ tests in `__tests__/booking-algorithm`), and the issue explicitly calls out not to move them.
- **Past/disabled-cell computation** — still derived from `Date.now()` client-side (one comparison per cell) rather than baked into the server response, since "is this slot in the past" changes every second and shouldn't be pinned to fetch time.
- **`eventSlots`/`eventTentativeSlots`** (the "This Event" black/amber highlighting) — this fetch is deliberately NOT windowed to the visible calendar range (it needs the event's entire history for `pastEventSlotCount`), so it stays a separate small, event-scoped fetch; only the heavy whole-window join went away.

## Response-shape changes

Both extended endpoints are additive-only and gated:
- `availability-with-allocation`: new optional `overlappingAppointments` field per slot, only populated when `includeAppointmentDetails=true` **and** the session belongs to the consultant/privileged staff who owns the calendar. The endpoint is otherwise PUBLIC (consultee/trials browsing, see `middleware.ts`) — a consultee's request never satisfies the ownership check, so `ConsultantAvailability.tsx` and `TrialScheduleCalendar.tsx` (which only read `slotId`/`isAllocated`/`bookingStatus`) get a byte-identical response to before.
- `/api/slots/appointments`: new optional top-level `weeklyConfirmedCallCounts` field, only present when `subscriptionId` + `slotsPerCall` are both passed.

## Bundle / compute impact

- Removes one full appointment-list network fetch (`AllocationService.fetchAppointments`) and its client-side filter/expand pass from every Allocate-Slots calendar load.
- Collapses the `slotStatusMap` build from `O(visibleCells × (availabilitySlots + appointments))` to `O(availabilitySlots) index build + O(visibleCells)` `Map` lookups.
- `countCompletedCallsForWeek` (re-derived on every subscription slot click) is now a single `Record` lookup.

## Tests

- New `__tests__/booking-algorithm/server-status-grid.test.ts` (15 cases): `computeWeeklyConfirmedCallCounts` parity against `SlotCalculationService.weekKey` (incl. per-appointment `schedulingTimezone`), tentative/slot-count/subscription-scope exclusions; `buildOverlapMetaIndex`/`overlapMetaCandidatesFor` bucket-overlap correctness (exact/multi-bucket/non-overlap/dedupe-by-id/same-bucket-different-appointment) and `extractOverlapTitleAndParticipant` per event type.
- Full existing suite green under both `TZ=UTC` and `TZ=Asia/Kolkata`: 128 suites / 1543 tests (`__tests__/booking-algorithm`, `__tests__/schedule`, `__tests__/booking`, and the rest of the repo suite), run in a sibling worktree (jest can't run inside `.claude/worktrees`).
- `NODE_OPTIONS="--max-old-space-size=12288" npx tsc --noEmit` clean; `eslint` clean on all changed files.

Part of #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)