### PR TITLE
feat(collaborators): relocate collaborator management by plan org-ness (#1025)

### DIFF
--- a/app/api/collaborations/route.ts
+++ b/app/api/collaborations/route.ts
@@ -1,13 +1,18 @@
 import * as Sentry from "@sentry/nextjs";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth-server";
 import prisma from "@/lib/prisma";
 import {
   getMyCollaborations,
   getHostedCollaborations,
 } from "@/lib/collaborators/service";
+import { resolveOrgScope } from "@/lib/api/scope/parse";
 
-export async function GET() {
+// #org-appts / #1025 — hosted-plan collaborators split by the PLAN's
+// org-ness: org-hosted plans belong in the org dashboard, B2C plans in the
+// personal one. `?orgScope=` picks the hosted-plan slice; received
+// invitations (getMyCollaborations) always aggregate personally.
+export async function GET(request: NextRequest) {
   try {
     const session = await getSession();
     if (!session?.user?.id) {
@@ -29,9 +34,28 @@ export async function GET() {
       });
     }
 
+    const { searchParams } = new URL(request.url);
+    const memberships = await prisma.membership.findMany({
+      where: { userId: session.user.id, status: "ACTIVE" },
+      select: { organizationId: true, status: true },
+    });
+    const scopeResolution = resolveOrgScope({
+      raw: searchParams.get("orgScope"),
+      memberships,
+      userRole: session.user.role,
+      // Self-scoped to the caller's own hosted plans — no cross-tenant leak.
+      allowAllForOwner: true,
+    });
+    if (!scopeResolution.ok) {
+      return NextResponse.json(
+        { error: scopeResolution.message, code: scopeResolution.code },
+        { status: scopeResolution.status },
+      );
+    }
+
     const [collaborations, hosted] = await Promise.all([
       getMyCollaborations(consultantProfile.id),
-      getHostedCollaborations(consultantProfile.id),
+      getHostedCollaborations(consultantProfile.id, scopeResolution.scope),
     ]);
 
     return NextResponse.json({

--- a/app/api/collaborations/route.ts
+++ b/app/api/collaborations/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const { searchParams } = new URL(request.url);
+    const { searchParams } = request.nextUrl;
     const memberships = await prisma.membership.findMany({
       where: { userId: session.user.id, status: "ACTIVE" },
       select: { organizationId: true, status: true },

--- a/app/dashboard/organization/[orgId]/collaborations/page.tsx
+++ b/app/dashboard/organization/[orgId]/collaborations/page.tsx
@@ -1,0 +1,46 @@
+/**
+ * /dashboard/organization/[orgId]/collaborations — this org's hosted-plan
+ * collaborators (#org-appts / #1025).
+ *
+ * Collaborators are split by the PLAN's org-ness, not the consultant's:
+ * webinar/class plans with this org's organizationId are managed here;
+ * B2C plans stay on the personal consultant dashboard. Received
+ * invitations still aggregate personally either way — this page only
+ * covers the host-perspective "my plans with collaborators" section.
+ *
+ * Access: ANY active member (requireOrgAccess floors at that); the sidebar
+ * additionally gates visibility on canHost + myArrangement.read (see
+ * layout.tsx) since only host-capable orgs have collaborator-bearing plans.
+ */
+
+import { notFound } from "next/navigation";
+
+import { requireOrgAccess } from "@/lib/auth-helpers";
+import { InvitationsPanel } from "@/components/collaborators/InvitationsPanel";
+
+export default async function OrgCollaborationsPage({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) {
+  const { orgId } = await params;
+
+  const access = await requireOrgAccess(orgId);
+  if (access.error) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Collaborations</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage invitations and active collaborations on {access.org.name}
+          &apos;s webinar and class plans.
+        </p>
+      </header>
+
+      <InvitationsPanel orgScope={orgId} />
+    </div>
+  );
+}

--- a/app/dashboard/organization/[orgId]/layout.tsx
+++ b/app/dashboard/organization/[orgId]/layout.tsx
@@ -227,6 +227,16 @@ export default function OrgLayout({
         show: can("myArrangement.read") && canHost,
       },
       {
+        // #org-appts / #1025 — collaborators on THIS org's hosted webinar/class
+        // plans. Mirrors Compensation's gate: only host-capable orgs have
+        // collaborator-bearing plans, and inviting/managing collaborators is
+        // the plan-owning EXPERT's own surface.
+        name: "Collaborations",
+        icon: Users,
+        path: "collaborations",
+        show: can("myArrangement.read") && canHost,
+      },
+      {
         // Any ACTIVE member — learners who ATTEND org sessions and experts
         // who DELIVER them both need their own per-org appointments surface.
         // Deliberately NOT gated on canHost (that would exclude pure
@@ -569,6 +579,7 @@ export default function OrgLayout({
     home:               "Overview",
     "my-appointments":  "My Appointments",
     compensation:       "Compensation",
+    collaborations:     "Collaborations",
     members:      "Members",
     invitations:  "Invitations",
     learners:     "Learners",

--- a/components/collaborators/InvitationsPanel.tsx
+++ b/components/collaborators/InvitationsPanel.tsx
@@ -11,6 +11,13 @@
  * the schedule cluster in ScheduleSummaries and shapes in types.ts.
  * There are deliberately NO confirm dialogs — Accept/Decline fire the
  * mutation directly, as before.
+ *
+ * #org-appts / #1025 — the Host section is scoped by the PLAN's org-ness.
+ * `orgScope` unset (personal dashboard) shows only B2C hosted plans;
+ * passing an orgId (org dashboard) shows only that org's hosted plans.
+ * Received invitations are unaffected either way. The scope is threaded
+ * into the query key so the two views don't collide in the react-query
+ * cache.
  */
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -28,14 +35,17 @@ import { PendingInvitationCard } from "./PendingInvitationCard";
 import { ActiveCollaborationCard } from "./ActiveCollaborationCard";
 import { HostedPlanCard } from "./HostedPlanCard";
 
-export function InvitationsPanel() {
+export function InvitationsPanel({ orgScope }: { orgScope?: string } = {}) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const { data, isLoading, isError, refetch } = useQuery<CollaborationsData>({
-    queryKey: ["my-collaborations"],
+    queryKey: ["my-collaborations", orgScope ?? "mine"],
     queryFn: async () => {
-      const res = await fetch("/api/collaborations");
+      const url = orgScope
+        ? `/api/collaborations?orgScope=${encodeURIComponent(orgScope)}`
+        : "/api/collaborations";
+      const res = await fetch(url);
       if (!res.ok) throw new Error("Failed to fetch collaborations");
       const json = await res.json();
       return json.data;

--- a/lib/collaborators/service.ts
+++ b/lib/collaborators/service.ts
@@ -15,6 +15,7 @@ import {
   notifyCollaboratorRemoved,
 } from "@/lib/novu/service";
 import { getAppUrl } from "@/lib/url";
+import { scopeToWhereOrgId, type Scope } from "@/lib/api/scope/parse";
 
 type PlanType = "webinar" | "class";
 
@@ -688,12 +689,23 @@ export async function getMyCollaborations(consultantProfileId: string) {
 /**
  * Get all plans owned by this consultant that have collaborators.
  * Returns plans with their collaborator lists and schedule data (host perspective).
+ *
+ * #org-appts / #1025 — split by the PLAN's org-ness, not the consultant's:
+ * `personal` (default) surfaces only B2C plans (organizationId: null), an
+ * `org` scope surfaces only that org's plans. Received invitations
+ * (getMyCollaborations) are unaffected — those still aggregate personally.
  */
-export async function getHostedCollaborations(consultantProfileId: string) {
+export async function getHostedCollaborations(
+  consultantProfileId: string,
+  scope: Scope = { kind: "personal" },
+) {
+  const orgFilter = scopeToWhereOrgId(scope);
+
   const [webinarPlans, classPlans] = await Promise.all([
     prisma.webinarPlan.findMany({
       where: {
         consultantProfileId,
+        ...orgFilter,
         collaborators: {
           some: { status: { in: ["PENDING", "ACCEPTED"] } },
         },
@@ -740,6 +752,7 @@ export async function getHostedCollaborations(consultantProfileId: string) {
     prisma.classPlan.findMany({
       where: {
         consultantProfileId,
+        ...orgFilter,
         collaborators: {
           some: { status: { in: ["PENDING", "ACCEPTED"] } },
         },


### PR DESCRIPTION
## Summary

Splits collaborator management by the **plan's org-ness** (follow-up to the personal-vs-org dashboard split, #1021/#1023): collaborators on an **org-hosted** webinar/class plan are managed in the **org dashboard**; collaborators on a **B2C** plan in the **personal consultant dashboard**. Received invitations still aggregate in the personal dashboard (unchanged).

## What changed
- **`lib/collaborators/service.ts`** — `getHostedCollaborations` takes an optional `Scope` (default `personal` → `organizationId: null`; org → that org), applied to the webinar/class plan `where` via the existing `scopeToWhereOrgId`. `getMyCollaborations` (received invites) untouched.
- **`app/api/collaborations/route.ts`** — parses `?orgScope=` via `resolveOrgScope`, requires an ACTIVE org membership for an org scope (403 otherwise), passes the resolved scope to `getHostedCollaborations`. Absent → personal (B2C).
- **`components/collaborators/InvitationsPanel.tsx`** — optional `orgScope` prop threaded into the fetch URL + react-query key so personal/org views don't collide in cache; invalidation still prefix-matches both.
- **New `app/dashboard/organization/[orgId]/collaborations/page.tsx`** — org surface, `requireOrgAccess` (active member; 404 otherwise), renders the panel in org mode. New org nav item + `PAGE_LABELS` entry.
- Personal consultant collaborations page now shows only B2C-plan collaborators (API personal default).

Revenue-split / invite / accept logic is untouched — only the hosted-plan listing gains an org dimension.

## Testing
tsc 0, eslint clean. No existing test exercises the hosted-plan listing directly; the revenue-split money tests are untouched.

Closes #1025
Part of #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an organization-specific Collaborations page with access controls.
  * Added a Collaborations tab to eligible organization dashboards.
  * Collaboration invitations now support personal and organization-scoped views.
  * Hosted collaborations are filtered according to the selected organization scope.
  * Updated navigation breadcrumbs to recognize the Collaborations page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->