### PR TITLE
fix(scope): stop default scopes silently hiding org-funded rows

### DIFF
--- a/__tests__/security/org-scope-defaults.test.ts
+++ b/__tests__/security/org-scope-defaults.test.ts
@@ -1,0 +1,119 @@
+/**
+ * A default scope that silently hides org-funded rows has now been found four
+ * times: the consultee home feed, the consultee payments list, the chat inbox,
+ * and the consultant Requests tab. Each was fixed where it was found; this file
+ * pins the whole class so the fifth one fails a test instead of shipping.
+ *
+ * The failure mode is always the same and always quiet. Nothing errors, no row
+ * is marked missing — a surface simply renders a subset and looks complete. The
+ * Requests case was the worst of the four: `RequestSlotAllocationTab` fetches
+ * the two endpoints an expert uses to allocate slots, both of which drop
+ * org-funded rows when `orgScope` is absent. An org-sponsored subscription was
+ * therefore paid for and then never scheduled, because the request to allocate
+ * its slots never appeared on the only surface that can act on it.
+ *
+ * Why the call sites rather than the defaults: the right default genuinely
+ * differs by surface. A spend report wants personal; an inbox wants everything.
+ * Flipping `resolveOrgScope` to `all` would relocate the bug into the surfaces
+ * this repo spent PR #1029 narrowing. So each caller states its intent, and
+ * these tests make omission loud.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { execFileSync } from "child_process";
+
+const read = (rel: string) => readFileSync(join(process.cwd(), rel), "utf8");
+
+/** ripgrep-free source sweep over the app, restricted to tracked files. */
+function trackedFiles(...globs: string[]): string[] {
+  const out = execFileSync("git", ["ls-files", ...globs], {
+    encoding: "utf8",
+    cwd: process.cwd(),
+  });
+  return out.split("\n").filter(Boolean);
+}
+
+describe("useOrgScope callers state their default", () => {
+  const CALLERS = trackedFiles("app/**/*.tsx", "app/**/*.ts", "components/**/*.tsx")
+    .filter((f) => read(f).includes("useOrgScope("))
+    .filter((f) => !f.endsWith("hooks/useOrgScope.ts"));
+
+  it("finds the call sites (guards against the sweep silently matching nothing)", () => {
+    expect(CALLERS.length).toBeGreaterThan(0);
+  });
+
+  it.each(CALLERS)("%s passes defaultForOrgMember explicitly", (rel) => {
+    const src = read(rel);
+    // A bare `useOrgScope()` inherits "first-org", which pins the surface to
+    // whichever org happens to be first and hides the member's personal rows
+    // plus every other org's. That is never what a caller means; it is what a
+    // caller forgot to say.
+    expect(src).not.toMatch(/useOrgScope\(\s*\)/);
+    expect(src).toContain("defaultForOrgMember");
+  });
+});
+
+describe("routes that drop org rows by default are always called with a scope", () => {
+  /**
+   * `/api/bookings/consultations` and `/api/bookings/subscriptions` apply
+   * `appointments: { none: { organizationId: { not: null } } }` when the param
+   * is missing. Any caller that omits it gets B2C rows only.
+   */
+  const GUARDED_ENDPOINTS = [
+    "/api/bookings/consultations",
+    "/api/bookings/subscriptions",
+  ];
+
+  const CALLERS = trackedFiles(
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "components/**/*.tsx",
+    "hooks/**/*.ts",
+  ).filter((f) => {
+    if (f.startsWith("app/api/")) return false; // the routes themselves
+    const src = read(f);
+    return GUARDED_ENDPOINTS.some((e) => src.includes(`${e}?`));
+  });
+
+  it("finds the call sites", () => {
+    expect(CALLERS.length).toBeGreaterThan(0);
+  });
+
+  it.each(CALLERS)("%s sends orgScope on every guarded fetch", (rel) => {
+    const src = read(rel);
+    // Every line that builds one of these URLs must carry the param. Checking
+    // per line rather than per file, so a file with one correct and one
+    // forgotten call still fails.
+    const offenders = src
+      .split("\n")
+      .filter((line) =>
+        GUARDED_ENDPOINTS.some((e) => line.includes(`${e}?`)),
+      )
+      .filter((line) => !line.includes("orgScope="));
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("the two guarded routes still behave as documented", () => {
+  it.each([
+    "app/api/bookings/consultations/route.ts",
+    "app/api/bookings/subscriptions/route.ts",
+  ])("%s excludes org rows when the param is absent", (rel) => {
+    const src = read(rel);
+    // Pinning the behaviour the callers above compensate for. If this ever
+    // changes, the call-site requirement can be relaxed — but deliberately,
+    // not by accident.
+    //
+    // The two routes phrase the exclusion differently and both are correct:
+    // subscriptions uses `appointments: { none: { organizationId: not null } }`,
+    // while consultations needs an OR because a consultation with no
+    // Appointment row is not org-funded. Assert the behaviour, not one route's
+    // wording.
+    expect(src).toContain("defaultPersonal");
+    expect(src).toMatch(
+      /none: \{ organizationId: \{ not: null \} \}|appointment: \{ organizationId: null \}/,
+    );
+  });
+});

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTab.tsx
@@ -158,10 +158,10 @@ export function RequestSlotAllocationTab({
       // Fetch data in parallel (only PENDING requests).
       const [consultationsResult, subscriptionsResult] = await Promise.all([
         fetchDataFromApi<ConsultationApiResponse[]>(
-          `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING`,
+          `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING&orgScope=all`,
         ),
         fetchDataFromApi<SubscriptionApiResponse[]>(
-          `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING`,
+          `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING&orgScope=all`,
         ),
       ]);
 

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTabMini.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/RequestSlotAllocationTabMini.tsx
@@ -49,10 +49,10 @@ export function RequestSlotAllocationTabMini() {
         setLoading(true);
         const [consultationsRes, subscriptionsRes] = await Promise.all([
           fetch(
-            `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING`,
+            `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING&orgScope=all`,
           ),
           fetch(
-            `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING`,
+            `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING&orgScope=all`,
           ),
         ]);
 

--- a/app/dashboard/consultant/[consultantId]/utils/fetchHelpers.ts
+++ b/app/dashboard/consultant/[consultantId]/utils/fetchHelpers.ts
@@ -81,10 +81,10 @@ export async function fetchApprovals(
     // Fetch both consultations and subscriptions
     const [consultationsRes, subscriptionsRes] = await Promise.all([
       fetch(
-        `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING`,
+        `/api/bookings/consultations?consultantProfileId=${consultantId}&status=PENDING&orgScope=all`,
       ),
       fetch(
-        `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING`,
+        `/api/bookings/subscriptions?consultantProfileId=${consultantId}&status=PENDING&orgScope=all`,
       ),
     ]);
 

--- a/components/chat/ChatSidebar.tsx
+++ b/components/chat/ChatSidebar.tsx
@@ -149,7 +149,13 @@ ChannelItem.displayName = "ChannelItem";
 export const ChatSidebar = () => {
   const { client, setActiveChannel } = useChatContext();
   const userRole = client?.user?.role as string | undefined;
-  const { scope } = useOrgScope();
+  // `all`, not the hook's `first-org` default. A conversation belongs to the
+  // two people in it; scoping the inbox by who funded the session hid a
+  // member's B2C chats behind their first org, and hid every conversation in a
+  // second org entirely — with no picker to change it, since ADR 19 removed the
+  // personal-dashboard context filter. The org still cannot read any of this;
+  // see ADR 20. Chat is mounted only in the personal trees.
+  const { scope } = useOrgScope({ defaultForOrgMember: "all" });
   const [teamChannels, setTeamChannels] = useState<Channel[]>([]);
   const [directMessages, setDirectMessages] = useState<Channel[]>([]);
   const [activeChannelId, setActiveChannelId] = useState<string | null>(null);

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -142,12 +142,16 @@ function useEventsInternal(mode: TEventQueryMode): IEventsResult {
           queryParam = `consulteeProfileId=${identifier}`;
         }
 
+        // `orgScope=all` on every leg: these routes exclude org-funded rows
+        // when the param is absent, and every consumer of this hook wants the
+        // caller's whole picture. `all` is "all of MY rows" here — the routes
+        // are self-scoped by profile id (allowAllForOwner in parse.ts).
         const [consultationsRes, subscriptionsRes, webinarsRes, classesRes] =
           await Promise.all([
-            fetch(`/api/bookings/consultations?${queryParam}`),
-            fetch(`/api/bookings/subscriptions?${queryParam}`),
-            fetch(`/api/bookings/webinars?${queryParam}`),
-            fetch(`/api/bookings/classes?${queryParam}`),
+            fetch(`/api/bookings/consultations?${queryParam}&orgScope=all`),
+            fetch(`/api/bookings/subscriptions?${queryParam}&orgScope=all`),
+            fetch(`/api/bookings/webinars?${queryParam}&orgScope=all`),
+            fetch(`/api/bookings/classes?${queryParam}&orgScope=all`),
           ]);
 
         if (


### PR DESCRIPTION
Fourth instance of one pattern: a surface resolves a default scope, that default
excludes org-funded rows, and the surface renders a subset while looking
complete. Nothing errors and no row is marked missing. `consultee/home` and
`consultee/payments` were fixed when found; these two were not.

## 1. Slot-allocation requests never reached the expert

`RequestSlotAllocationTab` is the **only** surface in the product that allocates
slots — there is no requests or allocation page anywhere under
`app/dashboard/organization/`. It fetched `/api/bookings/consultations` and
`/api/bookings/subscriptions` with no `orgScope`, and both routes apply this
when the param is absent:

```ts
const defaultPersonal = !rawOrgScope && !isPrivileged(role);
if (explicitPersonal || defaultPersonal) { /* excludes org-funded rows */ }
```

So an org-sponsored subscription was paid for and then **never scheduled**. The
request to allocate its slots existed and appeared on no surface that could act
on it. Money moved; the sessions did not happen.

Four call sites now send `orgScope=all` — the requests tab, its home-page mini
variant, the shared consultant `fetchHelpers`, and `useEvents`. All four read
the caller's OWN rows and the routes are self-scoped by profile id, so `all`
means "all of mine" (`allowAllForOwner`), not a widening.

## 2. The chat inbox was pinned to one org

`ChatSidebar` called `useOrgScope()` bare. That defaults to `first-org`, so the
channel query became `organization_id: { $eq: firstOrgId }` — a member's B2C
conversations disappeared behind their first org, and a member of two orgs never
saw the second one's at all. With no way to change it, since ADR 19 removed the
personal-dashboard context filter and nothing renders a scope picker.

The channel topology needed nothing: `messaging` DMs for consultations and
subscriptions, `team` channels for webinars and classes, all tagged with
`organization_id` by the shared creator, and the sidebar already queried both
types. Only the filter was wrong.

**Chat stays out of the organization dashboard and the org still cannot read any
of it — ADR 20 is untouched.** This is about a member reaching their own
conversations.

## Why the call sites, not the defaults

The right default genuinely differs by surface: a spend report wants personal,
an inbox wants everything. Flipping `resolveOrgScope` would relocate the bug
into the surfaces #1029 spent its length narrowing.

`__tests__/security/org-scope-defaults.test.ts` pins the class instead — every
`useOrgScope` caller must state `defaultForOrgMember`, and every caller of the
two org-excluding endpoints must send `orgScope`, checked per line so one
correct and one forgotten call in the same file still fails.

## Verification

`tsc` clean · 1807 tests / 157 suites · lint clean on the diff. The new test was
confirmed failing 4/11 against the pre-fix code.

Audit scope, per the agreed approach: 4 `useOrgScope` call sites (3 already
correct), 2 routes carrying the excluding default, 4 callers of those routes.
All now explicit.

No schema change, so no DB push.

## Not in this PR

The participant affordances for the org dashboard — a Message action on session
cards, plus reschedule/cancel and own-documents — are agreed but are feature
work. They follow separately so this correctness fix is not held behind them.

Part of #1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected data loading so pending requests, events, and conversations consistently include the appropriate scope.
  * Ensured relevant booking data is not inadvertently hidden when viewing request and event lists.
  * Added safeguards to prevent future scope-related regressions across protected routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->