### PR TITLE
feat(earnings): split consultant earnings view by org-ness (#1024)

### DIFF
--- a/app/api/consultant/earnings/route.ts
+++ b/app/api/consultant/earnings/route.ts
@@ -47,10 +47,9 @@ export async function GET(req: NextRequest) {
     // Membership lookup is only needed to authorize a specific `orgId`
     // scope value; "mine"/"personal"/"all" never touch the membership
     // table.
-    const rawOrgScope = searchParams.get("orgScope");
+    const rawOrgScope = searchParams.get("orgScope")?.trim();
     const needsMemberships =
-      !!rawOrgScope &&
-      !["mine", "personal", "all"].includes(rawOrgScope.trim());
+      !!rawOrgScope && !["mine", "personal", "all"].includes(rawOrgScope);
     const callerMemberships = needsMemberships
       ? await prisma.membership.findMany({
           where: { userId: session.user.id, status: "ACTIVE" },
@@ -74,9 +73,10 @@ export async function GET(req: NextRequest) {
     const organizationId =
       scopeResolution.scope.kind === "personal"
         ? null
-        : scopeResolution.scope.kind === "org"
+        : scopeResolution.scope.kind === "org" ||
+            scopeResolution.scope.kind === "orgMember"
           ? scopeResolution.scope.orgId
-          : undefined; // "all" → no filter
+          : undefined; // "all" → no filter (org-data isolation for org/orgMember)
 
     const payload = await buildConsultantEarningsPayload(consultantProfile.id, {
       status: status || undefined,

--- a/app/api/consultant/earnings/route.ts
+++ b/app/api/consultant/earnings/route.ts
@@ -9,6 +9,7 @@ import prisma from "@/lib/prisma";
 import { EarningStatus } from "@prisma/client";
 import { getSession } from "@/lib/auth-server";
 import { buildConsultantEarningsPayload } from "@/lib/data/consultant-earnings-analytics";
+import { resolveOrgScope } from "@/lib/api/scope/parse";
 
 /**
  * GET /api/consultant/earnings
@@ -42,11 +43,47 @@ export async function GET(req: NextRequest) {
     // analytics page. Absent param = response unchanged.
     const includeMonthly = searchParams.get("includeMonthly") === "1";
 
+    // #org-appts (#1024) — personal Earnings view splits by org-ness.
+    // Membership lookup is only needed to authorize a specific `orgId`
+    // scope value; "mine"/"personal"/"all" never touch the membership
+    // table.
+    const rawOrgScope = searchParams.get("orgScope");
+    const needsMemberships =
+      !!rawOrgScope &&
+      !["mine", "personal", "all"].includes(rawOrgScope.trim());
+    const callerMemberships = needsMemberships
+      ? await prisma.membership.findMany({
+          where: { userId: session.user.id, status: "ACTIVE" },
+          select: { organizationId: true, status: true },
+        })
+      : [];
+    const scopeResolution = resolveOrgScope({
+      raw: rawOrgScope,
+      memberships: callerMemberships,
+      userRole: session.user.role,
+      // Self-scoped consultant endpoint — `?orgScope=all` just means
+      // "everything I earned, personal + every org I belong to".
+      allowAllForOwner: true,
+    });
+    if (!scopeResolution.ok) {
+      return NextResponse.json(
+        { error: scopeResolution.message, code: scopeResolution.code },
+        { status: scopeResolution.status },
+      );
+    }
+    const organizationId =
+      scopeResolution.scope.kind === "personal"
+        ? null
+        : scopeResolution.scope.kind === "org"
+          ? scopeResolution.scope.orgId
+          : undefined; // "all" → no filter
+
     const payload = await buildConsultantEarningsPayload(consultantProfile.id, {
       status: status || undefined,
       limit,
       offset,
       includeMonthly,
+      organizationId,
     });
 
     return NextResponse.json(payload);

--- a/app/dashboard/consultant/[consultantId]/(features)/analytics/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/analytics/page.tsx
@@ -26,9 +26,12 @@ export default async function AnalyticsPage({ params }: Readonly<PageProps>) {
     queryClient.prefetchQuery({
       queryKey: ["consultant-earnings-analytics", consultantId],
       queryFn: () =>
+        // #org-appts (#1024) — personal dashboard = B2C-only VIEW.
+        // Explicit to match the client's default (unset orgScope).
         buildConsultantEarningsPayload(consultantId, {
           limit: 1,
           includeMonthly: true,
+          organizationId: null,
         }),
     }),
     queryClient.prefetchQuery({

--- a/lib/data/consultant-earnings-analytics.ts
+++ b/lib/data/consultant-earnings-analytics.ts
@@ -23,10 +23,16 @@ export interface MonthlyEarning {
  * Aggregates ALL rows in the window (not the paginated history slice —
  * a `limit`-truncated reduce would undercount every month but the newest).
  * Empty months are zero-filled so the chart never has gaps.
+ *
+ * `organizationId` is an OPTIONAL view-scope filter (#org-appts #1024):
+ * omitted (`undefined`) = no filter, identical to pre-#1024 behavior, for
+ * any caller outside the earnings-view path. `null` scopes to personal
+ * (B2C) earnings; a string scopes to that org's earnings.
  */
 export async function getConsultantMonthlyEarnings(
   consultantProfileId: string,
   months = 6,
+  organizationId?: string | null,
 ): Promise<MonthlyEarning[]> {
   // One clock read for the whole computation — repeated new Date() calls
   // could straddle a month rollover and misalign the buckets vs the query
@@ -34,7 +40,11 @@ export async function getConsultantMonthlyEarnings(
   const now = new Date();
   const since = startOfMonth(subMonths(now, months - 1));
   const rows = await prisma.consultantEarnings.findMany({
-    where: { consultantProfileId, createdAt: { gte: since } },
+    where: {
+      consultantProfileId,
+      createdAt: { gte: since },
+      ...(organizationId !== undefined ? { payment: { organizationId } } : {}),
+    },
     select: { createdAt: true, consultantSharePaise: true },
   });
 
@@ -63,6 +73,14 @@ export interface ConsultantEarningsPayloadOptions {
   limit?: number;
   offset?: number;
   includeMonthly?: boolean;
+  /**
+   * #org-appts (#1024) — VIEW scope. `null` (default, including when the
+   * key is omitted entirely) = personal/B2C-only, matching the personal
+   * dashboard's Earnings view. A string scopes to that org's earnings.
+   * `undefined` means "no filter" (admin `?orgScope=all`) — passed
+   * explicitly, since an omitted key defaults to personal instead.
+   */
+  organizationId?: string | null;
 }
 
 /**
@@ -75,13 +93,28 @@ export async function buildConsultantEarningsPayload(
   options: ConsultantEarningsPayloadOptions = {},
 ) {
   const { status, limit = 20, offset = 0, includeMonthly = false } = options;
+  // Explicit key check (not a destructuring default): an admin's
+  // `?orgScope=all` resolves to organizationId === undefined (no filter),
+  // which a destructuring default would silently collapse back to `null`
+  // (personal). Omitting the key entirely still defaults to personal —
+  // #org-appts (#1024): VIEW splits by org-ness; payout eligibility stays
+  // whole (shared instrument), so it's never scoped below.
+  const organizationId: string | null | undefined =
+    "organizationId" in options ? options.organizationId : null;
 
   const [summary, eligibility, history, monthlyEarnings] = await Promise.all([
-    getConsultantEarningsSummary(consultantProfileId),
+    getConsultantEarningsSummary(consultantProfileId, organizationId),
+    // #org-appts (#1024) — VIEW splits by org-ness; payout eligibility
+    // stays whole (shared instrument).
     checkPayoutEligibility(consultantProfileId),
-    getConsultantEarnings(consultantProfileId, { status, limit, offset }),
+    getConsultantEarnings(consultantProfileId, {
+      status,
+      limit,
+      offset,
+      organizationId,
+    }),
     includeMonthly
-      ? getConsultantMonthlyEarnings(consultantProfileId)
+      ? getConsultantMonthlyEarnings(consultantProfileId, 6, organizationId)
       : Promise.resolve(undefined),
   ]);
 

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -847,35 +847,67 @@ export async function releaseEarningsFromHold(): Promise<number> {
 }
 
 /**
- * Get consultant earnings summary
+ * Get consultant earnings summary.
+ *
+ * `organizationId` is an OPTIONAL view-scope filter (#org-appts #1024):
+ * omitted (`undefined`) = no filter, identical to pre-#1024 behavior, for
+ * any caller outside the earnings-view path. `null` scopes to personal
+ * (B2C) earnings; a string scopes to that org's earnings.
  */
 export async function getConsultantEarningsSummary(
   consultantProfileId: string,
+  organizationId?: string | null,
 ): Promise<EarningsSummary> {
+  const orgFilter =
+    organizationId !== undefined ? { payment: { organizationId } } : {};
   const [pending, ready, batched, paid, held, pendingTrust] =
     await Promise.all([
       prisma.consultantEarnings.aggregate({
-        where: { consultantProfileId, status: EarningStatus.PENDING },
+        where: {
+          consultantProfileId,
+          status: EarningStatus.PENDING,
+          ...orgFilter,
+        },
         _sum: { consultantSharePaise: true },
       }),
       prisma.consultantEarnings.aggregate({
-        where: { consultantProfileId, status: EarningStatus.READY },
+        where: {
+          consultantProfileId,
+          status: EarningStatus.READY,
+          ...orgFilter,
+        },
         _sum: { consultantSharePaise: true },
       }),
       prisma.consultantEarnings.aggregate({
-        where: { consultantProfileId, status: EarningStatus.BATCHED },
+        where: {
+          consultantProfileId,
+          status: EarningStatus.BATCHED,
+          ...orgFilter,
+        },
         _sum: { consultantSharePaise: true },
       }),
       prisma.consultantEarnings.aggregate({
-        where: { consultantProfileId, status: EarningStatus.PAID },
+        where: {
+          consultantProfileId,
+          status: EarningStatus.PAID,
+          ...orgFilter,
+        },
         _sum: { consultantSharePaise: true },
       }),
       prisma.consultantEarnings.aggregate({
-        where: { consultantProfileId, status: EarningStatus.HELD },
+        where: {
+          consultantProfileId,
+          status: EarningStatus.HELD,
+          ...orgFilter,
+        },
         _sum: { consultantSharePaise: true },
       }),
       prisma.consultantEarnings.aggregate({
-        where: { consultantProfileId, status: EarningStatus.PENDING_TRUST },
+        where: {
+          consultantProfileId,
+          status: EarningStatus.PENDING_TRUST,
+          ...orgFilter,
+        },
         _sum: { consultantSharePaise: true },
       }),
     ]);
@@ -908,7 +940,12 @@ export async function getConsultantEarningsSummary(
 }
 
 /**
- * Get consultant earnings with pagination and filters
+ * Get consultant earnings with pagination and filters.
+ *
+ * `organizationId` is an OPTIONAL view-scope filter (#org-appts #1024):
+ * omitted (`undefined`) = no filter, identical to pre-#1024 behavior, for
+ * any caller outside the earnings-view path. `null` scopes to personal
+ * (B2C) earnings; a string scopes to that org's earnings.
  */
 export async function getConsultantEarnings(
   consultantProfileId: string,
@@ -916,15 +953,19 @@ export async function getConsultantEarnings(
     status?: EarningStatus;
     limit?: number;
     offset?: number;
+    organizationId?: string | null;
   },
 ) {
-  const { status, limit = 20, offset = 0 } = options || {};
+  const { status, limit = 20, offset = 0, organizationId } = options || {};
+  const orgFilter =
+    organizationId !== undefined ? { payment: { organizationId } } : {};
 
   const [earnings, total] = await Promise.all([
     prisma.consultantEarnings.findMany({
       where: {
         consultantProfileId,
         ...(status ? { status } : {}),
+        ...orgFilter,
       },
       include: {
         payment: {
@@ -958,6 +999,7 @@ export async function getConsultantEarnings(
       where: {
         consultantProfileId,
         ...(status ? { status } : {}),
+        ...orgFilter,
       },
     }),
   ]);


### PR DESCRIPTION
## Summary

Completes the **money-view split by org-ness** (follow-up to #1021/#1023). The personal consultant dashboard's **Earnings view** was mixing B2C and org-hosted earnings; it now shows **B2C only** (org-hosted earnings live in the org dashboard's existing compensation/earnings surfaces).

A full audit (see #1024) found the other money views **already** split: consultee payments already use `resolveOrgScope`; org earnings/payouts/compensation are physically separate tables/surfaces; disputes are admin/org-scoped via the payment; credit-notes have no list view. So **consultant earnings was the only gap** — this PR closes it.

## What changed
- **`lib/payments/payouts/earnings-service.ts`** — `getConsultantEarningsSummary` + `getConsultantEarnings` gain an **optional** `organizationId?: string | null`; when set it adds `payment: { organizationId }` to the `where`, when omitted nothing changes (backward-compatible).
- **`lib/data/consultant-earnings-analytics.ts`** — `getConsultantMonthlyEarnings` + `buildConsultantEarningsPayload` thread the optional filter into the three **VIEW** functions (summary, history, monthly). Default = personal (`null`).
- **`app/api/consultant/earnings/route.ts`** — parses `?orgScope=` (`resolveOrgScope`, `allowAllForOwner`); absent → personal, org → that org, `all` (admin) → unfiltered.
- **analytics page** — SSR prefetch passes `organizationId: null` for hydration parity.

## Money-safety (the key invariant)
The split is **view-only**. `checkPayoutEligibility` and all payout/settlement code have a **zero-line diff** — payout eligibility reflects the **shared PayoutAccount instrument** (the whole payout), which is *not* split, per the money model (views split, instruments shared). No money arithmetic changed; only `where`-clause filters were added, all gated on `organizationId !== undefined`.

## Testing
tsc 0, eslint clean. Earnings/payout suites green (10 suites / 35 tests, incl. `earning-status-transitions`, `multi-party-booking-journal`, `collaborator-org-earnings`).

Closes #1024
Part of #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added earnings analytics filtering by personal, organization-specific, or all available earnings.
  * Added support for organization scope selection through the consultant earnings view.
  * Ensured summaries, monthly trends, earnings lists, and pagination reflect the selected scope.

* **Bug Fixes**
  * Improved handling of invalid or unauthorized organization scopes with structured errors.
  * Preserved personal dashboard behavior when no organization scope is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->