### PR TITLE
release: dev → prod — 2026-07-28 (#2) waitlist signup hardening

### DIFF
--- a/__tests__/waitlist/confirm-email-signing.test.ts
+++ b/__tests__/waitlist/confirm-email-signing.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The email layer itself, unmocked.
+ *
+ * `subscribe-send-failure.test.ts` mocks `lib/email` wholesale, so
+ * `buildConfirmUrl` never runs there and the original regression would slip
+ * through it. This suite exercises the real signing path: with no
+ * `WAITLIST_HMAC_SECRET` in a production environment, link construction
+ * throws, and the sender must absorb that and return `{ success: false }`
+ * rather than throwing into its caller.
+ */
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: { failedEmail: { create: jest.fn() } },
+}));
+
+/** NODE_ENV is typed readonly; go through the record to set it in tests. */
+function setNodeEnv(value: string) {
+  (process.env as Record<string, string | undefined>).NODE_ENV = value;
+}
+
+describe("sendWaitlistConfirmEmail — signing failures", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns a failure result instead of throwing when the signing key is absent", async () => {
+    setNodeEnv("production");
+    delete process.env.WAITLIST_HMAC_SECRET;
+    process.env.RESEND_API_KEY = "re_test_key";
+
+    const { sendWaitlistConfirmEmail } = await import("../../lib/email");
+
+    const result = await sendWaitlistConfirmEmail({
+      email: "reader@example.com",
+      name: null,
+      issuedAt: Date.now(),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("never prints a live confirmation link outside development", async () => {
+    setNodeEnv("production");
+    process.env.WAITLIST_HMAC_SECRET = "test-secret-value";
+    delete process.env.RESEND_API_KEY;
+
+    const log = jest.spyOn(console, "log").mockImplementation(() => {});
+    const { sendWaitlistConfirmEmail } = await import("../../lib/email");
+
+    await sendWaitlistConfirmEmail({
+      email: "reader@example.com",
+      name: null,
+      issuedAt: Date.now(),
+    });
+
+    // The link is a bearer token: printing it would let anyone with log
+    // access confirm the address.
+    const printed = log.mock.calls.flat().join(" ");
+    expect(printed).not.toContain("token=");
+    expect(printed).not.toContain("/api/waitlist/confirm");
+    log.mockRestore();
+  });
+});
+
+describe("canSignLinks", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("reports false in production with no secret, without throwing", async () => {
+    setNodeEnv("production");
+    delete process.env.WAITLIST_HMAC_SECRET;
+
+    const { canSignLinks } = await import("../../lib/waitlist/tokens");
+    expect(canSignLinks()).toBe(false);
+  });
+
+  it("reports true once the secret is configured", async () => {
+    setNodeEnv("production");
+    process.env.WAITLIST_HMAC_SECRET = "test-secret-value";
+
+    const { canSignLinks } = await import("../../lib/waitlist/tokens");
+    expect(canSignLinks()).toBe(true);
+  });
+});

