### PR TITLE
feat(enterprise): productionize the enterprise subsystem — reversal wiring, dispute freeze, overage credit-back, consent gates, host honesty (#705 freeze)

### DIFF
--- a/__tests__/booking-algorithm/authorization.test.ts
+++ b/__tests__/booking-algorithm/authorization.test.ts
@@ -28,6 +28,8 @@ jest.mock("../../lib/prisma", () => ({
     $transaction: jest.fn(),
     appointment: { findUnique: jest.fn() },
     slotOfAppointment: { findMany: jest.fn(), deleteMany: jest.fn() },
+    // #1008 — reschedule/cancel routes read prisma.dispute.findFirst.
+    dispute: { findFirst: jest.fn().mockResolvedValue(null) },
     $disconnect: jest.fn(),
   },
 }));
@@ -40,6 +42,14 @@ jest.mock("../../lib/waitlist/slot-handler", () => ({
   handleSlotOpening: jest.fn().mockResolvedValue({ notified: 0 }),
 }));
 
+jest.mock("../../lib/payments/operations/event-refunds", () => ({
+  refundWholeEventPayments: jest.fn().mockResolvedValue({
+    refundsIssued: 0,
+    refundedPaise: 0,
+    childRefundIds: [],
+    failures: [],
+  }),
+}));
 jest.mock("../../lib/novu", () => ({
   notifyAppointmentCancelled: jest.fn().mockResolvedValue(undefined),
 }));

--- a/__tests__/booking-algorithm/rescheduleCancel.test.ts
+++ b/__tests__/booking-algorithm/rescheduleCancel.test.ts
@@ -25,6 +25,9 @@ jest.mock("../../lib/prisma", () => ({
     $transaction: jest.fn(),
     appointment: { findUnique: jest.fn() },
     slotOfAppointment: { findMany: jest.fn(), deleteMany: jest.fn() },
+    // #1008 — the cancel/reschedule routes call hasActiveDisputeForAppointment,
+    // which reads prisma.dispute.findFirst. Default to no live dispute.
+    dispute: { findFirst: jest.fn().mockResolvedValue(null) },
     $disconnect: jest.fn(),
   },
 }));
@@ -42,6 +45,17 @@ jest.mock("../../lib/waitlist/slot-handler", () => ({
 // Mock novu notifications
 jest.mock("../../lib/novu", () => ({
   notifyAppointmentCancelled: jest.fn().mockResolvedValue(undefined),
+}));
+
+// #776 §C — whole-event (class/webinar) cancel refunds are exercised in their
+// own suite; here the cancel route just needs a benign summary back.
+jest.mock("../../lib/payments/operations/event-refunds", () => ({
+  refundWholeEventPayments: jest.fn().mockResolvedValue({
+    refundsIssued: 0,
+    refundedPaise: 0,
+    childRefundIds: [],
+    failures: [],
+  }),
 }));
 
 // ─── Imports ────────────────────────────────────────────────────────────────

--- a/__tests__/booking-algorithm/rescheduleResponses.test.ts
+++ b/__tests__/booking-algorithm/rescheduleResponses.test.ts
@@ -21,6 +21,8 @@ jest.mock("../../lib/prisma", () => ({
     $transaction: jest.fn(),
     appointment: { findUnique: jest.fn() },
     slotOfAppointment: { findMany: jest.fn(), deleteMany: jest.fn() },
+    // #1008 — reschedule/cancel routes read prisma.dispute.findFirst.
+    dispute: { findFirst: jest.fn().mockResolvedValue(null) },
     $disconnect: jest.fn(),
   },
 }));

--- a/__tests__/enterprise/consent-gates.test.ts
+++ b/__tests__/enterprise/consent-gates.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #701 — the fail-closed contract the new consent gates (org-sponsored checkout,
+ * invite acceptance, data export) all depend on: checkConsent returns true ONLY
+ * for a live, non-withdrawn, non-expired artifact carrying the purpose code.
+ */
+
+const mockFindFirst = jest.fn();
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: { consentArtifact: { findFirst: (...a: unknown[]) => mockFindFirst(...a) } },
+}));
+
+import { checkConsent } from "@/lib/compliance/dpdp";
+import { PURPOSE_CODES } from "@/lib/compliance/purpose-codes";
+
+beforeEach(() => mockFindFirst.mockReset());
+
+describe("checkConsent — fail-closed (#701)", () => {
+  it("is true when a live artifact for the purpose exists", async () => {
+    mockFindFirst.mockResolvedValue({ id: "c1" });
+    const ok = await checkConsent({
+      userId: "u1",
+      purposeCode: PURPOSE_CODES.SESSION_BOOKING,
+    });
+    expect(ok).toBe(true);
+    // The query must filter withdrawn + expired out and match the purpose code.
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where.userId).toBe("u1");
+    expect(where.purposeCodes).toEqual({ has: PURPOSE_CODES.SESSION_BOOKING });
+    expect(where.withdrawnAt).toBeNull();
+    expect(where.auditRetainedUntil.gt).toBeInstanceOf(Date);
+  });
+
+  it("is false (fail-closed) when no matching artifact exists", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    const ok = await checkConsent({
+      userId: "u1",
+      purposeCode: PURPOSE_CODES.PRIMARY_PROCESSING,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("SESSION_BOOKING + PRIMARY_PROCESSING are canonical codes the gates use", () => {
+    expect(PURPOSE_CODES.SESSION_BOOKING).toBe("SESSION_BOOKING");
+    expect(PURPOSE_CODES.PRIMARY_PROCESSING).toBe("PRIMARY_PROCESSING");
+  });
+});

--- a/__tests__/enterprise/dispute-freeze.test.ts
+++ b/__tests__/enterprise/dispute-freeze.test.ts
@@ -11,7 +11,10 @@
  *      rejected while a dispute is live, and allowed once it's terminal.
  */
 
-import { TERMINAL_DISPUTE_STATUSES } from "@/lib/payments/dispute-status";
+import {
+  TERMINAL_DISPUTE_STATUSES,
+  DISPUTE_INACTIVE_FOR_GATING,
+} from "@/lib/payments/dispute-status";
 
 const mockDisputeFindFirst = jest.fn();
 
@@ -25,13 +28,15 @@ import { hasActiveDisputeForAppointment } from "@/lib/payments/dispute-guard";
 beforeEach(() => mockDisputeFindFirst.mockReset());
 
 describe("hasActiveDisputeForAppointment (#1008)", () => {
-  it("queries with the terminal set excluded and the appointment relation", async () => {
+  it("queries with the inactive-for-gating set excluded and the appointment relation", async () => {
     mockDisputeFindFirst.mockResolvedValue({ id: "d1" });
     const active = await hasActiveDisputeForAppointment("appt1");
     expect(active).toBe(true);
     const where = mockDisputeFindFirst.mock.calls[0][0].where;
     expect(where.payment).toEqual({ appointmentId: "appt1" });
-    expect(where.status.notIn).toEqual(TERMINAL_DISPUTE_STATUSES);
+    // #1019 — terminal verdicts AND a resolved WARNING_CLOSED must not freeze.
+    expect(where.status.notIn).toEqual(DISPUTE_INACTIVE_FOR_GATING);
+    expect(where.status.notIn).toContain("WARNING_CLOSED");
   });
 
   it("returns false when no live dispute is found", async () => {
@@ -42,7 +47,7 @@ describe("hasActiveDisputeForAppointment (#1008)", () => {
   it("terminal statuses are exactly WON/LOST/CHARGE_REFUNDED/CLOSED", () => {
     // Guards the freeze semantics: a resolved dispute must NOT freeze the
     // appointment or block refunds.
-    expect(TERMINAL_DISPUTE_STATUSES.sort()).toEqual(
+    expect([...TERMINAL_DISPUTE_STATUSES].sort()).toEqual(
       ["CHARGE_REFUNDED", "CLOSED", "LOST", "WON"],
     );
   });

--- a/__tests__/enterprise/dispute-freeze.test.ts
+++ b/__tests__/enterprise/dispute-freeze.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #1008 — dispute freeze. Two independent pieces, unit-tested against small
+ * mocks:
+ *   1. hasActiveDisputeForAppointment — the mutation-guard predicate (true iff a
+ *      non-terminal dispute exists on any payment for the appointment).
+ *   2. refundPayment's REFUND_BLOCKED_BY_DISPUTE guard — an app refund is
+ *      rejected while a dispute is live, and allowed once it's terminal.
+ */
+
+import { TERMINAL_DISPUTE_STATUSES } from "@/lib/payments/dispute-status";
+
+const mockDisputeFindFirst = jest.fn();
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: { dispute: { findFirst: (...a: unknown[]) => mockDisputeFindFirst(...a) } },
+}));
+
+import { hasActiveDisputeForAppointment } from "@/lib/payments/dispute-guard";
+
+beforeEach(() => mockDisputeFindFirst.mockReset());
+
+describe("hasActiveDisputeForAppointment (#1008)", () => {
+  it("queries with the terminal set excluded and the appointment relation", async () => {
+    mockDisputeFindFirst.mockResolvedValue({ id: "d1" });
+    const active = await hasActiveDisputeForAppointment("appt1");
+    expect(active).toBe(true);
+    const where = mockDisputeFindFirst.mock.calls[0][0].where;
+    expect(where.payment).toEqual({ appointmentId: "appt1" });
+    expect(where.status.notIn).toEqual(TERMINAL_DISPUTE_STATUSES);
+  });
+
+  it("returns false when no live dispute is found", async () => {
+    mockDisputeFindFirst.mockResolvedValue(null);
+    expect(await hasActiveDisputeForAppointment("appt1")).toBe(false);
+  });
+
+  it("terminal statuses are exactly WON/LOST/CHARGE_REFUNDED/CLOSED", () => {
+    // Guards the freeze semantics: a resolved dispute must NOT freeze the
+    // appointment or block refunds.
+    expect(TERMINAL_DISPUTE_STATUSES.sort()).toEqual(
+      ["CHARGE_REFUNDED", "CLOSED", "LOST", "WON"],
+    );
+  });
+});

--- a/__tests__/enterprise/event-cancel-refunds.test.ts
+++ b/__tests__/enterprise/event-cancel-refunds.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #776 §C — whole-event refund partition. Gateway/card seats MUST credit the
+ * gateway (refundPayment); internal org-funded seats MUST reverse in-ledger
+ * (one CLASS_MULTI reversal) — a card seat routed through the engine would
+ * strand the customer's money. This asserts the partition + the member-overage
+ * follow-up, with prisma / reversal-engine / refund mocked.
+ */
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    payment: { findMany: jest.fn() },
+    $transaction: jest.fn((fn: (tx: unknown) => unknown) => fn({})),
+  },
+}));
+jest.mock("../../lib/db/serializable-retry", () => ({
+  withSerializableRetry: (fn: () => unknown) => fn(),
+}));
+jest.mock("../../lib/payments/operations/reversal-engine", () => ({
+  applyReversal: jest.fn(),
+}));
+jest.mock("../../lib/payments/operations/refund", () => ({
+  refundPayment: jest.fn(),
+  RefundValidationError: class extends Error {
+    code: string;
+    constructor(m: string, c: string) {
+      super(m);
+      this.code = c;
+    }
+  },
+}));
+jest.mock("@sentry/nextjs", () => ({ captureException: jest.fn() }));
+jest.mock("../../lib/enterprise/system-events", () => ({
+  recordSystemError: jest.fn().mockResolvedValue(undefined),
+}));
+
+import prisma from "../../lib/prisma";
+import { applyReversal } from "../../lib/payments/operations/reversal-engine";
+import { refundPayment } from "../../lib/payments/operations/refund";
+import { refundWholeEventPayments } from "@/lib/payments/operations/event-refunds";
+
+const findMany = (prisma as unknown as { payment: { findMany: jest.Mock } })
+  .payment.findMany;
+const applyReversalMock = applyReversal as jest.Mock;
+const refundPayment_ = refundPayment as jest.Mock;
+
+beforeEach(() => {
+  findMany.mockReset();
+  applyReversalMock.mockReset();
+  refundPayment_.mockReset();
+  refundPayment_.mockResolvedValue({
+    refundId: "r1",
+    amountRefundedPaise: 1000,
+  });
+  applyReversalMock.mockResolvedValue({
+    kind: "CLASS_MULTI",
+    cascades: [],
+    childRefundIds: [],
+    clawbackPosted: false,
+  });
+});
+
+describe("refundWholeEventPayments — funding partition", () => {
+  it("routes card/mock seats to refundPayment and org seats to CLASS_MULTI", async () => {
+    findMany.mockResolvedValue([
+      { id: "pay_card", amount: 1000, paymentIntent: "pay_abc" },
+      { id: "p_mock", amount: 2000, paymentIntent: "cs_mock_1" },
+      { id: "p_org1", amount: 3000, paymentIntent: "org_wallet_1" },
+      { id: "p_org2", amount: 4000, paymentIntent: "org_invoice_2" },
+    ]);
+
+    const summary = await refundWholeEventPayments("class", "cls1", "cancel", "admin1");
+
+    // Two gateway seats → two refundPayment calls; NEVER the org seats.
+    const refundedIds = refundPayment_.mock.calls.map((c) => c[0].paymentId);
+    expect(refundedIds).toEqual(expect.arrayContaining(["pay_card", "p_mock"]));
+    expect(refundedIds).not.toContain("p_org1");
+    expect(refundedIds).not.toContain("p_org2");
+
+    // One CLASS_MULTI reversal covering EXACTLY the two org seats, full total.
+    expect(applyReversalMock).toHaveBeenCalledTimes(1);
+    const arg = applyReversalMock.mock.calls[0][1];
+    expect(arg.source.kind).toBe("CLASS_MULTI");
+    expect(arg.source.paymentIds).toEqual(["p_org1", "p_org2"]);
+    expect(arg.amountPaise).toBe(7000);
+
+    expect(summary.refundsIssued).toBe(2); // 2 gateway; org childRefundIds empty here
+    expect(summary.failures).toHaveLength(0);
+  });
+
+  it("all-internal event never calls refundPayment for the seats", async () => {
+    findMany.mockResolvedValue([
+      { id: "p_org1", amount: 3000, paymentIntent: "org_license_1" },
+    ]);
+    applyReversalMock.mockResolvedValue({
+      kind: "CLASS_MULTI",
+      cascades: [{ memberOverageRefundDue: null }],
+      childRefundIds: ["child1"],
+      clawbackPosted: false,
+    });
+
+    const summary = await refundWholeEventPayments("webinar", "web1", "cancel", null);
+
+    expect(refundPayment_).not.toHaveBeenCalled();
+    expect(applyReversalMock).toHaveBeenCalledTimes(1);
+    expect(summary.refundedPaise).toBe(3000);
+    expect(summary.childRefundIds).toContain("child1");
+  });
+
+  it("issues a member-overage credit-back refund surfaced by the internal cascade", async () => {
+    findMany.mockResolvedValue([
+      { id: "p_org1", amount: 3000, paymentIntent: "org_wallet_1" },
+    ]);
+    applyReversalMock.mockResolvedValue({
+      kind: "CLASS_MULTI",
+      cascades: [{ memberOverageRefundDue: { overagePaymentId: "pay_side" } }],
+      childRefundIds: ["child1"],
+      clawbackPosted: false,
+    });
+
+    await refundWholeEventPayments("class", "cls1", "cancel", "admin1");
+
+    // The side-payment (a gateway charge) is credited back via refundPayment.
+    expect(refundPayment_).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentId: "pay_side" }),
+    );
+  });
+
+  it("captures a gateway refund failure without throwing", async () => {
+    findMany.mockResolvedValue([
+      { id: "pay_card", amount: 1000, paymentIntent: "pay_abc" },
+    ]);
+    refundPayment_.mockRejectedValueOnce(new Error("gateway down"));
+
+    const summary = await refundWholeEventPayments("class", "cls1", "cancel", "a");
+    expect(summary.failures).toEqual([
+      { paymentId: "pay_card", error: "gateway down" },
+    ]);
+    expect(summary.refundsIssued).toBe(0);
+  });
+
+  it("no-ops on an event with no paid seats", async () => {
+    findMany.mockResolvedValue([]);
+    const summary = await refundWholeEventPayments("class", "cls1", "cancel", "a");
+    expect(refundPayment_).not.toHaveBeenCalled();
+    expect(applyReversalMock).not.toHaveBeenCalled();
+    expect(summary.refundsIssued).toBe(0);
+  });
+});

--- a/__tests__/enterprise/list-appointments-scope.test.ts
+++ b/__tests__/enterprise/list-appointments-scope.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #674 — personal-scope appointment query. Consultee arms stay scoped to
+ * non-org bookings (sponsored sessions are org business); consultant arms cover
+ * every session the user DELIVERS, sponsored or not, since an independent
+ * consultant / host EXPERT has no org-scope access to see them otherwise.
+ */
+
+import { buildWhere } from "@/lib/api/scope/list-appointments";
+
+describe("buildWhere — personal scope (#674)", () => {
+  const where = buildWhere({
+    scope: { kind: "personal" },
+    userId: "u1",
+  }) as {
+    OR: Array<Record<string, unknown>>;
+  };
+
+  it("has consultee arms constrained to organizationId: null", () => {
+    const consulteeArms = where.OR.filter(
+      (a) => "organizationId" in a && a.organizationId === null,
+    );
+    // consultation / subscription / trial (consultee side)
+    expect(consulteeArms).toHaveLength(3);
+  });
+
+  it("has consultant arms NOT constrained by organizationId (sponsored visible)", () => {
+    const consultantArms = where.OR.filter((a) => !("organizationId" in a));
+    // consultation-plan / subscription-plan / trial / webinar-plan / class-plan
+    expect(consultantArms).toHaveLength(5);
+    // each keys off the plan's consultantProfile userId
+    const hasConsultantUser = consultantArms.some((a) =>
+      JSON.stringify(a).includes('"consultantProfile":{"userId":"u1"}'),
+    );
+    expect(hasConsultantUser).toBe(true);
+  });
+
+  it("org scope filters by orgId with no user OR", () => {
+    const w = buildWhere({
+      scope: { kind: "org", orgId: "org1" },
+      userId: "u1",
+    }) as Record<string, unknown>;
+    expect(w.organizationId).toBe("org1");
+    expect(w.OR).toBeUndefined();
+  });
+});

--- a/__tests__/enterprise/overage-credit-back.test.ts
+++ b/__tests__/enterprise/overage-credit-back.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #715/#716 — post-collection overage credit-back. A CHARGED overage may now
+ * transition to REVERSED (credit-back on full refund), but ONLY via the
+ * CHARGED-scoped guard: the uncollected reversal path (reverseBookingUtilization)
+ * must NOT flip a CHARGED event, and a replay against an already-REVERSED event
+ * must match zero rows. The guard IS the filter, so these are all assertions on
+ * the updateMany WHERE clause the transition builds.
+ */
+
+import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+import type { OverageChargeStatus } from "@prisma/client";
+
+function mockTx(count = 1) {
+  const updateMany = jest.fn().mockResolvedValue({ count });
+  return { updateMany, tx: { overageEvent: { updateMany } } as never };
+}
+
+describe("transitionOverage — CHARGED → REVERSED credit-back (#715/#716)", () => {
+  it("allows CHARGED → REVERSED and stamps reversedAt when scoped to CHARGED", async () => {
+    const m = mockTx(1);
+    const reversedAt = new Date("2026-07-17T00:00:00Z");
+    const moved = await transitionOverage(
+      m.tx,
+      { id: "ov1" },
+      "REVERSED",
+      { reversedAt },
+      { fromIn: ["CHARGED"] },
+    );
+    expect(moved).toBe(1);
+    expect(m.updateMany).toHaveBeenCalledWith({
+      where: { id: "ov1", chargeStatus: { in: ["CHARGED"] } },
+      data: { chargeStatus: "REVERSED", reversedAt },
+    });
+  });
+
+  it("does NOT flip a CHARGED event on the uncollected path (fromIn excludes CHARGED)", async () => {
+    const m = mockTx(0);
+    // Mirrors reverseBookingUtilization's narrowed guard.
+    await transitionOverage(m.tx, { bookingUtilizationId: "bu1" }, "REVERSED", undefined, {
+      fromIn: ["PENDING", "ACCRUED", "FAILED"],
+    });
+    const call = m.updateMany.mock.calls[0][0];
+    expect(call.where.chargeStatus.in).not.toContain("CHARGED");
+    expect(call.where.chargeStatus.in).toEqual(
+      expect.arrayContaining(["PENDING", "ACCRUED", "FAILED"]),
+    );
+  });
+
+  it("fromIn is intersected with the legal from-set, never widened", async () => {
+    const m = mockTx(0);
+    // REVERSED legally accepts PENDING/ACCRUED/FAILED/CHARGED; a caller asking
+    // for BLOCKED (illegal) gets it filtered out, not honored.
+    await transitionOverage(m.tx, { id: "ov1" }, "REVERSED", undefined, {
+      fromIn: ["CHARGED", "BLOCKED" as OverageChargeStatus],
+    });
+    const call = m.updateMany.mock.calls[0][0];
+    expect(call.where.chargeStatus.in).toEqual(["CHARGED"]);
+  });
+
+  it("replay against an already-REVERSED event matches zero rows (idempotent)", async () => {
+    const m = mockTx(0); // guard filters the REVERSED row out
+    const moved = await transitionOverage(
+      m.tx,
+      { id: "ov1" },
+      "REVERSED",
+      { reversedAt: new Date() },
+      { fromIn: ["CHARGED"] },
+    );
+    expect(moved).toBe(0);
+  });
+
+  it("keeps the default REVERSED guard (uncollected) available without fromIn", async () => {
+    const m = mockTx(1);
+    await transitionOverage(m.tx, { id: "ov1" }, "REVERSED");
+    const call = m.updateMany.mock.calls[0][0];
+    // Default guard now spans the whole legal set including CHARGED — callers
+    // that must exclude CHARGED pass fromIn (as reverseBookingUtilization does).
+    expect(call.where.chargeStatus.in).toEqual(
+      expect.arrayContaining(["PENDING", "ACCRUED", "FAILED", "CHARGED"]),
+    );
+  });
+});

--- a/__tests__/enterprise/payout-balance-preflight.test.ts
+++ b/__tests__/enterprise/payout-balance-preflight.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #863 — RazorpayX balance preflight. Insufficient balance holds the batch
+ * (ok:false) and pages ops; an unknown balance or a disabled flag fails OPEN
+ * (ok:true) so a new read dependency never stalls payouts.
+ */
+
+const mockGetBalance = jest.fn();
+const mockConfigured = jest.fn();
+const mockRecordSystemError = jest.fn().mockResolvedValue(undefined);
+let liveEnabled = true;
+
+jest.mock("../../lib/feature-flags", () => ({
+  get ENABLE_LIVE_PAYOUTS() {
+    return liveEnabled;
+  },
+}));
+jest.mock("../../lib/payments/payouts/razorpay-payouts", () => ({
+  getRazorpayPayoutsService: () => ({ getAccountBalance: mockGetBalance }),
+  isRazorpayPayoutsConfigured: () => mockConfigured(),
+}));
+jest.mock("../../lib/enterprise/system-events", () => ({
+  recordSystemError: (...a: unknown[]) => mockRecordSystemError(...a),
+}));
+
+import { assertPayoutBalance } from "@/lib/payments/payouts/balance-preflight";
+
+beforeEach(() => {
+  mockGetBalance.mockReset();
+  mockRecordSystemError.mockClear();
+  mockConfigured.mockReturnValue(true);
+  liveEnabled = true;
+});
+
+describe("assertPayoutBalance (#863)", () => {
+  it("holds the batch and pages ops when the balance is known-insufficient", async () => {
+    mockGetBalance.mockResolvedValue(500);
+    const r = await assertPayoutBalance(1000);
+    expect(r.ok).toBe(false);
+    expect(r.balancePaise).toBe(500);
+    expect(mockRecordSystemError).toHaveBeenCalledTimes(1);
+    expect(mockRecordSystemError.mock.calls[0][0].summary).toMatch(
+      /RAZORPAYX_BALANCE_INSUFFICIENT/,
+    );
+  });
+
+  it("passes when the balance covers the batch", async () => {
+    mockGetBalance.mockResolvedValue(2000);
+    const r = await assertPayoutBalance(1000);
+    expect(r.ok).toBe(true);
+    expect(mockRecordSystemError).not.toHaveBeenCalled();
+  });
+
+  it("fails OPEN on an unknown balance (null)", async () => {
+    mockGetBalance.mockResolvedValue(null);
+    const r = await assertPayoutBalance(1000);
+    expect(r.ok).toBe(true);
+    expect(r.balancePaise).toBeNull();
+    expect(mockRecordSystemError).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op ok when live payouts are disabled (never reads the balance)", async () => {
+    liveEnabled = false;
+    const r = await assertPayoutBalance(1000);
+    expect(r.ok).toBe(true);
+    expect(mockGetBalance).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op ok when the gateway is not configured", async () => {
+    mockConfigured.mockReturnValue(false);
+    const r = await assertPayoutBalance(1000);
+    expect(r.ok).toBe(true);
+    expect(mockGetBalance).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/payments/dispute-refund-correctness.test.ts
+++ b/__tests__/payments/dispute-refund-correctness.test.ts
@@ -121,6 +121,12 @@ function txStub() {
     consultantEarnings: {
       updateMany: jest.fn(async () => ({ count: 0 })),
     },
+    // #1008 — org earnings hold/release/refund mirror the consultant side.
+    organizationEarnings: {
+      updateMany: jest.fn(async () => ({ count: 0 })),
+      findMany: jest.fn(async () => []),
+      update: jest.fn(async () => ({})),
+    },
   };
 }
 

--- a/__tests__/payments/refund-operation.test.ts
+++ b/__tests__/payments/refund-operation.test.ts
@@ -157,6 +157,16 @@ function txStub() {
           .reduce((acc, d) => acc + (d.amountPaise as number), 0);
         return { _sum: { amountPaise: sum } };
       }),
+      // #1008 — live-dispute guard reads (outer + in-tx). notIn = terminal set.
+      findFirst: jest.fn(async ({ where }: any) => {
+        const notIn: string[] = where.status?.notIn ?? [];
+        const d = state.disputes.find(
+          (d) =>
+            d.paymentId === where.paymentId &&
+            !notIn.includes(d.status as string),
+        );
+        return d ?? null;
+      }),
     },
     paymentLeg: {
       create: jest.fn(async ({ data }: any) => {

--- a/__tests__/payments/refund-operation.test.ts
+++ b/__tests__/payments/refund-operation.test.ts
@@ -253,6 +253,12 @@ function txStub() {
         return u;
       }),
     },
+    // #715/#716 — the cascade's overage credit-back step. These base tests
+    // register no overage events, so findFirst→null / updateMany→0 rows.
+    overageEvent: {
+      findFirst: jest.fn(async () => null),
+      updateMany: jest.fn(async () => ({ count: 0 })),
+    },
     programAssignment: {
       update: jest.fn(async ({ where, data }: any) => {
         const a = state.programAssignments.get(where.id);

--- a/app/api/admin/refunds/route.ts
+++ b/app/api/admin/refunds/route.ts
@@ -1,8 +1,15 @@
 import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Prisma, RefundStatus, PaymentGateway } from "@prisma/client";
 import { requirePrivilegedAuth } from "@/lib/auth-helpers";
+import {
+  refundPayment,
+  RefundValidationError,
+  RefundGatewayError,
+} from "@/lib/payments/operations/refund";
+import { refundWholeEventPayments } from "@/lib/payments/operations/event-refunds";
 
 export async function GET(req: NextRequest) {
   try {
@@ -77,5 +84,77 @@ export async function GET(req: NextRequest) {
       { error: "Failed to fetch refunds" },
       { status: 500 },
     );
+  }
+}
+
+// Admin-initiated refund (#776 §C). Exactly one target: a single payment, or a
+// whole class/webinar (every attendee). Single payments credit the gateway via
+// refundPayment; events fan out through the reversal engine (org-funded seats
+// reverse in-ledger, card seats credit the gateway).
+const RefundBodySchema = z
+  .object({
+    paymentId: z.string().min(1).optional(),
+    classId: z.string().min(1).optional(),
+    webinarId: z.string().min(1).optional(),
+    amountPaise: z.number().int().positive().optional(),
+    reason: z.string().min(1).max(500),
+  })
+  .refine(
+    (b) =>
+      [b.paymentId, b.classId, b.webinarId].filter(Boolean).length === 1,
+    { message: "Provide exactly one of paymentId, classId, webinarId" },
+  )
+  .refine((b) => !(b.amountPaise && (b.classId || b.webinarId)), {
+    message: "amountPaise applies only to a single paymentId refund",
+  });
+
+export async function POST(req: NextRequest) {
+  try {
+    const auth = await requirePrivilegedAuth();
+    if (auth.error) return auth.error;
+
+    const parsed = RefundBodySchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+        { status: 400 },
+      );
+    }
+    const body = parsed.data;
+    const initiatedByUserId = auth.session?.user?.id ?? null;
+
+    if (body.paymentId) {
+      const result = await refundPayment({
+        paymentId: body.paymentId,
+        amountPaise: body.amountPaise,
+        reason: `admin refund: ${body.reason}`,
+        initiatedByUserId,
+      });
+      return NextResponse.json({ kind: "payment", result });
+    }
+
+    const eventKind = body.classId ? "class" : "webinar";
+    const eventId = (body.classId ?? body.webinarId)!;
+    const summary = await refundWholeEventPayments(
+      eventKind,
+      eventId,
+      `admin whole-event refund: ${body.reason}`,
+      initiatedByUserId,
+    );
+    return NextResponse.json({ kind: eventKind, summary });
+  } catch (error) {
+    // Validation / gateway errors carry a caller-actionable message + code.
+    if (
+      error instanceof RefundValidationError ||
+      error instanceof RefundGatewayError
+    ) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error instanceof RefundValidationError ? 400 : 502 },
+      );
+    }
+    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "admin" } });
+    console.error("Admin refund error:", error);
+    return NextResponse.json({ error: "Refund failed" }, { status: 500 });
   }
 }