--- a/__tests__/waitlist/subscribe-send-failure.test.ts
+++ b/__tests__/waitlist/subscribe-send-failure.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * A signup writes the row first and sends the confirmation second. When the
+ * send fails the row is already on the list, so the caller must be told —
+ * silently reporting success strands the subscriber at PENDING with no
+ * confirmation link to click.
+ *
+ * Regression pin for the production incident where `WAITLIST_HMAC_SECRET` was
+ * unset: `buildConfirmUrl` threw from outside the sender's try block, the
+ * throw escaped `subscribe()`, and the route 500'd after the row was written.
+ */
+
+const mockUpsert = jest.fn();
+const mockFindUnique = jest.fn();
+const mockSendConfirm = jest.fn();
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    waitlist: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      upsert: (...args: unknown[]) => mockUpsert(...args),
+    },
+  },
+}));
+
+jest.mock("../../lib/email", () => ({
+  __esModule: true,
+  sendWaitlistConfirmEmail: (...args: unknown[]) => mockSendConfirm(...args),
+  sendWaitlistWelcomeEmail: jest.fn(),
+}));
+
+const mockCaptureMessage = jest.fn();
+const mockCaptureException = jest.fn();
+
+jest.mock("@sentry/nextjs", () => ({
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+jest.mock("../../lib/waitlist/tokens", () => ({
+  canSignLinks: () => true,
+  verifyConfirmToken: jest.fn(),
+  verifyUnsubscribeToken: jest.fn(),
+}));
+
+import { subscribe } from "../../lib/waitlist/service";
+
+const input = { email: "Reader@Example.com ", source: "FOOTER" as never };
+
+describe("subscribe — confirmation send failure", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindUnique.mockResolvedValue(null);
+    mockUpsert.mockResolvedValue({});
+  });
+
+  it("reports CONFIRMATION_FAILED when the send fails, and still writes the row", async () => {
+    mockSendConfirm.mockResolvedValue({ success: false, error: "no secret" });
+
+    const result = await subscribe(input);
+
+    expect(result).toEqual({ outcome: "CONFIRMATION_FAILED" });
+    // The row must still be on the list — the address opted in.
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+
+    // Removing the reporting call must fail this test, not pass silently.
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("waitlist confirmation email failed to send"),
+      expect.objectContaining({
+        level: "warning",
+        tags: { subsystem: "waitlist" },
+      }),
+    );
+    // Neither the address nor a signed link may reach the report.
+    const reported = JSON.stringify(mockCaptureMessage.mock.calls);
+    expect(reported).not.toContain("reader@example.com");
+    expect(reported).not.toContain("token=");
+  });
+
+  it("does not throw when the sender reports failure", async () => {
+    mockSendConfirm.mockResolvedValue({ success: false, error: "no secret" });
+    await expect(subscribe(input)).resolves.toBeDefined();
+  });
+
+  it("reports CONFIRMATION_SENT on a successful send", async () => {
+    mockSendConfirm.mockResolvedValue({ success: true, data: {} });
+
+    await expect(subscribe(input)).resolves.toEqual({
+      outcome: "CONFIRMATION_SENT",
+    });
+  });
+
+  it("normalises the address before writing and sending", async () => {
+    mockSendConfirm.mockResolvedValue({ success: true, data: {} });
+
+    await subscribe(input);
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { email: "reader@example.com" } }),
+    );
+    expect(mockSendConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "reader@example.com" }),
+    );
+  });
+
+  it("short-circuits an already-subscribed address without sending", async () => {
+    mockFindUnique.mockResolvedValue({ status: "SUBSCRIBED" });
+
+    await expect(subscribe(input)).resolves.toEqual({
+      outcome: "ALREADY_SUBSCRIBED",
+    });
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockSendConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/waitlist/route.ts
+++ b/app/api/waitlist/route.ts
@@ -36,15 +36,28 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // a session; the footer form is public.
     const session = await getSession().catch(() => null);
 
-    await subscribe({
+    const result = await subscribe({
       ...parsed.data,
       userId: session?.user?.id ?? null,
       ip: getClientIp(request),
       userAgent: request.headers.get("user-agent"),
     });
 
-    // Deliberately uniform: telling the caller whether the address was already
-    // subscribed would turn this into a membership oracle.
+    // A send failure is an infrastructure state, not a per-address one, so
+    // saying so leaks no membership — and silently claiming success would
+    // strand the subscriber at PENDING with no confirmation to click.
+    if (result.outcome === "CONFIRMATION_FAILED") {
+      return NextResponse.json(
+        {
+          error:
+            "We could not send your confirmation email. Please try again shortly.",
+        },
+        { status: 502 },
+      );
+    }
+
+    // Otherwise deliberately uniform: telling the caller whether the address
+    // was already subscribed would turn this into a membership oracle.
     return NextResponse.json({
       success: true,
       message: "Check your email to confirm your subscription.",

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -673,16 +673,21 @@ export async function sendWaitlistConfirmEmail({
   name?: string | null;
   issuedAt: number;
 }) {
-  const confirmLink = buildConfirmUrl(email, issuedAt);
-
-  // Dev affordance: mirrors sendVerificationEmail so the flow is testable
-  // without a Resend key.
-  if (!process.env.RESEND_API_KEY) {
-    console.log(`[waitlist-confirm] ${email} -> ${confirmLink}`);
-  }
-
   let sentMessage: RenderedEmail | undefined;
   try {
+    // Signing lives inside the boundary: it throws when
+    // WAITLIST_HMAC_SECRET is unset in production, and a sender must never
+    // throw into its caller.
+    const confirmLink = buildConfirmUrl(email, issuedAt);
+
+    // Dev affordance so the flow is testable without a Resend key. Gated on
+    // NODE_ENV, not on the key being absent: a misconfigured production would
+    // otherwise print a live confirmation link, and that link is a bearer
+    // token — anyone reading the logs could confirm the address.
+    if (process.env.NODE_ENV === "development") {
+      console.log(`[waitlist-confirm] ${email} -> ${confirmLink}`);
+    }
+
     const resend = getResendClient();
     if (!resend) {
       return { success: false, error: "Email service not configured" };

--- a/lib/waitlist/service.ts
+++ b/lib/waitlist/service.ts
@@ -7,6 +7,7 @@
  * result object and render the same copy either way.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import { createHash } from "node:crypto";
 import { Prisma, WaitlistSource, WaitlistStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
@@ -14,7 +15,11 @@ import {
   sendWaitlistConfirmEmail,
   sendWaitlistWelcomeEmail,
 } from "@/lib/email";
-import { verifyConfirmToken, verifyUnsubscribeToken } from "./tokens";
+import {
+  canSignLinks,
+  verifyConfirmToken,
+  verifyUnsubscribeToken,
+} from "./tokens";
 
 export type SubscribeInput = {
   email: string;
@@ -29,7 +34,9 @@ export type SubscribeInput = {
 
 export type SubscribeResult =
   | { outcome: "CONFIRMATION_SENT" }
-  | { outcome: "ALREADY_SUBSCRIBED" };
+  | { outcome: "ALREADY_SUBSCRIBED" }
+  /** Row is on the list as PENDING but the confirmation could not be sent. */
+  | { outcome: "CONFIRMATION_FAILED" };
 
 /**
  * Consent proof without storing a raw IP. Salted with the HMAC secret when
@@ -58,6 +65,18 @@ export async function subscribe(
 ): Promise<SubscribeResult> {
   const email = normalizeEmail(input.email);
   const now = new Date();
+
+  // Checked before the membership lookup, deliberately. If this ran after the
+  // ALREADY_SUBSCRIBED short-circuit, a signing outage would answer 200 for
+  // subscribed addresses and fail for everyone else — letting a caller probe
+  // membership by status code. Config health must not depend on the address.
+  if (!canSignLinks()) {
+    Sentry.captureMessage("waitlist signing key unavailable", {
+      level: "error",
+      tags: { subsystem: "waitlist" },
+    });
+    return { outcome: "CONFIRMATION_FAILED" };
+  }
 
   const existing = await prisma.waitlist.findUnique({
     where: { email },
@@ -97,11 +116,32 @@ export async function subscribe(
     },
   });
 
-  await sendWaitlistConfirmEmail({
+  const sent = await sendWaitlistConfirmEmail({
     email,
     name: input.name ?? null,
     issuedAt: now.getTime(),
   });
+
+  if (!sent.success) {
+    // The row is written and the address is on the list; only the email
+    // failed. Report it rather than claiming a confirmation went out — the
+    // subscriber is otherwise stuck at PENDING with no way to advance.
+    // The reason is carried through so every failure isn't one flat warning;
+    // neither the address nor the signed link is included.
+    const reason = sent.error;
+    if (reason instanceof Error) {
+      Sentry.captureException(reason, {
+        level: "warning",
+        tags: { subsystem: "waitlist" },
+      });
+    } else {
+      Sentry.captureMessage(
+        `waitlist confirmation email failed to send: ${String(reason)}`,
+        { level: "warning", tags: { subsystem: "waitlist" } },
+      );
+    }
+    return { outcome: "CONFIRMATION_FAILED" };
+  }
 
   return { outcome: "CONFIRMATION_SENT" };
 }

--- a/lib/waitlist/tokens.ts
+++ b/lib/waitlist/tokens.ts
@@ -80,6 +80,22 @@ function safeEquals(token: string, expected: () => string): boolean {
   }
 }
 
+/**
+ * Whether links can be signed at all, without throwing.
+ *
+ * Callers use this to fail the same way for every address. Deciding late —
+ * after a membership lookup has already short-circuited — makes the failure
+ * depend on membership, which turns the response into an oracle.
+ */
+export function canSignLinks(): boolean {
+  try {
+    getHmacSecret();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function buildConfirmUrl(email: string, issuedAt: number): string {
   const token = generateConfirmToken(email, issuedAt);
   return `${getAppUrl()}/api/waitlist/confirm?email=${encodeURIComponent(


### PR DESCRIPTION
Second release today. One commit.

| PR | Change |
|---|---|
| #1037 | Waitlist signup: keep signing inside the sender boundary, close the membership oracle, stop logging live confirm links |

## No database work

This ships **no schema change** — zero files under `prisma/`. Unlike this morning's release there is nothing to sequence and nothing to apply before merging.

## What it fixes in production

Both faults are live on prod right now:

- **A signup whose confirmation cannot be sent returns a 500 after writing the row**, leaving the subscriber at `PENDING` with no link to click. This is what happened between the #1035 deploy and `WAITLIST_HMAC_SECRET` being set.
- **A signing outage leaks list membership.** `subscribe()` short-circuits on an already-subscribed address before attempting a send, so during such an outage subscribed addresses answer 200 while unknown ones fail — distinguishing membership by status code. Signing availability is now decided before the membership lookup, so the failure is identical for every address.
- **Confirmation links were logged whenever `RESEND_API_KEY` was absent**, which is not a development-only condition. The link is a bearer token; anyone with log access could confirm an address they do not own. Now gated on `NODE_ENV === "development"`.

## Verification

`tsc --noEmit` clean, `eslint` clean, **161 suites / 1826 tests** green. CI passed on the PR head: Lint, TypeScript/Tests/Build, SonarCloud, and the Netlify preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)