--- a/app/api/admin/refunds/route.ts
+++ b/app/api/admin/refunds/route.ts
@@ -113,7 +113,16 @@ export async function POST(req: NextRequest) {
     const auth = await requirePrivilegedAuth();
     if (auth.error) return auth.error;
 
-    const parsed = RefundBodySchema.safeParse(await req.json());
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Malformed JSON request body" },
+        { status: 400 },
+      );
+    }
+    const parsed = RefundBodySchema.safeParse(payload);
     if (!parsed.success) {
       return NextResponse.json(
         { error: parsed.error.issues[0]?.message ?? "Invalid request" },

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -13,6 +13,10 @@ import { getSession } from "@/lib/auth-server";
 import { isPrivileged } from "@/lib/auth-helpers";
 import { refundPayment } from "@/lib/payments/operations/refund";
 import {
+  refundWholeEventPayments,
+  type WholeEventRefundSummary,
+} from "@/lib/payments/operations/event-refunds";
+import {
   computeRefundPct,
   parsePolicySnapshot,
 } from "@/lib/payments/operations/cancellation-policy";
@@ -303,8 +307,9 @@ export async function POST(
     // B1 — policy-driven refund, AFTER the cancel tx commits (refundPayment
     // runs its own Serializable tx; the CAS above guarantees this block runs
     // at most once per appointment — a second cancel 409s before reaching it).
-    // Scope: consultation/subscription. Webinar/class buyer refunds belong to
-    // the participant-removal flow, not whole-event cancellation.
+    // Scope here: consultation/subscription (single-payment, policy-tiered).
+    // Whole-event class/webinar refunds are handled just below via the
+    // reversal engine (#776 §C).
     let refund: { amountRefundedPaise: number; refundPct: number } | null =
       null;
     const isExclusiveType =
@@ -354,6 +359,23 @@ export async function POST(
       } else {
         refund = { amountRefundedPaise: 0, refundPct };
       }
+    }
+
+    // #776 §C — whole-event (class/webinar) cancellation refunds every attendee
+    // in full through the reversal engine: org-funded seats reverse in-ledger
+    // (CLASS_MULTI), card/mock seats credit the gateway. Same at-most-once CAS
+    // guarantee as the block above. Attendees didn't leave voluntarily (the
+    // event was cancelled on them), so this is a full refund, not policy-tiered.
+    let eventRefund: WholeEventRefundSummary | null = null;
+    if (appointment.class || appointment.webinar) {
+      const eventKind = appointment.class ? "class" : "webinar";
+      const eventId = appointment.class?.id ?? appointment.webinar!.id;
+      eventRefund = await refundWholeEventPayments(
+        eventKind,
+        eventId,
+        `whole-event ${eventKind} cancellation (${validatedData.reason ?? "cancelled"})`,
+        session.user.id,
+      );
     }
 
     // Notification metadata (for fire-and-forget notifications after transaction)
@@ -432,7 +454,7 @@ export async function POST(
     // Waitlist notifications should only fire when a participant leaves an
     // otherwise-active event (handled in participant removal flow).
 
-    return NextResponse.json({ ...result, refund });
+    return NextResponse.json({ ...result, refund, eventRefund });
   } catch (error) {
     if (error instanceof Error && "httpStatus" in error) {
       const status =

--- a/app/api/appointments/[appointmentId]/cancel/route.ts
+++ b/app/api/appointments/[appointmentId]/cancel/route.ts
@@ -16,6 +16,7 @@ import {
   refundWholeEventPayments,
   type WholeEventRefundSummary,
 } from "@/lib/payments/operations/event-refunds";
+import { hasActiveDisputeForAppointment } from "@/lib/payments/dispute-guard";
 import {
   computeRefundPct,
   parsePolicySnapshot,
@@ -188,6 +189,19 @@ export async function POST(
       consulteeName =
         appointment.subscription.requestedBy?.user?.name || undefined;
       planTitle = appointment.subscription.subscriptionPlan?.title;
+    }
+
+    // #1008 — refuse to cancel while a dispute is live on this appointment: the
+    // cancel would fire refunds that double-pay against a gateway chargeback.
+    if (await hasActiveDisputeForAppointment(appointmentId)) {
+      return NextResponse.json(
+        {
+          error:
+            "This appointment has an open payment dispute and can't be cancelled until it resolves.",
+          code: "DISPUTE_ACTIVE",
+        },
+        { status: 409 },
+      );
     }
 
     // Prepare cancellation data

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -12,6 +12,7 @@ import {
 import { notifyAppointmentRescheduled } from "@/lib/novu/service";
 import { logActivity } from "@/lib/activity/log-activity";
 import { getAppUrl } from "@/lib/url";
+import { hasActiveDisputeForAppointment } from "@/lib/payments/dispute-guard";
 import {
   CLASS_EVENT_ALLOWED_FROM,
   EVENT_ALLOWED_FROM,
@@ -56,6 +57,19 @@ export async function POST(
     const { appointmentId } = await params;
     const { searchParams } = new URL(request.url);
     const appointmentType = searchParams.get("type");
+
+    // #1008 — an appointment with a live payment dispute is frozen: its state is
+    // evidence and must not move while the dispute is contested.
+    if (await hasActiveDisputeForAppointment(appointmentId)) {
+      return NextResponse.json(
+        {
+          error:
+            "This appointment has an open payment dispute and can't be rescheduled until it resolves.",
+          code: "DISPUTE_ACTIVE",
+        },
+        { status: 409 },
+      );
+    }
 
     // Parse request body for optional slotIds (used for individual/multiple session reschedule)
     let slotIds: string[] | undefined;

--- a/app/api/compliance/grievances/route.ts
+++ b/app/api/compliance/grievances/route.ts
@@ -23,7 +23,16 @@ export async function POST(req: NextRequest) {
   if (limited) return limited;
 
   try {
-    const parsed = GrievanceSchema.safeParse(await req.json());
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Malformed JSON request body" },
+        { status: 400 },
+      );
+    }
+    const parsed = GrievanceSchema.safeParse(payload);
     if (!parsed.success) {
       return NextResponse.json(
         { error: parsed.error.issues[0]?.message ?? "Invalid request" },
@@ -40,12 +49,14 @@ export async function POST(req: NextRequest) {
       select: { id: true, status: true, createdAt: true },
     });
 
-    // Ops visibility — engineering-facing, not rendered to the user.
-    void recordSystemEvent({
+    // Ops visibility — engineering-facing, not rendered to the user. Awaited so
+    // the insert completes before the serverless function freezes (this is a
+    // low-volume compliance surface, so the extra insert is cheap).
+    await recordSystemEvent({
       category: "COMPLIANCE",
       message: `DPDP grievance ${grievance.id} filed by user ${userId}`,
       context: { grievanceId: grievance.id, userId },
-    }).catch(() => {});
+    });
 
     return NextResponse.json({ grievance }, { status: 201 });
   } catch (error) {

--- a/app/api/compliance/grievances/route.ts
+++ b/app/api/compliance/grievances/route.ts
@@ -1,0 +1,59 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+import prisma from "@/lib/prisma";
+import { requireApiAuth } from "@/lib/auth-helpers";
+import { applyRateLimit, spamLimiter } from "@/lib/rate-limit";
+import { recordSystemEvent } from "@/lib/enterprise/system-events";
+
+// #701 — DPDP Rule 13 grievance intake (minimal). A data principal files a
+// grievance; it's stored durably and surfaced to ops via a system event. The
+// redressal SLA workflow (assignment, deadlines, closure audit) is deferred.
+const GrievanceSchema = z.object({
+  subject: z.string().trim().min(3).max(200),
+  description: z.string().trim().min(10).max(5000),
+});
+
+export async function POST(req: NextRequest) {
+  const auth = await requireApiAuth();
+  if (auth.error) return auth.error;
+  const userId = auth.session.user.id;
+
+  const limited = await applyRateLimit(spamLimiter, `grievance:${userId}`);
+  if (limited) return limited;
+
+  try {
+    const parsed = GrievanceSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+        { status: 400 },
+      );
+    }
+
+    const grievance = await prisma.dpdpGrievance.create({
+      data: {
+        userId,
+        subject: parsed.data.subject,
+        description: parsed.data.description,
+      },
+      select: { id: true, status: true, createdAt: true },
+    });
+
+    // Ops visibility — engineering-facing, not rendered to the user.
+    void recordSystemEvent({
+      category: "COMPLIANCE",
+      message: `DPDP grievance ${grievance.id} filed by user ${userId}`,
+      context: { grievanceId: grievance.id, userId },
+    }).catch(() => {});
+
+    return NextResponse.json({ grievance }, { status: 201 });
+  } catch (error) {
+    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "compliance" } });
+    console.error("Grievance intake error:", error);
+    return NextResponse.json(
+      { error: "Failed to file grievance" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/organizations/[orgId]/billing-account/invoices/route.ts
+++ b/app/api/organizations/[orgId]/billing-account/invoices/route.ts
@@ -353,6 +353,8 @@ export async function POST(
       currency: body.displayCurrency,
       dueDate: body.dueDate.toISOString(),
       dashboardUrl: `${origin}/dashboard/organization/${orgId}/billing`,
+      // #438 — deep link to the PDF (route caches + 302s to a signed URL).
+      pdfUrl: `${origin}/api/organizations/${orgId}/billing-account/invoices/${invoice.id}/pdf`,
     }).catch((err) =>
       console.error("[notifyOrgInvoiceIssued] failed:", err),
     );

--- a/app/api/organizations/invitations/accept/route.ts
+++ b/app/api/organizations/invitations/accept/route.ts
@@ -17,6 +17,8 @@ import { z } from "zod";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { requireApiAuth } from "@/lib/auth-helpers";
+import { checkConsent } from "@/lib/compliance/dpdp";
+import { PURPOSE_CODES } from "@/lib/compliance/purpose-codes";
 import { MemberRoleSchema } from "@/lib/labels/org-labels";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { isOnboardingBlocked } from "@/lib/enterprise/org-status";
@@ -92,6 +94,26 @@ export async function POST(req: NextRequest) {
   const normalizedRole = roleResult.data;
 
   const userId = auth.session.user.id;
+
+  // #701 — DPDP: the invitee must hold live core-processing consent before we
+  // provision membership (which processes their PII on the org's behalf).
+  // Everyone gets PRIMARY_PROCESSING at signup; a withdrawal blocks acceptance
+  // until re-granted. TODO(#701): offer an inline grant step in the accept UI.
+  if (
+    !(await checkConsent({
+      userId,
+      purposeCode: PURPOSE_CODES.PRIMARY_PROCESSING,
+    }))
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "Consent required to join an organization. Restore data-processing consent in your privacy settings, then accept again.",
+        code: "CONSENT_REQUIRED",
+      },
+      { status: 403 },
+    );
+  }
 
   // ENT-5: A second concurrent accept for the same (user, org) pair can
   // race past the in-tx existence check and hit P2002 on Membership's

--- a/app/api/webhooks/utils.ts
+++ b/app/api/webhooks/utils.ts
@@ -34,6 +34,7 @@ import {
   mintInvoiceRefundCreditNote,
   mintRefundCreditNote,
 } from "@/lib/payments/operations/refund";
+import { applyReversal } from "@/lib/payments/operations/reversal-engine";
 import { recordTdsReversal } from "@/lib/payments/tax/tds-service";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { recordSystemError } from "@/lib/enterprise/system-events";
@@ -1116,6 +1117,19 @@ export async function handleDisputeCreated(
       );
     }
 
+    // #1008 — hold the HOST org's earnings too (mirrors the consultant hold).
+    // PENDING_TRUST is left alone — it's already un-releasable. Single CAS, so
+    // it's race-safe against payout batching without upgrading isolation.
+    const orgHeld = await tx.organizationEarnings.updateMany({
+      where: { paymentId: payment.id, status: { in: ["PENDING", "READY"] } },
+      data: { status: "HELD" },
+    });
+    if (orgHeld.count > 0) {
+      console.log(
+        `🔒 ${orgHeld.count} org earnings held due to dispute ${disputeId}`,
+      );
+    }
+
     // --- Novu notification (fire-and-forget) ---
     void notifyDisputeCreated([payment.userId], {
       disputeId,
@@ -1217,6 +1231,17 @@ export async function handleDisputeUpdated(
             `🔓 ${released.count} earnings released — dispute ${disputeId} won`,
           );
         }
+        // #1008 — release the org's held earnings too. No-op exactly when a
+        // refund already flipped them to REFUNDED (that path wins first).
+        const orgReleased = await tx.organizationEarnings.updateMany({
+          where: { paymentId: dispute.paymentId, status: "HELD" },
+          data: { status: "READY" },
+        });
+        if (orgReleased.count > 0) {
+          console.log(
+            `🔓 ${orgReleased.count} org earnings released — dispute ${disputeId} won`,
+          );
+        }
       } else if (
         mappedStatus === "LOST" ||
         mappedStatus === "CHARGE_REFUNDED"
@@ -1266,6 +1291,52 @@ export async function handleDisputeUpdated(
           console.log(
             `💸 Earnings ${earning.id} refunded (${remainingRefundable} paise) — dispute ${disputeId} lost`,
           );
+        }
+
+        // #1008 — HOST org earnings side (mirrors the consultant loop above).
+        // Held org earnings flip to REFUNDED; a share already paid out to the
+        // host org is clawed back through the reversal engine. This is the
+        // host-EARNINGS recovery — distinct from applyOrgChargeback below, which
+        // recovers the sponsor-FUNDER's money (different party, no double-count).
+        const heldOrgEarnings = await tx.organizationEarnings.findMany({
+          where: { paymentId: dispute.paymentId, status: "HELD" },
+          select: {
+            id: true,
+            orgSharePaise: true,
+            refundedAmountPaise: true,
+            organizationId: true,
+            orgPayoutId: true,
+            orgPayout: { select: { status: true } },
+          },
+        });
+        for (const oe of heldOrgEarnings) {
+          const alreadyRefunded = oe.refundedAmountPaise ?? 0;
+          const remaining = Math.max(oe.orgSharePaise - alreadyRefunded, 0);
+          await tx.organizationEarnings.update({
+            where: { id: oe.id },
+            data: {
+              status: "REFUNDED",
+              ...(remaining > 0
+                ? { refundedAmountPaise: { increment: remaining } }
+                : {}),
+            },
+          });
+          if (
+            oe.orgPayoutId &&
+            oe.orgPayout?.status === "COMPLETED" &&
+            remaining > 0
+          ) {
+            await applyReversal(tx, {
+              source: {
+                kind: "PAYOUT_CLAWBACK",
+                orgPayoutId: oe.orgPayoutId,
+                organizationId: oe.organizationId,
+              },
+              amountPaise: remaining,
+              reason: `chargeback lost (dispute ${disputeId})`,
+              refundId: `dispute:${dispute.id}`,
+            });
+          }
         }
 
         // #776 §C — org-funded chargeback money-path. When the disputed booking

--- a/app/dashboard/admin/AdminShell.tsx
+++ b/app/dashboard/admin/AdminShell.tsx
@@ -25,6 +25,7 @@ import {
   Users,
   Wallet,
   Wrench,
+  Landmark,
 } from "lucide-react";
 
 import {
@@ -59,13 +60,24 @@ export function AdminShell({
   userEmail,
   userImage,
   children,
+  // #863 — the TDS surface is flag-gated (ENABLE_TDS_ADMIN_VIEW). The server
+  // layout reads the flag and passes it, so the nav item only appears when the
+  // page would actually resolve (no link that 404s).
+  showTds = false,
 }: Pick<
   OperatorDashboardShellProps,
   "userName" | "userEmail" | "userImage" | "children"
->) {
+> & { showTds?: boolean }) {
+  const items = showTds
+    ? [
+        ...sidebarItems.slice(0, 11),
+        { name: "TDS", icon: Landmark, path: "tds" },
+        ...sidebarItems.slice(11),
+      ]
+    : sidebarItems;
   return (
     <OperatorDashboardShell
-      sidebarItems={sidebarItems}
+      sidebarItems={items}
       basePath="/dashboard/admin"
       title="Admin Portal"
       breadcrumbRoot="Admin"

--- a/app/dashboard/admin/layout.tsx
+++ b/app/dashboard/admin/layout.tsx
@@ -1,4 +1,5 @@
 import { requireUserRole } from "@/lib/auth-guard";
+import { ENABLE_TDS_ADMIN_VIEW } from "@/lib/feature-flags";
 import { AdminShell } from "./AdminShell";
 
 /**
@@ -28,6 +29,7 @@ export default async function AdminLayout({
       userName={session.user.name ?? null}
       userEmail={session.user.email ?? null}
       userImage={session.user.image ?? null}
+      showTds={ENABLE_TDS_ADMIN_VIEW}
     >
       {children}
     </AdminShell>

--- a/app/dashboard/admin/payouts/_sections/PendingPayoutsSection.tsx
+++ b/app/dashboard/admin/payouts/_sections/PendingPayoutsSection.tsx
@@ -171,6 +171,37 @@ export default function PendingPayoutsSection() {
       ),
     },
     {
+      key: "dueBy",
+      header: "Due by (MSME)",
+      cell: (payout) => {
+        if (!payout.mustPayByDate) {
+          return <span className="text-sm text-muted-foreground">—</span>;
+        }
+        const due = new Date(payout.mustPayByDate);
+        const daysLeft = Math.ceil(
+          (due.getTime() - Date.now()) / 86_400_000,
+        );
+        // <5 days (or overdue) is the §43B(h) alert window — flag it red.
+        const urgent = daysLeft < 5;
+        return (
+          <span
+            className={
+              urgent
+                ? "text-sm font-semibold text-destructive"
+                : "text-sm text-muted-foreground"
+            }
+          >
+            {due.toLocaleDateString()}
+            {urgent && (
+              <span className="ml-1">
+                ({daysLeft < 0 ? "overdue" : `${daysLeft}d`})
+              </span>
+            )}
+          </span>
+        );
+      },
+    },
+    {
       key: "date",
       header: "Date",
       cell: (payout) => (

--- a/app/dashboard/admin/tds/TdsPageClient.tsx
+++ b/app/dashboard/admin/tds/TdsPageClient.tsx
@@ -178,9 +178,9 @@ export default function TdsPageClient() {
                 </tr>
               </thead>
               <tbody>
-                {(consultants.data?.consultants ?? []).map((c, i) => (
+                {(consultants.data?.consultants ?? []).map((c) => (
                   <tr
-                    key={`${c.consultantProfileId}-${c.tdsRateBps}-${i}`}
+                    key={`${c.consultantProfileId}-${c.tdsRateBps}`}
                     className="border-b last:border-0"
                   >
                     <td className="py-2 pr-4 font-mono text-xs">

--- a/app/dashboard/admin/tds/TdsPageClient.tsx
+++ b/app/dashboard/admin/tds/TdsPageClient.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardHeader } from "@/components/dashboard/PageScaffold";
+
+type TdsSummary = {
+  financialYear: string;
+  quarterWise: { quarter: number; totalDeducted: number; count: number }[];
+  totalDeducted: number;
+  totalRecords: number;
+  unfiledRecords: number;
+};
+
+type ConsultantRow = {
+  consultantProfileId: string;
+  tdsRateBps: number;
+  _sum: { tdsDeducted: number | null; cumulativeAmountCredited: number | null };
+  _count: number;
+};
+
+function rupees(paise: number | null | undefined): string {
+  return `₹${((paise ?? 0) / 100).toLocaleString("en-IN", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+// India FY runs Apr–Mar; label as "YYYY-YY". Build the last few for the picker.
+function financialYearOptions(count = 4): string[] {
+  const now = new Date();
+  const startYear = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1;
+  return Array.from({ length: count }, (_, i) => {
+    const y = startYear - i;
+    return `${y}-${String((y + 1) % 100).padStart(2, "0")}`;
+  });
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Request failed (${res.status})`);
+  return res.json() as Promise<T>;
+}
+
+export default function TdsPageClient() {
+  const fyOptions = useMemo(() => financialYearOptions(), []);
+  const [fy, setFy] = useState(fyOptions[0]);
+
+  const summary = useQuery({
+    queryKey: ["admin-tds-summary", fy],
+    queryFn: () => fetchJson<TdsSummary>(`/api/admin/tds?fy=${fy}&view=summary`),
+    staleTime: 60_000,
+  });
+
+  const consultants = useQuery({
+    queryKey: ["admin-tds-consultants", fy],
+    queryFn: () =>
+      fetchJson<{ consultants: ConsultantRow[] }>(
+        `/api/admin/tds?fy=${fy}&view=consultants`,
+      ),
+    staleTime: 60_000,
+  });
+
+  return (
+    <div className="space-y-6">
+      <DashboardHeader
+        title="TDS"
+        subtitle="Tax deducted at source — summary and consultant breakdown"
+      />
+
+      <div className="flex items-center gap-2">
+        <label htmlFor="fy" className="text-sm text-muted-foreground">
+          Financial year
+        </label>
+        <select
+          id="fy"
+          value={fy}
+          onChange={(e) => setFy(e.target.value)}
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        >
+          {fyOptions.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {summary.isLoading ? (
+          <>
+            <Skeleton className="h-24" />
+            <Skeleton className="h-24" />
+            <Skeleton className="h-24" />
+          </>
+        ) : summary.isError ? (
+          <Card className="sm:col-span-3">
+            <CardContent className="py-6 text-sm text-destructive">
+              Failed to load TDS summary.
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <SummaryCard
+              label="Total deducted"
+              value={rupees(summary.data?.totalDeducted)}
+            />
+            <SummaryCard
+              label="TDS records"
+              value={String(summary.data?.totalRecords ?? 0)}
+            />
+            <SummaryCard
+              label="Unfiled records"
+              value={String(summary.data?.unfiledRecords ?? 0)}
+            />
+          </>
+        )}
+      </div>
+
+      {/* Quarter-wise */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Quarter-wise deduction</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="py-2 pr-4">Quarter</th>
+                <th className="py-2 pr-4">Records</th>
+                <th className="py-2">Deducted</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(summary.data?.quarterWise ?? []).map((q) => (
+                <tr key={q.quarter} className="border-b last:border-0">
+                  <td className="py-2 pr-4">Q{q.quarter}</td>
+                  <td className="py-2 pr-4">{q.count}</td>
+                  <td className="py-2">{rupees(q.totalDeducted)}</td>
+                </tr>
+              ))}
+              {!summary.isLoading &&
+                (summary.data?.quarterWise?.length ?? 0) === 0 && (
+                  <tr>
+                    <td
+                      colSpan={3}
+                      className="py-6 text-center text-muted-foreground"
+                    >
+                      No TDS recorded for {fy}.
+                    </td>
+                  </tr>
+                )}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+
+      {/* Consultant breakdown */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Consultant breakdown</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          {consultants.isLoading ? (
+            <Skeleton className="h-40" />
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="py-2 pr-4">Consultant</th>
+                  <th className="py-2 pr-4">Rate</th>
+                  <th className="py-2 pr-4">Credited</th>
+                  <th className="py-2 pr-4">Deducted</th>
+                  <th className="py-2">Records</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(consultants.data?.consultants ?? []).map((c, i) => (
+                  <tr
+                    key={`${c.consultantProfileId}-${c.tdsRateBps}-${i}`}
+                    className="border-b last:border-0"
+                  >
+                    <td className="py-2 pr-4 font-mono text-xs">
+                      {c.consultantProfileId}
+                    </td>
+                    <td className="py-2 pr-4">{c.tdsRateBps / 100}%</td>
+                    <td className="py-2 pr-4">
+                      {rupees(c._sum.cumulativeAmountCredited)}
+                    </td>
+                    <td className="py-2 pr-4">{rupees(c._sum.tdsDeducted)}</td>
+                    <td className="py-2">{c._count}</td>
+                  </tr>
+                ))}
+                {!consultants.isLoading &&
+                  (consultants.data?.consultants?.length ?? 0) === 0 && (
+                    <tr>
+                      <td
+                        colSpan={5}
+                        className="py-6 text-center text-muted-foreground"
+                      >
+                        No consultant TDS for {fy}.
+                      </td>
+                    </tr>
+                  )}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-semibold">{value}</div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/dashboard/admin/tds/page.tsx
+++ b/app/dashboard/admin/tds/page.tsx
@@ -1,0 +1,13 @@
+import { notFound } from "next/navigation";
+import { ENABLE_TDS_ADMIN_VIEW } from "@/lib/feature-flags";
+import TdsPageClient from "./TdsPageClient";
+
+// #863 — thin admin surface over the existing /api/admin/tds endpoint. Gated on
+// the same flag as the API (404 when off), so the page and endpoint appear and
+// disappear together. Auth is enforced by the admin route-group layout and the
+// endpoint's requirePrivilegedAuth. No Form 26Q/140 export UI — the CBDT codes
+// are unconfirmed; this is read-only summary + breakdown.
+export default function AdminTdsPage() {
+  if (!ENABLE_TDS_ADMIN_VIEW) notFound();
+  return <TdsPageClient />;
+}

--- a/app/dashboard/org-workspace/[orgWorkspaceId]/create/page.tsx
+++ b/app/dashboard/org-workspace/[orgWorkspaceId]/create/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 /**
  * Create-org wizard for an existing OrgWorkspace operator. Renders the
  * same `<CreateOrganizationWizard />` as /dashboard/organization/create
@@ -10,20 +8,24 @@
  * Cancel target is the operator overview (where they came from).
  * Success redirect is the same in both entry points (the wizard always
  * routes to /dashboard/organization/<newOrgId>/home).
+ *
+ * Server component so it can read ENABLE_HOST_ORGS (#863) and hide the host
+ * capability when off; the wizard itself is a client component.
  */
 
-import { use } from "react";
 import { CreateOrganizationWizard } from "@/components/organization/create-wizard/Wizard";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
-export default function OrgWorkspaceCreatePage({
+export default async function OrgWorkspaceCreatePage({
   params,
 }: {
   params: Promise<{ orgWorkspaceId: string }>;
 }) {
-  const { orgWorkspaceId } = use(params);
+  const { orgWorkspaceId } = await params;
   return (
     <CreateOrganizationWizard
       cancelHref={`/dashboard/org-workspace/${orgWorkspaceId}/home`}
+      hostOrgsEnabled={ENABLE_HOST_ORGS}
     />
   );
 }

--- a/app/dashboard/organization/(switcher)/create/page.tsx
+++ b/app/dashboard/organization/(switcher)/create/page.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import { CreateOrganizationWizard } from "@/components/organization/create-wizard/Wizard";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
 /**
  * Nth-time org creation for an already-authenticated ORG_WORKSPACE operator. The
@@ -8,7 +7,15 @@ import { CreateOrganizationWizard } from "@/components/organization/create-wizar
  * Organization Owner role tile; that caller passes `afterLaunch` to flip
  * `user.onboardingCompleted = true`. This page just wraps the shared
  * wizard with the dashboard's cancel path.
+ *
+ * Server component so it can read ENABLE_HOST_ORGS (#863) and hide the host
+ * capability when off — the wizard + steps are client components below.
  */
 export default function CreateOrganizationPage() {
-  return <CreateOrganizationWizard cancelHref="/dashboard/organization" />;
+  return (
+    <CreateOrganizationWizard
+      cancelHref="/dashboard/organization"
+      hostOrgsEnabled={ENABLE_HOST_ORGS}
+    />
+  );
 }

--- a/app/dashboard/organization/[orgId]/billing/WalletTab.tsx
+++ b/app/dashboard/organization/[orgId]/billing/WalletTab.tsx
@@ -522,6 +522,18 @@ export function WalletTab({
                     {alertsMutation.isPending ? "Saving…" : "Save alerts"}
                   </Button>
                 )}
+                {/* #863 residual — the auto-top-up executor (RBI e-mandate:
+                    ₹15k AFA-free cap + 24h pre-debit notice) is NOT built. The
+                    autoTopUp* columns + settings CRUD exist as config-of-intent;
+                    nothing fires a debit. TODO(#863): build the mandate +
+                    executor when a design partner needs it. Notify-only for now. */}
+                <div className="rounded-md border border-dashed border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">
+                    Automatic top-up — coming soon.
+                  </span>{" "}
+                  Today we email finance to top up the wallet manually; auto-debit
+                  arrives with RBI-compliant payment mandates.
+                </div>
               </CardContent>
             </Card>
           )}

--- a/app/dashboard/organization/[orgId]/members/MembersPageClient.tsx
+++ b/app/dashboard/organization/[orgId]/members/MembersPageClient.tsx
@@ -15,6 +15,7 @@ import {
   AddMemberPayloadSchema,
   MembersListResponseSchema,
   UpdateMemberPayloadSchema,
+  ORG_MEMBERS_PER_PAGE,
   type MemberRow,
 } from "@/schemas/organizations";
 import {
@@ -233,7 +234,7 @@ export function MembersPageClient({ orgId }: { orgId: string }) {
   // input; `debouncedSearch` is what actually hits the API (250ms) so a
   // fast typist doesn't fire a request per keystroke. Page resets to 1
   // whenever the search term changes.
-  const PER_PAGE = 20;
+  const PER_PAGE = ORG_MEMBERS_PER_PAGE;
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [page, setPage] = useState(1);

--- a/app/dashboard/organization/[orgId]/members/page.tsx
+++ b/app/dashboard/organization/[orgId]/members/page.tsx
@@ -4,7 +4,7 @@ import { requireOrgAccess } from "@/lib/auth-helpers";
 
 
 import { MembersPageClient } from "./MembersPageClient";
-import { getOrgMembers } from "@/lib/data/org-members";
+import { getOrgMembers, ORG_MEMBERS_PER_PAGE } from "@/lib/data/org-members";
 
 export default async function OrgMembersPage({
   params,
@@ -23,10 +23,13 @@ export default async function OrgMembersPage({
 
   const queryClient = new QueryClient();
 
+  // #902 — the key + shape MUST match the client's first query
+  // (["org-members", orgId, "", 1] → {members,total}) or hydration misses and
+  // the roster re-fetches on mount (the bug this fixes).
   await Promise.allSettled([
     queryClient.prefetchQuery({
-      queryKey: ["org-members", orgId],
-      queryFn: () => getOrgMembers(orgId),
+      queryKey: ["org-members", orgId, "", 1],
+      queryFn: () => getOrgMembers(orgId, { page: 1, perPage: ORG_MEMBERS_PER_PAGE }),
     }),
   ]);
 

--- a/app/explore/enterprise/organisations/page.tsx
+++ b/app/explore/enterprise/organisations/page.tsx
@@ -231,9 +231,11 @@ export default async function ExploreOrganisationsPage({
   const { industry } = await searchParams;
   // Outside the orgs Suspense boundary — a transient timeout here would crash the
   // whole page, so degrade to no industry filters rather than erroring (#925).
-  const industries = await fetchIndustryList().catch(
-    emptyOnTransientDbError("org industries"),
-  );
+  // #1019 — skip the query entirely while host orgs are gated: the grid + filters
+  // are replaced by the "coming soon" state, so the industries list is unused.
+  const industries = ENABLE_HOST_ORGS
+    ? await fetchIndustryList().catch(emptyOnTransientDbError("org industries"))
+    : [];
 
   return (
     <main className="min-h-screen bg-background">

--- a/app/explore/enterprise/organisations/page.tsx
+++ b/app/explore/enterprise/organisations/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import prisma from "@/lib/prisma";
 import { emptyOnTransientDbError } from "@/lib/data/fail-open";
+import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
 
 // Stream behind the static layout's instant skeleton; don't prerender at build (#932).
 // (Replaces the prior `revalidate = 60`, which was inert while the layout forced dynamic.)
@@ -263,7 +264,29 @@ export default async function ExploreOrganisationsPage({
         </div>
       </section>
 
-      {/* Filters + Grid */}
+      {/* #863 — host orgs are gated (ENABLE_HOST_ORGS). While off, this
+          directory (which filters canHost=true) is guaranteed empty, so show an
+          honest announcement instead of a blank grid. */}
+      {!ENABLE_HOST_ORGS ? (
+        <section className="py-16 md:py-24">
+          <div className="max-w-xl mx-auto px-4 text-center">
+            <div className="inline-flex items-center gap-2 px-4 py-2 bg-muted rounded-full mb-6">
+              <Sparkles className="w-4 h-4 text-muted-foreground" />
+              <span className="text-sm font-medium text-muted-foreground">
+                Coming soon
+              </span>
+            </div>
+            <h2 className="text-2xl font-semibold text-foreground mb-3">
+              The organisation directory isn&apos;t open yet
+            </h2>
+            <p className="text-muted-foreground">
+              We&apos;re onboarding expert networks and agencies now. Check back
+              soon to discover and book their curated experts.
+            </p>
+          </div>
+        </section>
+      ) : (
+      /* Filters + Grid */
       <section className="py-10 md:py-16">
         <div className="max-w-[1400px] mx-auto px-4 md:px-8">
           {/* Industry filter chips — Link-based for SSR filtering */}
@@ -311,6 +334,7 @@ export default async function ExploreOrganisationsPage({
           </Suspense>
         </div>
       </section>
+      )}
     </main>
   );
 }

--- a/app/explore/programs/ProgramsInteractiveContent.tsx
+++ b/app/explore/programs/ProgramsInteractiveContent.tsx
@@ -36,6 +36,8 @@ interface ProgramsInteractiveContentProps {
   initialNewest: Program[];
   initialTopics: TopicWithCount[];
   initialStats: ProgramStats | null;
+  /** #664 — viewer's ACTIVE org memberships as { orgId: orgName }. */
+  viewerOrgs?: Record<string, string>;
 }
 
 const FALLBACK_STATS = [
@@ -65,6 +67,7 @@ export default function ProgramsInteractiveContent({
   initialNewest,
   initialTopics,
   initialStats,
+  viewerOrgs = {},
 }: ProgramsInteractiveContentProps) {
   const { data: session } = useSession();
   const userId = session?.user?.id;
@@ -294,6 +297,7 @@ export default function ProgramsInteractiveContent({
               isLoading={isLoading}
               viewMode={viewMode}
               sentinelRef={sentinelRef}
+              viewerOrgs={viewerOrgs}
             />
           </div>
         </div>

--- a/app/explore/programs/components/ProgramCard.tsx
+++ b/app/explore/programs/components/ProgramCard.tsx
@@ -17,6 +17,8 @@ interface ProgramCardProps {
   program: Program;
   variant?: ProgramCardVariant;
   badge?: ProgramBadge;
+  /** #664 — viewer's ACTIVE org memberships as { orgId: orgName }. */
+  viewerOrgs?: Record<string, string>;
 }
 
 const badgeConfig: Record<
@@ -444,15 +446,34 @@ function ProgramCardImpl({
   program,
   variant = "grid",
   badge,
+  viewerOrgs,
 }: ProgramCardProps) {
-  switch (variant) {
-    case "list":
-      return <ListCard program={program} badge={badge} />;
-    case "carousel":
-      return <CarouselCard program={program} badge={badge} />;
-    default:
-      return <GridCard program={program} badge={badge} />;
-  }
+  const card = (() => {
+    switch (variant) {
+      case "list":
+        return <ListCard program={program} badge={badge} />;
+      case "carousel":
+        return <CarouselCard program={program} badge={badge} />;
+      default:
+        return <GridCard program={program} badge={badge} />;
+    }
+  })();
+
+  // #664 — badge a plan the viewer's org sponsors. Rendered as a chip above the
+  // card (no collision with the type/registration/extra badges on the image).
+  const orgName = program.organizationId
+    ? viewerOrgs?.[program.organizationId]
+    : undefined;
+  if (!orgName) return card;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="inline-flex w-fit items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+        Recommended by {orgName}
+      </span>
+      {card}
+    </div>
+  );
 }
 
 const ProgramCard = memo(ProgramCardImpl);

--- a/app/explore/programs/components/ProgramResults.tsx
+++ b/app/explore/programs/components/ProgramResults.tsx
@@ -11,6 +11,8 @@ interface ProgramResultsProps {
   isLoading: boolean;
   viewMode: "grid" | "list";
   sentinelRef: RefObject<HTMLDivElement>;
+  /** #664 — viewer's ACTIVE org memberships as { orgId: orgName }. */
+  viewerOrgs?: Record<string, string>;
 }
 
 function EmptyState() {
@@ -44,6 +46,7 @@ function ProgramResultsImpl({
   isLoading,
   viewMode,
   sentinelRef,
+  viewerOrgs,
 }: ProgramResultsProps) {
   return (
     <>
@@ -60,7 +63,7 @@ function ProgramResultsImpl({
                 delay: Math.min(index * 0.05, 0.6),
               }}
             >
-              <ProgramCard program={item} variant="grid" />
+              <ProgramCard program={item} variant="grid" viewerOrgs={viewerOrgs} />
             </motion.div>
           ))}
         </div>
@@ -77,7 +80,7 @@ function ProgramResultsImpl({
                 delay: Math.min(index * 0.05, 0.6),
               }}
             >
-              <ProgramCard program={item} variant="list" />
+              <ProgramCard program={item} variant="list" viewerOrgs={viewerOrgs} />
             </motion.div>
           ))}
         </div>

--- a/app/explore/programs/page.tsx
+++ b/app/explore/programs/page.tsx
@@ -5,7 +5,7 @@ import {
 import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
-import { getSession } from "@/lib/auth-helpers";
+import { getSession } from "@/lib/auth-server";
 import ProgramsInteractiveContent from "./ProgramsInteractiveContent";
 
 // #664 — the viewer's ACTIVE org memberships, as { orgId: orgName }. Viewer-

--- a/app/explore/programs/page.tsx
+++ b/app/explore/programs/page.tsx
@@ -5,7 +5,30 @@ import {
 import { emptyOnTransientDbError } from "@/lib/data/fail-open";
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/auth-helpers";
 import ProgramsInteractiveContent from "./ProgramsInteractiveContent";
+
+// #664 — the viewer's ACTIVE org memberships, as { orgId: orgName }. Viewer-
+// specific, so it must NOT enter the shared curated cache — it's fetched
+// per-request here and prop-drilled to the card, which badges a plan
+// "Recommended by <org>" when the viewer's org sponsors that plan's program.
+// Fail-open to an empty map (signed-out or a transient read → no badges).
+async function getViewerOrgs(): Promise<Record<string, string>> {
+  try {
+    const session = await getSession();
+    const userId = session?.user?.id;
+    if (!userId) return {};
+    const memberships = await prisma.membership.findMany({
+      where: { userId, status: "ACTIVE" },
+      select: { organization: { select: { id: true, name: true } } },
+    });
+    return Object.fromEntries(
+      memberships.map((m) => [m.organization.id, m.organization.name]),
+    );
+  } catch {
+    return {};
+  }
+}
 
 // Stream behind the static layout's instant skeleton; don't prerender at build (#932).
 export const dynamic = "force-dynamic";
@@ -23,7 +46,7 @@ export const dynamic = "force-dynamic";
 export default async function ExplorePrograms() {
   // Degrade gracefully: a heavy curated read that times out (cold query brushing
   // the pg query budget) renders an empty row instead of erroring the whole page.
-  const [trendingPrograms, newestPrograms, topicsWithCount, stats] =
+  const [trendingPrograms, newestPrograms, topicsWithCount, stats, viewerOrgs] =
     await Promise.all([
       getCuratedPrograms("all", "trending", 8).catch(
         emptyOnTransientDbError("trending programs"),
@@ -33,6 +56,7 @@ export default async function ExplorePrograms() {
       ),
       getTopicsWithCount("all").catch(emptyOnTransientDbError("topics")),
       fetchProgramStats(),
+      getViewerOrgs(),
     ]);
 
   return (
@@ -41,6 +65,7 @@ export default async function ExplorePrograms() {
       initialNewest={newestPrograms}
       initialTopics={topicsWithCount}
       initialStats={stats}
+      viewerOrgs={viewerOrgs}
     />
   );
 }

--- a/app/form/onboarding/page.tsx
+++ b/app/form/onboarding/page.tsx
@@ -456,6 +456,10 @@ const MultiStepForm: React.FC = () => {
   // user lands on their new org's home fully onboarded.
   if (currentRole === "ORG_WORKSPACE" && step > 0) {
     const userId = session?.user?.id;
+    // #863 — hostOrgsEnabled defaults to false here (host capability hidden),
+    // which is the honest state while ENABLE_HOST_ORGS is off. This is a client
+    // component with no server parent to read the flag; TODO(#863): thread the
+    // server flag when host orgs launch (e.g. a server action or a server shell).
     return (
       <CreateOrganizationWizard
         onCancel={() => setStep(0)}

--- a/components/organization/create-wizard/OrgInfoStep.tsx
+++ b/components/organization/create-wizard/OrgInfoStep.tsx
@@ -50,6 +50,7 @@ export function OrgInfoStep({
   canGoBack,
   initialData,
   isSubmitting,
+  hostOrgsEnabled = false,
 }: StepProps) {
   const {
     register,
@@ -118,21 +119,26 @@ export function OrgInfoStep({
               </p>
             </div>
           </label>
-          <label className="flex items-start gap-3 rounded-lg border border-zinc-200 p-3 cursor-pointer hover:border-zinc-300">
-            <Checkbox
-              checked={canHost}
-              onCheckedChange={(v) => setValue("canHost", v === true)}
-              className="mt-0.5"
-            />
-            <div>
-              <p className="text-sm font-medium">Host consultants</p>
-              <p className="text-xs text-zinc-500">
-                The organization hosts consultants who deliver sessions. Enables
-                the payout account and rate cards. Admin verification required
-                before the first booking.
-              </p>
-            </div>
-          </label>
+          {/* #863 — host capability only shown when ENABLE_HOST_ORGS is on.
+              Hidden (not disabled) when off so the user can't tick a box the
+              POST would reject with 400 HOST_ORGS_GATED. */}
+          {hostOrgsEnabled && (
+            <label className="flex items-start gap-3 rounded-lg border border-zinc-200 p-3 cursor-pointer hover:border-zinc-300">
+              <Checkbox
+                checked={canHost}
+                onCheckedChange={(v) => setValue("canHost", v === true)}
+                className="mt-0.5"
+              />
+              <div>
+                <p className="text-sm font-medium">Host consultants</p>
+                <p className="text-xs text-zinc-500">
+                  The organization hosts consultants who deliver sessions.
+                  Enables the payout account and rate cards. Admin verification
+                  required before the first booking.
+                </p>
+              </div>
+            </label>
+          )}
         </div>
         {capabilityError && (
           <p className="text-sm text-red-500" role="alert">

--- a/components/organization/create-wizard/Wizard.tsx
+++ b/components/organization/create-wizard/Wizard.tsx
@@ -37,6 +37,13 @@ export interface CreateOrganizationWizardProps {
   afterLaunch?: (orgId: string) => Promise<void> | void;
   /** Override the post-launch redirect target. */
   finalRedirectPath?: (orgId: string) => string;
+  /**
+   * #863 — whether host orgs are enabled (ENABLE_HOST_ORGS). The flag is
+   * server-only, so the render sites read it and pass it here; OrgInfoStep
+   * hides the "Host consultants" capability when false so a user can't tick a
+   * box the POST would only reject with 400 HOST_ORGS_GATED.
+   */
+  hostOrgsEnabled?: boolean;
 }
 
 export function CreateOrganizationWizard({
@@ -44,6 +51,7 @@ export function CreateOrganizationWizard({
   onCancel,
   afterLaunch,
   finalRedirectPath,
+  hostOrgsEnabled = false,
 }: CreateOrganizationWizardProps = {}) {
   const [step, setStep] = useState(0);
   const [wizardData, setWizardData] = useState<Partial<OrgWizardData>>({});
@@ -95,6 +103,8 @@ export function CreateOrganizationWizard({
     // Expose whether Back is meaningful on this step. OrgInfoStep reads
     // this to decide if its Back button should render.
     canGoBack: step > 0 || !!onCancel,
+    // #863 — OrgInfoStep hides the host capability when host orgs are off.
+    hostOrgsEnabled,
   };
 
   const currentStep = steps[step];

--- a/components/organization/create-wizard/types.ts
+++ b/components/organization/create-wizard/types.ts
@@ -54,6 +54,9 @@ export interface StepProps {
    * button.
    */
   canGoBack?: boolean;
+  /** #863 — host orgs enabled (ENABLE_HOST_ORGS). OrgInfoStep hides the host
+   *  capability when false. Server-read, threaded through the wizard. */
+  hostOrgsEnabled?: boolean;
   /**
    * Optional hook for the Review step: runs after the final PATCH and
    * invitations succeed, before navigation. The onboarding caller uses

--- a/docs/enterprise/00-foundations/03-funding-and-programs.md
+++ b/docs/enterprise/00-foundations/03-funding-and-programs.md
@@ -287,7 +287,7 @@ The sell-supported matrix — capability (`canSponsor`/`canHost`, see [organizat
 | HYBRID | any above | `canSponsor:true, canHost:true` | sponsor leg as above **plus** an `OrganizationEarnings` row on the host side | + payout cron |
 | HOST | — | `canHost:true` + `OrganizationPayoutAccount` | no sponsor leg; earns `OrganizationEarnings` on member bookings | payout cron (`orgpayout:` posting) |
 
-`ENABLE_HOST_ORGS` (renamed from the dead `ENABLE_PROVIDER_ORGS`) gates the entire host side: while false (the pre-MVP default) `canHost=true` and `role=EXPERT` are rejected at create with 501, the host routes (`payouts`/`payout-account`/`earnings`/`rate-cards`) return 501, and the earnings split in `lib/payments/payouts/earnings-service.ts` takes the sponsor-only path. The sponsor-side funding sources above are unaffected by the flag. See [feature-flags-and-rollout](../30-programs-and-lifecycle/06-feature-flags-and-rollout.md).
+`ENABLE_HOST_ORGS` (renamed from the dead `ENABLE_PROVIDER_ORGS`) gates the entire host side: while false (the pre-MVP default) creating an org with `canHost=true` is rejected with a 400 `HOST_ORGS_GATED` response and `role=EXPERT` is likewise rejected at create, the host routes (`payouts`/`payout-account`/`earnings`/`rate-cards`) stay gated, and the earnings split in `lib/payments/payouts/earnings-service.ts` takes the sponsor-only path. The org-create wizard also hides the host capability entirely while the flag is off, so the 400 gate is a backstop rather than the first thing a user sees. The sponsor-side funding sources above are unaffected by the flag. See [feature-flags-and-rollout](../30-programs-and-lifecycle/06-feature-flags-and-rollout.md).
 
 ## Related docs
 

--- a/docs/enterprise/00-foundations/06-hierarchy.md
+++ b/docs/enterprise/00-foundations/06-hierarchy.md
@@ -2,14 +2,23 @@
 title: Organization hierarchy
 band: 00-foundations
 audience: sde2
-status: partial
-last-reviewed: 2026-06-05
+status: dropped
+last-reviewed: 2026-07-17
 ---
 
 # Organization hierarchy
 
-This doc covers the schema-only group-hierarchy columns on `Organization` (#771 D3)
-and explains what is, and is not, wired in v1. It was last updated 2026-06-05.
+> **Status update (2026-07-17, #705 schema freeze):** the schema-only
+> group-hierarchy columns described below (`parentOrganizationId`,
+> `rootOrganizationId`, and the `OrgHierarchy` self-relation) have been
+> **dropped**. A repo-wide grep confirmed they had zero readers, so they were
+> removed rather than carried as inert columns through the launch freeze.
+> Subsidiary scoping for a conglomerate buyer remains a future structural change
+> if the demand materializes. The rest of this document is retained as historical
+> design context for that eventual work.
+
+This doc covers the (now-removed) group-hierarchy columns on `Organization`
+(#771 D3) and explains what was, and was not, wired.
 
 > 🟡 **Gap:** the subtree-scoping work that would make these columns live —
 > population on create, the `requireOrgAccess` subtree scope, the helper functions,

--- a/docs/enterprise/30-programs-and-lifecycle/06-feature-flags-and-rollout.md
+++ b/docs/enterprise/30-programs-and-lifecycle/06-feature-flags-and-rollout.md
@@ -18,7 +18,7 @@ Exactly five flags are exported from the module, and each one is the literal exp
 
 | Flag | Default | Purpose | Gated surfaces when OFF |
 |---|---|---|---|
-| `ENABLE_HOST_ORGS` | off | Hosting orgs (agencies hosting experts, 3-way split). | `POST /organizations` rejects `canHost=true` (501); `POST …/members` rejects `role=EXPERT` (501); org-create wizard hides the host checkbox; `…/{payouts,payout-account,earnings,rate-cards}` return 501; `/experts` + `/payouts` nav hidden; `earnings-service` takes the sponsor-only split. |
+| `ENABLE_HOST_ORGS` | off | Hosting orgs (agencies hosting experts, 3-way split). | `POST /organizations` rejects `canHost=true` with 400 `HOST_ORGS_GATED`; `POST …/members` rejects `role=EXPERT`; the org-create wizard hides the host capability (server flag threaded to the wizard); the public org directory shows a "coming soon" state; the host routes stay gated; `/experts` + `/payouts` nav hidden; `earnings-service` takes the sponsor-only split. |
 | `ENABLE_LIVE_PAYOUTS` | off | Live payout **disbursement** gate (#776 §B). | The whole pipeline runs (batches, ledger, TDS, status machine) but gateway submission is held; org/consultant payouts sit `PROCESSING`, surfaced honestly as "pending platform enablement", **never** as a failure. Server-only — the home action-center + payout surfaces read it server-side and pass the boolean down. |
 | `ENABLE_IRP_UPLOADER` | off | IRP (Invoice Registration Portal) live e-invoice submission. | ClearTax GSP connector is wired (`lib/compliance/irp.ts`, `jobs/compliance/irp-uploader.ts`) but the GitHub Action short-circuits so CI doesn't burn minutes on a stub; sub-₹5cr orgs ride the `{ status: "FAILED", reason: "STUB" }` return (they don't need IRN to claim ITC). |
 | `ENABLE_TDS_ADMIN_VIEW` | off | Admin TDS dashboard + Form 26Q filing surfaces. | `app/api/admin/tds/route.ts` returns 404 (hides from discovery). TDS data is still captured continuously by the payout pipeline; only the *filing workflow* (mark-as-filed, decrypted-PAN view) is gated. |
@@ -33,8 +33,8 @@ governs:
 flowchart TD
   F{"ENABLE_HOST_ORGS<br/>=== 'true'?"}
   F -- OFF (default) --> OFF["host capability dark"]
-  OFF --> A["POST /organizations rejects canHost=true → 501"]
-  OFF --> B["POST …/members rejects role=EXPERT → 501"]
+  OFF --> A["POST /organizations rejects canHost=true → 400 HOST_ORGS_GATED"]
+  OFF --> B["POST …/members rejects role=EXPERT"]
   OFF --> C["wizard hides the host checkbox"]
   OFF --> D["…/{payouts,payout-account,earnings,rate-cards} → 501"]
   OFF --> E["/experts + /payouts nav hidden"]

--- a/docs/enterprise/40-compliance-and-data/06-cross-cutting-integrations.md
+++ b/docs/enterprise/40-compliance-and-data/06-cross-cutting-integrations.md
@@ -53,7 +53,7 @@ flowchart TB
   subgraph ACCESS["C · Membership & access"]
     ROLES["Roles · Invitations<br/>Membership.role"]:::wired
     SSO["SSO + domain claims + break-glass<br/>OrganizationSSOSettings"]:::wired
-    SCIM["SCIM provisioning"]:::parked
+    SCIM["SCIM provisioning"]:::wired
   end
 
   subgraph PROG["D · Programs & rate plans"]
@@ -277,12 +277,11 @@ Each section also lists:
 - **Why:** Self-serve recovery after an admin rejection, instead of forcing a support ticket to re-open the KYB review.
 - **Future work:** none open.
 
-### C.5 SCIM provisioning — ⏸ Parked (stubbed 501)
+### C.5 SCIM provisioning — ✅ Live
 
 - **Schema:** `ScimToken`, `ScimGroupMapping`.
-- **Code paths:** Routes return 501 by default.
-- **Why:** Schema is ready for the first customer that asks. Zero customers today, so the route handlers are stubbed instead of implemented — saves ~500 LoC of speculative provisioning code while keeping the option open.
-- **Future work:** Implement when a customer commits to SCIM.
+- **Code paths:** The SCIM 2.0 endpoints are implemented under `/scim/v2/**`, authenticated by bearer token (`requireScimAuth`, `lib/scim/auth.ts`). Tokens are stored as SHA-256 hashes, scoped to an org, and honour an optional `expiresAt` deadline — an expired token stops authenticating with a 401 while its row stays ACTIVE so an operator can see it lapsed (#789). Earlier docs describing SCIM as "parked / stubbed 501" are stale.
+- **Future work:** Rotation-reminder cron over `ScimToken.expiresAt` (the enforcement read already ships).
 
 ---
 

--- a/docs/enterprise/90-audits/02-subsystem-checklist.md
+++ b/docs/enterprise/90-audits/02-subsystem-checklist.md
@@ -266,7 +266,7 @@ __tests__/enterprise/   cap, overage, credit-pool, reachable-paths, billing-admi
 - [ ] `LEDGER_BALANCE_SNAPSHOT_DRIFT` (maintained `LedgerAccountBalance` vs journal) `✅` #776 — O(1) balance reads replace the O(n) groupBy scan
 - [ ] `REFUND_BOOKING_COHERENCE` (refund ↔ utilization-reversal coherence) `✅` #776
 - [ ] `COMPLETED_PAYOUT_WITHOUT_LEDGER_TXN` (a COMPLETED payout with no original `PAYOUT`/`ORG_PAYOUT` posting) `✅` #812/#813 — covers **both** org and consultant payouts, keyed on the original posting's idempotencyKey so a reversal row can't mask a missing original
-- [ ] Money type Int32→BigInt (₹2.14cr overflow) `❌` #780 (v0-blocker)
+- [ ] Money type Int32→BigInt (₹2.14cr overflow) `✅` #780 — shipped across the money columns; verified in the 2026-06-12 triage and against the current schema (this row previously lagged the fix)
 - [ ] Reconcile run → `ok:true`, 0 findings on fresh reseed `✅`
 
 ## Phase 16 — Earnings & payouts
@@ -378,8 +378,8 @@ __tests__/enterprise/   cap, overage, credit-pool, reachable-paths, billing-admi
 ## Phase 27 — Data fixtures, hierarchy & feature flags
 **Code:** `prisma/seedFiles/15a-create-organizations.ts`, `lib/feature-flags.ts`, hierarchy columns
 - [ ] Seed cohort: Wipro (SPONSOR/INVOICE/LICENSED_SEAT), LearnPro (HOST), IIT (HYBRID/WALLET), Rahul (solo HOST), tour-owner `✅` — verification fixture
-- [ ] Org hierarchy (`parentOrganizationId`/`rootOrganizationId`/`depth`) `❌ INERT` (no reads) — trim helpers #721/#779
-- [ ] Feature flags inventory: `ENABLE_HOST_ORGS`, `ENABLE_LIVE_PAYOUTS`, `ENABLE_ROUTED_WALLET`, `ENABLE_IRP_*`, `ENABLE_CONSOLIDATED_INVOICE`, `ENABLE_CSP_ENFORCE`, `DPDP_SWEEPER_DELETE` `✅` — `lib/feature-flags.ts`
+- [ ] Org hierarchy (`parentOrganizationId`/`rootOrganizationId`) `✅ DROPPED` — the inert columns were grep-verified to have zero readers and removed in the #705 schema freeze. Subsidiary scoping remains a future structural change if a conglomerate buyer materializes. (There was never a `depth` column.)
+- [ ] Feature flags inventory `✅` — the flags actually exported from `lib/feature-flags.ts` are `ENABLE_HOST_ORGS`, `ENABLE_LIVE_PAYOUTS`, `ENABLE_TDS_ADMIN_VIEW`, `ENABLE_BETTERSTACK_TELEMETRY`, and `ENABLE_DUNNING_SUSPEND` (centralized in #863). IRP is gated only by the `ENABLE_IRP_UPLOADER` GitHub Actions repo variable, not an app const. The previously-listed `ENABLE_ROUTED_WALLET`, `ENABLE_CONSOLIDATED_INVOICE`, `ENABLE_CSP_ENFORCE`, and `DPDP_SWEEPER_DELETE` are not in the module.
 
 ---
 

--- a/jobs/billing/dunning.ts
+++ b/jobs/billing/dunning.ts
@@ -27,6 +27,7 @@
 
 import "dotenv/config";
 import prisma from "@/lib/prisma";
+import { ENABLE_DUNNING_SUSPEND } from "@/lib/feature-flags";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { notifyOrgInvoiceOverdue } from "@/lib/novu/org-workflows";
 import { getAppUrl } from "@/lib/url";
@@ -43,7 +44,7 @@ const MAX_REMINDERS = 3;
 // cascade only runs when ENABLE_DUNNING_SUSPEND=true, so wiring it changes
 // nothing until explicitly enabled. The booking-side gate lives in checkout.ts
 // behind the SAME flag.
-const SUSPEND_ENABLED = process.env.ENABLE_DUNNING_SUSPEND === "true";
+const SUSPEND_ENABLED = ENABLE_DUNNING_SUSPEND;
 const SUSPEND_GRACE_MS = 7 * 24 * 60 * 60 * 1000; // 7d past the final reminder
 
 // #779 — only dun orgs that are still reachable. DEACTIVATED orgs are torn

--- a/jobs/billing/generate-subscription-invoices.ts
+++ b/jobs/billing/generate-subscription-invoices.ts
@@ -32,7 +32,10 @@ import { abortIfMaintenance } from "@/lib/maintenance-cron";
 import { deriveGstBreakdown } from "@/lib/compliance/gst";
 import { generateOrgInvoiceNumber } from "@/lib/payments/billing/invoice-numbering";
 import { BILLABLE_ORG_STATUSES } from "@/lib/enterprise/org-status";
-import { notifyOrgLicenseRenewalUpcoming } from "@/lib/novu/org-workflows";
+import {
+  notifyOrgLicenseRenewalUpcoming,
+  notifyOrgInvoiceIssued,
+} from "@/lib/novu/org-workflows";
 import { getAppUrl } from "@/lib/url";
 import { Currency, OrgInvoiceStatus, Prisma } from "@prisma/client";
 import { withCronLock, CronLockHeldError, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
@@ -64,6 +67,7 @@ export async function runGenerateSubscriptionInvoices(): Promise<{
           organization: {
             select: {
               id: true,
+              name: true,
               slug: true,
               invoiceNumberPrefix: true,
               taxInfo: { select: { gstStateCode: true, gstin: true } },
@@ -190,7 +194,12 @@ export async function runGenerateSubscriptionInvoices(): Promise<{
             },
           });
 
-          return { claimed: true as const, invoiceId: invoice.id };
+          return {
+            claimed: true as const,
+            invoiceId: invoice.id,
+            invoiceNumber,
+            totalPaise: gst.totalPaise,
+          };
         },
         {
           isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
@@ -199,6 +208,22 @@ export async function runGenerateSubscriptionInvoices(): Promise<{
 
       if (result.claimed) {
         generated++;
+        // #438 — email the issued invoice (bell + billingEmail channel). No
+        // request in a cron, so build the origin from getAppUrl(). Fire-and-
+        // forget, mirroring notifyOrgLicenseRenewalUpcoming below.
+        const origin = getAppUrl();
+        const orgId = sub.contract.organization.id;
+        void notifyOrgInvoiceIssued(orgId, {
+          invoiceNumber: result.invoiceNumber,
+          orgName: sub.contract.organization.name,
+          totalPaise: result.totalPaise,
+          currency: Currency.INR,
+          dueDate: dueDate.toISOString(),
+          dashboardUrl: `${origin}/dashboard/organization/${orgId}/billing`,
+          pdfUrl: `${origin}/api/organizations/${orgId}/billing-account/invoices/${result.invoiceId}/pdf`,
+        }).catch((err) =>
+          console.error("[cron] notifyOrgInvoiceIssued failed:", err),
+        );
       } else {
         console.log(
           `[cron] Subscription ${sub.id} already claimed by another worker, skipping`,

--- a/lib/api/operators/payouts.ts
+++ b/lib/api/operators/payouts.ts
@@ -135,7 +135,13 @@ export async function getOperatorPayouts(
           select: { id: true },
         },
       },
-      orderBy: { createdAt: "desc" },
+      // #863 — MSME §43B(h): pay micro/small vendors within their statutory
+      // window first. Order by mustPayByDate ascending (soonest deadline on top,
+      // nulls last), then newest. Gives ops a due-date-first work queue.
+      orderBy: [
+        { mustPayByDate: { sort: "asc", nulls: "last" } },
+        { createdAt: "desc" },
+      ],
       take: limit,
       skip: offset,
     }),
@@ -161,6 +167,8 @@ export async function getOperatorPayouts(
       processedAt: p.processedAt,
       failureReason: p.failureReason,
       createdAt: p.createdAt,
+      // #863 — MSME statutory pay-by date (null for non-MSME vendors).
+      mustPayByDate: p.mustPayByDate,
     })),
     stats,
     pagination: {

--- a/lib/api/organizations/program-helpers.ts
+++ b/lib/api/organizations/program-helpers.ts
@@ -641,11 +641,17 @@ export async function reverseBookingUtilization(
       },
     });
     // #775 — the over-cap charge for this booking is no longer owed. Cancel the
-    // linked OverageEvent only while it's still uncollected (the REVERSED guard
-    // in transitionOverage permits PENDING/ACCRUED/FAILED). An already-CHARGED
+    // linked OverageEvent only while it's still uncollected — an already-CHARGED
     // overage (member card captured, or org invoice paid) needs a real refund /
-    // credit note — left to the refund flow + #716, not a silent status flip.
-    await transitionOverage(tx, { bookingUtilizationId: util.id }, "REVERSED");
+    // credit note, handled by the refund cascade (#715/#716), not a silent flip.
+    // fromIn excludes CHARGED explicitly now that REVERSED accepts it.
+    await transitionOverage(
+      tx,
+      { bookingUtilizationId: util.id },
+      "REVERSED",
+      undefined,
+      { fromIn: ["PENDING", "ACCRUED", "FAILED"] },
+    );
   }
 
   return {

--- a/lib/api/scope/list-appointments.ts
+++ b/lib/api/scope/list-appointments.ts
@@ -43,14 +43,15 @@ export interface ListAppointmentsResult {
  * Build the Prisma `where` clause for the requested scope.
  *
  *   - `personal`: rows with `organizationId IS NULL` AND the user
- *     participates (consultee on Consultation/Subscription/Trial OR
- *     consultant on the linked plan). v1 narrows to consultee for
- *     simplicity; consultant-side filtering can layer on later.
+ *     participates — either as the consultee (booked the session) OR as the
+ *     consultant (owns the linked plan). Both sides are covered (#674): a
+ *     consultant's own B2C sessions appear in their personal list; org-hosted
+ *     sessions carry an organizationId and fall under `org` scope instead.
  *   - `org`: rows where `organizationId = orgId`. No user filter —
  *     MANAGER+ sees the org's full activity.
  *   - `all`: no scope filter; admin-only.
  */
-function buildWhere(
+export function buildWhere(
   params: ListAppointmentsParams,
 ): Prisma.AppointmentWhereInput {
   const base: Prisma.AppointmentWhereInput = {
@@ -60,13 +61,30 @@ function buildWhere(
   };
 
   if (params.scope.kind === "personal") {
+    // Consultee arms stay scoped to non-org bookings: a learner's sponsored
+    // sessions are org business (they surface on the home dashboard with a
+    // "Sponsored · Org" pill and under org scope), deliberately kept out of the
+    // personal LIST. Consultant arms are NOT so constrained — an independent
+    // consultant (or a host EXPERT) has no org-scope access, so every session
+    // they DELIVER must appear here, sponsored or not. The org relation is
+    // included so the client can badge the sponsored ones.
+    const uid = params.userId;
     return {
       ...base,
-      organizationId: null,
       OR: [
-        { consultation: { requestedBy: { userId: params.userId } } },
-        { subscription: { requestedBy: { userId: params.userId } } },
-        { trialSession: { consulteeProfile: { userId: params.userId } } },
+        // Consultee side — self-funded (non-org) bookings only.
+        { organizationId: null, consultation: { requestedBy: { userId: uid } } },
+        { organizationId: null, subscription: { requestedBy: { userId: uid } } },
+        {
+          organizationId: null,
+          trialSession: { consulteeProfile: { userId: uid } },
+        },
+        // Consultant side (#674) — every session the user delivers.
+        { consultation: { consultationPlan: { consultantProfile: { userId: uid } } } },
+        { subscription: { subscriptionPlan: { consultantProfile: { userId: uid } } } },
+        { trialSession: { consultantProfile: { userId: uid } } },
+        { webinar: { webinarPlan: { consultantProfile: { userId: uid } } } },
+        { class: { classPlan: { consultantProfile: { userId: uid } } } },
       ],
     };
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -262,6 +262,9 @@ export const auth = betterAuth({
               for (const purposeCode of [
                 PURPOSE_CODES.PRIMARY_PROCESSING,
                 PURPOSE_CODES.STREAM_DATA_PROCESSING,
+                // #701 — session-booking consent, gated fail-closed at
+                // org-sponsored checkout. Granted at signup like the others.
+                PURPOSE_CODES.SESSION_BOOKING,
               ] as const) {
                 const draft = buildConsentArtifact({
                   userId: user.id,

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -203,16 +203,25 @@ export async function checkConsentBatch(params: {
   const { userIds, purposeCode } = params;
   if (userIds.length === 0) return new Set();
 
-  const artifacts = await prisma.consentArtifact.findMany({
-    where: {
-      userId: { in: userIds },
-      purposeCodes: { has: purposeCode },
-      withdrawnAt: null,
-      auditRetainedUntil: { gt: new Date() },
-    },
-    select: { userId: true },
-  });
-  return new Set(artifacts.map((a) => a.userId));
+  // Chunk the id list so a very large org can't overflow Postgres's bind
+  // parameter ceiling (65,535). 10k per query keeps the round-trip count tiny
+  // while staying well under the limit.
+  const CHUNK = 10_000;
+  const now = new Date();
+  const consented = new Set<string>();
+  for (let i = 0; i < userIds.length; i += CHUNK) {
+    const artifacts = await prisma.consentArtifact.findMany({
+      where: {
+        userId: { in: userIds.slice(i, i + CHUNK) },
+        purposeCodes: { has: purposeCode },
+        withdrawnAt: null,
+        auditRetainedUntil: { gt: now },
+      },
+      select: { userId: true },
+    });
+    for (const a of artifacts) consented.add(a.userId);
+  }
+  return consented;
 }
 
 /**

--- a/lib/compliance/dpdp.ts
+++ b/lib/compliance/dpdp.ts
@@ -189,6 +189,33 @@ export async function checkConsent(params: {
 }
 
 /**
+ * Batch form of `checkConsent` (#1019) — resolve consent for many users in ONE
+ * query instead of N. Same fail-closed semantics (a live, non-withdrawn,
+ * in-retention artifact carrying the purpose code). Returns the set of userIds
+ * that HAVE consent; absentees are implicitly denied. Pool-safe for large
+ * exports where a per-user loop (sequential or Promise.all) would either be slow
+ * or spike the connection pool.
+ */
+export async function checkConsentBatch(params: {
+  userIds: string[];
+  purposeCode: PurposeCode;
+}): Promise<Set<string>> {
+  const { userIds, purposeCode } = params;
+  if (userIds.length === 0) return new Set();
+
+  const artifacts = await prisma.consentArtifact.findMany({
+    where: {
+      userId: { in: userIds },
+      purposeCodes: { has: purposeCode },
+      withdrawnAt: null,
+      auditRetainedUntil: { gt: new Date() },
+    },
+    select: { userId: true },
+  });
+  return new Set(artifacts.map((a) => a.userId));
+}
+
+/**
  * Record a user-initiated consent withdrawal. Idempotent — repeated
  * calls for the same (userId, purposeCodes) set `withdrawnAt` once and
  * return the existing row on subsequent calls.

--- a/lib/compliance/index.ts
+++ b/lib/compliance/index.ts
@@ -1,15 +1,18 @@
 /**
  * India compliance barrel.
  *
- * Status as of 2026-05-02 (after #738 Round 2):
+ * Status as of 2026-07-17:
  *   - tds.ts          — DTAA + section selection live; rate constant
  *                       still being normalised (see compliance docs 01).
  *   - msme.ts         — `computeMsmePaymentDeadline` live (15/45-day rule).
  *   - gst.ts          — `deriveGstBreakdown` live (CGST/SGST/IGST split).
  *   - irp.ts          — env-gated ClearTax connector (production-approval
  *                       still pending).
- *   - dpdp.ts         — `buildConsentArtifact` live; `checkConsent` still
- *                       a stub (returns true). #701 owns the cascade.
+ *   - dpdp.ts         — `buildConsentArtifact` + `checkConsent` (fail-closed)
+ *                       live. `checkConsent` is now wired at org-sponsored
+ *                       checkout, invite acceptance, and data export (#701);
+ *                       the remaining call-site cascade (SCIM / Stream /
+ *                       analytics) is tracked in #701.
  *   - form15.ts       — schema-only; cross-border remittance refs not
  *                       yet captured. See compliance doc 07.
  *
@@ -17,11 +20,9 @@
  *
  *   docs/compliance/13-implementation-roadmap.md
  *
- * Callers MUST treat any function that is still flagged as a stub
- * ("checkConsent", "form15.*") as "sensible default, safe but not
- * compliant" and NOT rely on it for:
+ * Callers MUST treat any function still flagged as a stub ("form15.*") as
+ * "sensible default, safe but not compliant" and NOT rely on it for:
  *   - Audit-ready filings
- *   - Real consent enforcement
  *   - Cross-border remittance approvals
  *
  * See each module's header docblock for live-implementation status.

--- a/lib/data/org-members.ts
+++ b/lib/data/org-members.ts
@@ -36,22 +36,58 @@ export interface MemberRow {
   };
 }
 
+// #902 — the page size is shared from a client-safe module (schemas/) so both
+// this server prefetch and the client component use the same value without
+// pulling prisma into the client bundle.
+export { ORG_MEMBERS_PER_PAGE } from "@/schemas/organizations";
+import { ORG_MEMBERS_PER_PAGE } from "@/schemas/organizations";
+
+/**
+ * #902 — the prefetch and the client query must produce the SAME cache entry:
+ * the client keys `["org-members", orgId, q, page]` and expects `{members,total}`
+ * (the members API's search + pagination). Mirror that here so the server
+ * prefetch under `["org-members", orgId, "", 1]` hydrates without a fetch.
+ */
 export async function getOrgMembers(
   orgId: string,
-): Promise<{ members: MemberRow[] }> {
-  const rows = await prisma.membership.findMany({
-    where: { organizationId: orgId },
-    select: {
-      id: true,
-      role: true,
-      status: true,
-      payoutRecipient: true,
-      createdAt: true,
-      user: { select: { id: true, name: true, email: true, image: true } },
-    },
-    orderBy: { createdAt: "desc" },
-  });
+  opts: { q?: string; page?: number; perPage?: number } = {},
+): Promise<{ members: MemberRow[]; total: number }> {
+  const page = Math.max(1, opts.page ?? 1);
+  const perPage = Math.min(100, Math.max(1, opts.perPage ?? ORG_MEMBERS_PER_PAGE));
+  const q = opts.q?.trim() || undefined;
+
+  const where = {
+    organizationId: orgId,
+    ...(q && {
+      user: {
+        OR: [
+          { name: { contains: q, mode: "insensitive" as const } },
+          { email: { contains: q, mode: "insensitive" as const } },
+        ],
+      },
+    }),
+  };
+
+  const [total, rows] = await prisma.$transaction([
+    prisma.membership.count({ where }),
+    prisma.membership.findMany({
+      where,
+      select: {
+        id: true,
+        role: true,
+        status: true,
+        payoutRecipient: true,
+        createdAt: true,
+        user: { select: { id: true, name: true, email: true, image: true } },
+      },
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * perPage,
+      take: perPage,
+    }),
+  ]);
+
   return {
+    total,
     members: rows.map((r) => ({
       id: r.id,
       role: r.role,

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -17,11 +17,14 @@
  * `OrganizationEarnings`), code paths, and API routes for hosting orgs
  * all exist in this codebase but are gated by this flag. When false (the
  * default pre-MVP):
- *   - POST /api/organizations rejects `canHost=true` with 501
- *   - POST /api/organizations/[id]/members rejects `role === "EXPERT"` with 501
- *   - The org-create wizard hides the "host experts" capability checkbox
- *   - /api/organizations/[id]/{payouts,payout-account,earnings,rate-cards}
- *     return 501
+ *   - POST /api/organizations rejects `canHost=true` with 400 HOST_ORGS_GATED
+ *   - POST /api/organizations/[id]/members rejects `role === "EXPERT"`
+ *   - The org-create wizard hides the "host consultants" capability checkbox
+ *     (the render sites read this server flag and pass hostOrgsEnabled to the
+ *     wizard; the 400 gate above stays as the server-side backstop) — #863
+ *   - The public /explore/enterprise/organisations directory shows an honest
+ *     "coming soon" state instead of a silently-empty grid — #863
+ *   - The host earnings/payout surfaces stay gated
  *   - /dashboard/organization/[id]/{experts,payouts} nav links hidden
  *   - The earnings split in lib/payments/payouts/earnings-service.ts takes
  *     the sponsor-only path even if the org has `canHost=true`

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -68,13 +68,17 @@ export const ENABLE_LIVE_PAYOUTS = process.env.ENABLE_LIVE_PAYOUTS === "true";
  * Sub-₹5cr orgs ride along on the stub `{ status: "FAILED", reason: "STUB" }`
  * return and don't need IRN to claim ITC. When the platform crosses the
  * threshold (or onboards a customer who does):
- *   1. Set `ENABLE_IRP_UPLOADER=true` in the deployment environment
+ *   1. Set the `ENABLE_IRP_UPLOADER=true` repo VARIABLE on GitHub Actions
  *   2. Set CLEARTAX_API_KEY + CLEARTAX_GSP_TOKEN + CLEARTAX_GSTIN
  *      secrets on GitHub Actions
  *   3. Run the workflow once manually (workflow_dispatch) to confirm
  *   4. See Issue #713 for the full IRP rollout checklist
+ *
+ * No exported const: the only gate is the CI repo variable read in
+ * `.github/workflows/irp-uploader.yml` (`vars.ENABLE_IRP_UPLOADER`). The former
+ * `export const ENABLE_IRP_UPLOADER` had zero importers — removed to avoid
+ * implying an app-runtime gate that never existed.
  */
-export const ENABLE_IRP_UPLOADER = process.env.ENABLE_IRP_UPLOADER === "true";
 
 /**
  * Admin TDS dashboard + Form 26Q filing surfaces.
@@ -116,4 +120,20 @@ export const ENABLE_TDS_ADMIN_VIEW = process.env.ENABLE_TDS_ADMIN_VIEW === "true
  */
 export const ENABLE_BETTERSTACK_TELEMETRY =
   process.env.ENABLE_BETTERSTACK_TELEMETRY === "true";
+
+/**
+ * Dunning stage-3 booking-suspend cascade (#812).
+ *
+ * The dunning cron always sends reminders and marks invoices OVERDUE. When this
+ * flag is ON, its final stage also stamps `OrganizationInvoice.dunningSuspendedAt`
+ * and the checkout path blocks new sponsored bookings for an org with a
+ * suspended overdue invoice (paying it lifts the block). When OFF (default),
+ * dunning notifies only — no auto-suspend.
+ *
+ * Read on the server at both gate sites (jobs/billing/dunning.ts +
+ * lib/payments/operations/checkout.ts). Previously read as raw `process.env` at
+ * both; centralized here so the flag inventory is complete.
+ */
+export const ENABLE_DUNNING_SUSPEND =
+  process.env.ENABLE_DUNNING_SUSPEND === "true";
 

--- a/lib/moderation/cancel-user-engagements.ts
+++ b/lib/moderation/cancel-user-engagements.ts
@@ -13,6 +13,7 @@ import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
 import { notifyAppointmentCancelled } from "@/lib/novu";
 import { refundPayment } from "@/lib/payments/operations/refund";
+import { refundWholeEventPayments } from "@/lib/payments/operations/event-refunds";
 import { handleSlotOpening } from "@/lib/waitlist";
 import {
   CANCELLABLE_FROM,
@@ -439,22 +440,32 @@ async function cancelGroupEvent(
 
   ctx.summary.engagementsCancelled += 1;
 
-  // Whole-event moderation cancel refunds EVERY attendee in full — unlike the
-  // consultant-initiated cancel route, which defers buyer refunds to the
-  // participant-removal flow.
-  const payments = await prisma.payment.findMany({
+  // Whole-event moderation cancel refunds EVERY attendee in full via the
+  // reversal engine (#776 §C): org-funded seats reverse in-ledger (CLASS_MULTI),
+  // card/mock seats credit the gateway. The old per-payment refundPayment loop
+  // failed org-funded seats (createRefund → UNKNOWN_GATEWAY on a synthetic id).
+  const eventRefund = await refundWholeEventPayments(
+    isWebinar ? "webinar" : "class",
+    eventId,
+    "moderation (100% — platform-initiated cancellation)",
+    ctx.initiatedByUserId,
+  );
+  ctx.summary.refundsIssued += eventRefund.refundsIssued;
+  ctx.summary.refundedPaise += eventRefund.refundedPaise;
+  for (const f of eventRefund.failures) {
+    ctx.summary.failures.push({ kind: "refund", id: f.paymentId, error: f.error });
+  }
+
+  // Light query for attendee notification (the helper doesn't return userIds).
+  const attendees = await prisma.payment.findMany({
     where: {
       appointment: isWebinar ? { webinarId: eventId } : { classId: eventId },
       paymentStatus: "SUCCEEDED",
       amount: { gt: 0 },
     },
-    select: { id: true, userId: true },
+    select: { userId: true },
   });
-  for (const payment of payments) {
-    await issueFullRefund(payment.id, ctx.initiatedByUserId, ctx.summary);
-  }
-
-  const attendeeIds = Array.from(new Set(payments.map((p) => p.userId)));
+  const attendeeIds = Array.from(new Set(attendees.map((p) => p.userId)));
   if (attendeeIds.length > 0) {
     void notifyAppointmentCancelled(attendeeIds, {
       appointmentType: isWebinar ? "WEBINAR" : "CLASS",

--- a/lib/novu/workflows.ts
+++ b/lib/novu/workflows.ts
@@ -393,6 +393,8 @@ export type OrgInvoiceIssuedPayload = {
   currency: string;
   dueDate: string;
   dashboardUrl: string;
+  /** #438 — deep link to the invoice PDF route (302s to a signed URL). */
+  pdfUrl?: string;
 };
 
 export type OrgInvoicePaidPayload = {

--- a/lib/payments/billing/overage-transitions.ts
+++ b/lib/payments/billing/overage-transitions.ts
@@ -15,7 +15,11 @@ import type { Tx } from "@/lib/prisma";
  *   FAILED ──▶ CHARGED                       (late capture webhook recovers a
  *                                             sweep-FAILed charge that was paid)
  *   ACCRUED / FAILED ──▶ REVERSED            (refund of an un-charged overage)
- *   CHARGED ──▶ (terminal)                   reversal needs a credit note (#716)
+ *   CHARGED ──▶ REVERSED                     (credit-back on full refund: the
+ *                                             CHARGE_MEMBER side-payment is
+ *                                             refunded / the CHARGE_ORG invoice
+ *                                             is netted by a credit note —
+ *                                             #715/#716, stamps reversedAt)
  *   BLOCKED ──▶ (terminal)                   set at creation only
  */
 import type { OverageChargeStatus, Prisma } from "@prisma/client";
@@ -28,7 +32,11 @@ const ALLOWED_FROM: Record<OverageChargeStatus, OverageChargeStatus[]> = {
   ACCRUED: ["PENDING"], // CHARGE_ORG rolled onto an issued invoice
   CHARGED: ["PENDING", "ACCRUED", "FAILED"], // money collected (member webhook / invoice paid); FAILED→CHARGED recovers a charge the abandoned-sweep wrongly FAILed while its capture webhook was stuck (#785)
   FAILED: ["PENDING"], // member side-charge abandoned
-  REVERSED: ["PENDING", "ACCRUED", "FAILED"], // booking refunded before collection
+  // uncollected reversal (booking refunded before collection) OR post-collection
+  // credit-back on full refund (#715/#716). Callers pass fromIn to disambiguate:
+  // the uncollected path (reverseBookingUtilization) narrows to non-CHARGED; the
+  // credit-back path (refund cascade) narrows to CHARGED + stamps reversedAt.
+  REVERSED: ["PENDING", "ACCRUED", "FAILED", "CHARGED"],
   BLOCKED: [], // set at creation only
 };
 
@@ -47,6 +55,8 @@ export async function transitionOverage(
     paymentId?: string | null;
     invoiceLineItemId?: string | null;
     settledAt?: Date | null;
+    /** #715/#716 — stamped when a CHARGED overage is credited back on refund. */
+    reversedAt?: Date | null;
     /** #779 §A telemetry — why a FAILED write-off happened (sweep/timeout). */
     chargeFailureReason?: string | null;
   },

--- a/lib/payments/dispute-guard.ts
+++ b/lib/payments/dispute-guard.ts
@@ -1,0 +1,24 @@
+import prisma from "@/lib/prisma";
+import { TERMINAL_DISPUTE_STATUSES } from "./dispute-status";
+
+/**
+ * #1008 — true when a non-terminal (live) dispute exists on any payment for the
+ * appointment. Callers block state mutations (cancel / reschedule) while a
+ * dispute is contested: the appointment is evidence, and a cancel-driven refund
+ * would double-pay against a gateway chargeback that may still land.
+ *
+ * Served by Dispute(paymentId,status) + Payment(appointmentId) indexes. No
+ * admin bypass in v1 — TODO(#1008): allow an explicit privileged override.
+ */
+export async function hasActiveDisputeForAppointment(
+  appointmentId: string,
+): Promise<boolean> {
+  const dispute = await prisma.dispute.findFirst({
+    where: {
+      payment: { appointmentId },
+      status: { notIn: TERMINAL_DISPUTE_STATUSES },
+    },
+    select: { id: true },
+  });
+  return dispute !== null;
+}

--- a/lib/payments/dispute-guard.ts
+++ b/lib/payments/dispute-guard.ts
@@ -1,5 +1,5 @@
 import prisma from "@/lib/prisma";
-import { TERMINAL_DISPUTE_STATUSES } from "./dispute-status";
+import { DISPUTE_INACTIVE_FOR_GATING } from "./dispute-status";
 
 /**
  * #1008 — true when a non-terminal (live) dispute exists on any payment for the
@@ -16,7 +16,7 @@ export async function hasActiveDisputeForAppointment(
   const dispute = await prisma.dispute.findFirst({
     where: {
       payment: { appointmentId },
-      status: { notIn: TERMINAL_DISPUTE_STATUSES },
+      status: { notIn: DISPUTE_INACTIVE_FOR_GATING },
     },
     select: { id: true },
   });

--- a/lib/payments/dispute-status.ts
+++ b/lib/payments/dispute-status.ts
@@ -22,6 +22,21 @@ export const TERMINAL_DISPUTE_STATUSES: DisputeStatus[] = [
   "CLOSED",
 ];
 
+/**
+ * #1019 — statuses that must NOT block an app refund or an appointment mutation.
+ * The terminal verdicts plus WARNING_CLOSED: a closed early-fraud warning is
+ * treated as resolved (handleDisputeUpdated already releases held earnings on
+ * it). It can re-escalate to NEEDS_RESPONSE later, but the refundable
+ * computation nets a subsequent LOST/CHARGE_REFUNDED at that point, so a
+ * resolved warning must not strand a legitimate refund or freeze the
+ * appointment. Active warnings (WARNING_NEEDS_RESPONSE / WARNING_UNDER_REVIEW)
+ * are deliberately absent — those still block while under review.
+ */
+export const DISPUTE_INACTIVE_FOR_GATING: DisputeStatus[] = [
+  ...TERMINAL_DISPUTE_STATUSES,
+  "WARNING_CLOSED",
+];
+
 /** Allowed forward transitions. Same-status is handled separately (idempotent). */
 const ALLOWED: Record<DisputeStatus, DisputeStatus[]> = {
   WARNING_NEEDS_RESPONSE: [

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -76,6 +76,7 @@ import {
 } from "@/lib/enterprise/governance";
 import { checkConsent } from "@/lib/compliance/dpdp";
 import { PURPOSE_CODES } from "@/lib/compliance/purpose-codes";
+import { ENABLE_DUNNING_SUSPEND } from "@/lib/feature-flags";
 import {
   notifyOrgProgramExhausted,
   notifyOrgProgramCapNear,
@@ -1997,7 +1998,7 @@ export async function handleCheckout(
     // unpaid past the grace window; while any such invoice is still OVERDUE, new
     // sponsored bookings for the org are blocked until it is paid. Paying the
     // invoice clears its OVERDUE status, which lifts this gate naturally.
-    if (process.env.ENABLE_DUNNING_SUSPEND === "true") {
+    if (ENABLE_DUNNING_SUSPEND) {
       const suspended = await prisma.organizationInvoice.findFirst({
         where: {
           organizationId: org.id,

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -74,6 +74,8 @@ import {
   getInvoiceCreditLimitPaise,
   assertVerifiedDomainOrThrow,
 } from "@/lib/enterprise/governance";
+import { checkConsent } from "@/lib/compliance/dpdp";
+import { PURPOSE_CODES } from "@/lib/compliance/purpose-codes";
 import {
   notifyOrgProgramExhausted,
   notifyOrgProgramCapNear,
@@ -2021,6 +2023,27 @@ export async function handleCheckout(
     });
     if (!callerMembership || callerMembership.status !== "ACTIVE") {
       throw new Error("You are not an active member of this organization.");
+    }
+
+    // #701 — DPDP consent gate. The member is having a session booked + paid on
+    // their behalf by the org; require a live SESSION_BOOKING consent artifact
+    // before processing it. Fail-closed (checkConsent is false with no artifact).
+    if (
+      !(await checkConsent({
+        userId,
+        purposeCode: PURPOSE_CODES.SESSION_BOOKING,
+      }))
+    ) {
+      throw Object.assign(
+        new Error(
+          "Consent required before your organization can book sessions for you. Grant session-booking consent in your organization's privacy settings.",
+        ),
+        {
+          httpStatus: 403,
+          code: "CONSENT_REQUIRED",
+          purposeCode: "SESSION_BOOKING",
+        },
+      );
     }
 
     organizationId = org.id;

--- a/lib/payments/operations/event-refunds.ts
+++ b/lib/payments/operations/event-refunds.ts
@@ -1,0 +1,166 @@
+import * as Sentry from "@sentry/nextjs";
+import { Prisma } from "@prisma/client";
+import prisma from "@/lib/prisma";
+import { withSerializableRetry } from "@/lib/db/serializable-retry";
+import { recordSystemError } from "@/lib/enterprise/system-events";
+import { applyReversal } from "./reversal-engine";
+import { refundPayment, RefundValidationError } from "./refund";
+
+/**
+ * Whole-event refund (#776 §C) — the production front door for the reversal
+ * engine's CLASS_MULTI path.
+ *
+ * A cancelled class/webinar must refund EVERY attendee. Those attendees paid
+ * through two very different rails, and each needs its own reversal:
+ *
+ *   - GATEWAY / MOCK seats (paymentIntent pi_/cs_/order_/pay_/…_mock_) — real
+ *     card money. They must credit the card, so they go through `refundPayment`
+ *     (which owns the gateway phases + its own overage credit-back). Routing
+ *     them through the engine would strand the customer's money — the engine
+ *     never calls the gateway.
+ *   - INTERNAL org-funded seats (paymentIntent org_wallet/org_license/
+ *     org_invoice) — no card ever charged; the money lives in the wallet /
+ *     invoice accrual / license ledger. `refundPayment` can't refund these
+ *     (createRefund throws UNKNOWN_GATEWAY on a synthetic id), so they reverse
+ *     purely in-ledger via one CLASS_MULTI transaction.
+ *
+ * Idempotency: this fans out NEW refunds each call, so callers must invoke it at
+ * most once per event — the appointment-cancel CAS and the moderation
+ * `moved === 0` guard both provide that. A second call would double-refund.
+ */
+
+export type WholeEventRefundSummary = {
+  refundsIssued: number;
+  refundedPaise: number;
+  childRefundIds: string[];
+  failures: { paymentId: string; error: string }[];
+};
+
+/** Org-funded seats carry a synthetic paymentIntent the gateways can't refund. */
+function isInternalFunded(paymentIntent: string): boolean {
+  return paymentIntent.startsWith("org_");
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export async function refundWholeEventPayments(
+  kind: "class" | "webinar",
+  eventId: string,
+  reason: string,
+  initiatedByUserId: string | null,
+): Promise<WholeEventRefundSummary> {
+  const summary: WholeEventRefundSummary = {
+    refundsIssued: 0,
+    refundedPaise: 0,
+    childRefundIds: [],
+    failures: [],
+  };
+
+  const payments = await prisma.payment.findMany({
+    where: {
+      appointment:
+        kind === "webinar" ? { webinarId: eventId } : { classId: eventId },
+      paymentStatus: "SUCCEEDED",
+      amount: { gt: 0 },
+    },
+    select: { id: true, amount: true, paymentIntent: true },
+  });
+  if (payments.length === 0) return summary;
+
+  const internal = payments.filter((p) => isInternalFunded(p.paymentIntent));
+  const gateway = payments.filter((p) => !isInternalFunded(p.paymentIntent));
+
+  // Gateway / mock seats — one gateway-aware refund each (refundPayment also
+  // handles any CHARGE_MEMBER overage credit-back internally).
+  for (const p of gateway) {
+    try {
+      const r = await refundPayment({ paymentId: p.id, reason, initiatedByUserId });
+      summary.refundsIssued += 1;
+      summary.refundedPaise += r.amountRefundedPaise;
+      summary.childRefundIds.push(r.refundId);
+    } catch (err) {
+      summary.failures.push({ paymentId: p.id, error: errMsg(err) });
+      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
+        tags: { subsystem: "payments", feature: "whole-event-refund" },
+        extra: { paymentId: p.id, eventId, kind },
+      });
+    }
+  }
+
+  // Internal org-funded seats — one CLASS_MULTI reversal (ledger-only). Full
+  // reversal: amountPaise == Σ child amounts, so each child reverses in full.
+  const memberOverageFollowUps: string[] = [];
+  if (internal.length > 0) {
+    const internalTotal = internal.reduce((s, p) => s + p.amount, 0);
+    try {
+      const result = await withSerializableRetry(() =>
+        prisma.$transaction(
+          (tx) =>
+            applyReversal(tx, {
+              source: {
+                kind: "CLASS_MULTI",
+                paymentIds: internal.map((p) => p.id),
+              },
+              amountPaise: internalTotal,
+              reason,
+              // Correlation tag only — reverseClassMulti mints its own child
+              // Refund rows and keys idempotency off those, not this string.
+              refundId: `event:${kind}:${eventId}`,
+              initiatedByUserId,
+            }),
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+        ),
+      );
+      summary.refundsIssued += result.childRefundIds.length;
+      summary.refundedPaise += internalTotal;
+      summary.childRefundIds.push(...result.childRefundIds);
+      for (const c of result.cascades) {
+        if (c.memberOverageRefundDue) {
+          memberOverageFollowUps.push(c.memberOverageRefundDue.overagePaymentId);
+        }
+      }
+    } catch (err) {
+      // The whole internal batch rolled back atomically — surface each seat.
+      for (const p of internal) {
+        summary.failures.push({ paymentId: p.id, error: errMsg(err) });
+      }
+      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
+        tags: { subsystem: "payments", feature: "whole-event-refund" },
+        extra: { eventId, kind, internalCount: internal.length },
+      });
+    }
+  }
+
+  // #715/#716 — CHARGE_MEMBER overages on the internal seats were collected on
+  // separate gateway side-payments the CLASS_MULTI tx can't touch. Credit them
+  // back now (best-effort; ops-paged on non-benign failure).
+  for (const overagePaymentId of memberOverageFollowUps) {
+    try {
+      const r = await refundPayment({
+        paymentId: overagePaymentId,
+        reason: `overage credit-back — ${kind} ${eventId} cancelled`,
+        initiatedByUserId,
+      });
+      summary.childRefundIds.push(r.refundId);
+    } catch (err) {
+      const benign =
+        err instanceof RefundValidationError &&
+        (err.code === "ALREADY_FULLY_REFUNDED" ||
+          err.code === "PAYMENT_NOT_SUCCEEDED");
+      if (!benign) {
+        summary.failures.push({ paymentId: overagePaymentId, error: errMsg(err) });
+        void recordSystemError({
+          organizationId: null,
+          category: "PAYMENT",
+          summary: `Overage credit-back failed for side-payment ${overagePaymentId}`,
+          err,
+          context: { overagePaymentId, eventId, kind },
+        }).catch(() => {});
+      }
+    }
+  }
+
+  return summary;
+}

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -50,6 +50,7 @@ import {
 import { createRefund as createGatewayRefund } from "@/lib/payments";
 import { walletCredit } from "@/lib/api/organizations/wallet";
 import { reverseBookingUtilization } from "@/lib/api/organizations/program-helpers";
+import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
 import { assertEarningStatusTransitionLegal } from "@/lib/payments/payouts/earning-status";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { postLedgerTxn, type Posting } from "@/lib/payments/ledger/post";
@@ -378,7 +379,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
   // PHASE 3b — settle: cascade + SUCCEEDED atomically. A throw here rolls
   // back the cascade AND the cascadedAt claim, leaving the row PENDING under
   // its gateway id for the webhook redelivery / backstop cron to re-drive.
-  return prisma.$transaction(
+  const settled = await prisma.$transaction(
     async (tx) => {
       const cascade = await applyRefundCascade(tx, {
         paymentId: input.paymentId,
@@ -403,6 +404,47 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
     },
     { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
   );
+
+  // #715/#716 — the parent booking was fully refunded and carried a CHARGED
+  // CHARGE_MEMBER overage on a SEPARATE side-payment. Refund it now that the
+  // parent settled: outside the tx (its own gateway call + Serializable
+  // cascade), and best-effort so a hiccup never rolls back the parent refund.
+  if (settled.memberOverageRefundDue) {
+    const sidePaymentId = settled.memberOverageRefundDue.overagePaymentId;
+    try {
+      await refundPayment({
+        paymentId: sidePaymentId,
+        reason: `overage credit-back — parent booking ${input.paymentId} refunded`,
+        initiatedByUserId: input.initiatedByUserId ?? null,
+      });
+    } catch (err) {
+      // ALREADY_FULLY_REFUNDED / PAYMENT_NOT_SUCCEEDED are benign idempotent
+      // re-drives; anything else is a real gap between the parent refund and the
+      // member's credit-back — page ops rather than fail the settled parent.
+      if (
+        !(err instanceof RefundValidationError) ||
+        (err.code !== "ALREADY_FULLY_REFUNDED" &&
+          err.code !== "PAYMENT_NOT_SUCCEEDED")
+      ) {
+        Sentry.captureException(
+          err instanceof Error ? err : new Error(String(err)),
+          {
+            tags: { subsystem: "payments", feature: "overage-credit-back" },
+            extra: { parentPaymentId: input.paymentId, sidePaymentId },
+          },
+        );
+        void recordSystemError({
+          organizationId: null,
+          category: "PAYMENT",
+          summary: `Overage credit-back refund failed for side-payment ${sidePaymentId}`,
+          err,
+          context: { parentPaymentId: input.paymentId, sidePaymentId },
+        }).catch(() => {});
+      }
+    }
+  }
+
+  return settled;
 }
 
 // ============================================================================
@@ -422,6 +464,14 @@ export type ApplyRefundCascadeResult = {
   consultantEarningsReversed: number;
   organizationEarningsReversed: number;
   clawbackInitiated: boolean;
+  /**
+   * #715/#716 — set when a fully-refunded booking had a CHARGED CHARGE_MEMBER
+   * overage. The marginal was collected on a SEPARATE side-payment that this
+   * cascade cannot touch, so the orchestrator (`refundPayment`) must refund it
+   * after this tx commits. Null for CHARGE_ORG (netted here via credit note)
+   * and when there is no charged member overage.
+   */
+  memberOverageRefundDue: { overagePaymentId: string } | null;
 };
 
 /**
@@ -451,6 +501,7 @@ export async function applyRefundCascade(
       consultantEarningsReversed: 0,
       organizationEarningsReversed: 0,
       clawbackInitiated: false,
+      memberOverageRefundDue: null,
     };
   }
 
@@ -481,6 +532,7 @@ export async function applyRefundCascade(
       consultantEarningsReversed: 0,
       organizationEarningsReversed: 0,
       clawbackInitiated: false,
+      memberOverageRefundDue: null,
     };
   }
 
@@ -838,12 +890,63 @@ export async function applyRefundCascade(
   // reversal. Idempotent on refundId, so calling it from both paths (or a cron
   // retry) is safe.
   // -----------------------------------------------------------------------
-  await mintRefundCreditNote(tx, {
+  const refundCreditNote = await mintRefundCreditNote(tx, {
     paymentId: payment.id,
     refundId: input.refundId,
     amountPaise: input.amountPaise,
     reason: input.reason,
   });
+
+  // -----------------------------------------------------------------------
+  // Step 7.6 (#715/#716): credit-back for an ALREADY-CHARGED overage on full
+  // refund. reverseBookingUtilization only cancels UNCOLLECTED overages; a
+  // CHARGED one moved real money. Full-reversal-only — a partial parent refund
+  // leaves the overage standing (no clean proration for a surcharge).
+  //   CHARGE_ORG   — the marginal rode inside this payment.amount and its
+  //                  invoice was paid, so the credit note above returns it;
+  //                  flip the event once the CN is actually minted.
+  //   CHARGE_MEMBER — the marginal was a SEPARATE side-payment; this cascade
+  //                  can't touch it, so surface it for the orchestrator to
+  //                  refund post-commit (that refund's own cascade flips it).
+  // -----------------------------------------------------------------------
+  let memberOverageRefundDue: { overagePaymentId: string } | null = null;
+  if (payment.bookingUtilization && input.amountPaise === payment.amount) {
+    const charged = await tx.overageEvent.findFirst({
+      where: {
+        bookingUtilizationId: payment.bookingUtilization.id,
+        chargeStatus: "CHARGED",
+      },
+      select: { id: true, overageBehavior: true, paymentId: true },
+    });
+    if (
+      charged?.overageBehavior === "CHARGE_ORG" &&
+      refundCreditNote.creditNoteId
+    ) {
+      await transitionOverage(
+        tx,
+        { id: charged.id },
+        "REVERSED",
+        { reversedAt: new Date() },
+        { fromIn: ["CHARGED"] },
+      );
+    } else if (
+      charged?.overageBehavior === "CHARGE_MEMBER" &&
+      charged.paymentId
+    ) {
+      memberOverageRefundDue = { overagePaymentId: charged.paymentId };
+    }
+  }
+
+  // A CHARGE_MEMBER side-payment refunding ITSELF (whether via the credit-back
+  // above or a direct refund) flips its own event. Keyed by paymentId —
+  // side-charges carry no bookingUtilization, so the branch above misses them.
+  await transitionOverage(
+    tx,
+    { paymentId: payment.id, overageBehavior: "CHARGE_MEMBER" },
+    "REVERSED",
+    { reversedAt: new Date() },
+    { fromIn: ["CHARGED"] },
+  );
 
   // #738-A — TCS u/s 52 parity: if collection ever stamped this payment
   // (flag-gated, schema-live), the refund must net it out of the next GSTR-8.
@@ -1082,6 +1185,7 @@ export async function applyRefundCascade(
     consultantEarningsReversed,
     organizationEarningsReversed,
     clawbackInitiated,
+    memberOverageRefundDue,
   };
 }
 

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -51,6 +51,7 @@ import { createRefund as createGatewayRefund } from "@/lib/payments";
 import { walletCredit } from "@/lib/api/organizations/wallet";
 import { reverseBookingUtilization } from "@/lib/api/organizations/program-helpers";
 import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
+import { TERMINAL_DISPUTE_STATUSES } from "@/lib/payments/dispute-status";
 import { assertEarningStatusTransitionLegal } from "@/lib/payments/payouts/earning-status";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { postLedgerTxn, type Posting } from "@/lib/payments/ledger/post";
@@ -199,6 +200,25 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
     );
   }
 
+  // #1008 — block an app-initiated refund while a dispute is LIVE (non-terminal)
+  // on this payment: the gateway may still pull the money via the dispute, so
+  // refunding now risks paying the customer twice. Terminal disputes already
+  // reduce `refundable` above. Gateway-webhook-driven cascades (applyRefundCascade
+  // directly) bypass this — they reflect money the bank already moved.
+  const liveDispute = await prisma.dispute.findFirst({
+    where: {
+      paymentId: input.paymentId,
+      status: { notIn: TERMINAL_DISPUTE_STATUSES },
+    },
+    select: { status: true },
+  });
+  if (liveDispute) {
+    throw new RefundValidationError(
+      `Payment ${input.paymentId} has an open dispute (${liveDispute.status}); resolve it before refunding`,
+      "REFUND_BLOCKED_BY_DISPUTE",
+    );
+  }
+
   const requested = input.amountPaise ?? refundable;
   if (requested <= 0) {
     throw new RefundValidationError(
@@ -252,6 +272,24 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         throw new RefundValidationError(
           `Race-loss: refund amount ${requested} exceeds refundable ${remainingNow} on payment ${input.paymentId}`,
           "AMOUNT_EXCEEDS_REFUNDABLE",
+        );
+      }
+
+      // #1008 — re-check for a live dispute inside the Serializable tx. Reading
+      // the dispute table here makes SSI abort the loser when a dispute-status
+      // change (handleDisputeUpdated, also Serializable) interleaves between the
+      // outer read and this reservation.
+      const liveDisputeNow = await tx.dispute.findFirst({
+        where: {
+          paymentId: input.paymentId,
+          status: { notIn: TERMINAL_DISPUTE_STATUSES },
+        },
+        select: { id: true },
+      });
+      if (liveDisputeNow) {
+        throw new RefundValidationError(
+          `Payment ${input.paymentId} has an open dispute; resolve it before refunding`,
+          "REFUND_BLOCKED_BY_DISPUTE",
         );
       }
 

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -940,13 +940,17 @@ export async function applyRefundCascade(
   // A CHARGE_MEMBER side-payment refunding ITSELF (whether via the credit-back
   // above or a direct refund) flips its own event. Keyed by paymentId —
   // side-charges carry no bookingUtilization, so the branch above misses them.
-  await transitionOverage(
-    tx,
-    { paymentId: payment.id, overageBehavior: "CHARGE_MEMBER" },
-    "REVERSED",
-    { reversedAt: new Date() },
-    { fromIn: ["CHARGED"] },
-  );
+  // Scoped to side-charges (parentPaymentId set) so normal booking refunds skip
+  // this write entirely.
+  if (payment.parentPaymentId) {
+    await transitionOverage(
+      tx,
+      { paymentId: payment.id, overageBehavior: "CHARGE_MEMBER" },
+      "REVERSED",
+      { reversedAt: new Date() },
+      { fromIn: ["CHARGED"] },
+    );
+  }
 
   // #738-A — TCS u/s 52 parity: if collection ever stamped this payment
   // (flag-gated, schema-live), the refund must net it out of the next GSTR-8.

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -51,7 +51,7 @@ import { createRefund as createGatewayRefund } from "@/lib/payments";
 import { walletCredit } from "@/lib/api/organizations/wallet";
 import { reverseBookingUtilization } from "@/lib/api/organizations/program-helpers";
 import { transitionOverage } from "@/lib/payments/billing/overage-transitions";
-import { TERMINAL_DISPUTE_STATUSES } from "@/lib/payments/dispute-status";
+import { DISPUTE_INACTIVE_FOR_GATING } from "@/lib/payments/dispute-status";
 import { assertEarningStatusTransitionLegal } from "@/lib/payments/payouts/earning-status";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { postLedgerTxn, type Posting } from "@/lib/payments/ledger/post";
@@ -208,7 +208,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
   const liveDispute = await prisma.dispute.findFirst({
     where: {
       paymentId: input.paymentId,
-      status: { notIn: TERMINAL_DISPUTE_STATUSES },
+      status: { notIn: DISPUTE_INACTIVE_FOR_GATING },
     },
     select: { status: true },
   });
@@ -282,7 +282,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
       const liveDisputeNow = await tx.dispute.findFirst({
         where: {
           paymentId: input.paymentId,
-          status: { notIn: TERMINAL_DISPUTE_STATUSES },
+          status: { notIn: DISPUTE_INACTIVE_FOR_GATING },
         },
         select: { id: true },
       });

--- a/lib/payments/operations/reversal-engine.ts
+++ b/lib/payments/operations/reversal-engine.ts
@@ -20,6 +20,18 @@ import type { Tx } from "@/lib/prisma";
  * it's proven and heavily tested; this engine DISPATCHES to it rather than
  * re-implementing it. New capability here: CLASS_MULTI (fan a single logical
  * refund across the child payments of a consolidated CLASS purchase).
+ *
+ * Production callers (#776 §C):
+ *   - CLASS_MULTI       — `refundWholeEventPayments` (lib/payments/operations/
+ *                         event-refunds.ts), for the INTERNAL (org-funded) seats
+ *                         of a cancelled class/webinar. Gateway/card seats do NOT
+ *                         come here — they credit the card via `refundPayment`,
+ *                         which this engine never calls (reverseClassMulti marks
+ *                         its child refunds SUCCEEDED with no gateway leg).
+ *   - PAYOUT_CLAWBACK   — the dispute-lost branch of handleDisputeUpdated.
+ *   - BOOKING / OVERAGE — single-payment reversals still flow through
+ *                         `refundPayment` (it owns the gateway phases); nothing
+ *                         calls applyReversal for those from a route.
  */
 
 import { Prisma, RefundStatus } from "@prisma/client";
@@ -53,6 +65,8 @@ export interface ApplyReversalResult {
   kind: ReversalSource["kind"];
   /** Per-cascade results (one per payment touched). */
   cascades: ApplyRefundCascadeResult[];
+  /** Child Refund row ids created by CLASS_MULTI (one per reversed child). */
+  childRefundIds: string[];
   /** True if a payout clawback ledger posting was made. */
   clawbackPosted: boolean;
 }
@@ -74,7 +88,12 @@ export async function applyReversal(
         reason: input.reason,
         initiatedByUserId: input.initiatedByUserId ?? null,
       });
-      return { kind: "BOOKING", cascades: [cascade], clawbackPosted: false };
+      return {
+        kind: "BOOKING",
+        cascades: [cascade],
+        childRefundIds: [],
+        clawbackPosted: false,
+      };
     }
 
     case "OVERAGE": {
@@ -86,16 +105,26 @@ export async function applyReversal(
         reason: input.reason,
         initiatedByUserId: input.initiatedByUserId ?? null,
       });
-      return { kind: "OVERAGE", cascades: [cascade], clawbackPosted: false };
+      return {
+        kind: "OVERAGE",
+        cascades: [cascade],
+        childRefundIds: [],
+        clawbackPosted: false,
+      };
     }
 
     case "CLASS_MULTI": {
-      const cascades = await reverseClassMulti(
+      const { cascades, childRefundIds } = await reverseClassMulti(
         tx,
         input,
         input.source.paymentIds,
       );
-      return { kind: "CLASS_MULTI", cascades, clawbackPosted: false };
+      return {
+        kind: "CLASS_MULTI",
+        cascades,
+        childRefundIds,
+        clawbackPosted: false,
+      };
     }
 
     case "PAYOUT_CLAWBACK": {
@@ -105,7 +134,12 @@ export async function applyReversal(
         input.source.orgPayoutId,
         input.source.organizationId,
       );
-      return { kind: "PAYOUT_CLAWBACK", cascades: [], clawbackPosted: posted };
+      return {
+        kind: "PAYOUT_CLAWBACK",
+        cascades: [],
+        childRefundIds: [],
+        clawbackPosted: posted,
+      };
     }
 
     default: {
@@ -129,8 +163,11 @@ async function reverseClassMulti(
   tx: Tx,
   input: ApplyReversalInput,
   paymentIds: string[],
-): Promise<ApplyRefundCascadeResult[]> {
-  if (paymentIds.length === 0) return [];
+): Promise<{
+  cascades: ApplyRefundCascadeResult[];
+  childRefundIds: string[];
+}> {
+  if (paymentIds.length === 0) return { cascades: [], childRefundIds: [] };
 
   const payments = await tx.payment.findMany({
     where: { id: { in: paymentIds } },
@@ -145,7 +182,7 @@ async function reverseClassMulti(
     },
   });
   const totalAmount = payments.reduce((s, p) => s + p.amount, 0);
-  if (totalAmount <= 0) return [];
+  if (totalAmount <= 0) return { cascades: [], childRefundIds: [] };
 
   // Fail fast on an over-refund. Without this the per-child floor shares would
   // exceed their own amounts and crash deep inside a child cascade (after some
@@ -176,6 +213,7 @@ async function reverseClassMulti(
   }
 
   const results: ApplyRefundCascadeResult[] = [];
+  const childRefundIds: string[] = [];
   for (const { payment, share } of shares) {
     if (share <= 0) continue;
     // One Refund row per child so partial-class refunds reverse cleanly and a
@@ -211,8 +249,9 @@ async function reverseClassMulti(
       data: { status: RefundStatus.SUCCEEDED },
     });
     results.push(cascade);
+    childRefundIds.push(childRefund.id);
   }
-  return results;
+  return { cascades: results, childRefundIds };
 }
 
 /**

--- a/lib/payments/payouts/balance-preflight.ts
+++ b/lib/payments/payouts/balance-preflight.ts
@@ -1,0 +1,50 @@
+import { ENABLE_LIVE_PAYOUTS } from "@/lib/feature-flags";
+import { recordSystemError } from "@/lib/enterprise/system-events";
+import {
+  getRazorpayPayoutsService,
+  isRazorpayPayoutsConfigured,
+} from "./razorpay-payouts";
+
+export type BalancePreflight = {
+  /** False only on a KNOWN-insufficient balance — the caller holds the batch. */
+  ok: boolean;
+  /** Fetched balance in paise, or null when unknown (not fetched / bad shape). */
+  balancePaise: number | null;
+  reason?: string;
+};
+
+/**
+ * #863 — pre-batch RazorpayX balance check. Runs only when live payouts are on
+ * and the gateway is configured (otherwise nothing is wired to leave, so it's a
+ * no-op ok). On a KNOWN-insufficient balance it pages ops and returns ok:false,
+ * so the caller holds the batch — the rows stay PENDING, the same honest posture
+ * as the flag-off path, instead of half-submitting and stranding NEFT.
+ *
+ * A balance-read failure or unexpected shape fails OPEN (ok:true): a brand-new
+ * read dependency must never stall payouts, and RazorpayX's own
+ * `queue_if_low_balance` remains the gateway-side backstop.
+ */
+export async function assertPayoutBalance(
+  totalPaise: number,
+): Promise<BalancePreflight> {
+  if (!ENABLE_LIVE_PAYOUTS || !isRazorpayPayoutsConfigured()) {
+    return { ok: true, balancePaise: null };
+  }
+
+  const balancePaise = await getRazorpayPayoutsService().getAccountBalance();
+  if (balancePaise === null) {
+    return { ok: true, balancePaise: null }; // unknown → fail open
+  }
+  if (balancePaise < totalPaise) {
+    const reason = `RazorpayX balance ${balancePaise} < required ${totalPaise} paise`;
+    void recordSystemError({
+      organizationId: null,
+      category: "PAYOUT",
+      summary: `RAZORPAYX_BALANCE_INSUFFICIENT — ${reason}`,
+      err: new Error(reason),
+      context: { balancePaise, totalPaise },
+    }).catch(() => {});
+    return { ok: false, balancePaise, reason };
+  }
+  return { ok: true, balancePaise };
+}

--- a/lib/payments/payouts/org-payout-service.ts
+++ b/lib/payments/payouts/org-payout-service.ts
@@ -54,6 +54,7 @@ import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import type { PaymentGateway, PayoutStatus } from "@prisma/client";
 import { acquireLock, releaseLock } from "@/lib/redis";
+import { assertPayoutBalance } from "./balance-preflight";
 import { computeMsmePaymentDeadline } from "@/lib/compliance/msme";
 import { computeTdsForPayout } from "@/lib/compliance/tds";
 import { postLedgerTxn, type Posting } from "@/lib/payments/ledger/post";
@@ -707,6 +708,17 @@ async function submitOrgPayoutToGateway(payoutId: string): Promise<void> {
   const sdk = getRazorpayPayoutsService();
   const idempotencyKey = sdk.generateIdempotencyKey(payoutId);
   const mode = sdk.determinePayoutMode(payout.amountPaise, "bank_account");
+
+  // #863 — don't submit a high-value NEFT the RazorpayX balance can't cover.
+  // Leaves the row in PROCESSING for the reconcile cron to retry once funded
+  // (same posture as the Stripe-deferred return above). Fails open on unknown.
+  const preflight = await assertPayoutBalance(payout.amountPaise);
+  if (!preflight.ok) {
+    console.warn(
+      `[OrgPayoutService] Holding payout ${payoutId} — ${preflight.reason}`,
+    );
+    return;
+  }
 
   const response = await sdk.createPayout({
     fundAccountId,

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -24,6 +24,7 @@ import { postLedgerTxn, type Posting } from "@/lib/payments/ledger/post";
 import { computeMsmePaymentDeadline } from "@/lib/compliance/msme";
 import { randomUUID } from "crypto";
 import { acquireLock, releaseLock } from "@/lib/redis";
+import { assertPayoutBalance } from "./balance-preflight";
 import {
   getCurrentFYCumulativePayments,
   getFYDateRange,
@@ -486,6 +487,16 @@ export async function processApprovedPayouts(): Promise<PayoutResult[]> {
         },
       },
     });
+
+    // #863 — hold the whole batch if RazorpayX can't cover it (a no-op unless
+    // ENABLE_LIVE_PAYOUTS is on + the gateway is configured). Conservative:
+    // sums gross; the real debit is net of TDS. Fails open on an unknown balance.
+    const batchTotalPaise = approvedPayouts.reduce((s, p) => s + p.amount, 0);
+    const preflight = await assertPayoutBalance(batchTotalPaise);
+    if (!preflight.ok) {
+      console.warn(`[Payouts] Holding approved batch — ${preflight.reason}`);
+      return [];
+    }
 
     const results: PayoutResult[] = [];
 

--- a/lib/payments/payouts/razorpay-payouts.ts
+++ b/lib/payments/payouts/razorpay-payouts.ts
@@ -301,6 +301,27 @@ export class RazorpayPayoutsService {
     });
   }
 
+  /**
+   * #863 — current RazorpayX account balance in paise, or null when the
+   * response shape isn't what we expect. Used ONLY by the pre-batch balance
+   * preflight; a null is treated as "unknown" (fail-open) by the caller, so a
+   * shape mismatch or transient error never blocks payouts. The exact endpoint
+   * must be re-verified against the sandbox before ENABLE_LIVE_PAYOUTS flips.
+   */
+  async getAccountBalance(): Promise<number | null> {
+    try {
+      const res = await this.apiRequest<{
+        balance?: number;
+        balances?: Array<{ balance?: number }>;
+      }>("GET", `/accounts/${encodeURIComponent(this.config.accountNumber)}`);
+      if (typeof res.balance === "number") return res.balance;
+      const first = res.balances?.[0]?.balance;
+      return typeof first === "number" ? first : null;
+    } catch {
+      return null;
+    }
+  }
+
   // ============================================
   // Payouts API
   // ============================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2205,6 +2205,8 @@ model DpdpGrievance {
   resolvedAt  DateTime?       @db.Timestamptz
 
   @@index([status, createdAt])
+  // Postgres does not auto-index FKs; the Cascade delete scans by userId.
+  @@index([userId])
 }
 
 enum GrievanceStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,3 +1,8 @@
+// #705 schema freeze (2026-07-17) — enterprise schema is launch-frozen.
+// Additive-only until launch: new nullable columns / new models are allowed;
+// renames, drops of live columns, and type changes are not. Money columns are
+// BigInt paise; enums are declared below the model(s) that use them.
+
 generator client {
   provider = "prisma-client-js"
 }
@@ -70,6 +75,7 @@ model User {
   memberships      Membership[] // Typed enterprise memberships (Arch 4-Modified)
   invitationsSent  Invitation[]      @relation("InvitationsSent")
   consentArtifacts ConsentArtifact[]
+  dpdpGrievances   DpdpGrievance[]
 
   // Staff Dashboard Relations
   reportsSubmitted  ModerationReport[] @relation("ReportsSubmitted")
@@ -500,14 +506,10 @@ model Organization {
   canSponsor Boolean @default(true)
   canHost    Boolean @default(false)
 
-  // #771 D3 — group hierarchy for conglomerate buyers (Tata/Reliance/Birla-style
-  // subsidiary groups). Nullable + inert until group-billing/subsidiary-scoping
-  // APIs ship (stubbed 501). Re-adds the parent/root columns dropped in #768 so
-  // a future buyer doesn't force a structural migration. Self-relation.
-  parentOrganizationId String?
-  parentOrganization   Organization?  @relation("OrgHierarchy", fields: [parentOrganizationId], references: [id], onDelete: SetNull)
-  childOrganizations   Organization[] @relation("OrgHierarchy")
-  rootOrganizationId   String? // denormalized group root for fast subsidiary scoping
+  // #705 freeze — inert group-hierarchy columns (parentOrganizationId,
+  // rootOrganizationId, OrgHierarchy self-relation) dropped: never read by any
+  // code path. Subsidiary scoping remains a future structural change if a
+  // conglomerate buyer materializes. See docs/enterprise/00-foundations/06-hierarchy.md.
 
   // India / GCC context (all schema-final; compliance logic stubbed)
   dataResidencyRegion DataRegion        @default(IN)
@@ -663,7 +665,6 @@ model Organization {
   @@index([canSponsor, canHost])
   @@index([canHost, isPublic, status])
   @@index([dataResidencyRegion])
-  @@index([parentOrganizationId])
   @@map("organizations")
 }
 
@@ -757,11 +758,10 @@ model Membership {
   rateCardOverride   RateCard?       @relation("MembershipRateCardOverride", fields: [rateCardOverrideId], references: [id], onUpdate: Cascade, onDelete: SetNull)
 
   /// ADR 18 — org-declared exclusivity for internal consultants (pairs with
-  /// payoutRecipient=ORGANIZATION). Schema stub, UNENFORCED: nothing hides or
-  /// blocks the consultant's independent B2C plans yet; the flag exists now
-  /// because the schema freezes before launch. Enforcement (hide/block
-  /// independent plans while an exclusive engagement is active) is a future
-  /// feature gated on org demand.
+  /// payoutRecipient=ORGANIZATION). ENFORCED at checkout (#982): while an ACTIVE
+  /// membership sets this flag, the consultant's independent (non-org-owned)
+  /// plans cannot be booked — see checkout.ts. The "hide" half (filtering those
+  /// plans out of marketplace listings) remains future work per the ADR.
   exclusiveEngagement Boolean @default(false)
 
   // Entitlement tracking
@@ -1334,13 +1334,11 @@ model BookingUtilization {
   @@index([programAssignmentId, createdAt])
 }
 
-/// ADR 18 — optional curated consultant panel for a Program. Schema stub,
-/// UNENFORCED: the sponsor network stays open (a Program with zero rows
-/// imposes no restriction, and checkout does not consult this table yet).
-/// When a sponsor asks for a curated panel, enforcement slots into the
-/// checkout org-resolution block right after the ProgramAssignment is
-/// validated (see the ADR-18 comment in lib/payments/operations/checkout.ts):
-/// rows present ⇒ the booked plan's consultant must be listed.
+/// ADR 18 — optional curated consultant panel for a Program. ENFORCED at
+/// checkout (#971): a Program with zero rows keeps the sponsor network open;
+/// once rows exist, an org-sponsored booking's consultant must be listed or
+/// the checkout is rejected under the distributed lock (see the ADR-18
+/// allowlist block in lib/payments/operations/checkout.ts).
 model ProgramConsultantAllowlist {
   id                  String            @id @default(uuid())
   programId           String
@@ -2190,6 +2188,28 @@ model DataBreach {
   principalNotificationNote    String?   @db.Text
 
   @@index([detectedAt])
+}
+
+/// DPDP Rule 13 grievance intake (#701, minimal). A data principal files a
+/// grievance; ops sees it via a recorded system event and works it manually.
+/// The redressal SLA workflow (assignment, response deadlines, closure audit)
+/// is deferred — this row is the durable intake record.
+model DpdpGrievance {
+  id          String          @id @default(uuid())
+  userId      String
+  user        User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  subject     String          @db.VarChar(200)
+  description String          @db.Text
+  status      GrievanceStatus @default(OPEN)
+  createdAt   DateTime        @default(now()) @db.Timestamptz
+  resolvedAt  DateTime?       @db.Timestamptz
+
+  @@index([status, createdAt])
+}
+
+enum GrievanceStatus {
+  OPEN
+  RESOLVED
 }
 
 //////////////////////////////////////////////////// USER PROFILES and SLOTTING MECHANISM ////////////////////////////////////////////////////
@@ -5094,7 +5114,8 @@ enum EmailDeliveryStatus {
 /// Per-org SCIM 2.0 bearer tokens. Stored as SHA-256 hashes; the raw token
 /// is shown once at creation and never persisted. Auth path: bearer →
 /// sha256 → lookup in this table → load organizationId. Status flips to
-/// REVOKED on explicit DELETE; tokens never expire unless revoked.
+/// REVOKED on explicit DELETE; a token also stops authenticating once past
+/// its optional expiresAt (enforced in lib/scim/auth.ts).
 model ScimToken {
   id                    String          @id @default(cuid())
   organizationId        String
@@ -5106,12 +5127,10 @@ model ScimToken {
   createdAt             DateTime        @default(now())
   lastUsedAt            DateTime?
   revokedAt             DateTime?
-  /// Optional auto-rotation TTL. Null = "never expires"; non-null is
-  /// the absolute deadline after which `requireScimAuth` refuses the
-  /// token even if `status = ACTIVE`. The enforcement read is a
-  /// follow-up — the column exists today so OWNERs can set a 6/12
-  /// month TTL when minting + the rotation reminder cron has a
-  /// stable column to scan.
+  /// Optional auto-rotation TTL. Null = "never expires"; non-null is the
+  /// absolute deadline after which the SCIM auth path (#789) refuses the token
+  /// with 401 even while `status = ACTIVE` — the row stays ACTIVE so the
+  /// operator sees it lapsed rather than revoked.
   expiresAt             DateTime?
 
   @@index([organizationId, status])
@@ -5264,6 +5283,11 @@ model OverageEvent {
   invoiceLineItemId    String?
   invoiceLineItem      InvoiceLineItem?    @relation(fields: [invoiceLineItemId], references: [id], onDelete: SetNull)
   settledAt            DateTime?
+  /// #715/#716 — set when a CHARGED overage is credited back because its parent
+  /// booking was fully refunded (CHARGE_MEMBER side-payment refunded / CHARGE_ORG
+  /// invoice netted by the refund credit note). Uncollected reversals reuse the
+  /// existing chargeStatus history; this stamp marks the post-collection case.
+  reversedAt           DateTime?           @db.Timestamptz
 
   /// #779 §A — CHARGE_MEMBER timeout telemetry. A member-pays overage sits
   /// PENDING until the side-payment SUCCEEDS; if abandoned it must time out →

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -776,6 +776,9 @@ async function seedConsentArtifacts(users: UserWithProfiles[]) {
     for (const purposeCode of [
       PURPOSE_CODES.PRIMARY_PROCESSING,
       PURPOSE_CODES.STREAM_DATA_PROCESSING,
+      // #701 — session-booking consent, gated fail-closed at org-sponsored
+      // checkout. Mirror the signup hook so seeded users behave like signups.
+      PURPOSE_CODES.SESSION_BOOKING,
     ] as const) {
       const draft = buildConsentArtifact({
         userId: u.id,

--- a/schemas/organizations.ts
+++ b/schemas/organizations.ts
@@ -131,6 +131,12 @@ export const MemberRowSchema = z.object({
 });
 export type MemberRow = z.infer<typeof MemberRowSchema>;
 
+/** #902 — shared members page size. The SSR prefetch (lib/data/org-members) and
+ *  the client's first query MUST use this same value (and matching queryKey) or
+ *  hydration silently misses and the roster re-fetches on mount. Lives here (a
+ *  client-safe module, no prisma) so both sides can import it. */
+export const ORG_MEMBERS_PER_PAGE = 20;
+
 export const MembersListResponseSchema = z.object({
   data: z.array(MemberRowSchema).default([]),
   meta: z

--- a/scripts/cleanup/process-data-exports.ts
+++ b/scripts/cleanup/process-data-exports.ts
@@ -37,7 +37,7 @@ import { Resend } from "resend";
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
 import { recordSystemError } from "../../lib/enterprise/system-events";
-import { checkConsent } from "../../lib/compliance/dpdp";
+import { checkConsentBatch } from "../../lib/compliance/dpdp";
 import { PURPOSE_CODES } from "../../lib/compliance/purpose-codes";
 import { notifyOrgDataExportReady } from "../../lib/novu/org-workflows";
 import { getAppUrl } from "../../lib/url";
@@ -127,20 +127,16 @@ async function buildBundleFor(organizationId: string): Promise<ExportBundle> {
   // consent. Their name/email are dropped from `members` and scrubbed from the
   // membership rows (the org-relationship metadata stays). TODO(#701): extend to
   // field-level scoping across the rest of the bundle.
-  const memberConsent = new Map<string, boolean>();
-  for (const u of allMembers) {
-    memberConsent.set(
-      u.id,
-      await checkConsent({
-        userId: u.id,
-        purposeCode: PURPOSE_CODES.PRIMARY_PROCESSING,
-      }),
-    );
-  }
-  const members = allMembers.filter((u) => memberConsent.get(u.id) === true);
+  // #1019 — one batch query instead of a per-member loop (pool-safe for large
+  // orgs). consentedIds holds the members who HAVE core-processing consent.
+  const consentedIds = await checkConsentBatch({
+    userIds: allMembers.map((u) => u.id),
+    purposeCode: PURPOSE_CODES.PRIMARY_PROCESSING,
+  });
+  const members = allMembers.filter((u) => consentedIds.has(u.id));
   const excludedForConsent = allMembers.length - members.length;
   const scrubbedMemberships = memberships.map((m) =>
-    m.user && memberConsent.get(m.user.id) === false
+    m.user && !consentedIds.has(m.user.id)
       ? { ...m, user: { id: m.user.id, name: null, email: null } }
       : m,
   );

--- a/scripts/cleanup/process-data-exports.ts
+++ b/scripts/cleanup/process-data-exports.ts
@@ -37,6 +37,8 @@ import { Resend } from "resend";
 import prisma from "../../lib/prisma";
 import { AUDIT_ACTIONS } from "../../lib/enterprise/audit-actions";
 import { recordSystemError } from "../../lib/enterprise/system-events";
+import { checkConsent } from "../../lib/compliance/dpdp";
+import { PURPOSE_CODES } from "../../lib/compliance/purpose-codes";
 import { notifyOrgDataExportReady } from "../../lib/novu/org-workflows";
 import { getAppUrl } from "../../lib/url";
 import { withCronLock, LONG_JOB_TTL_MS } from "@/lib/cron/with-cron-lock";
@@ -67,6 +69,8 @@ interface ExportBundle {
   earnings: unknown[];
   payouts: unknown[];
   auditLog: unknown[];
+  /** #701 — count of members whose PII was withheld for lack of consent. */
+  excludedForConsent: number;
 }
 
 async function buildBundleFor(organizationId: string): Promise<ExportBundle> {
@@ -110,11 +114,33 @@ async function buildBundleFor(organizationId: string): Promise<ExportBundle> {
     }),
   ]);
 
-  const members = memberships
+  const allMembers = memberships
     .map((m) => m.user)
     .filter(
       (u, idx, arr) => arr.findIndex((x) => x.id === u.id) === idx,
     );
+
+  // #701 — DPDP: withhold PII for members who have withdrawn core-processing
+  // consent. Their name/email are dropped from `members` and scrubbed from the
+  // membership rows (the org-relationship metadata stays). TODO(#701): extend to
+  // field-level scoping across the rest of the bundle.
+  const memberConsent = new Map<string, boolean>();
+  for (const u of allMembers) {
+    memberConsent.set(
+      u.id,
+      await checkConsent({
+        userId: u.id,
+        purposeCode: PURPOSE_CODES.PRIMARY_PROCESSING,
+      }),
+    );
+  }
+  const members = allMembers.filter((u) => memberConsent.get(u.id) === true);
+  const excludedForConsent = allMembers.length - members.length;
+  const scrubbedMemberships = memberships.map((m) =>
+    m.user && memberConsent.get(m.user.id) === false
+      ? { ...m, user: { id: m.user.id, name: null, email: null } }
+      : m,
+  );
 
   return {
     organizationId,
@@ -122,13 +148,14 @@ async function buildBundleFor(organizationId: string): Promise<ExportBundle> {
     schemaVersion: 1,
     organization,
     members,
-    memberships,
+    memberships: scrubbedMemberships,
     contracts,
     programs,
     invoices,
     earnings,
     payouts,
     auditLog,
+    excludedForConsent,
   };
 }
 

--- a/scripts/cleanup/process-data-exports.ts
+++ b/scripts/cleanup/process-data-exports.ts
@@ -114,11 +114,14 @@ async function buildBundleFor(organizationId: string): Promise<ExportBundle> {
     }),
   ]);
 
+  const seenUserIds = new Set<string>();
   const allMembers = memberships
     .map((m) => m.user)
-    .filter(
-      (u, idx, arr) => arr.findIndex((x) => x.id === u.id) === idx,
-    );
+    .filter((u) => {
+      if (!u || seenUserIds.has(u.id)) return false;
+      seenUserIds.add(u.id);
+      return true;
+    });
 
   // #701 — DPDP: withhold PII for members who have withdrawn core-processing
   // consent. Their name/email are dropped from `members` and scrubbed from the

--- a/types/payouts.ts
+++ b/types/payouts.ts
@@ -20,4 +20,6 @@ export interface Payout {
   approvedBy?: string;
   processedAt?: string;
   failureReason?: string;
+  /** #863 — MSME §43B(h) statutory pay-by date; null for non-MSME vendors. */
+  mustPayByDate?: string | null;
 }


### PR DESCRIPTION
## Summary

Productionizes the **enterprise subsystem** so we can take on sponsor / host / hybrid customers (schools, colleges, corporate firms) across every funding mode (PERSONAL / LICENSE / WALLET / INVOICE) and entitlement (LICENSED_SEAT / CREDIT_POOL). This is one mega-PR of 11 focused commits rather than a fan-out of stacked PRs.

The work started from the Grok 4.5 charter (`prompts/enterprise-holistic-fix.md`), but every "gap" it listed was independently re-verified against `dev` first. Most were already shipped — the charter was written against a stale snapshot. The genuinely open items were narrower and mostly **"built but unwired"**, which is exactly the productionization this PR delivers.

**No schema deferrals:** this PR is the `#705` schema-freeze milestone. **Flag posture is unchanged** — every gate (`ENABLE_HOST_ORGS`, `ENABLE_LIVE_PAYOUTS`, `ENABLE_TDS_ADMIN_VIEW`, `ENABLE_DUNNING_SUSPEND`) stays off; nothing here flips production behavior on its own.

## Verification matrix (charter claim → reality on `dev`)

Recorded so reviewers can see why the scope is what it is. Each was checked against code before any change.

| Charter claim | Verdict | Evidence |
|---|---|---|
| Invoice PDF missing (#438) | **SHIPPED** | `lib/pdf/invoice-renderer.tsx` + `.../invoices/[invoiceId]/pdf/route.ts` — only *email delivery* was missing |
| Credit-limit not enforced | **SHIPPED** | hard block pre-lock + re-checked in the Serializable tx (`checkout.ts`) |
| Multi-collaborator refund journal missing | **SHIPPED** | per-collaborator `CONSULTANT_PAYABLE` loop (`refund.ts`, #812) |
| Dispute contest API missing | **SHIPPED** | `submitDisputeEvidence` → `POST /api/payments/disputes` |
| Allowlist / `exclusiveEngagement` unenforced | **SHIPPED** | enforced at checkout since #971/#982 (only the docstrings were stale) |
| SCIM token expiry unenforced | **SHIPPED** | `lib/scim/auth.ts` 401s an expired token (#789), with a regression test |
| `/billing` vs `/credits` split | **N/A** | there is no `/credits` route; one billing surface with tabs |
| `applyReversal` (CLASS multi-refund) | **UNWIRED → fixed here** | zero production callers |
| Overage credit-back on reverse | **MISSING → fixed here** | CHARGED was terminal |
| Dispute freeze (#1008) | **MISSING → fixed here** | no earnings hold / refund guard / mutation guard |
| `checkConsent()` call sites | **UNWIRED → fixed here** | real + fail-closed, zero callers |
| Consultant-side appointment scoping | **DEFERRED → fixed here** | `buildWhere` was consultee-only |

## What this PR changes

### Money trust
- **Overage credit-back (#715/#716)** — a fully-refunded booking now reverses a CHARGED overage. CHARGE_ORG nets via the existing refund credit note; CHARGE_MEMBER refunds the separate gateway side-payment after the parent settles (best-effort, ops-paged on failure). Full-reversal-only — partial refunds have no clean surcharge proration. `OverageChargeStatus.REVERSED` gains `CHARGED` as a legal from-state; `reverseBookingUtilization` narrows its guard so the uncollected and credit-back paths stay disjoint.
- **Reversal engine wired (#776 §C)** — new `lib/payments/operations/event-refunds.ts` `refundWholeEventPayments()` **partitions** a cancelled class/webinar's attendees: card/mock seats credit the gateway via `refundPayment`, org-funded seats (which `createRefund` can't route) reverse in-ledger via one `applyReversal(CLASS_MULTI)`. Routing a card seat through the engine would strand the customer's money, so the partition is load-bearing. Wired into the appointment-cancel route (class/webinar branch, after the at-most-once CAS), a **new admin refund POST** (`/api/admin/refunds`), and moderation's group-cancel (which previously failed org-funded seats with `UNKNOWN_GATEWAY`).
- **Dispute freeze (#1008)** — on dispute open, the host org's earnings are HELD alongside the consultant's. App-initiated `refundPayment` is rejected with `REFUND_BLOCKED_BY_DISPUTE` while a dispute is live (outer check + a Serializable in-tx re-check so SSI aborts a racing dispute update); the gateway-webhook cascade is deliberately **not** guarded. Cancel / reschedule return `409 DISPUTE_ACTIVE`. On terminal resolution the org earnings release (WON → READY) or refund (LOST → REFUNDED); a host share already paid out is clawed back through the reversal engine's `PAYOUT_CLAWBACK` — distinct from `applyOrgChargeback` (funder recovery), so no double-count.
- **RazorpayX balance preflight (#863)** — `assertPayoutBalance()` holds a batch when the account balance is known-insufficient (rows stay PENDING/PROCESSING, same posture as flag-off) and pages ops. Only active under `ENABLE_LIVE_PAYOUTS`; **fails open** on an unknown balance so a new read dependency can't stall payouts.

### Compliance
- **DPDP consent gates (#701 partial)** — `checkConsent` now gates the three flows that process member PII on an org's behalf: org-sponsored checkout (`SESSION_BOOKING` → 403 `CONSENT_REQUIRED`), invite acceptance (`PRIMARY_PROCESSING`), and org data export (non-consented members' PII is withheld, counted as `excludedForConsent`). Because the gate is fail-closed, `SESSION_BOOKING` is now granted at signup and in the seed (no backfill — pre-MVP reset). Adds a minimal DPDP **grievance intake** endpoint.
- **Admin TDS page** — a flag-gated read-only UI (summary, quarter-wise, consultant breakdown) over the existing `/api/admin/tds`. **No Form 26Q/140 export** — the CBDT successor codes are unconfirmed; data capture already ships.
- **MSME §43B(h)** — the admin pending-payout queue now orders by `mustPayByDate` (soonest first) with a red due-by badge inside the 5-day window.

### Dashboards / UX
- **Consultant-side appointment scoping (#674)** — `buildWhere` now returns sessions a user *delivers*, not just books, so a multi-role user (consultee + consultant, or a consultant delivering an org-sponsored booking) sees their work. Consultant arms are intentionally not constrained to `organizationId: null` because an independent consultant / host EXPERT has no org-scope access otherwise.
- **Explore "Recommended by [org]" badge (#664)** — shown when the viewer's ACTIVE org sponsors a plan's program. Viewer memberships are fetched per-request (never entering the shared curated cache).
- **Host honesty** — the create wizard hides the "Host consultants" capability when `ENABLE_HOST_ORGS` is off (the two dashboard create pages are now server components passing the real flag; the 400 gate stays as backstop); the public org directory shows a "coming soon" state instead of a silently-empty grid.
- **Invoice email (#438)** — `OrgInvoiceIssuedPayload` carries a `pdfUrl`, and the cron issuance path now fires the notification (previously only the manual route did).
- **Auto-top-up** — a "coming soon" banner makes the notify-only posture explicit (RBI e-mandate executor is a `#863` residual).
- **#902** — the org-members SSR prefetch keyed `["org-members", orgId]` returning `{members}` while the client keyed `["org-members", orgId, "", 1]` expecting `{members, total}`, so hydration never matched and the roster re-fetched on mount. Fixed the key + shape; page size is now shared from a client-safe module.

### Schema freeze + hygiene
- `#705` freeze: dropped the inert hierarchy columns, additive-only deltas, corrected stale docstrings, declared the freeze in the schema header.
- `ENABLE_DUNNING_SUSPEND` centralized into `lib/feature-flags.ts`; the dead `ENABLE_IRP_UPLOADER` export removed (its only gate is the CI repo variable). Enterprise docs synced (BigInt shipped, hierarchy dropped, SCIM live, host gate = 400 not 501).

## Open questions (decided; recommendations applied)

All resolved with the user before implementation. Notably: reversal engine wired now; overage credit-back automated both paths; dispute freeze full; auto-top-up stays notify-only; consent gates at key sites (not the full cascade); TDS UI without form export; consultant scoping implemented; host checkbox hidden; MSME queue-priority without §16 interest; broader schema cleanup (drop inert columns).

## Flag posture after this PR

- `ENABLE_HOST_ORGS`: **still off**
- `ENABLE_LIVE_PAYOUTS`: **still off**
- `ENABLE_TDS_ADMIN_VIEW`: **still off** (page + nav appear together with it)
- `ENABLE_DUNNING_SUSPEND`: **still off**

## Ops tasks before this fully lands

- Configure the Novu `org-invoice-issued` workflow's **email step** to the org `billingEmail` (code only triggers it) — required to fully close #438.
- **Sandbox-verify the RazorpayX balance endpoint** shape before `ENABLE_LIVE_PAYOUTS` ever flips.
- `db push` at merge (no migrations; pre-MVP reset posture).

## Known follow-ups (deliberately out of scope)

- Consultant **dashboard** org-pills (separate per-type endpoints with an `organizationId: null` filter) — a product call.
- Full #701 cascade (SCIM / Stream / analytics call sites) — `TODO(#701)` markers left in place.
- RBI-mandate auto-top-up executor (#863 residual).

## Testing

- `tsc --noEmit` clean on the touched source (two pre-existing `.next/types` errors for non-existent `lemon-squeezy`/`xflow` routes are stale build artifacts, unrelated).
- **1585 / 1585 jest tests pass**, including new suites: `overage-credit-back`, `event-cancel-refunds`, `dispute-freeze`, `consent-gates`, `payout-balance-preflight`, `list-appointments-scope`.

## Issue links

Closes #902
Closes #1008
Closes #664
Closes #438

Part of #863
Part of #746
Part of #701
Part of #705
Part of #677
Part of #684
Part of #688
Part of #715
Part of #716
Part of #674
Part of #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin refunds for single payments and whole classes/webinars.
  * Introduced DPDP grievance intake with fail-closed consent enforcement on relevant actions.
  * Added an admin TDS dashboard and “Recommended by” labels for sponsored program cards.
  * Added MSME “Due by (MSME)” visibility for pending payouts.
* **Bug Fixes**
  * Blocked appointment cancel/reschedule when a payment dispute is active.
  * Improved dispute-aware refunds, including whole-event refunds and overage credit-backs.
* **Updates**
  * Added direct PDF links to invoice notifications, refreshed host-org gating/coming-soon behavior, aligned org members pagination, and added consent-safe organization export scrubbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->