### PR TITLE
release: dev → prod (public IA + organisations directory, paid trials)

### DIFF
--- a/.github/workflows/expire-unpaid-trials.yml
+++ b/.github/workflows/expire-unpaid-trials.yml
@@ -1,0 +1,54 @@
+name: Expire Unpaid Trials
+
+on:
+  schedule:
+    # Run hourly. The payment window is 24h (clamped to the session start), so
+    # hourly granularity is ample — the slot is never held more than an hour
+    # past its deadline.
+    #
+    # Minute 40 is one of the few start-minutes not already taken by a recurring
+    # job; simultaneous starts stampede the Supavisor pool (#932), which is what
+    # scripts/ci/check-workflow-hygiene.ts guards against.
+    - cron: "40 * * * *"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  expire-unpaid-trials:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      # Database connection (required for Prisma)
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # #476 cron locks load lib/redis at import — every job entry needs these
+      UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+      UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+      DIRECT_URL: ${{ secrets.DIRECT_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Expire unpaid trials
+        run: npx --yes tsx@4.23.1 jobs/trials/expire-unpaid-trials.ts
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          SLACK_OPS_WEBHOOK_URL: ${{ secrets.SLACK_OPS_WEBHOOK_URL }}
+          # Fallback sink — Slack has never been provisioned, so this is
+          # what actually pages today. See 07-required-secrets.md.
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: bash scripts/ci/notify-ops-failure.sh "expire-unpaid-trials"

--- a/__tests__/booking-algorithm/unallocatedSlotExclusion.test.ts
+++ b/__tests__/booking-algorithm/unallocatedSlotExclusion.test.ts
@@ -85,14 +85,21 @@ describe("buildOccupiedAppointmentFilter", () => {
     expect(classFilter.class.classPlan.consultantProfileId).toBe("cp-001");
   });
 
-  it("should include trial session filter with SCHEDULED status", () => {
+  it("should include trial session filter for occupying statuses", () => {
     const filters = buildOccupiedAppointmentFilter("cp-001");
     const trialFilter = filters[4] as any;
 
     expect(trialFilter.trialSession).toBeDefined();
     expect(trialFilter.trialSession.is.consultantProfileId).toBe("cp-001");
-    expect(trialFilter.trialSession.is.status).toBe(
-      TrialSessionStatus.SCHEDULED,
+    // AWAITING_PAYMENT occupies too: a paid trial reserves its slot the moment
+    // the consultant accepts and holds it while the learner pays. Matching only
+    // SCHEDULED let someone else book the slot mid-payment, after which the
+    // capture webhook would confirm the trial into a double booking.
+    expect(trialFilter.trialSession.is.status.in).toEqual(
+      expect.arrayContaining([
+        TrialSessionStatus.SCHEDULED,
+        TrialSessionStatus.AWAITING_PAYMENT,
+      ]),
     );
   });
 
@@ -109,8 +116,11 @@ describe("buildOccupiedAppointmentFilter", () => {
     const filters = buildOccupiedAppointmentFilter();
     const trialFilter = filters[4] as any;
 
-    expect(trialFilter.trialSession.is.status).toBe(
-      TrialSessionStatus.SCHEDULED,
+    expect(trialFilter.trialSession.is.status.in).toEqual(
+      expect.arrayContaining([
+        TrialSessionStatus.SCHEDULED,
+        TrialSessionStatus.AWAITING_PAYMENT,
+      ]),
     );
     expect(trialFilter.trialSession.is.consultantProfileId).toBeUndefined();
   });

--- a/__tests__/payments/trial-payment-path.test.ts
+++ b/__tests__/payments/trial-payment-path.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Paid-trial money path.
+ *
+ * Covers the invariants that would cost real money or corrupt state if broken:
+ *  - the trial is charged its plan's trialPriceInPaise, never the plan price
+ *  - a free trial never mints a payment intent
+ *  - a TRIAL intent without a trialId is rejected before it reaches the gateway
+ *  - webhook metadata validates for TRIAL (an unhandled type routes to
+ *    CRITICAL_PAYMENT_WITHOUT_APPOINTMENT — learner charged, trial unscheduled)
+ *  - the payment deadline is 24h, clamped to the session start
+ *  - only live/delivered trials block a re-request; lapsed ones free the pair
+ *  - AWAITING_PAYMENT occupies its slot, so nobody can book over a trial that
+ *    is mid-payment
+ */
+
+import { AppointmentsType, TrialSessionStatus } from "@prisma/client";
+
+import {
+  blocksNewTrialRequest,
+  computeTrialPaymentDueAt,
+  TRIAL_PAYMENT_WINDOW_MS,
+} from "../../lib/trials/eligibility";
+import { validateWebhookMetadata } from "../../schemas/webhooks/metadata";
+import { buildOccupiedAppointmentFilter } from "../../utils/slotAllocation/occupancyPolicy";
+
+const CUID = "clw0000000000000000000000";
+const PLAN_CUID = "clw1111111111111111111111";
+const TRIAL_CUID = "clw2222222222222222222222";
+
+describe("trial payment deadline", () => {
+  it("is 24h from acceptance when the session is further out", () => {
+    const acceptedAt = new Date("2026-01-01T00:00:00.000Z");
+    const sessionStart = new Date("2026-01-05T00:00:00.000Z");
+
+    const due = computeTrialPaymentDueAt(acceptedAt, sessionStart);
+
+    expect(due.getTime()).toBe(acceptedAt.getTime() + TRIAL_PAYMENT_WINDOW_MS);
+  });
+
+  it("clamps to the session start when the slot is sooner than 24h", () => {
+    const acceptedAt = new Date("2026-01-01T00:00:00.000Z");
+    // Three hours out — the link must not outlive the session it pays for.
+    const sessionStart = new Date("2026-01-01T03:00:00.000Z");
+
+    const due = computeTrialPaymentDueAt(acceptedAt, sessionStart);
+
+    expect(due).toEqual(sessionStart);
+  });
+
+  it("falls back to the full window when there is no session time", () => {
+    const acceptedAt = new Date("2026-01-01T00:00:00.000Z");
+
+    const due = computeTrialPaymentDueAt(acceptedAt, null);
+
+    expect(due.getTime()).toBe(acceptedAt.getTime() + TRIAL_PAYMENT_WINDOW_MS);
+  });
+});
+
+describe("trial re-request eligibility", () => {
+  it.each([
+    TrialSessionStatus.PENDING,
+    TrialSessionStatus.AWAITING_PAYMENT,
+    TrialSessionStatus.SCHEDULED,
+    TrialSessionStatus.COMPLETED,
+    TrialSessionStatus.CONVERTED,
+  ])("blocks a new request while %s", (status) => {
+    expect(blocksNewTrialRequest(status)).toBe(true);
+  });
+
+  it.each([TrialSessionStatus.CANCELLED, TrialSessionStatus.REJECTED])(
+    "frees the pair after %s",
+    (status) => {
+      // The learner never received a trial, so their one shot isn't spent.
+      // A lapsed unpaid trial lands on CANCELLED via the expiry job.
+      expect(blocksNewTrialRequest(status)).toBe(false);
+    },
+  );
+});
+
+describe("webhook metadata for trials", () => {
+  const base = {
+    appointmentType: AppointmentsType.TRIAL,
+    userId: CUID,
+    planId: PLAN_CUID,
+    trialId: TRIAL_CUID,
+    startsAt: "2026-01-01T10:00:00.000Z",
+    endsAt: "2026-01-01T10:30:00.000Z",
+  };
+
+  it("accepts a well-formed TRIAL payload", () => {
+    // Before the TRIAL arm existed this threw "Unsupported appointment type",
+    // which routes to CRITICAL_PAYMENT_WITHOUT_APPOINTMENT.
+    const parsed = validateWebhookMetadata(
+      base as unknown as Record<string, string>,
+    );
+
+    expect(parsed).toMatchObject({
+      appointmentType: AppointmentsType.TRIAL,
+      trialId: TRIAL_CUID,
+    });
+  });
+
+  it("rejects a TRIAL payload with no trialId", () => {
+    const { trialId: _omitted, ...withoutTrialId } = base;
+
+    expect(() =>
+      validateWebhookMetadata(
+        withoutTrialId as unknown as Record<string, string>,
+      ),
+    ).toThrow();
+  });
+});
+
+describe("slot occupancy while awaiting payment", () => {
+  it("treats AWAITING_PAYMENT as occupying the slot", () => {
+    // Otherwise another learner could book the same slot during the payment
+    // window and the capture webhook would confirm into a double booking.
+    const filters = buildOccupiedAppointmentFilter("consultant-1");
+
+    const trialFilter = filters.find((f) => "trialSession" in f) as {
+      trialSession: { is: { status: { in: TrialSessionStatus[] } } };
+    };
+
+    expect(trialFilter.trialSession.is.status.in).toEqual(
+      expect.arrayContaining([
+        TrialSessionStatus.SCHEDULED,
+        TrialSessionStatus.AWAITING_PAYMENT,
+      ]),
+    );
+  });
+});

--- a/app/(pages)/become-an-expert/page.tsx
+++ b/app/(pages)/become-an-expert/page.tsx
@@ -1,0 +1,373 @@
+import {
+  ArrowRight,
+  BadgeCheck,
+  CalendarClock,
+  FileCheck,
+  Landmark,
+  Receipt,
+  Sparkles,
+  Target,
+  Wallet,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PAYOUT_CONSTANTS } from "@/lib/payments/payouts/constants";
+
+export const metadata: Metadata = {
+  title: "Become an Expert | Familiarise",
+  description:
+    "Share your expertise on Familiarise. Set your own rates, keep the majority of every session, and get paid with tax handled for you.",
+};
+
+// Derived from the real split rather than hardcoded copy, so the page can't
+// drift away from what the payout pipeline actually pays.
+const EXPERT_SHARE_PERCENT = 100 - PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE;
+
+const STEPS = [
+  {
+    icon: Sparkles,
+    title: "Apply",
+    description:
+      "Tell us who you are and what you do. It takes a few minutes and there's no cost to apply.",
+  },
+  {
+    icon: BadgeCheck,
+    title: "Get verified",
+    description:
+      "We review your credentials and experience so learners know every expert on the platform is genuine.",
+  },
+  {
+    icon: Target,
+    title: "Set your rates",
+    description:
+      "Decide what you charge and which formats you offer — one-off calls, ongoing mentorship, classes, or webinars.",
+  },
+  {
+    icon: CalendarClock,
+    title: "Start earning",
+    description:
+      "Publish the hours that suit you. Learners book only the slots you've opened.",
+  },
+];
+
+const REQUIREMENTS = [
+  {
+    icon: BadgeCheck,
+    title: "Demonstrable expertise",
+    description:
+      "Real professional experience in the field you want to advise on, which we verify before your profile goes live.",
+  },
+  {
+    icon: FileCheck,
+    title: "Identity and tax details",
+    description:
+      "PAN and the tax information we need to deduct TDS correctly and issue compliant invoices on your behalf.",
+  },
+  {
+    icon: Landmark,
+    title: "A bank account for payouts",
+    description:
+      "Indian bank account details so earnings can be settled to you. Payouts are made in INR.",
+  },
+  {
+    icon: CalendarClock,
+    title: "Availability you control",
+    description:
+      "There's no minimum commitment. You publish the slots you want and can change them whenever you like.",
+  },
+];
+
+const FAQ = [
+  {
+    question: "How much does it cost to join?",
+    answer:
+      "Nothing. There is no listing fee and no subscription. Familiarise only earns when you do, through the platform fee taken from each completed booking.",
+  },
+  {
+    question: "Who decides my pricing?",
+    answer:
+      "You do. You set the price for every plan you offer and can change it at any time. Learners always see the full price before they book.",
+  },
+  {
+    question: "What happens about tax?",
+    answer:
+      "TDS is deducted at the applicable rate and recorded against your PAN, and GST-compliant invoices are generated for each booking. You'll find the records in your dashboard when you need them for filing.",
+  },
+  {
+    question: "Do I have to commit to a fixed number of hours?",
+    answer:
+      "No. You publish availability when it suits you, and learners can only book the slots you have opened. There is no minimum.",
+  },
+  {
+    question: "Can my agency or institution join instead of me individually?",
+    answer:
+      "Yes. Organisations can host their own experts on Familiarise and appear in the public directory. Get in touch and we'll set that up with you.",
+  },
+];
+
+export default function BecomeAnExpertPage() {
+  return (
+    <main className="min-h-screen bg-background">
+      {/* Hero */}
+      <section className="relative overflow-hidden bg-zinc-950 pt-32 pb-20">
+        <div className="absolute inset-0">
+          <div className="animate-blob absolute left-1/4 top-1/4 h-[500px] w-[500px] rounded-full bg-zinc-800/30 blur-[120px]" />
+          <div className="animate-blob animation-delay-2000 absolute bottom-1/4 right-1/4 h-[400px] w-[400px] rounded-full bg-zinc-700/20 blur-[100px]" />
+        </div>
+        <div className="grid-pattern absolute inset-0 opacity-20" />
+
+        <div className="relative z-10 mx-auto max-w-[1100px] px-4 md:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-zinc-700/50 bg-zinc-800/50 px-4 py-2 backdrop-blur-sm">
+              <Sparkles className="h-4 w-4 text-white" />
+              <span className="text-sm font-medium text-zinc-300">
+                Share your expertise
+              </span>
+            </div>
+            <h1 className="text-fluid-4xl mb-6 font-bold tracking-tight text-white">
+              Share what you know.{" "}
+              <span className="silver-text">Get paid for it.</span>
+            </h1>
+            <p className="mx-auto mb-10 max-w-xl text-lg text-zinc-300">
+              Advise people who need exactly what you already know — on your own
+              schedule, at rates you set, with the billing and compliance
+              handled for you.
+            </p>
+            <div className="flex flex-col justify-center gap-3 sm:flex-row">
+              <Button
+                size="lg"
+                className="w-full bg-white text-zinc-900 hover:bg-zinc-200 sm:w-auto"
+                asChild
+              >
+                <Link href="/auth/signup">
+                  Apply to join
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="w-full border-zinc-700 bg-transparent text-white hover:bg-zinc-800 hover:text-white sm:w-auto"
+                asChild
+              >
+                <Link href="/explore/experts">See who&apos;s already here</Link>
+              </Button>
+            </div>
+            <p className="mt-5 text-sm text-zinc-500">
+              Free to apply · No listing fee · No minimum hours
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="py-20 md:py-24">
+        <div className="mx-auto max-w-[1100px] px-4 md:px-8">
+          <div className="mb-12 max-w-2xl">
+            <Badge variant="secondary" className="mb-4">
+              How it works
+            </Badge>
+            <h2 className="text-fluid-3xl font-bold tracking-tight text-foreground">
+              From application to first booking
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
+            {STEPS.map((step, index) => {
+              const Icon = step.icon;
+              return (
+                <div
+                  key={step.title}
+                  className="rounded-2xl border border-border bg-card p-6"
+                >
+                  <div className="mb-4 flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-sm font-bold text-primary-foreground">
+                      {index + 1}
+                    </div>
+                    <Icon className="h-5 w-5 text-muted-foreground" />
+                  </div>
+                  <h3 className="mb-2 font-semibold text-foreground">
+                    {step.title}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {step.description}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Earnings */}
+      <section className="bg-muted py-20 md:py-24">
+        <div className="mx-auto max-w-[1100px] px-4 md:px-8">
+          <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2">
+            <div>
+              <Badge variant="secondary" className="mb-4">
+                What you earn
+              </Badge>
+              <h2 className="text-fluid-3xl mb-4 font-bold tracking-tight text-foreground">
+                You keep {EXPERT_SHARE_PERCENT}% of every session
+              </h2>
+              <p className="mb-6 leading-relaxed text-muted-foreground">
+                You set the price; Familiarise takes a{" "}
+                {PAYOUT_CONSTANTS.PLATFORM_FEE_PERCENTAGE}% platform fee from
+                each completed booking and the rest is yours. There is no
+                listing fee and no subscription, so we only earn when you do.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Experts who join through an agency or institution on Familiarise
+                keep the same {EXPERT_SHARE_PERCENT}% share; the hosting
+                organisation&apos;s cut comes out of the platform fee, not out
+                of your earnings.
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex gap-4 rounded-2xl border border-border bg-card p-6">
+                <Wallet className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <div>
+                  <h3 className="mb-1 font-semibold text-foreground">
+                    Settled to your bank account
+                  </h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    Earnings accrue per completed session and are paid out in
+                    INR to the account you register.
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-4 rounded-2xl border border-border bg-card p-6">
+                <Receipt className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <div>
+                  <h3 className="mb-1 font-semibold text-foreground">
+                    Tax handled for you
+                  </h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    TDS is deducted at the applicable rate against your PAN and
+                    GST-compliant invoices are generated automatically.
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-4 rounded-2xl border border-border bg-card p-6">
+                <Target className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <div>
+                  <h3 className="mb-1 font-semibold text-foreground">
+                    Your rates, your formats
+                  </h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    Offer one-off calls, ongoing mentorship, classes or webinars
+                    — priced however you choose.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Requirements */}
+      <section className="py-20 md:py-24">
+        <div className="mx-auto max-w-[1100px] px-4 md:px-8">
+          <div className="mb-12 max-w-2xl">
+            <Badge variant="secondary" className="mb-4">
+              What we need from you
+            </Badge>
+            <h2 className="text-fluid-3xl font-bold tracking-tight text-foreground">
+              What it takes to get verified
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+            {REQUIREMENTS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <div
+                  key={item.title}
+                  className="flex gap-4 rounded-2xl border border-border bg-card p-6"
+                >
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-muted">
+                    <Icon className="h-5 w-5 text-muted-foreground" />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="mb-1.5 font-semibold text-foreground">
+                      {item.title}
+                    </h3>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="bg-muted py-20 md:py-24">
+        <div className="mx-auto max-w-[800px] px-4 md:px-8">
+          <div className="mb-10 text-center">
+            <Badge variant="secondary" className="mb-4">
+              FAQ
+            </Badge>
+            <h2 className="text-fluid-3xl font-bold tracking-tight text-foreground">
+              Questions people ask before applying
+            </h2>
+          </div>
+
+          <Accordion type="single" collapsible className="w-full">
+            {FAQ.map((item) => (
+              <AccordionItem key={item.question} value={item.question}>
+                <AccordionTrigger className="text-left font-medium text-foreground">
+                  {item.question}
+                </AccordionTrigger>
+                <AccordionContent className="leading-relaxed text-muted-foreground">
+                  {item.answer}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </section>
+
+      {/* Closing CTA */}
+      <section className="py-20 md:py-28">
+        <div className="mx-auto max-w-[800px] px-4 text-center md:px-8">
+          <h2 className="text-fluid-3xl mb-4 font-bold tracking-tight text-foreground">
+            Ready to start advising?
+          </h2>
+          <p className="mx-auto mb-8 max-w-xl text-muted-foreground">
+            Apply in a few minutes. We&apos;ll review your details and get back
+            to you about verification.
+          </p>
+          <div className="flex flex-col justify-center gap-3 sm:flex-row">
+            <Button size="lg" className="w-full sm:w-auto" asChild>
+              <Link href="/auth/signup">
+                Apply to join
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="w-full sm:w-auto"
+              asChild
+            >
+              <Link href="/contactus">Talk to us first</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/api/cleanup/expire-unpaid-trials/route.ts
+++ b/app/api/cleanup/expire-unpaid-trials/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Unpaid Trial Expiry API Endpoint
+ *
+ * Thin wrapper around scripts/trials/expire-unpaid-trials.ts
+ * Provides HTTP endpoint for manual triggering or alternative cron systems.
+ *
+ * The scheduled run is the GitHub Action (jobs/trials/expire-unpaid-trials.ts);
+ * no workflow curls this. Both entries share the cron lock held in the core.
+ *
+ * Schedule: Hourly (via GitHub Actions or external cron)
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+
+import { CronLockHeldError } from "@/lib/cron/with-cron-lock";
+import { expireUnpaidTrials } from "@/scripts/trials/expire-unpaid-trials";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    // Verify cron secret to prevent unauthorized access
+    const authHeader = req.headers.get("authorization");
+    const cronSecret =
+      process.env.CRON_SECRET || process.env.VERCEL_CRON_SECRET;
+
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+      console.warn("Unauthorized unpaid trial expiry attempt");
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    Sentry.logger.info("cron:expire-unpaid-trials started");
+    console.log("🧹 Starting unpaid trial expiry via API...");
+
+    const result = await expireUnpaidTrials();
+
+    console.log("✅ Unpaid trial expiry completed:", {
+      trialsExpired: result.trialsExpired,
+    });
+    Sentry.logger.info("cron:expire-unpaid-trials finished", {
+      trialsExpired: result.trialsExpired,
+    });
+
+    return NextResponse.json({
+      success: result.success,
+      trialsExpired: result.trialsExpired,
+      errors: result.errors,
+      timestamp: result.timestamp,
+    });
+  } catch (error) {
+    // #476 — concurrent invocation (schedule overlap / manual re-run)
+    // skips with a 409 instead of double-running.
+    if (error instanceof CronLockHeldError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    Sentry.captureException(error, {
+      tags: { subsystem: "cron", job: "expire-unpaid-trials" },
+    });
+    console.error("Error in unpaid trial expiry:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to expire unpaid trial sessions" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/dashboard/admin/approval-payments/route.ts
+++ b/app/api/dashboard/admin/approval-payments/route.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { AppointmentStatus } from "@prisma/client";
+import { AppointmentStatus, TrialSessionStatus } from "@prisma/client";
 import { getSession } from "@/lib/auth-server";
 
 /**
@@ -122,6 +122,26 @@ export async function GET() {
       },
     });
 
+    // Paid trials the consultant accepted but the learner hasn't paid for.
+    // Support needs these alongside consultations/subscriptions — the failure
+    // mode is identical (accepted, slot held, money not collected).
+    const pendingTrials = await prisma.trialSession.findMany({
+      where: { status: TrialSessionStatus.AWAITING_PAYMENT },
+      include: {
+        subscriptionPlan: {
+          include: {
+            consultantProfile: {
+              include: { user: { select: { name: true, email: true } } },
+            },
+          },
+        },
+        consulteeProfile: {
+          include: { user: { select: { name: true, email: true } } },
+        },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+
     // Transform data into a consistent format
     const approvalPayments = [
       ...pendingConsultations.map((consultation) => {
@@ -186,6 +206,35 @@ export async function GET() {
           isExpired,
           isExpiringSoon,
           status: subscription.status,
+        };
+      }),
+      ...pendingTrials.map((trial) => {
+        // Trials carry a real deadline instead of the 48h assumption above.
+        const expiresAt = trial.paymentDueAt ?? trial.updatedAt;
+        const timeUntilExpiry = expiresAt.getTime() - Date.now();
+        const isExpired = timeUntilExpiry < 0;
+        const isExpiringSoon =
+          !isExpired && timeUntilExpiry < 24 * 60 * 60 * 1000;
+
+        return {
+          id: trial.id,
+          type: "trial" as const,
+          title: `${trial.subscriptionPlan?.title ?? "Trial"} — trial`,
+          consultantName:
+            trial.subscriptionPlan?.consultantProfile?.user?.name ||
+            "Unknown Consultant",
+          consultantEmail:
+            trial.subscriptionPlan?.consultantProfile?.user?.email || "",
+          consulteeName: trial.consulteeProfile?.user?.name || "Unknown Consultee",
+          consulteeEmail: trial.consulteeProfile?.user?.email || "",
+          amount: Number(trial.subscriptionPlan?.trialPriceInPaise ?? 0),
+          currency: trial.subscriptionPlan?.priceCurrency || "INR",
+          paymentUrl: trial.pendingPaymentUrl || "",
+          approvedAt: trial.updatedAt.toISOString(),
+          expiresAt: expiresAt.toISOString(),
+          isExpired,
+          isExpiringSoon,
+          status: trial.status,
         };
       }),
     ].sort((a, b) => {

--- a/app/api/dashboard/consultee/[consulteeId]/pending-payments/route.ts
+++ b/app/api/dashboard/consultee/[consulteeId]/pending-payments/route.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-import { AppointmentStatus } from "@prisma/client";
+import { AppointmentStatus, TrialSessionStatus } from "@prisma/client";
 import {
   requireApiAuth,
   isPrivileged,
@@ -56,9 +56,13 @@ export async function GET(
       },
     } as const;
 
-    // Fetch all three data sources in parallel
-    const [pendingConsultations, pendingSubscriptions, pendingGatewayPayments] =
-      await Promise.all([
+    // Fetch all four data sources in parallel
+    const [
+      pendingConsultations,
+      pendingSubscriptions,
+      pendingGatewayPayments,
+      pendingTrials,
+    ] = await Promise.all([
         // Source 1: Consultations with APPROVED_PENDING_PAYMENT status
         prisma.consultation.findMany({
           where: {
@@ -141,6 +145,27 @@ export async function GET(
           },
           orderBy: { createdAt: "desc" },
         }),
+
+        // Source 4: Paid trials the consultant accepted but the learner hasn't
+        // paid for yet. Unlike the sources above these carry a real deadline
+        // (paymentDueAt) rather than an assumed 48h window.
+        prisma.trialSession.findMany({
+          where: {
+            consulteeProfileId: consulteeId,
+            status: TrialSessionStatus.AWAITING_PAYMENT,
+          },
+          include: {
+            subscriptionPlan: {
+              include: {
+                consultantProfile: {
+                  include: { user: { select: { name: true } } },
+                },
+              },
+            },
+            appointment: { select: { id: true } },
+          },
+          orderBy: { updatedAt: "desc" },
+        }),
       ]);
 
     // Transform approval-pending consultations
@@ -188,6 +213,30 @@ export async function GET(
           currency: subscription.subscriptionPlan?.priceCurrency || "INR",
           paymentUrl: subscription.pendingPaymentUrl || "",
           approvedAt: subscription.updatedAt.toISOString(),
+          expiresAt: expiresAt.toISOString(),
+          isExpiringSoon,
+          source: "approval_pending" as const,
+        };
+      }),
+      ...pendingTrials.map((trial) => {
+        // Real deadline, not the 48h assumption used above — a trial's slot may
+        // be sooner than that, in which case paymentDueAt is clamped to it.
+        const expiresAt = trial.paymentDueAt ?? trial.updatedAt;
+        const isExpiringSoon =
+          expiresAt.getTime() - Date.now() < 24 * 60 * 60 * 1000;
+
+        return {
+          id: trial.id,
+          appointmentId: trial.appointment?.id ?? null,
+          type: "trial" as const,
+          title: `${trial.subscriptionPlan?.title ?? "Trial"} — trial`,
+          consultantName:
+            trial.subscriptionPlan?.consultantProfile?.user?.name ||
+            "Consultant",
+          amount: Number(trial.subscriptionPlan?.trialPriceInPaise ?? 0),
+          currency: trial.subscriptionPlan?.priceCurrency || "INR",
+          paymentUrl: trial.pendingPaymentUrl || "",
+          approvedAt: trial.updatedAt.toISOString(),
           expiresAt: expiresAt.toISOString(),
           isExpiringSoon,
           source: "approval_pending" as const,

--- a/app/api/organizations/public/route.ts
+++ b/app/api/organizations/public/route.ts
@@ -1,103 +1,61 @@
 /**
  * GET /api/organizations/public
  *
- * Public (unauthenticated) listing of HOST/HYBRID organizations that have
- * opted in to marketplace discovery via Organization.isPublic=true.
+ * Public (unauthenticated) listing of organizations that have opted in to
+ * marketplace discovery via `Organization.isPublic = true`.
  *
- * SPONSOR-only orgs (canHost=false) are never included — they are B2B clients,
- * not marketplace participants, and exposing them publicly would be a privacy
- * concern for corporate clients who want confidentiality.
+ * Capability (canSponsor/canHost) is a filter here, not a precondition: gating
+ * the listing on canHost made it structurally empty, because ENABLE_HOST_ORGS
+ * blocks canHost from ever being set. An org appears here because its OWNER
+ * opted in, and for no other reason.
  *
- * Query params:
- *   industry  — filter by org.industry (case-insensitive contains)
- *   search    — full-text search on name/description (case-insensitive)
- *   page      — 1-indexed, default 1
- *   limit     — default 12, max 50
+ * Query params (all optional, repeated params for multi-value filters):
+ *   search      — matches name / description / industry, case-insensitive
+ *   type        — OrgDirectoryType, repeatable
+ *   industry    — exact industry, repeatable
+ *   size        — OrgSizeBucket, repeatable
+ *   capability  — host | sponsor | hybrid
+ *   hasExperts  — "true" to only list orgs with ACTIVE EXPERT members
+ *   sort        — nameAsc | nameDesc | expertsDesc | newest
+ *   page        — 1-indexed, default 1
+ *   limit       — default 24, max 50
  */
 
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
-import prisma from "@/lib/prisma";
+
 import { apiError } from "@/lib/errors";
+import {
+  getOrganisationsPage,
+  ORGANISATIONS_PER_PAGE,
+} from "@/lib/data/explore-organisations";
+import { orgFiltersFromSearchParams } from "@/lib/explore/organisation-filters";
 
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = req.nextUrl;
     const page = Math.max(1, parseInt(searchParams.get("page") || "1") || 1);
     const limit = Math.min(
-      Math.max(1, parseInt(searchParams.get("limit") || "12") || 12),
+      Math.max(
+        1,
+        parseInt(searchParams.get("limit") || String(ORGANISATIONS_PER_PAGE)) ||
+          ORGANISATIONS_PER_PAGE,
+      ),
       50,
     );
-    const industry = searchParams.get("industry")?.trim();
-    const search = searchParams.get("search")?.trim();
 
-    const skip = (page - 1) * limit;
-
-    const where = {
-      isPublic: true,
-      canHost: true,
-      status: "ACTIVE" as const,
-      ...(industry && {
-        industry: { contains: industry, mode: "insensitive" as const },
-      }),
-      ...(search && {
-        OR: [
-          { name: { contains: search, mode: "insensitive" as const } },
-          { description: { contains: search, mode: "insensitive" as const } },
-        ],
-      }),
-    };
-
-    const [orgs, total] = await Promise.all([
-      prisma.organization.findMany({
-        where,
-        select: {
-          id: true,
-          name: true,
-          slug: true,
-          canSponsor: true,
-          canHost: true,
-          brandingProfile: {
-            select: {
-              logo: true,
-              bannerImage: true,
-              description: true,
-              industry: true,
-              website: true,
-            },
-          },
-          _count: {
-            select: {
-              memberships: {
-                where: { role: "EXPERT", status: "ACTIVE" },
-              },
-            },
-          },
-        },
-        orderBy: { name: "asc" },
-        skip,
-        take: limit,
-      }),
-      prisma.organization.count({ where }),
-    ]);
-
-    const data = orgs.map((org) => ({
-      id: org.id,
-      name: org.name,
-      slug: org.slug,
-      logo: org.brandingProfile?.logo ?? null,
-      bannerImage: org.brandingProfile?.bannerImage ?? null,
-      description: org.brandingProfile?.description ?? null,
-      industry: org.brandingProfile?.industry ?? null,
-      website: org.brandingProfile?.website ?? null,
-      capabilityKind: org.canSponsor ? "hybrid" : "host",
-      expertCount: org._count.memberships,
-    }));
+    const filters = orgFiltersFromSearchParams(searchParams);
+    const result = await getOrganisationsPage(filters, page, limit);
 
     return NextResponse.json(
       {
-        data,
-        meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
+        data: result.items,
+        meta: {
+          total: result.total,
+          page: result.page,
+          limit,
+          totalPages: result.totalPages,
+        },
       },
       {
         headers: {
@@ -106,7 +64,10 @@ export async function GET(req: NextRequest) {
       },
     );
   } catch (error) {
-    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), { tags: { subsystem: "organizations" } });
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "organizations" } },
+    );
     return apiError({ tag: "[Organizations.Public.GET]", error });
   }
 }

--- a/app/api/plans/shared/plan-filters.ts
+++ b/app/api/plans/shared/plan-filters.ts
@@ -11,6 +11,7 @@ export interface PlanFilterParams {
   minPrice: number | undefined;
   maxPrice: number | undefined;
   search: string | null;
+  level: string | null;
   page: number;
   limit: number;
   skip: number;
@@ -42,6 +43,9 @@ export function parsePlanFilters(
     maxPrice:
       parsedMax !== undefined && !isNaN(parsedMax) ? parsedMax : undefined,
     search: searchParams.get("search"),
+    // "all" is the UI's no-op sentinel, not a stored level value.
+    level:
+      searchParams.get("level") === "all" ? null : searchParams.get("level"),
     page,
     limit,
     skip,
@@ -55,6 +59,7 @@ export function parsePlanFilters(
 export interface PlanWhereClause {
   consultantProfileId?: string;
   language?: string;
+  level?: string;
   price?: { gte?: number; lte?: number };
   title?: { contains: string; mode: "insensitive" };
   topics?: { some: { id: { in: string[] } } };
@@ -83,6 +88,11 @@ export function buildPlanWhereClause(
   }
   if (filters.language) {
     where.language = filters.language;
+  }
+  // Level used to be filtered client-side over the already-loaded infinite-scroll
+  // page, so a matching program on a later page simply never appeared.
+  if (filters.level) {
+    where.level = filters.level;
   }
   if (filters.minPrice !== undefined || filters.maxPrice !== undefined) {
     const price: { gte?: number; lte?: number } = {};

--- a/app/api/trials/[trialId]/route.ts
+++ b/app/api/trials/[trialId]/route.ts
@@ -1,5 +1,13 @@
+import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
-import { TrialSessionStatus, AppointmentsType, Prisma } from "@prisma/client";
+import { createApprovalPaymentIntent } from "@/lib/payments/operations/approval-payment";
+import { computeTrialPaymentDueAt } from "@/lib/trials/eligibility";
+import {
+  TrialSessionStatus,
+  AppointmentsType,
+  PaymentGateway,
+  Prisma,
+} from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import {
   logTrialCompleted,
@@ -213,11 +221,17 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     // Handle status transitions
     if (status) {
-      // Simplified state machine: PENDING → SCHEDULED → COMPLETED → CONVERTED
-      // REJECTED = consultant declines, CANCELLED = consultee cancels
+      // State machine:
+      //   free trial   PENDING → SCHEDULED → COMPLETED → CONVERTED
+      //   paid trial   PENDING → AWAITING_PAYMENT → SCHEDULED → …
+      // REJECTED = consultant declines, CANCELLED = consultee cancels or the
+      // pay-link lapses past paymentDueAt.
       const validTransitions: Record<TrialSessionStatus, TrialSessionStatus[]> =
         {
-          PENDING: ["SCHEDULED", "CANCELLED", "REJECTED"],
+          PENDING: ["AWAITING_PAYMENT", "SCHEDULED", "CANCELLED", "REJECTED"],
+          // Only the webhook moves this to SCHEDULED (on payment capture); the
+          // expiry job and the consultee move it to CANCELLED.
+          AWAITING_PAYMENT: ["SCHEDULED", "CANCELLED"],
           SCHEDULED: ["COMPLETED", "CANCELLED"],
           COMPLETED: ["CONVERTED"],
           CONVERTED: [],
@@ -270,6 +284,18 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       }
 
       updateData.status = status;
+
+      // A paid trial cannot go straight to SCHEDULED: the consultant accepting
+      // only issues the pay-link. The slot is still held (the appointment is
+      // created below) so nobody else can take it while the learner pays, and
+      // the expiry job releases it if they never do.
+      const trialPriceInPaise = Number(
+        existingTrial.subscriptionPlan.trialPriceInPaise ?? 0,
+      );
+      const requiresPayment =
+        status === TrialSessionStatus.SCHEDULED &&
+        existingTrial.status === TrialSessionStatus.PENDING &&
+        trialPriceInPaise > 0;
 
       // Handle scheduling with distributed locking
       if (status === TrialSessionStatus.SCHEDULED) {
@@ -357,12 +383,18 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
               },
             });
 
-            // Update trial with appointment link and scheduled status
+            // Update trial with appointment link and the resulting status —
+            // AWAITING_PAYMENT for a paid trial, SCHEDULED for a free one.
             const updatedTrial = await tx.trialSession.update({
               where: { id: trialId },
               data: {
-                status: TrialSessionStatus.SCHEDULED,
+                status: requiresPayment
+                  ? TrialSessionStatus.AWAITING_PAYMENT
+                  : TrialSessionStatus.SCHEDULED,
                 appointmentId: appointment.id,
+                paymentDueAt: requiresPayment
+                  ? computeTrialPaymentDueAt(new Date(), startTime)
+                  : null,
               },
               include: {
                 consulteeProfile: {
@@ -420,7 +452,46 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             startTime,
           );
 
-          // Notify the consultee that their trial has been scheduled
+          // 5. Paid trial: mint the pay-link now that the slot is held.
+          //
+          // Deliberately AFTER the transaction — createApprovalPaymentIntent
+          // takes its own distributed lock and calls the gateway, so running it
+          // inside would hold a DB transaction open across a network round trip.
+          // If it throws, the trial stays AWAITING_PAYMENT with no link; the
+          // consultee sees nothing payable and the expiry job releases the slot,
+          // which is the safe direction to fail.
+          let paymentUrl: string | null = null;
+          if (requiresPayment) {
+            try {
+              const intent = await createApprovalPaymentIntent({
+                userId: existingTrial.consulteeProfile.user.id,
+                appointmentType: "TRIAL",
+                trialId,
+                // The appointment already exists — link it so the webhook
+                // confirms it instead of creating a second one.
+                appointmentId: result.appointmentId ?? undefined,
+                planId: existingTrial.subscriptionPlanId,
+                paymentGateway: PaymentGateway.RAZORPAY,
+                startsAt: startTime.toISOString(),
+                endsAt: endTime.toISOString(),
+              });
+              paymentUrl = intent.checkoutUrl;
+              await prisma.trialSession.update({
+                where: { id: trialId },
+                data: { pendingPaymentUrl: intent.checkoutUrl },
+              });
+            } catch (error) {
+              Sentry.captureException(
+                error instanceof Error ? error : new Error(String(error)),
+                { tags: { subsystem: "trials" }, extra: { trialId } },
+              );
+              console.error("[Trials] pay-link generation failed:", error);
+            }
+          }
+
+          // Notify the consultee — "pay to confirm" for a paid trial, plain
+          // confirmation for a free one. Sending "your trial is scheduled" for
+          // something still awaiting payment would be a lie.
           void notifyTrialSessionScheduled(
             existingTrial.consulteeProfile.user.id,
             {
@@ -429,8 +500,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
               consulteeName: existingTrial.consulteeProfile.user.name || "User",
               planTitle: existingTrial.subscriptionPlan.title,
               dateTime: startTime.toISOString(),
-              status: TrialSessionStatus.SCHEDULED,
-              dashboardUrl: "/dashboard",
+              status: requiresPayment
+                ? TrialSessionStatus.AWAITING_PAYMENT
+                : TrialSessionStatus.SCHEDULED,
+              dashboardUrl: paymentUrl ?? "/dashboard",
             },
           );
 

--- a/app/api/trials/check-eligibility/route.ts
+++ b/app/api/trials/check-eligibility/route.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
+import { blocksNewTrialRequest } from "@/lib/trials/eligibility";
 import { NextRequest, NextResponse } from "next/server";
 import { requireApiAuth, isPrivileged } from "@/lib/auth-helpers";
 
@@ -98,18 +99,25 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    const isEligible = !existingTrial && planTrialEnabled;
+    // A prior trial only blocks if it's live or was actually delivered — a
+    // declined, withdrawn or lapsed-unpaid trial frees the pair. See
+    // lib/trials/eligibility.ts for the abuse trade-off this represents.
+    const blockingTrial =
+      existingTrial && blocksNewTrialRequest(existingTrial.status)
+        ? existingTrial
+        : null;
+    const isEligible = !blockingTrial && planTrialEnabled;
 
     return NextResponse.json({
       data: {
         isEligible,
-        hasExistingTrial: !!existingTrial,
-        existingTrial: existingTrial
+        hasExistingTrial: !!blockingTrial,
+        existingTrial: blockingTrial
           ? {
-              id: existingTrial.id,
-              status: existingTrial.status,
-              subscriptionPlanId: existingTrial.subscriptionPlanId,
-              requestedAt: existingTrial.requestedAt,
+              id: blockingTrial.id,
+              status: blockingTrial.status,
+              subscriptionPlanId: blockingTrial.subscriptionPlanId,
+              requestedAt: blockingTrial.requestedAt,
             }
           : null,
         planTrialEnabled,
@@ -117,7 +125,7 @@ export async function GET(request: NextRequest) {
         planTrialPriceInPaise,
         plansWithTrialEnabled,
         reason: !isEligible
-          ? existingTrial
+          ? blockingTrial
             ? "You have already requested or completed a trial with this consultant"
             : "This plan does not offer trials"
           : null,

--- a/app/api/trials/route.ts
+++ b/app/api/trials/route.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { blocksNewTrialRequest } from "@/lib/trials/eligibility";
 import { Prisma, TrialSessionStatus } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { logTrialRequested } from "@/lib/activity/log-activity";
@@ -278,11 +279,19 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    // Only a live or already-delivered trial blocks a new request. A declined,
+    // withdrawn or lapsed-unpaid trial frees the pair — never paying isn't the
+    // same as having used your trial. The freed row must be deleted rather than
+    // left in place, because the pair is @@unique. See lib/trials/eligibility.ts
+    // for the abuse trade-off and how to tighten it if this gets gamed.
     if (existingTrial) {
-      return NextResponse.json(
-        { error: "You have already requested a trial with this consultant" },
-        { status: 409 },
-      );
+      if (blocksNewTrialRequest(existingTrial.status)) {
+        return NextResponse.json(
+          { error: "You have already requested a trial with this consultant" },
+          { status: 409 },
+        );
+      }
+      await prisma.trialSession.delete({ where: { id: existingTrial.id } });
     }
 
     // Verify the subscription plan exists and has trials enabled
@@ -318,16 +327,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Paid-trial checkout isn't wired yet (createApprovalPaymentIntent must
-    // accept TRIAL first) — fail closed rather than booking an uncollected
-    // paid trial. The wiring PR removes this gate.
-    if (subscriptionPlan.trialPriceInPaise > 0) {
-      return NextResponse.json(
-        { error: "Paid trials are not yet available. Please check back soon." },
-        { status: 400 },
-      );
-    }
-
+    // Paid trials are wired: no money moves at request time. The consultant
+    // accepts first, which mints the pay-link and puts the trial in
+    // AWAITING_PAYMENT — so a declined request never needs a refund.
     // Get consultee info for activity log
     const consulteeProfile = await prisma.consulteeProfile.findUnique({
       where: { id: consulteeProfileId },

--- a/app/api/user/consultants/route.ts
+++ b/app/api/user/consultants/route.ts
@@ -84,9 +84,30 @@ export async function GET(request: NextRequest) {
     // #781 §B — soft-deleted profiles leave public surfaces
     conditions.push({ deletedAt: null });
 
-    if (domain) conditions.push({ domainId: domain });
+    // Accept either a domain id (what FilterPanel sends, from metadata) or a
+    // domain NAME. Every human-authored link — the nav category chips, the
+    // footer expertise band, the use-case pages — spells the domain out
+    // (`?domain=Technology`), which silently matched nothing while this only
+    // compared against the cuid.
+    if (domain) {
+      conditions.push({
+        OR: [
+          { domainId: domain },
+          { domain: { name: { equals: domain, mode: "insensitive" } } },
+        ],
+      });
+    }
     if (subdomain) {
-      conditions.push({ subDomains: { some: { id: subdomain } } });
+      conditions.push({
+        OR: [
+          { subDomains: { some: { id: subdomain } } },
+          {
+            subDomains: {
+              some: { name: { equals: subdomain, mode: "insensitive" } },
+            },
+          },
+        ],
+      });
     }
     if (tags.length > 0) {
       conditions.push({ tags: { some: { name: { in: tags } } } });

--- a/app/checkout/plans/trial/[trialId]/TrialPayButton.tsx
+++ b/app/checkout/plans/trial/[trialId]/TrialPayButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { CreditCard } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * Hands off to the gateway pay-link minted when the consultant accepted.
+ *
+ * A client component only because it opens a new tab; there is no order
+ * creation here. When this page eventually replaces the hosted pay-link, this
+ * is where the Razorpay/Stripe checkout component would mount instead.
+ */
+export function TrialPayButton({ paymentUrl }: { paymentUrl: string }) {
+  return (
+    <Button
+      className="w-full"
+      size="lg"
+      onClick={() => {
+        // Guard the scheme — pendingPaymentUrl is gateway-supplied, and an
+        // unchecked value here would be an open-redirect / javascript: sink.
+        if (/^https?:\/\//.test(paymentUrl)) {
+          window.open(paymentUrl, "_blank", "noopener,noreferrer");
+        }
+      }}
+    >
+      <CreditCard className="mr-2 h-4 w-4" />
+      Pay to confirm
+    </Button>
+  );
+}

--- a/app/checkout/plans/trial/[trialId]/page.tsx
+++ b/app/checkout/plans/trial/[trialId]/page.tsx
@@ -1,0 +1,176 @@
+import { AlertCircle, CalendarClock, Clock } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getSession } from "@/lib/auth-server";
+import prisma from "@/lib/prisma";
+
+import { TrialPayButton } from "./TrialPayButton";
+
+/**
+ * Branded checkout page for a paid trial.
+ *
+ * NOT YET LINKED. `TrialSession.pendingPaymentUrl` still points at the Razorpay
+ * hosted pay-link, which is what the approval email and every dashboard
+ * affordance open. This page exists so switching to our own surface later is a
+ * one-line change (point pendingPaymentUrl here) rather than a fresh build.
+ *
+ * It deliberately does NOT create a payment intent. Unlike the four
+ * direct-purchase checkout families, a trial's intent already exists — it was
+ * minted when the consultant accepted. Re-creating one here would double-charge
+ * and would trip the duplicate-payment guard in createApprovalPaymentIntent.
+ * This page's job is to authorise the viewer, prove the trial is still payable,
+ * and hand off to the gateway.
+ */
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Complete your trial booking | Familiarise",
+  robots: { index: false, follow: false },
+};
+
+export default async function TrialCheckoutPage({
+  params,
+}: {
+  params: Promise<{ trialId: string }>;
+}) {
+  const { trialId } = await params;
+  const session = await getSession(true);
+
+  if (!session?.user?.id) notFound();
+
+  const trial = await prisma.trialSession.findUnique({
+    where: { id: trialId },
+    select: {
+      id: true,
+      status: true,
+      paymentDueAt: true,
+      pendingPaymentUrl: true,
+      consulteeProfile: { select: { userId: true } },
+      subscriptionPlan: {
+        select: {
+          title: true,
+          trialPriceInPaise: true,
+          trialDurationMinutes: true,
+          priceCurrency: true,
+          consultantProfile: {
+            select: { user: { select: { name: true } } },
+          },
+        },
+      },
+      appointment: {
+        select: {
+          slotsOfAppointment: {
+            select: { startsAt: true },
+            orderBy: { startsAt: "asc" },
+            take: 1,
+          },
+        },
+      },
+    },
+  });
+
+  // 404 rather than 403 for someone else's trial — an existence oracle on a
+  // guessable id would leak who is trialling whom.
+  if (!trial || trial.consulteeProfile.userId !== session.user.id) notFound();
+
+  const startsAt = trial.appointment?.slotsOfAppointment[0]?.startsAt ?? null;
+  const isPayable =
+    trial.status === "AWAITING_PAYMENT" &&
+    Boolean(trial.pendingPaymentUrl) &&
+    (!trial.paymentDueAt || trial.paymentDueAt > new Date());
+
+  return (
+    <main className="mx-auto max-w-xl px-4 py-16">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {isPayable ? "Complete your trial booking" : "Trial unavailable"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          <div>
+            <p className="text-lg font-semibold text-foreground">
+              {trial.subscriptionPlan.title} — trial
+            </p>
+            <p className="text-sm text-muted-foreground">
+              with{" "}
+              {trial.subscriptionPlan.consultantProfile?.user?.name ??
+                "your expert"}
+            </p>
+          </div>
+
+          <div className="space-y-2 rounded-xl border border-border bg-muted/50 p-4 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Amount</span>
+              <span className="font-semibold text-foreground">
+                {new Intl.NumberFormat("en-IN", {
+                  style: "currency",
+                  currency: trial.subscriptionPlan.priceCurrency,
+                  maximumFractionDigits: 0,
+                }).format(Number(trial.subscriptionPlan.trialPriceInPaise) / 100)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                <Clock className="h-3.5 w-3.5" />
+                Duration
+              </span>
+              <span className="text-foreground">
+                {trial.subscriptionPlan.trialDurationMinutes} minutes
+              </span>
+            </div>
+            {startsAt && (
+              <div className="flex items-center justify-between">
+                <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                  <CalendarClock className="h-3.5 w-3.5" />
+                  Session
+                </span>
+                <span className="text-foreground">
+                  {startsAt.toLocaleString("en-IN", {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {isPayable ? (
+            <>
+              <TrialPayButton paymentUrl={trial.pendingPaymentUrl!} />
+              {trial.paymentDueAt && (
+                <p className="text-center text-xs text-muted-foreground">
+                  Your slot is held until{" "}
+                  {trial.paymentDueAt.toLocaleString("en-IN", {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                  . After that it is released to other learners.
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex gap-3 rounded-xl border border-border bg-muted/50 p-4">
+                <AlertCircle className="h-5 w-5 shrink-0 text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">
+                  {trial.status === "SCHEDULED"
+                    ? "This trial is already paid for and confirmed."
+                    : "This trial is no longer awaiting payment — it may have been cancelled, or the payment window may have closed. You can request a new trial with this expert."}
+                </p>
+              </div>
+              <Button asChild variant="outline" className="w-full">
+                <Link href="/dashboard">Go to dashboard</Link>
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/dashboard/consultant/[consultantId]/(features)/trials/TrialsTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/trials/TrialsTab.tsx
@@ -112,6 +112,9 @@ function maskEmail(email: string): string {
 // the consultant side (they did the declining — "Rejected" reads wrong).
 const statusBgColors: Record<string, string> = {
   PENDING: "bg-yellow-50 hover:bg-yellow-100 border-yellow-200",
+  // Same amber family as PENDING — both are "waiting", and the label says who
+  // we're waiting on.
+  AWAITING_PAYMENT: "bg-amber-50 hover:bg-amber-100 border-amber-200",
   SCHEDULED: "bg-purple-50 hover:bg-purple-100 border-purple-200",
   COMPLETED: "bg-green-50 hover:bg-green-100 border-green-200",
   CONVERTED: "bg-emerald-50 hover:bg-emerald-100 border-emerald-200",
@@ -121,6 +124,7 @@ const statusBgColors: Record<string, string> = {
 
 const statusTextColors: Record<string, string> = {
   PENDING: "text-yellow-700",
+  AWAITING_PAYMENT: "text-amber-700",
   SCHEDULED: "text-purple-700",
   COMPLETED: "text-green-700",
   CONVERTED: "text-emerald-700",
@@ -295,9 +299,18 @@ export function TrialsTab() {
         throw new Error(errorData.error || "Failed to schedule trial");
       }
 
+      // A paid trial is NOT scheduled by accepting — it moves to
+      // AWAITING_PAYMENT and the learner gets a pay-link. Saying "scheduled"
+      // would tell the consultant to expect someone who may never pay.
+      const result = await response.json().catch(() => null);
+      const awaitingPayment =
+        result?.data?.status === "AWAITING_PAYMENT";
+
       toast({
         title: "Success",
-        description: "Trial session approved and scheduled",
+        description: awaitingPayment
+          ? "Trial approved. The slot is held while the learner pays — it confirms once payment lands, and is released if they don't pay in time."
+          : "Trial session approved and scheduled",
       });
 
       setShowScheduleDialog(false);
@@ -465,6 +478,8 @@ export function TrialsTab() {
 
   const statusOrder = [
     "PENDING",
+    // Sits between PENDING and SCHEDULED — it's the step in between.
+    "AWAITING_PAYMENT",
     "SCHEDULED",
     "COMPLETED",
     "CONVERTED",
@@ -568,6 +583,7 @@ export function TrialsTab() {
           <SelectContent>
             <SelectItem value="all">All Statuses</SelectItem>
             <SelectItem value="PENDING">Pending</SelectItem>
+            <SelectItem value="AWAITING_PAYMENT">Awaiting payment</SelectItem>
             <SelectItem value="SCHEDULED">Scheduled</SelectItem>
             <SelectItem value="COMPLETED">Completed</SelectItem>
             <SelectItem value="CONVERTED">Converted</SelectItem>

--- a/app/explore/components/FacetCombobox.tsx
+++ b/app/explore/components/FacetCombobox.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/utils/tailwind";
+
+import type { FacetOption } from "./FacetGroup";
+
+interface FacetComboboxProps<T extends string> {
+  label: string;
+  placeholder?: string;
+  options: FacetOption<T>[];
+  selected: T[];
+  onToggle: (value: T) => void;
+  onClear?: () => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}
+
+/**
+ * Multi-select autocomplete for large facet sets (tags, companies, industries,
+ * topics).
+ *
+ * Replaces three near-identical hand-rolled implementations — an `<input>` plus
+ * an absolutely-positioned `<div>` and a `mousedown` outside-click listener —
+ * that were duplicated across the experts and programs filter panels. Radix
+ * Popover was already a dependency but had no component wrapping it; it brings
+ * focus trapping, escape-to-close and outside-click dismissal for free.
+ */
+export default function FacetCombobox<T extends string>({
+  label,
+  placeholder = "Search…",
+  options,
+  selected,
+  onToggle,
+  onClear,
+  disabled = false,
+  disabledHint,
+}: FacetComboboxProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((option) => option.label.toLowerCase().includes(q));
+  }, [options, query]);
+
+  const selectedOptions = useMemo(
+    () => options.filter((option) => selected.includes(option.value)),
+    [options, selected],
+  );
+
+  return (
+    <div className="border-b border-border pb-4 last:border-b-0">
+      <div className="flex items-center justify-between py-3">
+        <span className="text-sm font-semibold text-foreground">{label}</span>
+        {selected.length > 0 && onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild disabled={disabled}>
+          <button
+            type="button"
+            aria-expanded={open}
+            aria-haspopup="listbox"
+            className={cn(
+              "flex w-full items-center justify-between gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm transition-colors",
+              disabled
+                ? "cursor-not-allowed opacity-50"
+                : "hover:border-foreground/30",
+            )}
+          >
+            <span className="truncate text-muted-foreground">
+              {disabled && disabledHint
+                ? disabledHint
+                : selected.length > 0
+                  ? `${selected.length} selected`
+                  : placeholder}
+            </span>
+            <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          </button>
+        </PopoverTrigger>
+
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-2">
+          <Input
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={placeholder}
+            className="mb-2 h-9"
+          />
+          <div className="max-h-56 overflow-y-auto" role="listbox">
+            {filtered.length === 0 ? (
+              <p className="px-2 py-3 text-center text-xs text-muted-foreground">
+                No matches
+              </p>
+            ) : (
+              filtered.map((option) => {
+                const isSelected = selected.includes(option.value);
+                // Match FacetGroup: a zero-count option leads to a known-empty
+                // result set, so don't offer it — unless it's already applied,
+                // which must stay removable.
+                const isEmpty = option.count === 0 && !isSelected;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    disabled={isEmpty}
+                    onClick={() => onToggle(option.value)}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted",
+                      isEmpty &&
+                        "cursor-not-allowed opacity-50 hover:bg-transparent",
+                    )}
+                  >
+                    <Check
+                      className={cn(
+                        "h-3.5 w-3.5 shrink-0",
+                        isSelected ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      {option.label}
+                    </span>
+                    {option.count !== undefined && (
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                        {option.count}
+                      </span>
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {selectedOptions.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {selectedOptions.map((option) => (
+            <span
+              key={option.value}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+            >
+              {option.label}
+              <button
+                type="button"
+                onClick={() => onToggle(option.value)}
+                aria-label={`Remove ${option.label}`}
+                className="rounded-full p-0.5 transition-colors hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/explore/components/FacetGroup.tsx
+++ b/app/explore/components/FacetGroup.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+import { cn } from "@/utils/tailwind";
+
+export interface FacetOption<T extends string = string> {
+  value: T;
+  label: string;
+  /** Result count for this option. Omit when the count isn't known. */
+  count?: number;
+}
+
+interface FacetGroupProps<T extends string> {
+  title: string;
+  icon?: React.ReactNode;
+  options: FacetOption<T>[];
+  selected: T[];
+  onToggle: (value: T) => void;
+  /** Single-select behaves like a radio: picking a new value replaces it. */
+  singleSelect?: boolean;
+  defaultOpen?: boolean;
+  /** Options beyond this are hidden behind a "Show all" toggle. */
+  collapseAfter?: number;
+}
+
+/**
+ * A collapsible group of checkbox facets with result counts.
+ *
+ * Counts matter: NN/g's faceted-search guidance is that a filter which returns
+ * zero results should say so before it's clicked, not after.
+ */
+export default function FacetGroup<T extends string>({
+  title,
+  icon,
+  options,
+  selected,
+  onToggle,
+  singleSelect = false,
+  defaultOpen = true,
+  collapseAfter = 6,
+}: FacetGroupProps<T>) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [expanded, setExpanded] = useState(false);
+
+  if (options.length === 0) return null;
+
+  const visible = expanded ? options : options.slice(0, collapseAfter);
+  const hiddenCount = options.length - visible.length;
+
+  return (
+    <div className="border-b border-border pb-4 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between py-3 text-left"
+      >
+        <span className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
+          {icon}
+          {title}
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 text-muted-foreground transition-transform duration-200",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="space-y-1">
+          {visible.map((option) => {
+            const isSelected = selected.includes(option.value);
+            const isEmpty = option.count === 0 && !isSelected;
+            return (
+              <label
+                key={option.value}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors hover:bg-muted",
+                  isEmpty && "cursor-not-allowed opacity-50 hover:bg-transparent",
+                )}
+              >
+                <input
+                  type={singleSelect ? "radio" : "checkbox"}
+                  checked={isSelected}
+                  disabled={isEmpty}
+                  onChange={() => onToggle(option.value)}
+                  className="h-4 w-4 shrink-0 accent-primary"
+                />
+                <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                  {option.label}
+                </span>
+                {option.count !== undefined && (
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {option.count}
+                  </span>
+                )}
+              </label>
+            );
+          })}
+
+          {hiddenCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Show {hiddenCount} more
+            </button>
+          )}
+          {expanded && options.length > collapseAfter && (
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              className="px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Show less
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/explore/components/FacetRail.tsx
+++ b/app/explore/components/FacetRail.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { SlidersHorizontal } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+interface FacetRailProps {
+  /** The facet groups. Rendered identically in the rail and the mobile sheet. */
+  children: React.ReactNode;
+  /** Count of currently-applied filters, shown on the mobile trigger. */
+  activeCount?: number;
+  onClearAll?: () => void;
+  /** Result count, e.g. "24 organisations". */
+  resultSummary?: string;
+}
+
+/**
+ * Shared filter shell for the explore surfaces.
+ *
+ * Desktop gets a sticky left rail; mobile gets a slide-out Sheet rather than a
+ * separate filter page, which is the pattern NN/g recommends because it keeps
+ * the result list one dismissal away. Offset by --header-height so the sticky
+ * rail clears the fixed navbar.
+ */
+export default function FacetRail({
+  children,
+  activeCount = 0,
+  onClearAll,
+  resultSummary,
+}: FacetRailProps) {
+  const [open, setOpen] = useState(false);
+
+  const header = (
+    <div className="flex items-center justify-between">
+      <span className="text-sm font-semibold text-foreground">Filters</span>
+      {activeCount > 0 && onClearAll && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile trigger */}
+      <div className="flex items-center justify-between gap-3 lg:hidden">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button variant="outline" className="gap-2">
+              <SlidersHorizontal className="h-4 w-4" />
+              Filters
+              {activeCount > 0 && (
+                <span className="ml-1 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-primary-foreground">
+                  {activeCount}
+                </span>
+              )}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-[88%] max-w-sm overflow-y-auto">
+            <SheetHeader>
+              <SheetTitle>Filters</SheetTitle>
+            </SheetHeader>
+            <div className="mt-4 space-y-1">
+              {activeCount > 0 && onClearAll && (
+                <div className="pb-2">{header}</div>
+              )}
+              {children}
+            </div>
+          </SheetContent>
+        </Sheet>
+        {resultSummary && (
+          <span className="text-sm text-muted-foreground">{resultSummary}</span>
+        )}
+      </div>
+
+      {/* Desktop rail */}
+      <aside
+        className="hidden lg:block"
+        style={{
+          position: "sticky",
+          top: "calc(var(--header-height, 5rem) + 1rem)",
+          alignSelf: "start",
+        }}
+        aria-label="Filters"
+      >
+        <div className="max-h-[calc(100vh-var(--header-height,5rem)-3rem)] overflow-y-auto rounded-2xl border border-border bg-card p-4">
+          {header}
+          <div className="mt-2">{children}</div>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/app/explore/enterprise/organisations/OrgCard.tsx
+++ b/app/explore/enterprise/organisations/OrgCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { BadgeCheck, Building2, Users } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import type { OrganisationListItem } from "@/lib/explore/organisation-types";
+import {
+  ORG_DIRECTORY_TYPE_LABEL,
+  ORG_PUBLIC_CAPABILITY_LABEL,
+  ORG_SIZE_BUCKET_LABEL,
+} from "@/lib/labels/org-labels";
+
+export default function OrgCard({
+  org,
+}: Readonly<{ org: OrganisationListItem }>) {
+  // Type is the primary badge; capability is secondary supporting detail. Both
+  // are neutral taxonomy, so both render monochrome — filled for identity,
+  // muted for the supporting fact.
+  const typeLabel = org.directoryType
+    ? ORG_DIRECTORY_TYPE_LABEL[org.directoryType]
+    : null;
+  const capabilityLabel = ORG_PUBLIC_CAPABILITY_LABEL[org.capability];
+
+  return (
+    <Link
+      href={`/explore/enterprise/organisations/${org.slug}`}
+      className="group flex flex-col overflow-hidden rounded-2xl border border-border bg-card transition-all duration-300 hover:shadow-lg"
+    >
+      <div className="relative h-24 overflow-hidden bg-gradient-to-br from-muted to-muted">
+        {org.bannerImage && (
+          <Image
+            src={org.bannerImage}
+            alt=""
+            fill
+            sizes="(min-width: 1280px) 33vw, (min-width: 640px) 50vw, 100vw"
+            className="object-cover opacity-60"
+          />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent to-black/20" />
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 p-5">
+        <div className="relative -mt-10 flex items-center gap-3">
+          <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl border-2 border-card bg-card shadow-md">
+            {org.logo ? (
+              <Image
+                src={org.logo}
+                alt={org.name}
+                width={56}
+                height={56}
+                className="object-contain"
+              />
+            ) : (
+              <Building2 className="h-7 w-7 text-muted-foreground/70" />
+            )}
+          </div>
+          <div className="min-w-0 pt-8">
+            <h3 className="flex items-center gap-1 truncate font-bold text-foreground transition-colors group-hover:text-muted-foreground">
+              <span className="truncate">{org.name}</span>
+              {org.isVerified && (
+                <BadgeCheck
+                  className="h-4 w-4 flex-shrink-0 text-foreground"
+                  aria-label="Verified organisation"
+                />
+              )}
+            </h3>
+            {org.industry && (
+              <p className="truncate text-xs text-muted-foreground">
+                {org.industry}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {org.description && (
+          <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+            {org.description}
+          </p>
+        )}
+
+        <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-2">
+          {typeLabel && (
+            <Badge
+              variant="outline"
+              className="border-transparent bg-primary px-2 py-0.5 text-[10px] text-primary-foreground"
+            >
+              {typeLabel}
+            </Badge>
+          )}
+          {capabilityLabel && (
+            <Badge
+              variant="outline"
+              className="border-border bg-muted px-2 py-0.5 text-[10px] text-muted-foreground"
+            >
+              {capabilityLabel}
+            </Badge>
+          )}
+          {org.sizeBucket && (
+            <Badge
+              variant="outline"
+              className="border-border bg-muted px-2 py-0.5 text-[10px] text-muted-foreground"
+            >
+              {ORG_SIZE_BUCKET_LABEL[org.sizeBucket]}
+            </Badge>
+          )}
+        </div>
+
+        {/* Expert count is only meaningful for orgs that host experts. */}
+        {(org.capability === "host" || org.capability === "hybrid") && (
+          <div className="flex items-center gap-1 border-t border-border pt-2 text-xs text-muted-foreground">
+            <Users className="h-3.5 w-3.5" />
+            <span>
+              {org.expertCount} expert{org.expertCount !== 1 ? "s" : ""}
+            </span>
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+export function OrgCardSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="h-24 bg-muted" />
+      <div className="flex flex-col gap-3 p-5">
+        <div className="-mt-10 flex items-center gap-3">
+          <div className="h-14 w-14 rounded-xl bg-muted" />
+          <div className="flex flex-col gap-1 pt-8">
+            <div className="h-4 w-28 rounded bg-muted" />
+            <div className="h-3 w-20 rounded bg-muted" />
+          </div>
+        </div>
+        <div className="h-3 w-full rounded bg-muted" />
+        <div className="h-3 w-3/4 rounded bg-muted" />
+        <div className="flex gap-1.5 pt-2">
+          <div className="h-5 w-20 rounded-full bg-muted" />
+          <div className="h-5 w-16 rounded-full bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/explore/enterprise/organisations/OrganisationsInteractiveContent.tsx
+++ b/app/explore/enterprise/organisations/OrganisationsInteractiveContent.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { Building2, Layers, Search, Users } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDebouncedCallback } from "use-debounce";
+import {
+  DEFAULT_ORGANISATION_FILTERS,
+  type IOrganisationFilters,
+  type OrganisationListItem,
+  type OrganisationsMetadata,
+  type OrgCapabilityFilter,
+  type OrgSortOption,
+} from "@/lib/explore/organisation-types";
+import {
+  hasActiveOrgFilters,
+  orgFiltersFromSearchParams,
+  orgFiltersToSearchParams,
+  ORG_SORT_LABEL,
+  ORG_SORT_OPTIONS,
+} from "@/lib/explore/organisation-filters";
+import {
+  ORG_DIRECTORY_TYPE_LABEL,
+  ORG_PUBLIC_CAPABILITY_LABEL,
+  ORG_SIZE_BUCKET_LABEL,
+} from "@/lib/labels/org-labels";
+
+import FacetCombobox from "../../components/FacetCombobox";
+import FacetGroup from "../../components/FacetGroup";
+import FacetRail from "../../components/FacetRail";
+import FilterChips, { type ActiveFilter } from "../../components/FilterChips";
+import { useUrlSyncedFilters } from "../../hooks/useUrlSyncedFilters";
+import OrgCard, { OrgCardSkeleton } from "./OrgCard";
+
+const BASE_PATH = "/explore/enterprise/organisations";
+
+interface Props {
+  metadata: OrganisationsMetadata;
+  initialItems: OrganisationListItem[];
+  initialTotal: number;
+}
+
+interface OrgsResponse {
+  data: OrganisationListItem[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+}
+
+export default function OrganisationsInteractiveContent({
+  metadata,
+  initialItems,
+  initialTotal,
+}: Props) {
+  const { filters, updateFilters, clearFilters } =
+    useUrlSyncedFilters<IOrganisationFilters>({
+      basePath: BASE_PATH,
+      defaults: DEFAULT_ORGANISATION_FILTERS,
+      fromSearchParams: orgFiltersFromSearchParams,
+      toSearchParams: orgFiltersToSearchParams,
+    });
+
+  // Local mirror so typing stays responsive while the query key debounces.
+  const [searchInput, setSearchInput] = useState(filters.search);
+  const pushSearch = useDebouncedCallback((value: string) => {
+    updateFilters({ search: value });
+  }, 300);
+
+  const queryString = orgFiltersToSearchParams(filters);
+  const isDefaultView = !hasActiveOrgFilters(filters);
+
+  const { data, isFetching, isPending } = useQuery<OrgsResponse>({
+    queryKey: ["organisations", queryString],
+    queryFn: async () => {
+      const res = await fetch(`/api/organizations/public?${queryString}`);
+      if (!res.ok) throw new Error("Failed to load organisations");
+      return res.json();
+    },
+    // The RSC already rendered the unfiltered first page; don't refetch it.
+    initialData: isDefaultView
+      ? {
+          data: initialItems,
+          meta: {
+            total: initialTotal,
+            page: 1,
+            limit: initialItems.length,
+            totalPages: 1,
+          },
+        }
+      : undefined,
+    placeholderData: keepPreviousData,
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const orgs = data?.data ?? [];
+  const total = data?.meta.total ?? 0;
+
+  const toggleIn = useCallback(
+    <T extends string>(list: T[], value: T): T[] =>
+      list.includes(value)
+        ? list.filter((item) => item !== value)
+        : [...list, value],
+    [],
+  );
+
+  const activeChips = useMemo<ActiveFilter[]>(() => {
+    const chips: ActiveFilter[] = [];
+    if (filters.search)
+      chips.push({ key: "search", label: "Search", value: filters.search });
+    for (const type of filters.types) {
+      chips.push({
+        key: `type:${type}`,
+        label: "Type",
+        value: ORG_DIRECTORY_TYPE_LABEL[type],
+      });
+    }
+    for (const industry of filters.industries) {
+      chips.push({
+        key: `industry:${industry}`,
+        label: "Industry",
+        value: industry,
+      });
+    }
+    for (const size of filters.sizes) {
+      chips.push({
+        key: `size:${size}`,
+        label: "Size",
+        value: ORG_SIZE_BUCKET_LABEL[size],
+      });
+    }
+    if (filters.capability) {
+      chips.push({
+        key: "capability",
+        label: "Role",
+        value: ORG_PUBLIC_CAPABILITY_LABEL[filters.capability],
+      });
+    }
+    if (filters.hasExperts) {
+      chips.push({
+        key: "hasExperts",
+        label: "Has experts",
+        value: "Yes",
+      });
+    }
+    return chips;
+  }, [filters]);
+
+  const removeChip = useCallback(
+    (key: string) => {
+      // Split on the FIRST colon only — industry values legitimately contain
+      // colons, and a greedy split would corrupt the removal target.
+      const separator = key.indexOf(":");
+      const kind = separator === -1 ? key : key.slice(0, separator);
+      const value = separator === -1 ? "" : key.slice(separator + 1);
+      switch (kind) {
+        case "search":
+          pushSearch.cancel();
+          setSearchInput("");
+          updateFilters({ search: "" });
+          break;
+        case "type":
+          updateFilters({
+            types: filters.types.filter((item) => item !== value),
+          });
+          break;
+        case "industry":
+          updateFilters({
+            industries: filters.industries.filter((item) => item !== value),
+          });
+          break;
+        case "size":
+          updateFilters({
+            sizes: filters.sizes.filter((item) => item !== value),
+          });
+          break;
+        case "capability":
+          updateFilters({ capability: null });
+          break;
+        case "hasExperts":
+          updateFilters({ hasExperts: false });
+          break;
+      }
+    },
+    [filters, updateFilters, pushSearch],
+  );
+
+  const handleClearAll = useCallback(() => {
+    // Cancel the in-flight debounce, or it lands ~300ms later and writes the
+    // pre-clear search term back over the cleared state.
+    pushSearch.cancel();
+    setSearchInput("");
+    clearFilters();
+  }, [clearFilters, pushSearch]);
+
+  useEffect(() => () => pushSearch.cancel(), [pushSearch]);
+
+  const facets = (
+    <>
+      <FacetGroup
+        title="Type"
+        icon={<Layers className="h-3.5 w-3.5 text-muted-foreground" />}
+        options={metadata.types.map((entry) => ({
+          value: entry.value,
+          label: ORG_DIRECTORY_TYPE_LABEL[entry.value],
+          count: entry.count,
+        }))}
+        selected={filters.types}
+        onToggle={(value) =>
+          updateFilters({ types: toggleIn(filters.types, value) })
+        }
+      />
+
+      <FacetGroup
+        title="What they do"
+        icon={<Users className="h-3.5 w-3.5 text-muted-foreground" />}
+        singleSelect
+        options={metadata.capabilities.map((entry) => ({
+          value: entry.value,
+          label: ORG_PUBLIC_CAPABILITY_LABEL[entry.value],
+          count: entry.count,
+        }))}
+        selected={filters.capability ? [filters.capability] : []}
+        onToggle={(value) =>
+          updateFilters({
+            capability: filters.capability === value ? null : value,
+          })
+        }
+      />
+
+      <FacetCombobox
+        label="Industry"
+        placeholder="Search industries…"
+        options={metadata.industries.map((entry) => ({
+          value: entry.value,
+          label: entry.value,
+          count: entry.count,
+        }))}
+        selected={filters.industries}
+        onToggle={(value) =>
+          updateFilters({ industries: toggleIn(filters.industries, value) })
+        }
+        onClear={() => updateFilters({ industries: [] })}
+      />
+
+      <FacetGroup
+        title="Size"
+        icon={<Building2 className="h-3.5 w-3.5 text-muted-foreground" />}
+        options={metadata.sizes.map((entry) => ({
+          value: entry.value,
+          label: ORG_SIZE_BUCKET_LABEL[entry.value],
+          count: entry.count,
+        }))}
+        selected={filters.sizes}
+        onToggle={(value) =>
+          updateFilters({ sizes: toggleIn(filters.sizes, value) })
+        }
+      />
+
+      <div className="py-3">
+        <label className="flex cursor-pointer items-center gap-2.5">
+          <input
+            type="checkbox"
+            checked={filters.hasExperts}
+            onChange={(event) =>
+              updateFilters({ hasExperts: event.target.checked })
+            }
+            className="h-4 w-4 accent-primary"
+          />
+          <span className="text-sm text-foreground">
+            Only show organisations with experts
+          </span>
+        </label>
+      </div>
+    </>
+  );
+
+  return (
+    <section className="py-10 md:py-16">
+      <div className="mx-auto max-w-[1400px] px-4 md:px-8">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-[260px_1fr]">
+          <FacetRail
+            activeCount={activeChips.length}
+            onClearAll={handleClearAll}
+            resultSummary={`${total} result${total !== 1 ? "s" : ""}`}
+          >
+            {facets}
+          </FacetRail>
+
+          <div className="min-w-0">
+            {/* Search + sort */}
+            <div className="mb-5 flex flex-col gap-3 sm:flex-row">
+              <div className="relative flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={searchInput}
+                  onChange={(event) => {
+                    setSearchInput(event.target.value);
+                    pushSearch(event.target.value);
+                  }}
+                  placeholder="Search organisations by name, industry, or description…"
+                  className="h-11 pl-9"
+                  aria-label="Search organisations"
+                />
+              </div>
+              <Select
+                value={filters.sort}
+                onValueChange={(value) =>
+                  updateFilters({ sort: value as OrgSortOption })
+                }
+              >
+                <SelectTrigger className="h-11 sm:w-52">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ORG_SORT_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {ORG_SORT_LABEL[option]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {activeChips.length > 0 && (
+              <div className="mb-5">
+                <FilterChips
+                  filters={activeChips}
+                  onRemove={removeChip}
+                  onClearAll={handleClearAll}
+                />
+              </div>
+            )}
+
+            <p className="mb-4 hidden text-sm text-muted-foreground lg:block">
+              {total} organisation{total !== 1 ? "s" : ""}
+            </p>
+
+            {/* Landing on a filtered URL has no initialData, so without this
+                guard the first paint claimed "no organisations match" before
+                the request had even resolved. */}
+            {isPending ? (
+              <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <OrgCardSkeleton key={index} />
+                ))}
+              </div>
+            ) : orgs.length === 0 ? (
+              <div className="flex flex-col items-center justify-center rounded-2xl border border-border bg-card py-24 text-center">
+                <Building2 className="mb-4 h-12 w-12 text-muted-foreground/70" />
+                <p className="text-lg font-medium text-muted-foreground">
+                  No organisations match these filters
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground/70">
+                  {activeChips.length > 0 ? (
+                    <button
+                      onClick={handleClearAll}
+                      className="underline transition-colors hover:text-foreground"
+                    >
+                      Clear all filters
+                    </button>
+                  ) : (
+                    "Organisations can opt in to marketplace discovery from their settings."
+                  )}
+                </p>
+              </div>
+            ) : (
+              <div
+                className={`grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 ${
+                  isFetching ? "opacity-60 transition-opacity" : ""
+                }`}
+              >
+                {orgs.map((org) => (
+                  <OrgCard key={org.id} org={org} />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function OrganisationsGridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <OrgCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+}

--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -15,6 +15,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import prisma from "@/lib/prisma";
 import { fallbackOnTransientDbError } from "@/lib/data/fail-open";
+import {
+  ORG_DIRECTORY_TYPE_LABEL,
+  ORG_SIZE_BUCKET_LABEL,
+} from "@/lib/labels/org-labels";
 import { cache } from "react";
 import type { Metadata } from "next";
 
@@ -26,7 +30,9 @@ export const dynamic = "force-dynamic";
 // instead of running this heavy org read twice (more visible now it's per-request).
 const fetchOrgBySlug = cache(async (slug: string) => {
   const row = await prisma.organization.findFirst({
-    where: { slug, isPublic: true, canHost: true, status: "ACTIVE" },
+    // canHost intentionally absent: the directory lists every opted-in ACTIVE
+    // org, so requiring it here would 404 exactly the orgs the index links to.
+    where: { slug, isPublic: true, status: "ACTIVE", deletedAt: null },
     select: {
       id: true,
       name: true,
@@ -40,6 +46,8 @@ const fetchOrgBySlug = cache(async (slug: string) => {
           description: true,
           industry: true,
           website: true,
+          sizeBucket: true,
+          directoryType: true,
         },
       },
       // #778 elegance — the org "catalog" is its org-owned per-type plans
@@ -142,6 +150,8 @@ const fetchOrgBySlug = cache(async (slug: string) => {
     description: row.brandingProfile?.description ?? null,
     industry: row.brandingProfile?.industry ?? null,
     website: row.brandingProfile?.website ?? null,
+    sizeBucket: row.brandingProfile?.sizeBucket ?? null,
+    directoryType: row.brandingProfile?.directoryType ?? null,
   };
 });
 
@@ -209,7 +219,7 @@ function ExpertMiniCard({
             {expert.user.name}
           </p>
           {expert.isVerified && (
-            <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />
+            <BadgeCheck className="w-4 h-4 text-foreground flex-shrink-0" />
           )}
         </div>
         {expert.headline && (
@@ -245,13 +255,18 @@ export default async function OrgProfilePage({
 
   if (!org) notFound();
 
-  const capabilityLabel =
-    org.canSponsor && org.canHost ? "Hybrid" : "Host Agency";
-  // Binary categorical badge, no dark: variants — monochrome (filled vs muted).
-  const capabilityClass =
-    org.canSponsor && org.canHost
-      ? "bg-primary text-primary-foreground border-transparent"
-      : "bg-muted text-muted-foreground border-border";
+  // Lead with what the org *is* rather than its billing capability — "Hybrid"
+  // is internal vocabulary that means nothing to a visitor. Falls back to the
+  // derived capability only while directoryType is unset.
+  const capabilityLabel = org.directoryType
+    ? ORG_DIRECTORY_TYPE_LABEL[org.directoryType]
+    : org.canSponsor && org.canHost
+      ? "Hybrid"
+      : "Host Agency";
+  // Neutral taxonomy, no dark: variants — monochrome (filled vs muted).
+  const capabilityClass = org.directoryType
+    ? "bg-primary text-primary-foreground border-transparent"
+    : "bg-muted text-muted-foreground border-border";
 
   const exclusiveExperts = org.memberships
     .map((m) => m.consultantProfile)
@@ -331,13 +346,23 @@ export default async function OrgProfilePage({
               )}
 
               <div className="flex flex-wrap items-center gap-4">
-                <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                  <Users className="w-4 h-4 text-muted-foreground/70" />
-                  <span>
-                    <strong>{exclusiveExperts.length}</strong> exclusive expert
-                    {exclusiveExperts.length !== 1 ? "s" : ""}
-                  </span>
-                </div>
+                {/* Only hosting orgs have an expert roster; a sponsor-only org
+                    showing "0 exclusive experts" reads as a defect. */}
+                {org.canHost && (
+                  <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                    <Users className="w-4 h-4 text-muted-foreground/70" />
+                    <span>
+                      <strong>{exclusiveExperts.length}</strong> exclusive
+                      expert{exclusiveExperts.length !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                )}
+                {org.sizeBucket && (
+                  <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                    <Building2 className="w-4 h-4 text-muted-foreground/70" />
+                    <span>{ORG_SIZE_BUCKET_LABEL[org.sizeBucket]}</span>
+                  </div>
+                )}
                 {org.website && (
                   <a
                     href={org.website}
@@ -360,7 +385,11 @@ export default async function OrgProfilePage({
           <div className="lg:col-span-2 space-y-6">
             {exclusiveExperts.length > 0 ? (
               <>
-                <h2 className="text-xl font-bold text-foreground tracking-tight">
+                {/* The sidebar CTA targets #experts; nothing carried that id. */}
+                <h2
+                  id="experts"
+                  className="scroll-mt-28 text-xl font-bold text-foreground tracking-tight"
+                >
                   Exclusive Experts
                 </h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -370,12 +399,14 @@ export default async function OrgProfilePage({
                 </div>
               </>
             ) : (
-              <div className="flex flex-col items-center justify-center py-16 text-center bg-card rounded-2xl border border-border">
-                <Users className="w-10 h-10 text-muted-foreground/70 mb-3" />
-                <p className="text-muted-foreground">
-                  No exclusive experts listed yet
-                </p>
-              </div>
+              org.canHost && (
+                <div className="flex flex-col items-center justify-center py-16 text-center bg-card rounded-2xl border border-border">
+                  <Users className="w-10 h-10 text-muted-foreground/70 mb-3" />
+                  <p className="text-muted-foreground">
+                    No exclusive experts listed yet
+                  </p>
+                </div>
+              )
             )}
           </div>
 
@@ -424,25 +455,47 @@ export default async function OrgProfilePage({
               </div>
             )}
 
-            {/* CTA — intentional dark surface */}
+            {/* CTA — intentional dark surface. Now that sponsor-only orgs can
+                be listed, an experts CTA only makes sense where a roster
+                actually exists; otherwise point at the org's own site. */}
             <div className="bg-primary rounded-2xl p-5 text-center">
               <Building2 className="w-8 h-8 text-primary-foreground/70 mx-auto mb-3" />
               <p className="text-primary-foreground font-semibold text-sm mb-1">
                 Work with {org.name}
               </p>
-              <p className="text-primary-foreground/70 text-xs mb-4">
-                Browse their experts and book a session directly.
-              </p>
-              <Button
-                asChild
-                className="w-full bg-card text-foreground hover:bg-muted font-medium rounded-xl"
-              >
-                <Link
-                  href={`/explore/enterprise/organisations/${org.slug}#experts`}
-                >
-                  Browse Experts
-                </Link>
-              </Button>
+              {exclusiveExperts.length > 0 ? (
+                <>
+                  <p className="text-primary-foreground/70 text-xs mb-4">
+                    Browse their experts and book a session directly.
+                  </p>
+                  <Button
+                    asChild
+                    className="w-full bg-card text-foreground hover:bg-muted font-medium rounded-xl"
+                  >
+                    <Link href="#experts">Browse Experts</Link>
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <p className="text-primary-foreground/70 text-xs mb-4">
+                    {org.name} is listed on Familiarise.
+                  </p>
+                  {org.website && (
+                    <Button
+                      asChild
+                      className="w-full bg-card text-foreground hover:bg-muted font-medium rounded-xl"
+                    >
+                      <a
+                        href={org.website}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Visit website
+                      </a>
+                    </Button>
+                  )}
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/app/explore/enterprise/organisations/page.tsx
+++ b/app/explore/enterprise/organisations/page.tsx
@@ -1,264 +1,85 @@
+import { Sparkles } from "lucide-react";
+import type { Metadata } from "next";
 import { Suspense } from "react";
-import { Building2, Users, Globe, Sparkles } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import Image from "next/image";
-import Link from "next/link";
-import prisma from "@/lib/prisma";
-import { emptyOnTransientDbError } from "@/lib/data/fail-open";
-import { ENABLE_HOST_ORGS } from "@/lib/feature-flags";
+
+import {
+  DEFAULT_ORGANISATION_FILTERS,
+  getOrganisationsMetadata,
+  getOrganisationsPage,
+  type OrganisationsMetadata,
+} from "@/lib/data/explore-organisations";
+import { fallbackOnTransientDbError } from "@/lib/data/fail-open";
+
+import OrganisationsInteractiveContent, {
+  OrganisationsGridSkeleton,
+} from "./OrganisationsInteractiveContent";
 
 // Stream behind the static layout's instant skeleton; don't prerender at build (#932).
-// (Replaces the prior `revalidate = 60`, which was inert while the layout forced dynamic.)
 export const dynamic = "force-dynamic";
 
-async function fetchPublicOrgs(industry?: string) {
-  const rows = await prisma.organization.findMany({
-    where: {
-      isPublic: true,
-      canHost: true,
-      status: "ACTIVE",
-      ...(industry
-        ? {
-            brandingProfile: {
-              industry: { equals: industry, mode: "insensitive" },
-            },
-          }
-        : {}),
-    },
-    select: {
-      id: true,
-      name: true,
-      slug: true,
-      canSponsor: true,
-      canHost: true,
-      brandingProfile: {
-        select: {
-          logo: true,
-          bannerImage: true,
-          description: true,
-          industry: true,
-          website: true,
-        },
-      },
-      _count: {
-        select: {
-          memberships: { where: { role: "EXPERT", status: "ACTIVE" } },
-        },
-      },
-    },
-    orderBy: { name: "asc" },
-    take: 48,
-  });
-  // Flatten brandingProfile so the card renderer reads org.logo / .industry
-  // directly without touching every render site.
-  return rows.map((row) => ({
-    ...row,
-    logo: row.brandingProfile?.logo ?? null,
-    bannerImage: row.brandingProfile?.bannerImage ?? null,
-    description: row.brandingProfile?.description ?? null,
-    industry: row.brandingProfile?.industry ?? null,
-    website: row.brandingProfile?.website ?? null,
-  }));
-}
+export const metadata: Metadata = {
+  title: "Explore Organisations | Familiarise",
+  description:
+    "Discover expert networks, consulting agencies, and learning institutions on Familiarise. Browse their curated experts and programs.",
+};
 
-async function fetchIndustryList() {
-  const rows = await prisma.orgBrandingProfile.findMany({
-    where: {
-      organization: { isPublic: true, canHost: true, status: "ACTIVE" },
-      industry: { not: null },
-    },
-    select: { industry: true },
-    distinct: ["industry"],
-    orderBy: { industry: "asc" },
-  });
-  return rows.map((r) => r.industry as string);
-}
+const EMPTY_METADATA: OrganisationsMetadata = {
+  industries: [],
+  types: [],
+  sizes: [],
+  capabilities: [],
+  total: 0,
+};
 
-function OrgCard({
-  org,
-}: {
-  org: Awaited<ReturnType<typeof fetchPublicOrgs>>[number];
-}) {
-  const capabilityLabel = org.canSponsor && org.canHost ? "Hybrid" : "Host";
-  // Capability is a binary categorical badge with no dark: variants — render it
-  // monochrome (filled = Hybrid, muted = Host) rather than off-brand purple/blue.
-  const capabilityClass =
-    org.canSponsor && org.canHost
-      ? "bg-primary text-primary-foreground border-transparent"
-      : "bg-muted text-muted-foreground border-border";
+async function OrganisationsDirectory() {
+  // Both reads degrade rather than crash the page on a transient pooler
+  // timeout (cross-region cold connect, #932).
+  const [meta, firstPage] = await Promise.all([
+    getOrganisationsMetadata().catch(
+      fallbackOnTransientDbError("org directory metadata", EMPTY_METADATA),
+    ),
+    getOrganisationsPage(DEFAULT_ORGANISATION_FILTERS).catch(
+      fallbackOnTransientDbError("org directory page", {
+        items: [],
+        total: 0,
+        page: 1,
+        totalPages: 1,
+      }),
+    ),
+  ]);
 
   return (
-    <Link
-      href={`/explore/enterprise/organisations/${org.slug}`}
-      className="group flex flex-col bg-card rounded-2xl border border-border hover:border-border hover:shadow-lg transition-all duration-300 overflow-hidden"
-    >
-      {/* Banner / header area */}
-      <div className="relative h-24 bg-gradient-to-br from-muted to-muted overflow-hidden">
-        {org.bannerImage && (
-          <Image
-            src={org.bannerImage}
-            alt=""
-            fill
-            className="object-cover opacity-60"
-          />
-        )}
-        <div className="absolute inset-0 bg-gradient-to-b from-transparent to-black/20" />
-      </div>
-
-      <div className="p-5 flex flex-col gap-3 flex-1">
-        {/* Logo + name row */}
-        <div className="flex items-center gap-3 -mt-10 relative">
-          <div className="w-14 h-14 rounded-xl bg-card border-2 border-card shadow-md flex items-center justify-center overflow-hidden flex-shrink-0">
-            {org.logo ? (
-              <Image
-                src={org.logo}
-                alt={org.name}
-                width={56}
-                height={56}
-                className="object-contain"
-              />
-            ) : (
-              <Building2 className="w-7 h-7 text-muted-foreground/70" />
-            )}
-          </div>
-          <div className="pt-8 min-w-0">
-            <h3 className="font-bold text-foreground group-hover:text-muted-foreground transition-colors truncate">
-              {org.name}
-            </h3>
-            {org.industry && (
-              <p className="text-xs text-muted-foreground truncate">
-                {org.industry}
-              </p>
-            )}
-          </div>
-        </div>
-
-        {/* Description */}
-        {org.description && (
-          <p className="text-sm text-muted-foreground line-clamp-2 leading-relaxed">
-            {org.description}
-          </p>
-        )}
-
-        {/* Footer: badges + expert count */}
-        <div className="mt-auto flex items-center justify-between gap-2 pt-2">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <Badge
-              variant="outline"
-              className={`text-[10px] px-2 py-0.5 ${capabilityClass}`}
-            >
-              {capabilityLabel}
-            </Badge>
-          </div>
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
-            <Users className="w-3.5 h-3.5" />
-            <span>
-              {org._count.memberships} expert
-              {org._count.memberships !== 1 ? "s" : ""}
-            </span>
-          </div>
-        </div>
-      </div>
-    </Link>
+    <OrganisationsInteractiveContent
+      metadata={meta}
+      initialItems={firstPage.items}
+      initialTotal={firstPage.total}
+    />
   );
 }
 
-function OrgCardSkeleton() {
-  return (
-    <div className="flex flex-col bg-card rounded-2xl border border-border overflow-hidden animate-pulse">
-      <div className="h-24 bg-muted" />
-      <div className="p-5 flex flex-col gap-3">
-        <div className="flex items-center gap-3 -mt-10">
-          <div className="w-14 h-14 rounded-xl bg-muted" />
-          <div className="pt-8 flex flex-col gap-1">
-            <div className="h-4 w-28 bg-muted rounded" />
-            <div className="h-3 w-20 bg-muted rounded" />
-          </div>
-        </div>
-        <div className="h-3 bg-muted rounded w-full" />
-        <div className="h-3 bg-muted rounded w-3/4" />
-        <div className="flex justify-between pt-2">
-          <div className="h-5 w-14 bg-muted rounded-full" />
-          <div className="h-4 w-16 bg-muted rounded" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-async function OrgsGrid({ industry }: { industry?: string }) {
-  const orgs = await fetchPublicOrgs(industry);
-
-  if (orgs.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-24 text-center">
-        <Building2 className="w-12 h-12 text-muted-foreground/70 mb-4" />
-        <p className="text-muted-foreground text-lg font-medium">
-          {industry
-            ? `No agencies in ${industry} yet`
-            : "No agencies listed yet"}
-        </p>
-        <p className="text-muted-foreground/70 text-sm mt-1">
-          {industry ? (
-            <Link
-              href="/explore/enterprise/organisations"
-              className="underline hover:text-foreground"
-            >
-              View all industries
-            </Link>
-          ) : (
-            "Check back soon — organizations can opt in to marketplace discovery from their settings."
-          )}
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-      {orgs.map((org) => (
-        <OrgCard key={org.id} org={org} />
-      ))}
-    </div>
-  );
-}
-
-export default async function ExploreOrganisationsPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ industry?: string }>;
-}) {
-  const { industry } = await searchParams;
-  // Outside the orgs Suspense boundary — a transient timeout here would crash the
-  // whole page, so degrade to no industry filters rather than erroring (#925).
-  // #1019 — skip the query entirely while host orgs are gated: the grid + filters
-  // are replaced by the "coming soon" state, so the industries list is unused.
-  const industries = ENABLE_HOST_ORGS
-    ? await fetchIndustryList().catch(emptyOnTransientDbError("org industries"))
-    : [];
-
+export default function ExploreOrganisationsPage() {
   return (
     <main className="min-h-screen bg-background">
       {/* Hero */}
-      <section className="relative pt-32 pb-16 bg-zinc-950 overflow-hidden">
+      <section className="relative overflow-hidden bg-zinc-950 pt-32 pb-16">
         <div className="absolute inset-0">
-          <div className="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-zinc-800/30 rounded-full blur-[120px] animate-blob" />
-          <div className="absolute bottom-1/4 right-1/4 w-[400px] h-[400px] bg-zinc-700/20 rounded-full blur-[100px] animate-blob animation-delay-2000" />
+          <div className="animate-blob absolute left-1/4 top-1/4 h-[500px] w-[500px] rounded-full bg-zinc-800/30 blur-[120px]" />
+          <div className="animate-blob animation-delay-2000 absolute bottom-1/4 right-1/4 h-[400px] w-[400px] rounded-full bg-zinc-700/20 blur-[100px]" />
         </div>
-        <div className="absolute inset-0 grid-pattern opacity-20" />
+        <div className="grid-pattern absolute inset-0 opacity-20" />
 
-        <div className="max-w-[1400px] mx-auto px-4 md:px-8 relative z-10">
-          <div className="max-w-3xl mx-auto text-center">
-            <div className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800/50 backdrop-blur-sm border border-zinc-700/50 rounded-full mb-8">
-              <Sparkles className="w-4 h-4 text-white" />
+        <div className="relative z-10 mx-auto max-w-[1400px] px-4 md:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-zinc-700/50 bg-zinc-800/50 px-4 py-2 backdrop-blur-sm">
+              <Sparkles className="h-4 w-4 text-white" />
               <span className="text-sm font-medium text-zinc-300">
-                Expert Networks & Agencies
+                Expert Networks &amp; Agencies
               </span>
             </div>
-            <h1 className="text-fluid-4xl font-bold text-white mb-6 tracking-tight">
+            <h1 className="text-fluid-4xl mb-6 font-bold tracking-tight text-white">
               Explore <span className="silver-text">Organisations</span>
             </h1>
-            <p className="text-lg text-zinc-300 max-w-xl mx-auto">
+            <p className="mx-auto max-w-xl text-lg text-zinc-300">
               Discover expert networks, consulting agencies, and learning
               institutions on Familiarise. Book their curated experts directly.
             </p>
@@ -266,77 +87,17 @@ export default async function ExploreOrganisationsPage({
         </div>
       </section>
 
-      {/* #863 — host orgs are gated (ENABLE_HOST_ORGS). While off, this
-          directory (which filters canHost=true) is guaranteed empty, so show an
-          honest announcement instead of a blank grid. */}
-      {!ENABLE_HOST_ORGS ? (
-        <section className="py-16 md:py-24">
-          <div className="max-w-xl mx-auto px-4 text-center">
-            <div className="inline-flex items-center gap-2 px-4 py-2 bg-muted rounded-full mb-6">
-              <Sparkles className="w-4 h-4 text-muted-foreground" />
-              <span className="text-sm font-medium text-muted-foreground">
-                Coming soon
-              </span>
+      <Suspense
+        fallback={
+          <section className="py-10 md:py-16">
+            <div className="mx-auto max-w-[1400px] px-4 md:px-8">
+              <OrganisationsGridSkeleton />
             </div>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
-              The organisation directory isn&apos;t open yet
-            </h2>
-            <p className="text-muted-foreground">
-              We&apos;re onboarding expert networks and agencies now. Check back
-              soon to discover and book their curated experts.
-            </p>
-          </div>
-        </section>
-      ) : (
-      /* Filters + Grid */
-      <section className="py-10 md:py-16">
-        <div className="max-w-[1400px] mx-auto px-4 md:px-8">
-          {/* Industry filter chips — Link-based for SSR filtering */}
-          {industries.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-8">
-              <Link
-                href="/explore/enterprise/organisations"
-                className={`inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-full transition-colors ${
-                  !industry
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-muted text-muted-foreground border border-border hover:bg-muted/80"
-                }`}
-              >
-                <Globe className="w-3.5 h-3.5" />
-                All Industries
-              </Link>
-              {industries.map((ind) => (
-                <Link
-                  key={ind}
-                  href={`/explore/enterprise/organisations?industry=${encodeURIComponent(ind)}`}
-                  className={`inline-flex items-center px-4 py-2 text-sm font-medium rounded-full transition-colors ${
-                    industry?.toLowerCase() === ind.toLowerCase()
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-muted-foreground border border-border hover:bg-muted/80"
-                  }`}
-                >
-                  {ind}
-                </Link>
-              ))}
-            </div>
-          )}
-
-          {/* Org Cards Grid */}
-          <Suspense
-            key={industry ?? "all"}
-            fallback={
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-                {Array.from({ length: 8 }).map((_, i) => (
-                  <OrgCardSkeleton key={i} />
-                ))}
-              </div>
-            }
-          >
-            <OrgsGrid industry={industry} />
-          </Suspense>
-        </div>
-      </section>
-      )}
+          </section>
+        }
+      >
+        <OrganisationsDirectory />
+      </Suspense>
     </main>
   );
 }

--- a/app/explore/experts/ExpertsInteractiveContent.tsx
+++ b/app/explore/experts/ExpertsInteractiveContent.tsx
@@ -7,6 +7,7 @@ import type { IConsultantCardData } from "@/types/consultant";
 import { useCurrency } from "@/hooks/useCurrency";
 import SectionHeader from "@/app/explore/components/SectionHeader";
 import FilterChips from "@/app/explore/components/FilterChips";
+import FacetRail from "@/app/explore/components/FacetRail";
 import {
   useConsultants,
   useExpertsFilters,
@@ -103,7 +104,13 @@ export default function ExpertsInteractiveContent({
         />
 
         {/* Browse All Experts */}
-        <div ref={browseSectionRef} id="all-experts">
+        {/* The nav's "Top rated" deep-links here with ?sort=rating, so the
+            anchor needs the same fixed-navbar offset as #domains. */}
+        <div
+          ref={browseSectionRef}
+          id="all-experts"
+          className="scroll-mt-[calc(var(--header-height,5rem)+1rem)]"
+        >
           <SectionHeader
             title="Browse Familiarise Experts"
             icon={<Search className="w-5 h-5 text-white" />}
@@ -138,22 +145,7 @@ export default function ExpertsInteractiveContent({
             </div>
           </motion.div>
 
-          {/* Filters */}
-          <motion.div
-            className="mb-8"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: 0.1 }}
-          >
-            <FilterPanel
-              metadata={metadata}
-              filters={filters}
-              updateFilters={updateFilters}
-            />
-          </motion.div>
-
-          {/* Search Bar */}
+          {/* Search banner */}
           <motion.div
             className="mb-6"
             initial={{ opacity: 0, y: 20 }}
@@ -176,35 +168,54 @@ export default function ExpertsInteractiveContent({
                 </p>
               </div>
             </div>
-            <SearchBar
-              onSearch={(term) => updateFilters({ search: term })}
-              onSort={(option) => updateFilters({ sort: option })}
-              sortBy={filters.sort}
-              initialSearch={filters.search}
-            />
           </motion.div>
 
-          {/* Active Filter Chips */}
-          {chips.length > 0 && (
-            <div className="mb-6">
-              <FilterChips
-                filters={chips}
-                onRemove={removeChip}
-                onClearAll={clearAll}
+          {/* Filters move into a sticky rail (mobile: Sheet drawer) so the
+              results keep the full column instead of starting below a
+              three-row filter grid. */}
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-[280px_1fr]">
+            <FacetRail activeCount={chips.length} onClearAll={clearAll}>
+              <FilterPanel
+                metadata={metadata}
+                filters={filters}
+                updateFilters={updateFilters}
+              />
+            </FacetRail>
+
+            <div className="min-w-0">
+              <div className="mb-6">
+                <SearchBar
+                  onSearch={(term) => updateFilters({ search: term })}
+                  onSort={(option) => updateFilters({ sort: option })}
+                  sortBy={filters.sort}
+                  initialSearch={filters.search}
+                />
+              </div>
+
+              {chips.length > 0 && (
+                <div className="mb-6">
+                  <FilterChips
+                    filters={chips}
+                    onRemove={removeChip}
+                    onClearAll={clearAll}
+                  />
+                </div>
+              )}
+
+              {/* Kept as a full-width vertical stack, not a grid: ConsultantCard
+                  is a two-column card (profile + plan tabs) that collapses
+                  badly inside a narrow grid cell. */}
+              <ExpertResults
+                consultants={consultants}
+                metadata={metadata}
+                isLoading={isLoading}
+                isRefetching={isRefetching}
+                isLoadingMore={isLoadingMore}
+                groupByDomainId={filters.domain}
+                sentinelRef={sentinelRef}
               />
             </div>
-          )}
-
-          {/* Results */}
-          <ExpertResults
-            consultants={consultants}
-            metadata={metadata}
-            isLoading={isLoading}
-            isRefetching={isRefetching}
-            isLoadingMore={isLoadingMore}
-            groupByDomainId={filters.domain}
-            sentinelRef={sentinelRef}
-          />
+          </div>
         </div>
       </div>
     </section>

--- a/app/explore/experts/components/ConsultantCard.tsx
+++ b/app/explore/experts/components/ConsultantCard.tsx
@@ -176,6 +176,20 @@ export const ConsultantCard = memo(function ConsultantCard({
     },
     {},
   );
+  // Trial CTA is driven by real plan data. Previously it rendered
+  // unconditionally, so an expert offering no trial — or one whose trial is
+  // priced — showed a button that dead-ended. Cheapest trial across the
+  // consultant's plans is the honest headline price.
+  const trialPlans = sortedPlans.filter((plan) => plan.trialEnabled);
+  const trialOffer =
+    trialPlans.length > 0
+      ? {
+          priceInPaise: Math.min(
+            ...trialPlans.map((plan) => plan.trialPriceInPaise ?? 0),
+          ),
+        }
+      : null;
+
   const durationSeen: Record<number, number> = {};
   const tabLabels = sortedPlans.map((plan) => {
     const base = `${plan.durationInMonths} Mo`;
@@ -409,14 +423,22 @@ export const ConsultantCard = memo(function ConsultantCard({
                 <ArrowRight className="w-4 h-4 ml-2" />
               </Link>
             </Button>
-            <div className="grid grid-cols-2 gap-2">
-              <Button
-                asChild
-                variant="outline"
-                className="h-10 border-border hover:bg-muted text-muted-foreground rounded-xl text-sm font-medium"
-              >
-                <Link href={`${profileHref}?action=trial`}>Trial</Link>
-              </Button>
+            <div
+              className={`grid gap-2 ${trialOffer ? "grid-cols-2" : "grid-cols-1"}`}
+            >
+              {trialOffer && (
+                <Button
+                  asChild
+                  variant="outline"
+                  className="h-10 border-border hover:bg-muted text-muted-foreground rounded-xl text-sm font-medium"
+                >
+                  <Link href={`${profileHref}?action=trial`}>
+                    {trialOffer.priceInPaise > 0
+                      ? `Trial · ${formatPrice(trialOffer.priceInPaise)}`
+                      : "Free intro call"}
+                  </Link>
+                </Button>
+              )}
               <Button
                 asChild
                 variant="outline"

--- a/app/explore/experts/components/ConsultantCard.tsx
+++ b/app/explore/experts/components/ConsultantCard.tsx
@@ -10,7 +10,6 @@ import type { IConsultantCardData } from "@/types/consultant";
 import { CompanyLogo } from "@/components/ui/company-logo";
 import {
   Star,
-  MapPin,
   Clock,
   Briefcase,
   Globe,
@@ -45,6 +44,25 @@ const ConsultantInfo = ({
     <span className="text-foreground font-medium">
       {value || "Not specified"}
     </span>
+  </div>
+);
+
+/**
+ * A labelled row of badges. The label column is fixed-width so the "Domain" and
+ * "Skills" rows align with each other and with the ConsultantInfo rows above.
+ */
+const BadgeRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex items-start gap-2 mt-2">
+    <span className="w-16 shrink-0 pt-1.5 text-sm text-muted-foreground">
+      {label}:
+    </span>
+    <div className="flex flex-wrap gap-2">{children}</div>
   </div>
 );
 
@@ -196,13 +214,20 @@ export const ConsultantCard = memo(function ConsultantCard({
               {/* TODO: Add real presence indicator when online tracking is implemented */}
             </div>
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-1.5">
-                <h3 className="text-xl font-bold text-foreground group-hover:text-muted-foreground transition-colors">
+              {/* Name and org badge share one row, so neither may wrap: a long
+                  org name ("Indian Institute of Technology Madras") otherwise
+                  breaks onto a second line and squeezes the name into wrapping
+                  too. Both truncate instead, and the badge keeps its `title`
+                  so the full name is still reachable on hover. */}
+              <div className="flex items-center gap-1.5 min-w-0">
+                <h3 className="truncate text-xl font-bold text-foreground group-hover:text-muted-foreground transition-colors">
                   {consultant.user.name}
                 </h3>
                 {consultant.isVerified && (
-                  <span title="Verified by Familiarise">
-                    <BadgeCheck className="w-5 h-5 text-blue-500" />
+                  <span title="Verified by Familiarise" className="shrink-0">
+                    {/* Verification is an attribute, not a semantic status —
+                        the off-brand blue was the only chromatic accent here. */}
+                    <BadgeCheck className="w-5 h-5 text-foreground" />
                   </span>
                 )}
                 {consultant.organizationBadge && (
@@ -210,14 +235,16 @@ export const ConsultantCard = memo(function ConsultantCard({
                     href={`/explore/enterprise/organisations/${consultant.organizationBadge.slug}`}
                     title={consultant.organizationBadge.name}
                     onClick={(e) => e.stopPropagation()}
-                    className="relative z-10"
+                    className="relative z-10 min-w-0"
                   >
                     <Badge
                       variant="outline"
-                      className="border-border text-foreground text-[10px] px-1.5 py-0 hover:bg-muted transition-colors"
+                      className="max-w-[180px] whitespace-nowrap border-border text-foreground text-[10px] px-1.5 py-0 hover:bg-muted transition-colors"
                     >
-                      <Building2 className="w-3 h-3 mr-0.5" />
-                      {consultant.organizationBadge.name}
+                      <Building2 className="w-3 h-3 mr-0.5 shrink-0" />
+                      <span className="truncate">
+                        {consultant.organizationBadge.name}
+                      </span>
                     </Badge>
                   </Link>
                 )}
@@ -263,11 +290,8 @@ export const ConsultantCard = memo(function ConsultantCard({
                     : null
                 }
               />
-              <ConsultantInfo
-                icon={MapPin}
-                label="Domain"
-                value={consultant.domain?.name}
-              />
+              {/* Domain moved to the labelled badge row below — it was stated
+                  twice, once here and once as the first badge. */}
             </div>
             {/* Languages */}
             {consultant.languages && consultant.languages.length > 0 && (
@@ -300,27 +324,32 @@ export const ConsultantCard = memo(function ConsultantCard({
               </div>
             )}
 
-          {/* Domain & Subdomains */}
-          <div className="flex flex-wrap gap-2">
-            {consultant.domain?.name && (
-              <Badge className="bg-primary text-primary-foreground hover:bg-primary/90 px-3 py-1">
-                {consultant.domain.name}
-              </Badge>
-            )}
-            {consultant.subDomains.slice(0, 2).map((sd) => (
-              <Badge
-                key={`${consultant.id}-subdomain-${sd.id}`}
-                variant="outline"
-                className="border-border text-muted-foreground px-3 py-1"
-              >
-                {sd.name}
-              </Badge>
-            ))}
-          </div>
+          {/* Domain & Subdomains. Labelled rather than a bare run of pills:
+              domain, subdomain and skill badges are visually interchangeable,
+              so without a label the reader can't tell which taxonomy they're
+              looking at. */}
+          {(consultant.domain?.name || consultant.subDomains.length > 0) && (
+            <BadgeRow label="Domain">
+              {consultant.domain?.name && (
+                <Badge className="bg-primary text-primary-foreground hover:bg-primary/90 px-3 py-1">
+                  {consultant.domain.name}
+                </Badge>
+              )}
+              {consultant.subDomains.slice(0, 2).map((sd) => (
+                <Badge
+                  key={`${consultant.id}-subdomain-${sd.id}`}
+                  variant="outline"
+                  className="border-border text-muted-foreground px-3 py-1"
+                >
+                  {sd.name}
+                </Badge>
+              ))}
+            </BadgeRow>
+          )}
 
           {/* Tags */}
           {consultant.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-2">
+            <BadgeRow label="Skills">
               {consultant.tags.slice(0, 3).map((t) => (
                 <Badge
                   key={`${consultant.id}-tag-${t.id}`}
@@ -329,7 +358,7 @@ export const ConsultantCard = memo(function ConsultantCard({
                   {t.name}
                 </Badge>
               ))}
-            </div>
+            </BadgeRow>
           )}
         </div>
 

--- a/app/explore/experts/components/ExpertMiniCard.tsx
+++ b/app/explore/experts/components/ExpertMiniCard.tsx
@@ -23,11 +23,13 @@ function ExpertMiniCardImpl({ expert, badge }: ExpertMiniCardProps) {
         {/* Badge */}
         {badge && (
           <div className="mb-3">
+            {/* Neutral taxonomy, not a status — monochrome, and unlike the
+                previous *-100/*-700 pairs these survive dark mode. */}
             <span
               className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide ${
                 badge === "trending"
-                  ? "bg-orange-100 text-orange-700"
-                  : "bg-emerald-100 text-emerald-700"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground border border-border"
               }`}
             >
               {badge === "trending" ? (
@@ -59,7 +61,7 @@ function ExpertMiniCardImpl({ expert, badge }: ExpertMiniCardProps) {
               </h3>
               {expert.isVerified && (
                 <span title="Verified by Familiarise">
-                  <BadgeCheck className="w-3.5 h-3.5 text-blue-500 flex-shrink-0" />
+                  <BadgeCheck className="w-3.5 h-3.5 text-foreground flex-shrink-0" />
                 </span>
               )}
             </div>

--- a/app/explore/experts/components/FeaturedExperts.tsx
+++ b/app/explore/experts/components/FeaturedExperts.tsx
@@ -126,7 +126,7 @@ function FeaturedExpertsImpl({ experts, isLoading }: FeaturedExpertsProps) {
                         </h3>
                         {expert.isVerified && (
                           <span title="Verified by Familiarise">
-                            <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />
+                            <BadgeCheck className="w-4 h-4 text-foreground flex-shrink-0" />
                           </span>
                         )}
                       </div>

--- a/app/explore/experts/components/FilterPanel.tsx
+++ b/app/explore/experts/components/FilterPanel.tsx
@@ -11,7 +11,6 @@ import { Slider } from "@/components/ui/slider";
 import { memo, useState, useCallback, useRef, useEffect } from "react";
 import {
   X,
-  Filter,
   Layers,
   Tag as TagIcon,
   Clock,
@@ -200,21 +199,14 @@ function FilterPanelImpl({
       return company.toLowerCase().includes(companySearchTerm.toLowerCase());
     }) || [];
 
+  // Renders inside FacetRail (sticky column on desktop, Sheet on mobile), so
+  // this no longer draws its own card or header — the rail owns both — and the
+  // facets stack in one column instead of the old three-across grid.
   return (
-    <div className="bg-muted rounded-2xl p-6 border border-border">
-      <div className="flex items-center gap-2 mb-6">
-        <div className="w-10 h-10 rounded-xl bg-primary flex items-center justify-center">
-          <Filter className="w-5 h-5 text-primary-foreground" />
-        </div>
-        <div>
-          <h3 className="font-semibold text-foreground">Filter Experts</h3>
-          <p className="text-sm text-muted-foreground">Refine your search</p>
-        </div>
-      </div>
-
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <div>
+      <div className="grid gap-4 grid-cols-1">
         {/* Domain & Subdomain */}
-        <div className="bg-card rounded-xl p-4 border border-border">
+        <div className="pb-4 border-b border-border last:border-b-0">
           <div className="flex items-center gap-2 mb-4">
             <Layers className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-medium text-muted-foreground">Category</span>
@@ -275,7 +267,7 @@ function FilterPanelImpl({
         </div>
 
         {/* Tags */}
-        <div className="bg-card rounded-xl p-4 border border-border">
+        <div className="pb-4 border-b border-border last:border-b-0">
           <div className="flex items-center gap-2 mb-4">
             <TagIcon className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-medium text-muted-foreground">
@@ -334,7 +326,7 @@ function FilterPanelImpl({
         </div>
 
         {/* Experience & Rating (combined) */}
-        <div className="bg-card rounded-xl p-4 border border-border">
+        <div className="pb-4 border-b border-border last:border-b-0">
           <div className="flex items-center gap-2 mb-4">
             <Clock className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-medium text-muted-foreground">
@@ -411,7 +403,7 @@ function FilterPanelImpl({
         </div>
 
         {/* Price Range — dual-thumb slider */}
-        <div className="bg-card rounded-xl p-4 border border-border">
+        <div className="pb-4 border-b border-border last:border-b-0">
           <div className="flex items-center gap-2 mb-4">
             <DollarSign className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-medium text-muted-foreground">
@@ -448,7 +440,7 @@ function FilterPanelImpl({
         </div>
 
         {/* Companies */}
-        <div className="bg-card rounded-xl p-4 border border-border">
+        <div className="pb-4 border-b border-border last:border-b-0">
           <div className="flex items-center gap-2 mb-4">
             <Building2 className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-medium text-muted-foreground">Company</span>
@@ -502,7 +494,7 @@ function FilterPanelImpl({
         </div>
 
         {/* Language */}
-        <div className="bg-card rounded-xl p-4 border border-border">
+        <div className="pb-4 border-b border-border last:border-b-0">
           <div className="flex items-center gap-2 mb-4">
             <Globe className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-medium text-muted-foreground">Language</span>

--- a/app/explore/experts/components/StaticTopRows.tsx
+++ b/app/explore/experts/components/StaticTopRows.tsx
@@ -57,9 +57,14 @@ function StaticTopRowsImpl({
         <ExpertRow experts={newestExperts} badge="new" isLoading={false} />
       </div>
 
-      {/* Browse by Domain */}
+      {/* Browse by Domain. The nav's "Browse by domain" item deep-links to
+          #domains; scroll-mt clears the fixed navbar so the heading isn't
+          hidden under it on landing. */}
       {metadata?.consultantMetadata?.consultantsByDomain && (
-        <div className="mb-14">
+        <div
+          id="domains"
+          className="mb-14 scroll-mt-[calc(var(--header-height,5rem)+1rem)]"
+        >
           <SectionHeader
             title="Browse by Domain"
             icon={<Briefcase className="w-5 h-5 text-white" />}

--- a/app/explore/experts/hooks/useExpertsFilters.ts
+++ b/app/explore/experts/hooks/useExpertsFilters.ts
@@ -65,7 +65,10 @@ export function useExpertsFilters(): UseExpertsFiltersResult {
     if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
     urlSyncRef.current = setTimeout(() => {
       const qs = filtersToSearchParams(filters);
-      const target = `/explore/experts${qs ? `?${qs}` : ""}`;
+      // Preserve the hash: deep-links like ?sort=rating#all-experts would
+      // otherwise lose their anchor when this rewrite lands 300ms after mount.
+      const hash = window.location.hash;
+      const target = `/explore/experts${qs ? `?${qs}` : ""}${hash}`;
       const current = window.location.pathname + window.location.search;
       if (target !== current) {
         window.history.replaceState(window.history.state, "", target);

--- a/app/explore/hooks/useUrlSyncedFilters.ts
+++ b/app/explore/hooks/useUrlSyncedFilters.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ReadonlyParams } from "@/lib/explore/filter-codec";
+
+const URL_SYNC_DEBOUNCE_MS = 300;
+
+interface UseUrlSyncedFiltersOptions<T> {
+  /** Pathname to write back to, e.g. "/explore/enterprise/organisations". */
+  basePath: string;
+  defaults: T;
+  fromSearchParams: (params: ReadonlyParams) => T;
+  toSearchParams: (filters: T) => string;
+}
+
+export interface UrlSyncedFilters<T> {
+  filters: T;
+  updateFilters: (partial: Partial<T>) => void;
+  clearFilters: () => void;
+}
+
+/**
+ * Filter state plus its URL mirror, generalised from `useExpertsFilters` so
+ * every explore surface gets bookmarkable filters (programs previously synced
+ * only `?tab=`).
+ *
+ * Two behaviours are carried over deliberately from the experts implementation:
+ *
+ * - `updateFilters` is SYNCHRONOUS. Consumers that fire rapid mutations (search
+ *   typing, slider drags) debounce their own propagation; doing it here would
+ *   make every consumer's query key lag behind the UI.
+ * - URL writes go through `window.history.replaceState`, not `router.replace`.
+ *   Next 15's App Router re-renders the tree via `useSearchParams` reactivity
+ *   even with `{ scroll: false }`, which causes mid-typing scroll-to-top jumps.
+ */
+export function useUrlSyncedFilters<T>({
+  basePath,
+  defaults,
+  fromSearchParams,
+  toSearchParams,
+}: UseUrlSyncedFiltersOptions<T>): UrlSyncedFilters<T> {
+  const searchParams = useSearchParams();
+
+  // Hydrate from the URL once so shareable links work. On the server
+  // `searchParams` is empty in client components, so this falls back to
+  // defaults during SSR and re-syncs on mount.
+  const [filters, setFilters] = useState<T>(() =>
+    fromSearchParams(searchParams),
+  );
+
+  const updateFilters = useCallback((partial: Partial<T>) => {
+    setFilters((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters(defaults);
+    // `defaults` is a module-level constant at every call site; listing it
+    // keeps the lint rule happy without changing identity across renders.
+  }, [defaults]);
+
+  const urlSyncRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
+    urlSyncRef.current = setTimeout(() => {
+      const qs = toSearchParams(filters);
+      // Preserve the hash — see the note in useExpertsFilters.
+      const hash = window.location.hash;
+      const target = `${basePath}${qs ? `?${qs}` : ""}${hash}`;
+      const current = window.location.pathname + window.location.search;
+      if (target !== current) {
+        window.history.replaceState(window.history.state, "", target);
+      }
+    }, URL_SYNC_DEBOUNCE_MS);
+
+    return () => {
+      if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
+    };
+  }, [filters, basePath, toSearchParams]);
+
+  return { filters, updateFilters, clearFilters };
+}

--- a/app/explore/programs/ProgramsInteractiveContent.tsx
+++ b/app/explore/programs/ProgramsInteractiveContent.tsx
@@ -5,12 +5,7 @@ import { motion } from "framer-motion";
 import { GraduationCap, Video, Users, Sparkles } from "lucide-react";
 import { useSession } from "@/lib/auth-client";
 import { useCurrency } from "@/hooks/useCurrency";
-import {
-  filterAndSortPrograms,
-  getUniqueLevels,
-  type Program,
-  type TopicWithCount,
-} from "@/lib/explore/programs";
+import { type Program, type TopicWithCount } from "@/lib/explore/programs";
 import {
   useCuratedPrograms,
   useInfiniteScroll,
@@ -38,6 +33,8 @@ interface ProgramsInteractiveContentProps {
   initialStats: ProgramStats | null;
   /** #664 — viewer's ACTIVE org memberships as { orgId: orgName }. */
   viewerOrgs?: Record<string, string>;
+  /** Every level in the catalog, read server-side — not just loaded rows. */
+  availableLevels?: string[];
 }
 
 const FALLBACK_STATS = [
@@ -68,6 +65,7 @@ export default function ProgramsInteractiveContent({
   initialTopics,
   initialStats,
   viewerOrgs = {},
+  availableLevels = [],
 }: ProgramsInteractiveContentProps) {
   const { data: session } = useSession();
   const userId = session?.user?.id;
@@ -79,7 +77,6 @@ export default function ProgramsInteractiveContent({
     handleTabChange,
     filters,
     updateFilters,
-    searchTerm,
     localSearchValue,
     onLocalSearchChange,
     selectedLevel,
@@ -142,7 +139,7 @@ export default function ProgramsInteractiveContent({
     filters,
     topics: topicsWithCount,
     selectedLevel,
-    searchTerm,
+    searchTerm: filters.search ?? "",
     formatPrice,
     updateFilters,
     setSelectedLevel,
@@ -170,12 +167,12 @@ export default function ProgramsInteractiveContent({
     [filters.topicIds, updateFilters],
   );
 
-  const filteredAndSortedPrograms = useMemo(
-    () => filterAndSortPrograms(programs, searchTerm, selectedLevel),
-    [programs, searchTerm, selectedLevel],
-  );
+  // `programs` is already fully filtered by the API — search and level used to
+  // be re-applied here over the loaded page only, which silently dropped
+  // matches that lived on later pages.
+  const filteredAndSortedPrograms = programs;
 
-  const uniqueLevels = useMemo(() => getUniqueLevels(programs), [programs]);
+  const uniqueLevels = availableLevels;
 
   return (
     <main className="min-h-screen bg-background">

--- a/app/explore/programs/components/ProgramCard.tsx
+++ b/app/explore/programs/components/ProgramCard.tsx
@@ -21,6 +21,9 @@ interface ProgramCardProps {
   viewerOrgs?: Record<string, string>;
 }
 
+// Curation state is a neutral taxonomy, not a status — colour is reserved for
+// destructive/success/warning/info here, so these read monochrome (filled for
+// the editorial pick, muted for the derived ones) and survive dark mode.
 const badgeConfig: Record<
   ProgramBadge,
   { label: string; icon: React.ReactNode; className: string }
@@ -28,17 +31,17 @@ const badgeConfig: Record<
   featured: {
     label: "Familiarise Pick",
     icon: <Sparkles className="w-3 h-3" />,
-    className: "bg-amber-500 text-white",
+    className: "bg-primary text-primary-foreground",
   },
   trending: {
     label: "Trending",
     icon: <Flame className="w-3 h-3" />,
-    className: "bg-rose-500 text-white",
+    className: "bg-background/90 text-foreground border border-border",
   },
   new: {
     label: "New",
     icon: <Sparkles className="w-3 h-3" />,
-    className: "bg-emerald-500 text-white",
+    className: "bg-background/90 text-foreground border border-border",
   },
 };
 

--- a/app/explore/programs/hooks/_helpers.ts
+++ b/app/explore/programs/hooks/_helpers.ts
@@ -55,6 +55,8 @@ export function buildFilterParams(filters: ProgramFilters): string {
   if (filters.maxPrice !== undefined)
     params.set("maxPrice", String(filters.maxPrice));
   if (filters.search) params.set("search", filters.search);
+  if (filters.level && filters.level !== "all")
+    params.set("level", filters.level);
   const str = params.toString();
   return str ? `&${str}` : "";
 }

--- a/app/explore/programs/hooks/useProgramsFilters.ts
+++ b/app/explore/programs/hooks/useProgramsFilters.ts
@@ -1,72 +1,107 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
+
 import type { ProgramFilters, ProgramType } from "@/lib/explore/programs";
 
 const SEARCH_DEBOUNCE_MS = 300;
+const URL_SYNC_DEBOUNCE_MS = 300;
 
 interface UseProgramsFiltersResult {
-  // Tab — URL-synced via window.history.replaceState
   programType: ProgramType;
   handleTabChange: (tab: ProgramType) => void;
 
-  // Server-side filters (drive React Query refetch)
+  /** All filters are server-side and drive the React Query refetch. */
   filters: ProgramFilters;
   updateFilters: (partial: Partial<ProgramFilters>) => void;
 
-  // Client-side filters
-  searchTerm: string; // debounced — fed into filterAndSortPrograms
-  localSearchValue: string; // immediate — controls the input
+  /** Immediate value controlling the search input. */
+  localSearchValue: string;
   onLocalSearchChange: (value: string) => void;
   selectedLevel: string;
   setSelectedLevel: (level: string) => void;
 
-  // View preference (purely cosmetic)
+  // View preference (purely cosmetic, deliberately not in the URL)
   viewMode: "grid" | "list";
   setViewMode: (mode: "grid" | "list") => void;
 
   clearAll: () => void;
 }
 
+function filtersFromParams(params: URLSearchParams): ProgramFilters {
+  const topicIds = params.get("topicIds");
+  const minPrice = params.get("minPrice");
+  const maxPrice = params.get("maxPrice");
+  return {
+    topicIds: topicIds ? topicIds.split(",").filter(Boolean) : undefined,
+    language: params.get("language") ?? undefined,
+    domainId: params.get("domainId") ?? undefined,
+    sort: params.get("sort") ?? undefined,
+    minPrice: minPrice !== null ? Number(minPrice) : undefined,
+    maxPrice: maxPrice !== null ? Number(maxPrice) : undefined,
+    search: params.get("search") ?? undefined,
+    level: params.get("level") ?? undefined,
+  };
+}
+
+function paramsFromFilters(
+  filters: ProgramFilters,
+  tab: ProgramType,
+): string {
+  const params = new URLSearchParams();
+  if (tab !== "all") params.set("tab", tab);
+  if (filters.topicIds && filters.topicIds.length > 0) {
+    params.set("topicIds", filters.topicIds.join(","));
+  }
+  if (filters.language) params.set("language", filters.language);
+  if (filters.domainId) params.set("domainId", filters.domainId);
+  if (filters.sort) params.set("sort", filters.sort);
+  if (filters.minPrice !== undefined)
+    params.set("minPrice", String(filters.minPrice));
+  if (filters.maxPrice !== undefined)
+    params.set("maxPrice", String(filters.maxPrice));
+  if (filters.search) params.set("search", filters.search);
+  if (filters.level && filters.level !== "all")
+    params.set("level", filters.level);
+  return params.toString();
+}
+
 /**
- * Owns all the local UI state for the programs listing page (tab, server
- * filters, client filters, view mode) plus the URL mirror for the active
- * tab.
+ * Owns the programs listing filter state and its URL mirror.
  *
- * Mirrors the experts page's `useExpertsFilters` shape but encodes the
- * programs-specific filter type. URL writes go through
- * `window.history.replaceState` so we don't trigger the Next 15
- * `useSearchParams()` reactivity that caused scroll-to-top jumps on the
- * experts listing.
+ * Previously `search` and `level` were applied CLIENT-side by
+ * `filterAndSortPrograms` over whatever infinite-scroll had already loaded, so
+ * a program matching the query on a later page never showed up — the results
+ * were simply wrong. Both are now server-side filters like every other, and
+ * every filter is bookmarkable (only `?tab=` used to be).
  *
- * Only the `tab` query param is URL-synced today (matching the original
- * behavior — topic / price / level filters were never bookmarkable).
+ * URL writes go through `window.history.replaceState` rather than
+ * `router.replace`: Next 15's App Router re-renders the tree via
+ * `useSearchParams` reactivity even with `{ scroll: false }`, which caused
+ * mid-typing scroll-to-top jumps on the experts listing.
  */
 export function useProgramsFilters(): UseProgramsFiltersResult {
   const searchParams = useSearchParams();
 
-  // Hydrate `programType` from `?tab=` once on mount.
   const [programType, setProgramType] = useState<ProgramType>(() => {
     const tab = searchParams.get("tab");
     return (tab as ProgramType) || "all";
   });
 
-  const [filters, setFilters] = useState<ProgramFilters>({});
+  const [filters, setFilters] = useState<ProgramFilters>(() =>
+    filtersFromParams(new URLSearchParams(searchParams.toString())),
+  );
 
-  // Search has both an immediate (input-controlled) and a debounced
-  // (filter-applied) value. The debounced one feeds the client-side
-  // filterAndSortPrograms, so rapid typing doesn't recompute the list
-  // on every keystroke.
-  const [searchTerm, setSearchTerm] = useState("");
-  const [localSearchValue, setLocalSearchValue] = useState("");
-
-  const [selectedLevel, setSelectedLevel] = useState("all");
+  // Immediate mirror so typing stays responsive while the query key debounces.
+  const [localSearchValue, setLocalSearchValue] = useState(
+    () => searchParams.get("search") ?? "",
+  );
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
 
   const debouncedSetSearch = useDebouncedCallback((value: string) => {
-    setSearchTerm(value);
+    setFilters((prev) => ({ ...prev, search: value || undefined }));
   }, SEARCH_DEBOUNCE_MS);
 
   const onLocalSearchChange = useCallback(
@@ -79,30 +114,46 @@ export function useProgramsFilters(): UseProgramsFiltersResult {
 
   const handleTabChange = useCallback((tab: ProgramType) => {
     setProgramType(tab);
-    const params = new URLSearchParams(window.location.search);
-    if (tab === "all") {
-      params.delete("tab");
-    } else {
-      params.set("tab", tab);
-    }
-    const qs = params.toString();
-    const target = `/explore/programs${qs ? `?${qs}` : ""}`;
-    window.history.replaceState(window.history.state, "", target);
   }, []);
 
   const updateFilters = useCallback((partial: Partial<ProgramFilters>) => {
     setFilters((prev) => ({ ...prev, ...partial }));
   }, []);
 
+  const selectedLevel = filters.level ?? "all";
+  const setSelectedLevel = useCallback((level: string) => {
+    setFilters((prev) => ({
+      ...prev,
+      level: level === "all" ? undefined : level,
+    }));
+  }, []);
+
   const clearAll = useCallback(() => {
     setFilters({});
-    setSelectedLevel("all");
-    setSearchTerm("");
     setLocalSearchValue("");
   }, []);
 
-  // Cancel any pending debounced search call on unmount so we don't
-  // setSearchTerm after the component is gone.
+  // Debounced URL sync so rapid filter changes coalesce into one history write.
+  const urlSyncRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
+    urlSyncRef.current = setTimeout(() => {
+      const qs = paramsFromFilters(filters, programType);
+      // Preserve the hash — see the note in useExpertsFilters.
+      const hash = window.location.hash;
+      const target = `/explore/programs${qs ? `?${qs}` : ""}${hash}`;
+      const current = window.location.pathname + window.location.search;
+      if (target !== current) {
+        window.history.replaceState(window.history.state, "", target);
+      }
+    }, URL_SYNC_DEBOUNCE_MS);
+
+    return () => {
+      if (urlSyncRef.current) clearTimeout(urlSyncRef.current);
+    };
+  }, [filters, programType]);
+
+  // Cancel any pending debounced search on unmount.
   useEffect(() => () => debouncedSetSearch.cancel(), [debouncedSetSearch]);
 
   return {
@@ -110,7 +161,6 @@ export function useProgramsFilters(): UseProgramsFiltersResult {
     handleTabChange,
     filters,
     updateFilters,
-    searchTerm,
     localSearchValue,
     onLocalSearchChange,
     selectedLevel,

--- a/app/explore/programs/page.tsx
+++ b/app/explore/programs/page.tsx
@@ -46,18 +46,25 @@ export const dynamic = "force-dynamic";
 export default async function ExplorePrograms() {
   // Degrade gracefully: a heavy curated read that times out (cold query brushing
   // the pg query budget) renders an empty row instead of erroring the whole page.
-  const [trendingPrograms, newestPrograms, topicsWithCount, stats, viewerOrgs] =
-    await Promise.all([
-      getCuratedPrograms("all", "trending", 8).catch(
-        emptyOnTransientDbError("trending programs"),
-      ),
-      getCuratedPrograms("all", "newest", 8).catch(
-        emptyOnTransientDbError("newest programs"),
-      ),
-      getTopicsWithCount("all").catch(emptyOnTransientDbError("topics")),
-      fetchProgramStats(),
-      getViewerOrgs(),
-    ]);
+  const [
+    trendingPrograms,
+    newestPrograms,
+    topicsWithCount,
+    stats,
+    viewerOrgs,
+    levels,
+  ] = await Promise.all([
+    getCuratedPrograms("all", "trending", 8).catch(
+      emptyOnTransientDbError("trending programs"),
+    ),
+    getCuratedPrograms("all", "newest", 8).catch(
+      emptyOnTransientDbError("newest programs"),
+    ),
+    getTopicsWithCount("all").catch(emptyOnTransientDbError("topics")),
+    fetchProgramStats(),
+    getViewerOrgs(),
+    getCachedProgramLevels().catch(emptyOnTransientDbError("program levels")),
+  ]);
 
   return (
     <ProgramsInteractiveContent
@@ -66,6 +73,7 @@ export default async function ExplorePrograms() {
       initialTopics={topicsWithCount}
       initialStats={stats}
       viewerOrgs={viewerOrgs}
+      availableLevels={levels}
     />
   );
 }
@@ -81,6 +89,40 @@ const getCachedProgramCounts = unstable_cache(
     return { classCount, webinarCount };
   },
   ["program-stats"],
+  { revalidate: 3600, tags: ["programs"] },
+);
+
+/** Every level that exists across both plan families.
+ *
+ *  The level dropdown used to be derived from whatever infinite-scroll had
+ *  already loaded (`getUniqueLevels(programs)`), so a level that only appeared
+ *  on a later page was not offerable — and picking one then filtered only the
+ *  loaded rows. Levels are a small, slow-moving set; read them once. */
+// Not exported: Next.js allows only a fixed set of exports from a page module,
+// and a stray one fails `next build` (which `tsc --noEmit` cannot catch).
+const getCachedProgramLevels = unstable_cache(
+  async () => {
+    const [classLevels, webinarLevels] = await Promise.all([
+      prisma.classPlan.findMany({
+        where: { level: { not: null } },
+        select: { level: true },
+        distinct: ["level"],
+      }),
+      prisma.webinarPlan.findMany({
+        where: { level: { not: null } },
+        select: { level: true },
+        distinct: ["level"],
+      }),
+    ]);
+    return [
+      ...new Set(
+        [...classLevels, ...webinarLevels]
+          .map((row) => row.level)
+          .filter((level): level is string => Boolean(level)),
+      ),
+    ].sort((a, b) => a.localeCompare(b));
+  },
+  ["program-levels"],
   { revalidate: 3600, tags: ["programs"] },
 );
 

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -4,6 +4,10 @@ import * as Sentry from "@sentry/nextjs";
 import NextError from "next/error";
 import { useEffect } from "react";
 
+import { sora } from "@/lib/fonts";
+
+import "./globals.css";
+
 export default function GlobalError({
   error,
 }: {
@@ -14,8 +18,11 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html lang="en">
-      <body>
+    // global-error legitimately replaces the root layout, so it owns the only
+    // <html>/<body> on this render — hence the font class here rather than
+    // inherited. Without it this surface fell back to the UA default font.
+    <html lang="en" className={sora.variable}>
+      <body className={`${sora.className} antialiased`}>
         {/* `NextError` is the default Next.js error page component. Its type
         definition requires a `statusCode` prop. However, since the App Router
         does not expose status codes for errors, we simply pass 0 to render a

--- a/app/globals.css
+++ b/app/globals.css
@@ -1266,3 +1266,52 @@
 [role="menu"] {
   z-index: 10001 !important;
 }
+
+/* ─── Reduced motion ──────────────────────────────────────────────────────
+ *
+ * `<MotionConfig reducedMotion="user">` only governs framer-motion; it cannot
+ * reach CSS keyframes. The decorative animations below are the ones that
+ * actually trigger vestibular discomfort — blurred blobs drifting behind
+ * heroes, floating cards, pulsing rings, sweeping shine and scan lines — and
+ * they run infinitely across ~11 surfaces, so they never stop on their own.
+ *
+ * Deliberately targeted rather than the blanket
+ * `*{animation-duration:0.01ms!important}` recipe: that also freezes the
+ * marquees mid-travel and flattens hover/focus transitions, which removes
+ * useful interaction feedback. Reveal-on-scroll animations are neutralised to
+ * their end state instead of removed, so content can't get stuck invisible.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .animate-blob,
+  .animate-float,
+  .animate-float-delayed,
+  .shimmer,
+  .shimmer-dark,
+  .count-up,
+  .pulse-ring::before,
+  .chrome-shine::after,
+  .scan-line::after {
+    animation: none !important;
+  }
+
+  /* Marquees carry CONTENT, not decoration. The track renders the list three
+     times inside an `overflow-hidden` section, so simply stopping the animation
+     clips everything past the first screenful with no way to reach it — worse
+     than the motion it avoids. Stop the travel and hand scrolling to the user
+     instead, so every item stays reachable. */
+  .animate-marquee,
+  .animate-marquee-reverse {
+    animation: none !important;
+    overflow-x: auto;
+    scrollbar-width: thin;
+  }
+
+  /* Entrance animations must settle VISIBLE — `animation: none` on a rule whose
+     keyframes start at opacity 0 would leave the content permanently hidden. */
+  .reveal-up,
+  .scale-in {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,15 +11,10 @@ import AuthSyncProvider from "@/providers/AuthSyncProvider";
 import { MaintenanceProvider } from "@/providers/MaintenanceProvider";
 import ReactQueryProvider from "@/providers/ReactQueryProvider";
 import type { Metadata, Viewport } from "next";
-import { Sora } from "next/font/google";
+
+import { sora } from "@/lib/fonts";
 
 import "./globals.css";
-
-const sora = Sora({
-  subsets: ["latin"],
-  variable: "--font-sora",
-  display: "swap",
-});
 
 export const viewport: Viewport = {
   width: "device-width",

--- a/app/maintenance/layout.tsx
+++ b/app/maintenance/layout.tsx
@@ -1,13 +1,4 @@
 import type { Metadata } from "next";
-import { Sora } from "next/font/google";
-
-import "../globals.css";
-
-const sora = Sora({
-  subsets: ["latin"],
-  variable: "--font-sora",
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "Maintenance | Familiarise",
@@ -15,19 +6,16 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// `app/maintenance/` is a plain nested segment, not a route group, so this
+// layout renders *inside* the root layout's <body>. It previously returned its
+// own <html>/<body> (plus a second `Sora()` call): the browser discarded the
+// nested pair and the duplicate font, leaving this route — which middleware can
+// rewrite ANY url to during a maintenance window — on a different Sora instance
+// than the rest of the app.
 export default function MaintenanceLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <html lang="en" className={sora.variable} suppressHydrationWarning>
-      <body
-        className={`${sora.className} min-h-screen antialiased`}
-        suppressHydrationWarning
-      >
-        {children}
-      </body>
-    </html>
-  );
+  return <>{children}</>;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import { UpcomingEventsSection } from "@/components/home/UpcomingEventsSection";
 import { TrustBadgesSection } from "@/components/home/TrustBadgesSection";
 import { HowItWorksSection } from "@/components/home/HowItWorksSection";
 import { BecomeExpertSection } from "@/components/home/BecomeExpertSection";
+import { EnterpriseSection } from "@/components/home/EnterpriseSection";
 import { FAQSection } from "@/components/home/FAQSection";
 import { SatisfiedTestimonial } from "@/app/explore/experts/components/SatisfiedTestimonial";
 import { getHomeExperts, getHomeReviews, getHomeImages } from "@/lib/data/home";
@@ -103,6 +104,10 @@ export default function Home() {
 
       {/* How It Works - Light with circles */}
       <HowItWorksSection />
+
+      {/* For teams & organisations - Dark. Sits next to the expert CTA so the
+          two "which side are you on?" paths are adjacent at the page's end. */}
+      <EnterpriseSection />
 
       {/* Become an Expert CTA - Light mesh gradient */}
       <BecomeExpertSection />

--- a/app/use-cases/UseCasePageLayout.tsx
+++ b/app/use-cases/UseCasePageLayout.tsx
@@ -1,195 +1,190 @@
 "use client";
 
+import { MotionConfig } from "framer-motion";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
+import {
+  UseCaseCadence,
+  UseCaseCategories,
+  UseCaseChecklist,
+  UseCaseClosing,
+  UseCaseComparison,
+  UseCaseDecoder,
+  UseCaseFaqs,
+  UseCaseHero,
+  UseCaseMatrix,
+  UseCasePains,
+  UseCaseSessions,
+  UseCaseTimeline,
+  type UseCaseCategoriesData,
+  type UseCaseClosingData,
+  type UseCaseCta,
+  type UseCaseComparisonData,
+  type UseCaseFaq,
+  type UseCaseHeroData,
+  type UseCaseSectionData,
+} from "./UseCaseSections";
+
+export type { UseCaseIcon } from "./UseCaseSections";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-interface PainPoint {
-  title: string;
-  description: string;
-}
+/**
+ * The section that carries the segment's distinctive argument. Each of the four
+ * pages picks a different renderer so they read as four pages, not one template
+ * with the nouns swapped.
+ */
+export type UseCaseSpine = UseCaseSectionData & {
+  variant: "timeline" | "decoder" | "matrix" | "cadence";
+};
 
-interface Solution {
-  title: string;
-  description: string;
-}
-
-interface CategoryLink {
-  label: string;
-  href: string;
-}
+export type UseCaseSectionKey =
+  | "pains"
+  | "spine"
+  | "sessions"
+  | "checklist"
+  | "comparison"
+  | "categories"
+  | "faqs";
 
 export interface UseCasePageData {
-  /** Main headline */
-  title: string;
-  /** Subtitle / value proposition */
-  subtitle: string;
-  /** Primary CTA label (default: "Get Started") */
-  ctaLabel?: string;
-  /** Primary CTA href (default: "/auth/signup") */
-  ctaHref?: string;
-  /** 3-4 pain points the audience faces */
-  painPoints: PainPoint[];
-  /** 3-4 ways Familiarise solves those pain points */
-  solutions: Solution[];
-  /** Expert categories relevant to this audience */
-  categories: CategoryLink[];
-  /** Bottom CTA section headline */
-  bottomCtaTitle: string;
-  /** Bottom CTA section description */
-  bottomCtaDescription: string;
+  hero: UseCaseHeroData;
+  pains: UseCaseSectionData;
+  spine: UseCaseSpine;
+  sessions: UseCaseSectionData;
+  /** Optional — only pages with a genuine pre-flight list use it. */
+  checklist?: UseCaseSectionData;
+  comparison: UseCaseComparisonData;
+  categories: UseCaseCategoriesData;
+  faqs: {
+    eyebrow: string;
+    title: string;
+    intro: string;
+    items: UseCaseFaq[];
+  };
+  closing: UseCaseClosingData;
+  /** Body order. Ordering is part of the argument, so each page sets its own. */
+  order: UseCaseSectionKey[];
 }
 
-// ─── Layout Component ────────────────────────────────────────────────────────
+// ─── Sticky mobile CTA ───────────────────────────────────────────────────────
 
-export default function UseCasePageLayout({ data }: { data: UseCasePageData }) {
-  const ctaLabel = data.ctaLabel ?? "Get Started";
-  const ctaHref = data.ctaHref ?? "/auth/signup";
+/**
+ * These are long, high-consideration pages and the hero CTA scrolls away within
+ * one screen on a phone. Appears only once the hero is behind you, so it never
+ * competes with the CTA already on screen.
+ */
+function StickyMobileCta({ cta }: { cta: UseCaseCta }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
 
   return (
-    <div className="w-full">
-      {/* Hero — intentional dark landing section */}
-      <section className="bg-zinc-950 text-white py-20 md:py-28">
-        <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
-          <h1 className="text-fluid-5xl font-bold tracking-tight mb-6">
-            {data.title}
-          </h1>
-          <p className="text-fluid-lg md:text-fluid-xl text-zinc-400 mb-8 leading-relaxed">
-            {data.subtitle}
-          </p>
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link href={ctaHref} className="w-full sm:w-auto">
-              <Button
-                size="lg"
-                className="w-full sm:w-auto bg-white text-zinc-900 hover:bg-zinc-200 px-8 h-12 text-base"
-              >
-                {ctaLabel}
-                <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-            <Link href="/explore/experts" className="w-full sm:w-auto">
-              <Button
-                variant="outline"
-                size="lg"
-                className="w-full sm:w-auto bg-transparent border-zinc-600 text-white hover:bg-zinc-800 px-8 h-12 text-base"
-              >
-                Browse Experts
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Pain Points */}
-      <section className="py-16 md:py-24 bg-card">
-        <div className="container mx-auto px-4 md:px-6 max-w-5xl">
-          <h2 className="text-fluid-3xl md:text-fluid-4xl font-bold tracking-tight text-center mb-4">
-            The Challenge
-          </h2>
-          <p className="text-muted-foreground text-center mb-12 max-w-2xl mx-auto">
-            Common problems that hold you back — and why generic solutions
-            don&apos;t cut it.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {data.painPoints.map((point, i) => (
-              <div
-                key={i}
-                className="p-6 rounded-2xl border border-border bg-muted"
-              >
-                <div className="w-10 h-10 rounded-xl bg-error/10 text-error flex items-center justify-center font-bold text-lg mb-4">
-                  {i + 1}
-                </div>
-                <h3 className="text-lg font-semibold text-foreground mb-2">
-                  {point.title}
-                </h3>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  {point.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Solutions */}
-      <section className="py-16 md:py-24 bg-muted">
-        <div className="container mx-auto px-4 md:px-6 max-w-5xl">
-          <h2 className="text-fluid-3xl md:text-fluid-4xl font-bold tracking-tight text-center mb-4">
-            How Familiarise Helps
-          </h2>
-          <p className="text-muted-foreground text-center mb-12 max-w-2xl mx-auto">
-            Real guidance from real experts — not AI-generated advice or
-            pre-recorded videos.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {data.solutions.map((solution, i) => (
-              <div
-                key={i}
-                className="p-6 rounded-2xl border border-border bg-card"
-              >
-                <div className="w-10 h-10 rounded-xl bg-foreground text-card flex items-center justify-center font-bold text-lg mb-4">
-                  {i + 1}
-                </div>
-                <h3 className="text-lg font-semibold text-foreground mb-2">
-                  {solution.title}
-                </h3>
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  {solution.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Featured Categories */}
-      {data.categories.length > 0 && (
-        <section className="py-16 md:py-24 bg-card">
-          <div className="container mx-auto px-4 md:px-6 max-w-4xl text-center">
-            <h2 className="text-fluid-3xl md:text-fluid-4xl font-bold tracking-tight mb-4">
-              Explore Experts by Domain
-            </h2>
-            <p className="text-muted-foreground mb-10 max-w-2xl mx-auto">
-              Find verified consultants in the fields that matter to you.
-            </p>
-            <div className="flex flex-wrap justify-center gap-3">
-              {data.categories.map((cat) => (
-                <Link
-                  key={cat.href}
-                  href={cat.href}
-                  className="px-5 py-2.5 rounded-full border border-border text-sm font-medium text-muted-foreground hover:bg-foreground hover:text-card hover:border-foreground transition-colors"
-                >
-                  {cat.label}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Bottom CTA — intentional dark landing section */}
-      <section className="py-20 md:py-28 bg-zinc-950 text-white">
-        <div className="container mx-auto px-4 md:px-6 text-center max-w-2xl">
-          <h2 className="text-fluid-3xl md:text-fluid-4xl font-bold tracking-tight mb-4">
-            {data.bottomCtaTitle}
-          </h2>
-          <p className="text-zinc-400 mb-8 leading-relaxed">
-            {data.bottomCtaDescription}
-          </p>
-          <Link href={ctaHref} className="inline-block w-full sm:w-auto">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto bg-white text-zinc-900 hover:bg-zinc-200 px-8 h-12 text-base"
-            >
-              {ctaLabel}
-              <ArrowRight className="w-4 h-4 ml-2" />
-            </Button>
-          </Link>
-        </div>
-      </section>
+    <div
+      className={`md:hidden fixed inset-x-0 bottom-0 z-40 border-t border-border bg-card/95 backdrop-blur-sm p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] transition-transform duration-300 ${
+        visible ? "translate-y-0" : "translate-y-full"
+      }`}
+      aria-hidden={!visible}
+    >
+      <Button asChild size="lg" className="w-full h-12 text-base">
+        <Link href={cta.href} tabIndex={visible ? undefined : -1}>
+          {cta.label}
+          <ArrowRight className="w-4 h-4 ml-2" />
+        </Link>
+      </Button>
     </div>
+  );
+}
+
+// ─── Layout ──────────────────────────────────────────────────────────────────
+
+export default function UseCasePageLayout({ data }: { data: UseCasePageData }) {
+  const renderSection = (key: UseCaseSectionKey) => {
+    switch (key) {
+      case "pains":
+        return <UseCasePains key={key} data={data.pains} />;
+      case "spine":
+        switch (data.spine.variant) {
+          case "timeline":
+            return <UseCaseTimeline key={key} data={data.spine} />;
+          case "decoder":
+            return <UseCaseDecoder key={key} data={data.spine} />;
+          case "matrix":
+            return <UseCaseMatrix key={key} data={data.spine} />;
+          case "cadence":
+            return <UseCaseCadence key={key} data={data.spine} />;
+        }
+        return null;
+      case "sessions":
+        return <UseCaseSessions key={key} data={data.sessions} />;
+      case "checklist":
+        return data.checklist ? (
+          <UseCaseChecklist key={key} data={data.checklist} />
+        ) : null;
+      case "comparison":
+        return <UseCaseComparison key={key} data={data.comparison} />;
+      case "categories":
+        return <UseCaseCategories key={key} data={data.categories} />;
+      case "faqs":
+        return (
+          <UseCaseFaqs
+            key={key}
+            eyebrow={data.faqs.eyebrow}
+            title={data.faqs.title}
+            intro={data.faqs.intro}
+            items={data.faqs.items}
+          />
+        );
+    }
+  };
+
+  // Not for a rich result — Google retired FAQ rich results in May 2026
+  // (https://developers.google.com/search/docs/appearance/structured-data/faqpage).
+  // FAQPage is still a valid type that crawlers and answer engines parse, and
+  // these pages are the site's main organic-search surface, so it is cheap to
+  // keep emitting.
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: data.faqs.items.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  };
+
+  return (
+    // reducedMotion="user" makes framer-motion honour the OS "reduce motion"
+    // setting for every motion component below: transform animations are
+    // dropped, opacity fades are kept. Set once here rather than per-variant so
+    // a newly added animated block can't miss it.
+    <MotionConfig reducedMotion="user">
+      {/* Bottom padding on mobile so the fixed CTA bar doesn't cover the last
+          section — it sits above the content, not in flow. */}
+      <div className="w-full pb-24 md:pb-0">
+        <script
+          type="application/ld+json"
+          // Escape `<` so a `</script>` inside any FAQ answer can't close this
+          // block and inject markup. Copy is hardcoded today, but this is a
+          // script-injection sink and the guard costs nothing.
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(faqJsonLd).replace(/</g, "\\u003c"),
+          }}
+        />
+        <UseCaseHero data={data.hero} />
+        {data.order.map(renderSection)}
+        <UseCaseClosing data={data.closing} />
+        <StickyMobileCta cta={data.hero.primaryCta} />
+      </div>
+    </MotionConfig>
   );
 }

--- a/app/use-cases/UseCaseSections.tsx
+++ b/app/use-cases/UseCaseSections.tsx
@@ -1,0 +1,829 @@
+"use client";
+
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  Award,
+  BadgeCheck,
+  Banknote,
+  Briefcase,
+  Building2,
+  CalendarClock,
+  Check,
+  ClipboardList,
+  Code2,
+  Compass,
+  FileText,
+  GitBranch,
+  GraduationCap,
+  Globe2,
+  Handshake,
+  LineChart,
+  MapPin,
+  MessageSquare,
+  Plane,
+  Repeat,
+  Route,
+  ScrollText,
+  Search,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  TrendingUp,
+  UserCheck,
+  Users,
+  Video,
+  Wallet,
+} from "lucide-react";
+import Link from "next/link";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+// ─── Icons ───────────────────────────────────────────────────────────────────
+
+/**
+ * Page data lives in server components so each route can export `metadata`, and
+ * component references cannot cross that boundary — so pages name an icon and
+ * this client module resolves it.
+ */
+export const USE_CASE_ICONS = {
+  award: Award,
+  badgeCheck: BadgeCheck,
+  banknote: Banknote,
+  briefcase: Briefcase,
+  building: Building2,
+  calendar: CalendarClock,
+  clipboard: ClipboardList,
+  code: Code2,
+  compass: Compass,
+  file: FileText,
+  branch: GitBranch,
+  globe: Globe2,
+  graduation: GraduationCap,
+  handshake: Handshake,
+  chart: LineChart,
+  map: MapPin,
+  message: MessageSquare,
+  plane: Plane,
+  repeat: Repeat,
+  route: Route,
+  scroll: ScrollText,
+  search: Search,
+  shield: ShieldCheck,
+  sparkles: Sparkles,
+  target: Target,
+  trending: TrendingUp,
+  userCheck: UserCheck,
+  users: Users,
+  video: Video,
+  wallet: Wallet,
+} as const;
+
+export type UseCaseIcon = keyof typeof USE_CASE_ICONS;
+
+// ─── Shared bits ─────────────────────────────────────────────────────────────
+
+/**
+ * Shared entrance animation.
+ *
+ * Reduced motion is handled once, at the layout, via
+ * `<MotionConfig reducedMotion="user">` — framer-motion then strips transform
+ * animations (keeping opacity) for every motion component in the subtree. That
+ * beats threading a hook through all 14 call sites here, and it can't be
+ * forgotten when a new animated block is added.
+ */
+const fadeUp = {
+  initial: { opacity: 0, y: 20 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true },
+};
+
+function SectionHeading({
+  eyebrow,
+  title,
+  intro,
+  align = "center",
+}: {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  align?: "center" | "left";
+}) {
+  const isCentered = align === "center";
+  return (
+    <motion.div
+      {...fadeUp}
+      transition={{ duration: 0.5 }}
+      className={
+        isCentered ? "max-w-2xl mx-auto text-center mb-12" : "max-w-2xl mb-12"
+      }
+    >
+      <Badge
+        variant="secondary"
+        className="mb-4 bg-secondary text-secondary-foreground hover:bg-secondary border-0"
+      >
+        {eyebrow}
+      </Badge>
+      <h2 className="text-fluid-3xl md:text-fluid-4xl font-bold tracking-tight text-foreground mb-4">
+        {title}
+      </h2>
+      <p className="text-muted-foreground leading-relaxed">{intro}</p>
+    </motion.div>
+  );
+}
+
+function Footnote({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-10 text-center text-fluid-sm text-muted-foreground max-w-2xl mx-auto">
+      {children}
+    </p>
+  );
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface UseCaseCta {
+  label: string;
+  href: string;
+}
+
+export interface UseCaseItem {
+  /** Timeline period, glossary term, or "from → to" route marker. */
+  label?: string;
+  title: string;
+  description: string;
+  icon?: UseCaseIcon;
+}
+
+export interface UseCaseSectionData {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  items: UseCaseItem[];
+  footnote?: string;
+}
+
+// ─── Hero ────────────────────────────────────────────────────────────────────
+
+export interface UseCaseHeroData {
+  eyebrow: string;
+  titleLead: string;
+  titleAccent: string;
+  subtitle: string;
+  primaryCta: UseCaseCta;
+  secondaryCta: UseCaseCta;
+  /** Verifiable platform mechanics only — never volume or outcome claims. */
+  assurances: string[];
+  card: {
+    title: string;
+    items: string[];
+    footnote?: string;
+  };
+}
+
+export function UseCaseHero({ data }: { data: UseCaseHeroData }) {
+  return (
+    <section className="relative pt-32 pb-20 md:pb-28 bg-zinc-950 overflow-hidden">
+      <div className="absolute inset-0">
+        <div className="absolute top-1/4 left-1/4 w-[600px] h-[600px] bg-zinc-800/30 rounded-full blur-[120px] animate-blob" />
+        <div className="absolute bottom-0 right-1/4 w-[500px] h-[500px] bg-zinc-700/20 rounded-full blur-[100px] animate-blob animation-delay-2000" />
+      </div>
+      <div className="absolute inset-0 grid-pattern opacity-20" />
+
+      <div className="container mx-auto px-4 md:px-6 relative z-10">
+        <div className="grid lg:grid-cols-[1.15fr_1fr] gap-12 lg:gap-16 items-center">
+          <motion.div {...fadeUp} transition={{ duration: 0.5 }}>
+            <Badge
+              variant="outline"
+              className="mb-5 border-zinc-700 bg-zinc-800/50 text-zinc-300"
+            >
+              <Sparkles className="w-3.5 h-3.5 mr-1.5" />
+              {data.eyebrow}
+            </Badge>
+            <h1 className="text-fluid-4xl md:text-fluid-5xl font-bold tracking-tight text-white mb-5">
+              {data.titleLead}{" "}
+              <span className="silver-text">{data.titleAccent}</span>
+            </h1>
+            <p className="text-fluid-lg text-zinc-400 leading-relaxed mb-8 max-w-xl">
+              {data.subtitle}
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-3 mb-8">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto bg-white text-zinc-900 hover:bg-zinc-200 px-8 h-12 text-base"
+                asChild
+              >
+                <Link href={data.primaryCta.href} className="w-full sm:w-auto">
+                  {data.primaryCta.label}
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Link>
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto bg-transparent border-zinc-700 text-white hover:bg-zinc-800 hover:text-white px-8 h-12 text-base"
+                asChild
+              >
+                <Link
+                  href={data.secondaryCta.href}
+                  className="w-full sm:w-auto"
+                >
+                  {data.secondaryCta.label}
+                </Link>
+              </Button>
+            </div>
+
+            <ul className="flex flex-wrap gap-x-6 gap-y-2">
+              {data.assurances.map((line) => (
+                <li
+                  key={line}
+                  className="flex items-center gap-2 text-fluid-sm text-zinc-400"
+                >
+                  <Check className="w-4 h-4 text-zinc-500 shrink-0" />
+                  {line}
+                </li>
+              ))}
+            </ul>
+          </motion.div>
+
+          <motion.div
+            {...fadeUp}
+            transition={{ duration: 0.5, delay: 0.15 }}
+            className="rounded-2xl border border-zinc-800 bg-zinc-900/60 backdrop-blur-sm p-6 md:p-8"
+          >
+            <h2 className="text-fluid-lg font-semibold text-white mb-5">
+              {data.card.title}
+            </h2>
+            <ul className="space-y-4">
+              {data.card.items.map((item) => (
+                <li key={item} className="flex gap-3">
+                  <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-zinc-500 shrink-0" />
+                  <span className="text-fluid-sm text-zinc-300 leading-relaxed">
+                    {item}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            {data.card.footnote && (
+              <p className="mt-6 pt-5 border-t border-zinc-800 text-fluid-xs text-zinc-500 leading-relaxed">
+                {data.card.footnote}
+              </p>
+            )}
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Pain points ─────────────────────────────────────────────────────────────
+
+export function UseCasePains({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-card">
+      <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {data.items.map((item, i) => (
+            <motion.div
+              key={item.title}
+              {...fadeUp}
+              transition={{ duration: 0.4, delay: i * 0.06 }}
+              className="relative overflow-hidden p-6 rounded-2xl border border-border bg-muted"
+            >
+              <span
+                aria-hidden
+                className="absolute -top-3 right-3 text-7xl font-bold text-foreground/[0.06] select-none"
+              >
+                {i + 1}
+              </span>
+              <h3 className="relative text-fluid-lg font-semibold text-foreground mb-2 pr-10">
+                {item.title}
+              </h3>
+              <p className="relative text-fluid-sm text-muted-foreground leading-relaxed">
+                {item.description}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Spine: timeline ─────────────────────────────────────────────────────────
+
+/** Vertical rail with a period marker per row — for calendar-shaped stories. */
+export function UseCaseTimeline({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-muted relative overflow-hidden">
+      <div className="absolute inset-0 dot-pattern-light opacity-60" />
+      <div className="container mx-auto px-4 md:px-6 relative z-10">
+        <div className="grid lg:grid-cols-[1fr_1.2fr] gap-12 lg:gap-16 items-start">
+          <div className="lg:sticky lg:top-32">
+            <SectionHeading
+              eyebrow={data.eyebrow}
+              title={data.title}
+              intro={data.intro}
+              align="left"
+            />
+            {data.footnote && (
+              <p className="text-fluid-sm text-muted-foreground max-w-md -mt-6">
+                {data.footnote}
+              </p>
+            )}
+          </div>
+
+          <div>
+            {data.items.map((item, i) => (
+              <motion.div
+                key={item.title}
+                {...fadeUp}
+                transition={{ duration: 0.45, delay: i * 0.08 }}
+                className="flex gap-5"
+              >
+                <div className="flex flex-col items-center">
+                  <div className="w-3 h-3 rounded-full bg-foreground shrink-0 mt-2" />
+                  {i < data.items.length - 1 && (
+                    <div className="w-px flex-1 bg-border my-2" />
+                  )}
+                </div>
+                <div className="pb-10 min-w-0">
+                  {item.label && (
+                    <span className="inline-block mb-2 px-2.5 py-0.5 rounded-md bg-primary text-primary-foreground text-fluid-xs font-semibold">
+                      {item.label}
+                    </span>
+                  )}
+                  <h3 className="text-fluid-lg font-semibold text-foreground mb-1.5">
+                    {item.title}
+                  </h3>
+                  <p className="text-fluid-sm text-muted-foreground leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Spine: decoder ──────────────────────────────────────────────────────────
+
+/** Glossary/ledger rows — term on the left, plain-English meaning on the right. */
+export function UseCaseDecoder({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-muted">
+      <div className="container mx-auto px-4 md:px-6 max-w-4xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <div className="rounded-2xl border border-border bg-card overflow-hidden">
+          {data.items.map((item, i) => (
+            <motion.div
+              key={item.title}
+              {...fadeUp}
+              transition={{ duration: 0.35, delay: i * 0.05 }}
+              className={`grid sm:grid-cols-[13rem_1fr] gap-x-6 gap-y-2 p-6 ${
+                i > 0 ? "border-t border-border" : ""
+              }`}
+            >
+              <div>
+                {item.label && (
+                  <span className="block text-fluid-xs font-semibold uppercase tracking-widest text-muted-foreground mb-1">
+                    {item.label}
+                  </span>
+                )}
+                <h3 className="text-fluid-base font-semibold text-foreground">
+                  {item.title}
+                </h3>
+              </div>
+              <p className="text-fluid-sm text-muted-foreground leading-relaxed">
+                {item.description}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Spine: matrix ───────────────────────────────────────────────────────────
+
+/** "From → to" route cards, for readers choosing between named transitions. */
+export function UseCaseMatrix({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-muted">
+      <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {data.items.map((item, i) => {
+            const Icon = item.icon ? USE_CASE_ICONS[item.icon] : Route;
+            return (
+              <motion.div
+                key={item.title}
+                {...fadeUp}
+                transition={{ duration: 0.4, delay: i * 0.06 }}
+                className="p-6 rounded-2xl border border-border bg-card"
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="w-9 h-9 rounded-lg bg-primary text-primary-foreground flex items-center justify-center shrink-0">
+                    <Icon className="w-4 h-4" />
+                  </div>
+                  {item.label && (
+                    <span className="text-fluid-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                      {item.label}
+                    </span>
+                  )}
+                </div>
+                <h3 className="text-fluid-base font-semibold text-foreground mb-2">
+                  {item.title}
+                </h3>
+                <p className="text-fluid-sm text-muted-foreground leading-relaxed">
+                  {item.description}
+                </p>
+              </motion.div>
+            );
+          })}
+        </div>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Spine: cadence ──────────────────────────────────────────────────────────
+
+/** Horizontal stepped rail — for an engagement that unfolds over months. */
+export function UseCaseCadence({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-muted">
+      <div className="container mx-auto px-4 md:px-6 max-w-6xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-px bg-border rounded-2xl overflow-hidden border border-border">
+          {data.items.map((item, i) => (
+            <motion.div
+              key={item.title}
+              {...fadeUp}
+              transition={{ duration: 0.4, delay: i * 0.08 }}
+              className="bg-card p-6"
+            >
+              <div className="flex items-center gap-2 mb-4">
+                <span className="w-7 h-7 rounded-full bg-primary text-primary-foreground text-fluid-xs font-bold flex items-center justify-center shrink-0">
+                  {i + 1}
+                </span>
+                {item.label && (
+                  <span className="text-fluid-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                    {item.label}
+                  </span>
+                )}
+              </div>
+              <h3 className="text-fluid-base font-semibold text-foreground mb-2">
+                {item.title}
+              </h3>
+              <p className="text-fluid-sm text-muted-foreground leading-relaxed">
+                {item.description}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Sessions ────────────────────────────────────────────────────────────────
+
+/** What the reader actually books — the offer, stated concretely. */
+export function UseCaseSessions({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-card">
+      <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {data.items.map((item, i) => {
+            const Icon = item.icon ? USE_CASE_ICONS[item.icon] : Target;
+            return (
+              <motion.div
+                key={item.title}
+                {...fadeUp}
+                transition={{ duration: 0.4, delay: i * 0.06 }}
+                className="flex gap-4 p-6 rounded-2xl border border-border bg-muted"
+              >
+                <div className="w-11 h-11 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0">
+                  <Icon className="w-5 h-5" />
+                </div>
+                <div className="min-w-0">
+                  <h3 className="text-fluid-base font-semibold text-foreground mb-1.5">
+                    {item.title}
+                  </h3>
+                  <p className="text-fluid-sm text-muted-foreground leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Checklist ───────────────────────────────────────────────────────────────
+
+export function UseCaseChecklist({ data }: { data: UseCaseSectionData }) {
+  return (
+    <section className="py-16 md:py-24 bg-card">
+      <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <ul className="rounded-2xl border border-border bg-muted divide-y divide-border">
+          {data.items.map((item, i) => (
+            <motion.li
+              key={item.title}
+              {...fadeUp}
+              transition={{ duration: 0.35, delay: i * 0.05 }}
+              className="flex gap-4 p-5"
+            >
+              <span className="mt-0.5 w-6 h-6 rounded-md border border-border bg-card flex items-center justify-center shrink-0">
+                <Check className="w-3.5 h-3.5 text-foreground" />
+              </span>
+              <div className="min-w-0">
+                <h3 className="text-fluid-base font-semibold text-foreground mb-1">
+                  {item.title}
+                </h3>
+                <p className="text-fluid-sm text-muted-foreground leading-relaxed">
+                  {item.description}
+                </p>
+              </div>
+            </motion.li>
+          ))}
+        </ul>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Comparison ──────────────────────────────────────────────────────────────
+
+export interface UseCaseComparisonData {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  /** The two substitutes the reader is genuinely weighing us against. */
+  alternatives: [string, string];
+  ourLabel: string;
+  rows: {
+    criterion: string;
+    alternatives: [string, string];
+    ours: string;
+  }[];
+  footnote?: string;
+}
+
+export function UseCaseComparison({ data }: { data: UseCaseComparisonData }) {
+  return (
+    <section className="py-16 md:py-24 bg-muted">
+      <div className="container mx-auto px-4 md:px-6 max-w-5xl">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <motion.div
+          {...fadeUp}
+          transition={{ duration: 0.5 }}
+          className="overflow-x-auto rounded-2xl border border-border bg-card"
+        >
+          <table className="w-full min-w-[42rem] text-left border-collapse">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="p-4 md:p-5 text-fluid-xs font-semibold uppercase tracking-widest text-muted-foreground w-[22%]">
+                  <span className="sr-only">Criterion</span>
+                </th>
+                {data.alternatives.map((alt) => (
+                  <th
+                    key={alt}
+                    className="p-4 md:p-5 text-fluid-sm font-semibold text-muted-foreground w-[26%]"
+                  >
+                    {alt}
+                  </th>
+                ))}
+                <th className="p-4 md:p-5 text-fluid-sm font-semibold bg-primary text-primary-foreground w-[26%]">
+                  {data.ourLabel}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((row, i) => (
+                <tr
+                  key={row.criterion}
+                  className={i > 0 ? "border-t border-border" : ""}
+                >
+                  <th
+                    scope="row"
+                    className="p-4 md:p-5 align-top text-fluid-sm font-semibold text-foreground"
+                  >
+                    {row.criterion}
+                  </th>
+                  {row.alternatives.map((cell, j) => (
+                    <td
+                      key={j}
+                      className="p-4 md:p-5 align-top text-fluid-sm text-muted-foreground leading-relaxed"
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                  <td className="p-4 md:p-5 align-top text-fluid-sm text-foreground leading-relaxed bg-muted font-medium">
+                    {row.ours}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </motion.div>
+        {data.footnote && <Footnote>{data.footnote}</Footnote>}
+      </div>
+    </section>
+  );
+}
+
+// ─── Categories ──────────────────────────────────────────────────────────────
+
+export interface UseCaseCategoriesData {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  links: { label: string; href: string }[];
+}
+
+export function UseCaseCategories({ data }: { data: UseCaseCategoriesData }) {
+  return (
+    <section className="py-16 md:py-24 bg-card">
+      <div className="container mx-auto px-4 md:px-6 max-w-4xl text-center">
+        <SectionHeading
+          eyebrow={data.eyebrow}
+          title={data.title}
+          intro={data.intro}
+        />
+        <div className="flex flex-wrap justify-center gap-3">
+          {data.links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="px-5 py-2.5 rounded-full border border-border bg-muted text-fluid-sm font-medium text-muted-foreground hover:bg-primary hover:text-primary-foreground hover:border-primary transition-colors"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── FAQ ─────────────────────────────────────────────────────────────────────
+
+export interface UseCaseFaq {
+  question: string;
+  answer: string;
+}
+
+export function UseCaseFaqs({
+  eyebrow,
+  title,
+  intro,
+  items,
+}: {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  items: UseCaseFaq[];
+}) {
+  return (
+    <section className="py-16 md:py-24 bg-muted">
+      <div className="container mx-auto px-4 md:px-6 max-w-3xl">
+        <SectionHeading eyebrow={eyebrow} title={title} intro={intro} />
+        <div className="rounded-2xl border border-border bg-card px-6">
+          <Accordion type="single" collapsible className="w-full">
+            {items.map((faq, i) => (
+              <AccordionItem
+                key={faq.question}
+                value={`faq-${i}`}
+                className={i === items.length - 1 ? "border-b-0" : ""}
+              >
+                <AccordionTrigger className="text-left text-fluid-base font-semibold text-foreground hover:no-underline py-5">
+                  {faq.question}
+                </AccordionTrigger>
+                <AccordionContent className="text-fluid-sm text-muted-foreground leading-relaxed pb-5 pr-6">
+                  {faq.answer}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Closing CTA ─────────────────────────────────────────────────────────────
+
+export interface UseCaseClosingData {
+  title: string;
+  description: string;
+  primaryCta: UseCaseCta;
+  secondaryCta: UseCaseCta;
+  reassurance: string;
+}
+
+export function UseCaseClosing({ data }: { data: UseCaseClosingData }) {
+  return (
+    <section className="py-20 md:py-28 bg-zinc-950 relative overflow-hidden">
+      <div className="absolute inset-0 grid-pattern opacity-20" />
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-zinc-800/30 rounded-full blur-[120px] animate-blob" />
+
+      <div className="container mx-auto px-4 md:px-6 relative z-10 text-center max-w-2xl">
+        <motion.h2
+          {...fadeUp}
+          transition={{ duration: 0.5 }}
+          className="text-fluid-3xl md:text-fluid-4xl font-bold tracking-tight text-white mb-4"
+        >
+          {data.title}
+        </motion.h2>
+        <motion.p
+          {...fadeUp}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          className="text-zinc-400 leading-relaxed mb-8"
+        >
+          {data.description}
+        </motion.p>
+        <motion.div
+          {...fadeUp}
+          transition={{ duration: 0.5, delay: 0.2 }}
+          className="flex flex-col sm:flex-row gap-3 justify-center"
+        >
+          <Button
+            size="lg"
+            className="w-full sm:w-auto bg-white text-zinc-900 hover:bg-zinc-200 px-8 h-12 text-base"
+            asChild
+          >
+            <Link href={data.primaryCta.href} className="w-full sm:w-auto">
+              {data.primaryCta.label}
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto bg-transparent border-zinc-700 text-white hover:bg-zinc-800 hover:text-white px-8 h-12 text-base"
+            asChild
+          >
+            <Link href={data.secondaryCta.href} className="w-full sm:w-auto">
+              {data.secondaryCta.label}
+            </Link>
+          </Button>
+        </motion.div>
+        <p className="mt-6 text-fluid-xs text-zinc-500">{data.reassurance}</p>
+      </div>
+    </section>
+  );
+}

--- a/app/use-cases/career-switchers/page.tsx
+++ b/app/use-cases/career-switchers/page.tsx
@@ -1,68 +1,346 @@
+import type { Metadata } from "next";
+
 import UseCasePageLayout from "../UseCasePageLayout";
 import type { UseCasePageData } from "../UseCasePageLayout";
 
+export const metadata: Metadata = {
+  title: "Career Switch Guidance for Indian Professionals | Familiarise",
+  description:
+    "Service to product, QA to SDET, engineering to PM, abroad or a GCC at home. Talk to someone who already made the switch you are considering. No cohort fee, no income-share agreement.",
+};
+
+/**
+ * Segment thesis: a switch is not one decision, it is a choice among a small
+ * number of well-worn routes — so the spine is a matrix, and the page carries a
+ * pre-resignation checklist no other page has. The paperwork section exists
+ * because notice periods, bonus clawbacks and background verification are where
+ * Indian switches actually fail, well after the interviews are won.
+ *
+ * Framing sources (no figures used in copy, so nothing here needs to age well):
+ * the abroad-versus-GCC shift is grounded in the 2025 collapse in F-1 issuance
+ * to Indian students (https://www.forbes.com/sites/stuartanderson/2025/10/01/immigration-data-indicate-indian-student-enrollment-may-plummet/,
+ * https://www.business-standard.com/immigration/us-visa-curbs-fallout-indian-students-in-us-drop-6-9-to-352-644-in-2026-126040300236_1.html)
+ * set against continued Global Capability Centre expansion in India
+ * (https://nasscom.in/knowledge-center/publications/india-gcc-landscape-report-5-year-journey,
+ * https://www.businesstoday.in/jobs/story/at-5-1-lakh-jobs-indias-global-capability-centre-hiring-boom-scales-new-peak-540328-2026-07-01).
+ */
 const data: UseCasePageData = {
-  title: "Navigate the Career Switch With Confidence",
-  subtitle:
-    "Switching from service to product, changing domains, or pivoting entirely? Talk to people who've made the same transition — and learn what actually works.",
-  ctaLabel: "Talk to a Career Switcher",
-  ctaHref: "/explore/experts",
-  painPoints: [
-    {
-      title: "Your experience doesn't translate on paper",
-      description:
-        "You have 3–8 years of solid work, but recruiters don't see it as relevant. Your resume gets filtered before a human even reads it because the keywords don't match.",
+  hero: {
+    eyebrow: "For switchers with 3–10 years",
+    titleLead: "Three years of experience,",
+    titleAccent: "or one year lived three times.",
+    subtitle:
+      "Service to product, QA to development, engineer to PM, abroad or a global centre at home. Each of those is a known route with known costs. Talk to somebody who has already walked the one you are considering.",
+    primaryCta: { label: "Find an expert", href: "/explore/experts" },
+    secondaryCta: {
+      label: "See career-switch experts",
+      href: "/explore/experts?search=Career+Switching",
     },
-    {
-      title: "Don't know where to start",
-      description:
-        "Should you learn DSA? Build projects? Get a certification? Do a bootcamp? The advice online is contradictory and overwhelming.",
+    assurances: [
+      "No cohort, no income-share agreement",
+      "Cancel 24 hours ahead for a full refund",
+      "Pay in ₹ by UPI, card or net banking",
+    ],
+    card: {
+      title: "What the first call should settle",
+      items: [
+        "Whether the route you have picked is genuinely the shortest one from where you are standing.",
+        "Which parts of your CV a screener will quietly discount, and what can be done about them.",
+        "What the target interview loop actually tests — algorithms, low-level design, system design, or none of those.",
+        "What the move really costs you: notice period, a possible title reset, and how long it takes in practice.",
+      ],
+      footnote:
+        "Experts set their own price and session length, and both are on the profile. Nothing here asks you to join a cohort or sign an agreement.",
     },
-    {
-      title: "Interview processes are completely different",
-      description:
-        "Service company interviews test different skills than product companies. You need to understand new formats — system design, behavioral rounds, take-home assignments.",
+  },
+
+  pains: {
+    eyebrow: "Why switches stall",
+    title: "The switch rarely fails on ability",
+    intro:
+      "People who cannot make the jump are usually not the people who prepared least. They are the people who prepared for the wrong obstacle.",
+    items: [
+      {
+        title: "Your CV is read as your employer, not as your work",
+        description:
+          "Screeners use the current company as a shortcut, and client confidentiality often stops you describing what you genuinely built. Years of real delivery compress into a line that looks identical to everyone else's line.",
+      },
+      {
+        title: "The target loop tests things your job never asked of you",
+        description:
+          "Product interviews run algorithms, low-level design and system design, and hand out very little credit for tenure. You end up measured against a fresher on data structures and against a senior on architecture, in the same week.",
+      },
+      {
+        title: "A long notice period makes you the inconvenient candidate",
+        description:
+          "A team that can hire somebody in thirty days frequently will. Whether a buyout is even permitted, and who pays for it, was settled in a contract you signed years ago and probably have not reread since.",
+      },
+      {
+        title: "Nobody tells you what the switch actually costs",
+        description:
+          "Often a title reset, a flat or slightly lower first year, and six months of evenings. That can be an excellent trade — but it is one you should make with numbers in front of you rather than on optimism.",
+      },
+    ],
+  },
+
+  spine: {
+    variant: "matrix",
+    eyebrow: "Pick the road first",
+    title: "Switches in India are not infinite. They are a handful of routes.",
+    intro:
+      "Each one has its own interview format, its own timeline and its own price. Choosing between them is an hour's conversation; preparing for the wrong one is six months.",
+    items: [
+      {
+        icon: "branch",
+        label: "Services → Product",
+        title: "The most-attempted switch in Indian tech",
+        description:
+          "The blockers are remarkably consistent: rounds you have never practised, a CV that reads as maintenance, and a notice period that rules you out. All three are fixable, and the order you fix them in matters more than how hard you work at any one.",
+      },
+      {
+        icon: "code",
+        label: "Manual QA → SDET",
+        title: "The pivot with the clearest ladder",
+        description:
+          "Automation, a real programming language and pipeline work convert an existing testing career rather than restarting it. The difficult part is convincing a screener the change has already happened — a portfolio problem well before it is a skills problem.",
+      },
+      {
+        icon: "repeat",
+        label: "Support / Ops → Development",
+        title: "Closer than it feels from the inside",
+        description:
+          "You already understand the system's failure modes better than most of the people writing it. What is missing is shipped code with your name against it, and a story that frames the support years as domain depth rather than as time lost.",
+      },
+      {
+        icon: "compass",
+        label: "Engineering → Product",
+        title: "A change of evidence, not just of title",
+        description:
+          "Lateral product roles are scarce, so most people move internally first and then move companies. Ask someone who did it what they actually showed to earn the change, because working closely with a product manager persuades nobody by itself.",
+      },
+      {
+        icon: "chart",
+        label: "Engineering → Data and ML",
+        title: "Where the certificates stop working",
+        description:
+          "The market is saturated with courses and short of demonstrated work. Somebody who hires for these roles can tell you within an hour which projects on your CV count for something and which ones every other applicant also has.",
+      },
+      {
+        icon: "globe",
+        label: "Abroad, or a global centre at home",
+        title: "The arithmetic has changed recently",
+        description:
+          "A master's abroad followed by a work visa is a longer and less certain path than it was a few years ago, while global companies keep expanding their own centres inside India. Both remain real options — they just deserve a conversation with somebody living the outcome rather than a forum thread.",
+      },
+    ],
+    footnote:
+      "If your route is not on this list, it still exists — these are simply the ones people ask about most.",
+  },
+
+  sessions: {
+    eyebrow: "What you book",
+    title: "Four sessions that do most of the work",
+    intro:
+      "Each of these is a single booking with a named person, at a price you can see before you commit.",
+    items: [
+      {
+        icon: "route",
+        title: "Route selection",
+        description:
+          "An hour spent deciding which switch you are actually making, before you spend half a year preparing for a different one. This is the cheapest session on the list and usually the highest-leverage.",
+      },
+      {
+        icon: "file",
+        title: "A CV rewrite aimed at one role",
+        description:
+          "Attach your CV to the booking and get it back marked up by somebody who screens for the role you want — not reworded by somebody who has never had to reject anyone.",
+      },
+      {
+        icon: "video",
+        title: "A real interview loop, not a friendly chat",
+        description:
+          "Algorithms, low-level design, system design or a product case, run by somebody who conducts those rounds and will tell you plainly at which point you would have been rejected.",
+      },
+      {
+        icon: "wallet",
+        title: "Offer, notice period and counter-offer strategy",
+        description:
+          "What to ask for, what to concede, and how to leave without damaging a reference you may well need again in five years.",
+      },
+    ],
+  },
+
+  checklist: {
+    eyebrow: "The unglamorous part",
+    title: "Run this before you resign",
+    intro:
+      "Switches fail on paperwork more often than on interviews, and paperwork failures happen after you have already won the offer.",
+    items: [
+      {
+        title: "Read the notice-period clause itself, not your memory of it",
+        description:
+          "Confirm the length, whether a buyout is permitted, whether it is computed on basic or on gross, and whether your new employer will reimburse it. This single clause decides how many companies can realistically hire you.",
+      },
+      {
+        title: "Check the clawback dates on every bonus you have accepted",
+        description:
+          "Joining and retention bonuses are typically repayable in gross if you leave inside the stated window, even though you were taxed on them. Resigning a few weeks early can be a remarkably expensive way to save a few weeks.",
+      },
+      {
+        title: "Line up the documents your next background check will want",
+        description:
+          "Relieving letter, experience letter, recent payslips and Form 16. A clean exit is worth considerably more than a fast one, because a verification that comes back negative can withdraw an offer you have already accepted.",
+      },
+      {
+        title: "Get it in writing before you resign anything",
+        description:
+          "A verbal confirmation and a completed background check are not the same thing as a signed letter with a joining date printed on it.",
+      },
+      {
+        title: "Compare the offers on in-hand pay, not on the hike percentage",
+        description:
+          "A percentage flatters whichever number you happened to start from. Compare monthly take-home and real ownership, and treat variable pay as the conditional thing it is.",
+      },
+      {
+        title: "Decide now what you will do if they counter-offer",
+        description:
+          "Decide it while it is still hypothetical. The moment it becomes real you will be flattered and under time pressure simultaneously, which is not a state anyone negotiates well in.",
+      },
+    ],
+    footnote:
+      "General practice, not legal advice. Your contract governs — and reading it alongside somebody who has negotiated a few is exactly what a session is for.",
+  },
+
+  comparison: {
+    eyebrow: "The honest comparison",
+    title: "Three ways to make a switch",
+    intro:
+      "All three have produced successful moves. They differ in how much you must commit before you discover whether yours is one of them.",
+    alternatives: [
+      "Doing it alone from forums and courses",
+      "A cohort or pay-after-placement program",
+    ],
+    ourLabel: "Familiarise",
+    rows: [
+      {
+        criterion: "What you pay",
+        alternatives: [
+          "Course fees, plus months spent preparing for the wrong route.",
+          "A substantial fee, or a share of a salary you have not earned yet.",
+        ],
+        ours: "One expert's listed price, in rupees, visible before you book.",
+      },
+      {
+        criterion: "What you sign",
+        alternatives: [
+          "Nothing.",
+          "An agreement that attaches to your future income.",
+        ],
+        ours: "Nothing. No minimum term, no cohort, no agreement.",
+      },
+      {
+        criterion: "Who guides you",
+        alternatives: [
+          "Strangers whose constraints have nothing in common with yours.",
+          "Whoever the program has available in its pool.",
+        ],
+        ours: "The person you picked, whose identity and credentials our staff reviewed.",
+      },
+      {
+        criterion: "How fast you learn it is wrong",
+        alternatives: [
+          "Months, sometimes a year.",
+          "After the commitment has been made.",
+        ],
+        ours: "The first session, which is the entire point of the first session.",
+      },
+      {
+        criterion: "Backing out",
+        alternatives: ["Not applicable.", "Refund windows, clauses and notice."],
+        ours: "Full refund up to 24 hours before the session, on terms fixed at checkout.",
+      },
+    ],
+    footnote:
+      "We will not tell you a switch takes a set number of months, and we will not quote you a success rate. Anybody who does is guessing about you specifically.",
+  },
+
+  categories: {
+    eyebrow: "Where to start",
+    title: "Find someone who has made your move",
+    intro:
+      "Every listing shows the price, the session length, and reviews left by people who actually completed a session.",
+    links: [
+      { label: "Career switching", href: "/explore/experts?search=Career+Switching" },
+      { label: "System design", href: "/explore/experts?search=System+Design" },
+      { label: "DSA", href: "/explore/experts?search=DSA" },
+      { label: "Interview prep", href: "/explore/experts?search=Interview+Prep" },
+      { label: "Machine learning", href: "/explore/experts?search=Machine+Learning" },
+      { label: "Cloud architecture", href: "/explore/experts?search=Cloud" },
+      { label: "DevOps", href: "/explore/experts?search=DevOps" },
+      { label: "Business", href: "/explore/experts?search=Business" },
+    ],
+  },
+
+  faqs: {
+    eyebrow: "Before you book",
+    title: "What switchers ask us first",
+    intro: "Direct answers, none of which require a sales call.",
+    items: [
+      {
+        question: "All six of my years are support work. Is it too late?",
+        answer:
+          "That is precisely what a first session is for, and the answer turns on the route rather than on the number of years. What a screener discounts, and what they can be persuaded to value, is specific enough that guessing at it is the expensive option.",
+      },
+      {
+        question: "Will anyone actually tell me not to switch?",
+        answer:
+          "Some will, and that is worth paying for. You are not buying encouragement — and because experts here have their own careers, nobody has a program to sell you afterwards.",
+      },
+      {
+        question: "Do I have to commit to months of mentoring?",
+        answer:
+          "No. A consultation is a single booking. Some experts also offer monthly subscription plans if you decide you want ongoing help, but nothing on this platform requires a minimum term or an income-share agreement.",
+      },
+      {
+        question: "Can I share my current company's work?",
+        answer:
+          "Please don't. Bring the shape of the problem rather than the client's material — that is what an experienced reviewer works from in any case, and it keeps you on the right side of your own contract.",
+      },
+      {
+        question: "What if the session turns out to be unhelpful?",
+        answer:
+          "Cancel at least 24 hours ahead and you are refunded in full. If the expert cancels, you are refunded in full whenever that happens. And because only people who completed a session can leave a review, the ratings you chose them on came from real bookings.",
+      },
+      {
+        question: "I'm outside India. Can I book?",
+        answer:
+          "Yes. Prices are shown in your local currency and charged in rupees. Services to buyers outside India are zero-rated for GST as an export of services.",
+      },
+    ],
+  },
+
+  closing: {
+    title: "Pick the route before you start running",
+    description:
+      "An hour with somebody who has already made the switch you are weighing up — including, if that is where it lands, the hour in which they talk you out of it.",
+    primaryCta: { label: "Find an expert", href: "/explore/experts" },
+    secondaryCta: {
+      label: "Browse career-switch experts",
+      href: "/explore/experts?search=Career+Switching",
     },
-    {
-      title: "Fear of taking a step back",
-      description:
-        "Switching often means a pay cut or a lower title. You're unsure if the short-term sacrifice is worth the long-term gain, and there's no one to validate your plan.",
-    },
+    reassurance:
+      "No cohort. No income-share agreement. Cancel 24 hours ahead for a full refund.",
+  },
+
+  order: [
+    "pains",
+    "spine",
+    "sessions",
+    "checklist",
+    "comparison",
+    "categories",
+    "faqs",
   ],
-  solutions: [
-    {
-      title: "Transition roadmaps from successful switchers",
-      description:
-        "Connect with professionals who've made the exact switch you're planning — service to product, IT to consulting, engineering to PM. Get a realistic timeline and action plan.",
-    },
-    {
-      title: "Resume and LinkedIn makeovers",
-      description:
-        "Reframe your experience for your target industry. Consultants help you rewrite bullet points, highlight transferable skills, and position yourself as a strong candidate.",
-    },
-    {
-      title: "Domain-specific interview prep",
-      description:
-        "Practice the exact interview format used by your target companies. From DSA to system design to case studies — prepare with someone who's been on the other side.",
-    },
-    {
-      title: "Honest comp and career trajectory advice",
-      description:
-        "Understand realistic salary expectations, growth timelines, and what your first 6 months will look like. Make decisions based on data, not hope.",
-    },
-  ],
-  categories: [
-    { label: "Technology", href: "/explore/experts?domain=Technology" },
-    { label: "Business", href: "/explore/experts?domain=Business" },
-    { label: "Creative Arts", href: "/explore/experts?domain=Creative Arts" },
-    {
-      label: "Personal Development",
-      href: "/explore/experts?domain=Personal Development",
-    },
-  ],
-  bottomCtaTitle: "Your Next Chapter Starts Here",
-  bottomCtaDescription:
-    "Every successful career switcher had a moment where they decided to get real guidance. This is yours. Book a session and start building your transition plan today.",
 };
 
 export default function CareerSwitchersPage() {

--- a/app/use-cases/college-students/page.tsx
+++ b/app/use-cases/college-students/page.tsx
@@ -1,65 +1,296 @@
+import type { Metadata } from "next";
+
 import UseCasePageLayout from "../UseCasePageLayout";
 import type { UseCasePageData } from "../UseCasePageLayout";
 
+export const metadata: Metadata = {
+  title: "Career Guidance for College Students in India | Familiarise",
+  description:
+    "Placement season, off-campus hunting, and the job-vs-GATE-vs-CAT-vs-GRE fork — talk 1:1 with people who have already run them. Rupee pricing on the profile, full refund 24 hours ahead.",
+};
+
+/**
+ * Segment thesis: the student's problem is a *calendar*, not a skills gap — the
+ * decisions that matter (internship→PPO, eligibility, resume, drive formats,
+ * the higher-studies fork) are date-bound, so the spine is a timeline. Positioned
+ * against the two real substitutes for Indian students: free advice, and
+ * cohort/ISA programs. No outcome statistics anywhere — see the comparison
+ * footnote, which makes that refusal the differentiator.
+ *
+ * Framing sources (deliberately none of them quoted as figures in the copy, so
+ * nothing on this page can go stale or be challenged):
+ * - Tier-2/3 placement contraction and the entry-level experience paradox —
+ *   https://www.thequint.com/jobs/campus-placement-jobs-fall-economic-crisis-unemployment-iit-iim-ai-degrees
+ * - Employers shifting from marks to demonstrable "proof of work" —
+ *   https://www.business-standard.com/industry/news/nearly-73-employers-plan-to-hire-freshers-in-first-half-of-2026-report-126021800516_1.html
+ * - Season shape, Day 0 / slots / dream-offer rules as students describe them —
+ *   https://home.iitd.ac.in/show.php?id=804&in_sections=News and college
+ *   placement policies such as https://www.tce.edu/placement/categories
+ * - Buyers now distrust flawless social proof, which is why this page has none —
+ *   https://www.powerreviews.com/how-fake-reviews-destroy-consumer-trust/
+ */
 const data: UseCasePageData = {
-  title: "Career Guidance Before You Graduate",
-  subtitle:
-    "Stop guessing what comes next. Connect with industry professionals who've been where you are — and get personalized advice to land your first role.",
-  ctaLabel: "Find Your Mentor",
-  ctaHref: "/explore/experts",
-  painPoints: [
-    {
-      title: "Campus placements feel like a lottery",
-      description:
-        "You prepare for months but the process is opaque. Which companies to target, how to stand out, what skills actually matter — there's no one to ask who's been through it recently.",
+  hero: {
+    eyebrow: "For students in India",
+    titleLead: "Placement season is a calendar.",
+    titleAccent: "Not a lottery.",
+    subtitle:
+      "Talk to the people who have sat on the other side of the table — at the companies visiting your campus, and at the ones that never will. One call, one price, in rupees.",
+    primaryCta: { label: "Find an expert", href: "/explore/experts" },
+    secondaryCta: {
+      label: "See interview-prep experts",
+      href: "/explore/experts?search=Interview+Prep",
     },
-    {
-      title: "Generic career advice doesn't apply to you",
-      description:
-        "YouTube videos and blog posts give broad tips. You need someone who understands your specific branch, college tier, and career goals to give advice that's actually actionable.",
+    assurances: [
+      "Cancel 24 hours ahead for a full refund",
+      "Pay in ₹ by UPI, card or net banking",
+      "No cohort fee, no income-share agreement",
+    ],
+    card: {
+      title: "What a first session usually gets used for",
+      items: [
+        "Working out which companies on your campus list are worth a Day-1 slot, and which are a distraction.",
+        "A resume read by someone who has actually screened resumes for that role — not a template, not a checklist.",
+        "One mock round in the format you will really face: DSA, system design, case, guesstimate or HR.",
+        "An honest answer on job versus GATE, CAT, GRE or UPSC, from someone who picked one of them.",
+      ],
+      footnote:
+        "Experts set their own price and their own session length. Both are on the profile before you book, and the shortest consultation on the platform is 30 minutes.",
     },
-    {
-      title: "No real-world project experience",
-      description:
-        "Your resume has coursework and academic projects, but recruiters want to see real impact. You don't know where to start or how to build something meaningful.",
+  },
+
+  pains: {
+    eyebrow: "The real blockers",
+    title: "What actually stops students — and it isn't effort",
+    intro:
+      "The parts of placement season that decide the outcome are mostly invisible from inside a campus, which is why working harder at the visible parts changes so little.",
+    items: [
+      {
+        title: "The shortlist is decided before you walk in",
+        description:
+          "Sixty percent throughout, a CGPA cutoff, branch eligibility and active-backlog rules filter you out of drives long before anybody interviews you. Which of those constraints can still be worked around, and which are final, is the most useful thing to establish early — and nobody on campus is especially incentivised to tell you.",
+      },
+      {
+        title: "Off-campus is a completely different game",
+        description:
+          "If the companies you want do not visit your college, the route is referrals, cold applications and a profile that survives a keyword filter before a human sees it. That is a learnable skill with its own tactics, and it is not on anyone's syllabus.",
+      },
+      {
+        title: "Your seniors' advice has quietly expired",
+        description:
+          "Hiring bars, interview formats and the fresher market move faster than campus lore does. Advice from a batch that placed three years ago describes a market that no longer exists, delivered with total confidence.",
+      },
+      {
+        title: "You are deciding job versus higher studies on vibes",
+        description:
+          "CAT, GATE, GRE and UPSC each want a year of your life, and each application window closes before you feel ready to commit. Most students make that call on the opinion of whoever spoke to them last.",
+      },
+    ],
+  },
+
+  spine: {
+    variant: "timeline",
+    eyebrow: "The year, laid out",
+    title: "Where an hour of someone else's experience actually changes things",
+    intro:
+      "Almost all the leverage in placement season sits in the months before the drive, not the week of it. These are the points where a single conversation redirects what you do next.",
+    items: [
+      {
+        label: "Pre-final year",
+        title: "The summer internship, and the PPO it can become",
+        description:
+          "A pre-placement offer is the cheapest route through the entire season, and it is won a year before the season begins. Getting shortlisted for the internship is a different exercise from getting placed, and it rewards planning that most students start far too late.",
+      },
+      {
+        label: "Before the season opens",
+        title: "Eligibility, registration and the dream-offer rules",
+        description:
+          "Criteria, registrations and your placement cell's own rulebook land before anything else. This is when to work out which companies you are eligible for, what counts as a dream or super-dream offer at your college, and at what point accepting one puts you out of placement altogether.",
+      },
+      {
+        label: "Run-up to the drives",
+        title: "Resume, projects and the keyword filter",
+        description:
+          "Your resume gets about as much attention as it takes to scroll past it. This is the window to rewrite it around outcomes rather than coursework, and to finish the one project you can defend under questioning.",
+      },
+      {
+        label: "Drive season",
+        title: "Day 0, Day 1, and the slots after them",
+        description:
+          "Aptitude, DSA, system design, case rounds and HR, in formats that differ by company and by role. Practising the wrong round is worse than not practising at all, and a mock with somebody who has actually conducted that round tells you where you stand within an hour.",
+      },
+      {
+        label: "After the campus route",
+        title: "Off-campus, and the higher-studies fork",
+        description:
+          "If the campus process does not land, the off-campus one runs on referrals, timing and volume — and it carries a stigma it does not deserve, given how many people it is the default route for. Running in parallel are the CAT, GATE, GRE and UPSC calendars, each of which wants a decision rather than a maybe.",
+      },
+    ],
+    footnote:
+      "Calendars differ by college and by year. Treat this as the shape of the season, not as your institute's official schedule.",
+  },
+
+  sessions: {
+    eyebrow: "What you book",
+    title: "Specific sessions, not open-ended mentoring",
+    intro:
+      "You are booking a named person for a defined block of time to do one concrete thing. Everything below is a real session type on the platform.",
+    items: [
+      {
+        icon: "file",
+        title: "Resume and profile review",
+        description:
+          "Attach your resume and portfolio to the booking beforehand. Experts can return documents with review notes, so the call itself is spent on the conversation rather than on reading.",
+      },
+      {
+        icon: "video",
+        title: "A mock round in your actual format",
+        description:
+          "DSA, system design, case, guesstimate or HR — booked with someone who has run that round professionally, and who will tell you where you stand rather than being encouraging.",
+      },
+      {
+        icon: "target",
+        title: "Campus-list strategy",
+        description:
+          "Which drives to sit, which to skip, and where your first slot goes. An hour on this before the season is worth more than a month of preparation aimed at the wrong companies.",
+      },
+      {
+        icon: "compass",
+        title: "The higher-studies fork",
+        description:
+          "Job now, GATE, CAT, GRE or UPSC. Book people who took each of those roads and can describe what it actually cost them, before the forms close on you.",
+      },
+    ],
+  },
+
+  comparison: {
+    eyebrow: "Be honest about the alternatives",
+    title: "You have three options. Here they are, without the spin.",
+    intro:
+      "Free advice and paid programs both work for some people. This is where each of them puts the risk, and where we put it.",
+    alternatives: ["Free advice online", "Cohort and pay-after-placement programs"],
+    ourLabel: "Familiarise",
+    rows: [
+      {
+        criterion: "What it costs",
+        alternatives: [
+          "Nothing, plus the cost of acting on advice that did not apply to you.",
+          "A program fee, or a share of a salary you have not earned yet.",
+        ],
+        ours: "The expert's own price, in rupees, shown on their profile before you book.",
+      },
+      {
+        criterion: "What you commit to",
+        alternatives: [
+          "Nothing.",
+          "Fixed cohorts, minimum months, or an agreement signed before you start.",
+        ],
+        ours: "One session. No minimum, no lock-in, nothing to sign.",
+      },
+      {
+        criterion: "Who you get",
+        alternatives: [
+          "Whoever answers the cold message.",
+          "Whoever the program assigns you from its pool.",
+        ],
+        ours: "The person you choose, after reading their profile, credentials and reviews.",
+      },
+      {
+        criterion: "If it turns out to be useless",
+        alternatives: [
+          "You lost an evening.",
+          "A refund window measured in days, after a large upfront payment.",
+        ],
+        ours: "Cancel 24 hours ahead for a 100% refund. The policy is fixed at checkout and cannot change afterwards.",
+      },
+      {
+        criterion: "Reaching an actual human",
+        alternatives: [
+          "Depends on a cold message landing.",
+          "Usually a callback from a sales team before anything else.",
+        ],
+        ours: "Pick a slot and book it. No brochure, no callback, no counsellor.",
+      },
+    ],
+    footnote:
+      "We do not publish a placement rate. Nobody in this category can substantiate one, and we would rather you judged us on the profile in front of you.",
+  },
+
+  categories: {
+    eyebrow: "Where to start",
+    title: "Browse by what you need this month",
+    intro:
+      "Every listing shows the expert's price, session length and reviews before you commit to anything.",
+    links: [
+      { label: "Interview prep", href: "/explore/experts?search=Interview+Prep" },
+      { label: "DSA", href: "/explore/experts?search=DSA" },
+      { label: "System design", href: "/explore/experts?search=System+Design" },
+      { label: "Data science", href: "/explore/experts?search=Data+Science" },
+      { label: "Technology", href: "/explore/experts?search=Technology" },
+      { label: "Business", href: "/explore/experts?search=Business" },
+      { label: "Creative Arts", href: "/explore/experts?search=Creative+Arts" },
+      { label: "Education", href: "/explore/experts?search=Education" },
+    ],
+  },
+
+  faqs: {
+    eyebrow: "Before you book",
+    title: "The questions students actually ask us",
+    intro:
+      "Short answers, and none of them require you to speak to anyone first.",
+    items: [
+      {
+        question: "How much does a session cost?",
+        answer:
+          "Each expert sets their own price, and it is shown on their profile in rupees before you book. Our commission is already inside that number, so there is no separate booking fee. Buyers in India see 18% GST added at checkout because Indian law requires it; buyers outside India are zero-rated as an export of services.",
+      },
+      {
+        question: "I'm from a tier-2 or tier-3 college. Is this for me?",
+        answer:
+          "Particularly. On-campus hiring is the part of the process your college controls. Off-campus is the part you control, and it is the part almost nobody is taught. Here you choose an expert by what they have done and where they have worked, not by which campus they visit.",
+      },
+      {
+        question: "What if the session isn't useful?",
+        answer:
+          "Cancel at least 24 hours before the start time and you are refunded in full. If your expert cancels, you are refunded in full regardless of timing. The cancellation terms are recorded against your booking at checkout, so nothing about them can be changed after you have paid.",
+      },
+      {
+        question: "What if the expert doesn't turn up?",
+        answer:
+          "Report it from the booking itself. Our team reviews the session's attendance record and can arrange a full refund or a reschedule. We deliberately do not automate that decision, because a genuine connectivity failure and a no-show look identical to a script.",
+      },
+      {
+        question: "Can I send my resume before the call?",
+        answer:
+          "Yes. Documents attach to the booking, and the expert can return them with review notes. That way the session is spent discussing the work rather than reading it.",
+      },
+      {
+        question: "Are the experts actually verified?",
+        answer:
+          "Experts submit identity and credential documents, and a member of our staff reviews them individually before a profile is marked Verified. Separately, only someone who has completed a session with that expert can leave a review — so the ratings you are reading came from real bookings.",
+      },
+      {
+        question: "Can I reschedule if a drive clashes?",
+        answer:
+          "Yes, up to 24 hours before the session starts, at no extra cost. Inside 24 hours the slot is already committed on the expert's calendar and can no longer be moved.",
+      },
+    ],
+  },
+
+  closing: {
+    title: "Start with one hour, not one year",
+    description:
+      "Pick someone whose path you would want, read what people who actually met them said, and book a slot. No brochure, no callback, nothing to sign.",
+    primaryCta: { label: "Find an expert", href: "/explore/experts" },
+    secondaryCta: {
+      label: "Browse interview prep",
+      href: "/explore/experts?search=Interview+Prep",
     },
-    {
-      title: "Unclear on which career path to choose",
-      description:
-        "Software engineering, data science, product management, consulting — every option sounds good on paper. Without insider perspective, it's impossible to choose wisely.",
-    },
-  ],
-  solutions: [
-    {
-      title: "1-on-1 consultations with industry professionals",
-      description:
-        "Book a session with engineers, PMs, and designers at top companies. Get resume reviews, mock interviews, and career roadmap advice tailored to your background.",
-    },
-    {
-      title: "Mock interviews that mirror real processes",
-      description:
-        "Practice DSA rounds, system design, HR interviews, and case studies with consultants who've conducted these interviews at their companies.",
-    },
-    {
-      title: "Portfolio and resume reviews from hiring managers",
-      description:
-        "Get your resume and GitHub profile reviewed by people who actually make hiring decisions. Learn what stands out and what gets filtered out.",
-    },
-    {
-      title: "Domain exploration sessions",
-      description:
-        "Not sure if you want backend, frontend, ML, or DevOps? Book short exploration sessions with experts in each domain to understand day-to-day work and growth paths.",
-    },
-  ],
-  categories: [
-    { label: "Technology", href: "/explore/experts?domain=Technology" },
-    { label: "Business", href: "/explore/experts?domain=Business" },
-    { label: "Creative Arts", href: "/explore/experts?domain=Creative Arts" },
-    { label: "Education", href: "/explore/experts?domain=Education" },
-  ],
-  bottomCtaTitle: "Your Career Starts With One Conversation",
-  bottomCtaDescription:
-    "Join thousands of students who've fast-tracked their careers with personalized mentorship. Your first session could change everything.",
+    reassurance:
+      "Cancel 24 hours ahead for a full refund. Pay in ₹ by UPI, card, net banking or wallet.",
+  },
+
+  order: ["pains", "spine", "sessions", "comparison", "categories", "faqs"],
 };
 
 export default function CollegeStudentsPage() {

--- a/app/use-cases/early-career/page.tsx
+++ b/app/use-cases/early-career/page.tsx
@@ -1,68 +1,308 @@
+import type { Metadata } from "next";
+
 import UseCasePageLayout from "../UseCasePageLayout";
 import type { UseCasePageData } from "../UseCasePageLayout";
 
+export const metadata: Metadata = {
+  title: "Career Guidance for Early-Career Professionals in India | Familiarise",
+  description:
+    "CTC versus in-hand, variable pay, clawbacks, notice periods and whether your role is actually compounding. Book an hour with someone five years ahead of you. Rupee pricing, full refund 24 hours ahead.",
+};
+
+/**
+ * Segment thesis: this reader is not short of advice, they are short of
+ * *information asymmetry relief* — chiefly about what an Indian offer actually
+ * contains. So the spine is a decoder, and it runs before the pain section:
+ * the page opens by being useful, which is the opposite of the category's
+ * aspirational-imperative register ("Supercharge", "10X your career").
+ *
+ * Framing sources (no figures appear in the copy — the numbers that circulate
+ * hardest here, "in-hand is 30% below CTC" and "switch hikes are 30–40%", have
+ * no traceable primary source and are deliberately absent):
+ * - Absence of a growth path, not pay alone, is a leading stated reason Indian
+ *   professionals switch — https://www.businesstoday.in/jobs/story/almost-everyone-is-looking-to-switch-jobs-but-only-if-employers-meet-this-pay-demand-544684-2026-07-23
+ * - Internal increments by sector, Aon's 32nd survey of 1,400+ organisations —
+ *   https://www.aon.com/apac/in-the-press/asia-newsroom/2026/aon-survey-projects-slight-uptick-in-salaries-in-india-2026
+ * - Deferred appraisal cycles in Indian IT —
+ *   https://www.peoplematters.in/news/compensation-benefits/tcs-resumes-april-salary-hikes-after-delay-with-double-digit-raises-for-top-performers-49180
+ * - Above-the-fold attention concentration, which is why the hero carries a
+ *   content card rather than another screenful —
+ *   https://www.nngroup.com/articles/scrolling-and-attention/
+ */
 const data: UseCasePageData = {
-  title: "Accelerate Your First 1–5 Years",
-  subtitle:
-    "The early years define your trajectory. Get strategic guidance from professionals who've navigated the same growth phase — and came out ahead.",
-  ctaLabel: "Find an Expert",
-  ctaHref: "/explore/experts",
-  painPoints: [
-    {
-      title: "No senior mentor at work",
-      description:
-        "Your manager is busy, senior engineers are swamped, and there's no formal mentorship program. You're left figuring things out alone through trial and error.",
+  hero: {
+    eyebrow: "For 0–5 years of experience",
+    titleLead: "The first five years compound.",
+    titleAccent: "So do the mistakes.",
+    subtitle:
+      "Nobody at work is paid to tell you what your offer really contains, whether your role is going anywhere, or what you are worth on the open market. Book an hour with someone who will.",
+    primaryCta: { label: "Find an expert", href: "/explore/experts" },
+    secondaryCta: {
+      label: "See top-rated experts",
+      href: "/explore/experts?sort=rating",
     },
-    {
-      title: "Stuck in a role that doesn't grow",
-      description:
-        "You joined for the brand name but the work is repetitive. You're not learning new skills, your title isn't progressing, and you're worried about stagnating.",
+    assurances: [
+      "The expert's price is on their profile, in ₹",
+      "Cancel 24 hours ahead for a full refund",
+      "No callback, no counsellor, no brochure",
+    ],
+    card: {
+      title: "What people actually bring to a first session",
+      items: [
+        "Is this offer really better than my current one, once variable pay and the joining-bonus clawback come out of it?",
+        "My title has not moved in two years. Is that the team, the company, or me?",
+        "What has to be on my CV in the next six months for the companies I want to take my call?",
+        "How do I ask for a raise here without it becoming the reason I get managed out?",
+      ],
+      footnote:
+        "Consultations start at 30 minutes. If one call turns into an ongoing arrangement, some experts also run monthly subscription plans — reachable from the same profile.",
     },
-    {
-      title: "Don't know how to negotiate or switch",
-      description:
-        "Should you ask for a raise, switch teams, or change companies? You don't have enough data points to make a confident decision about your next move.",
+  },
+
+  spine: {
+    variant: "decoder",
+    eyebrow: "Start with something useful",
+    title: "Read your offer letter the way the person who wrote it does",
+    intro:
+      "An Indian offer is quoted as one large number you will never see in your bank account. Here is what that number is made of, and which parts of it are promises rather than pay.",
+    items: [
+      {
+        label: "CTC",
+        title: "Cost to company, not cost to you",
+        description:
+          "Everything your employer budgets for you, including their own provident-fund contribution and the gratuity they set aside. It is an accounting figure on their side. Your in-hand pay is what survives after those line items, your own PF share and income tax.",
+      },
+      {
+        label: "Variable pay",
+        title: "The conditional part, quoted as if it were certain",
+        description:
+          "Counted at 100% in the CTC and paid at whatever the company's performance and your rating decide. The question worth asking is what it actually paid out last cycle across the whole team, not what it is capable of paying out.",
+      },
+      {
+        label: "Joining bonus",
+        title: "A loan with a clawback clause attached",
+        description:
+          "Typically repayable in full if you leave within a stated period. It inflates your first-year CTC and quietly raises the cost of your next move. Read the recovery clause before you read the headline number.",
+      },
+      {
+        label: "Retention bonus",
+        title: "Priced to get you past your restless year",
+        description:
+          "Paid on a date rather than on performance. It is worth counting only to the extent that you intend to still be sitting there when that date arrives.",
+      },
+      {
+        label: "ESOPs and RSUs",
+        title: "Worth nothing until three separate things are true",
+        description:
+          "There has to be a vesting date you actually reach, a liquidity event or buyback that lets you sell, and a strike price that makes exercising worthwhile. In an unlisted company, ask about all three before you value them at the number on the sheet.",
+      },
+      {
+        label: "Notice period",
+        title: "The clause that decides what your next job can be",
+        description:
+          "A long notice period narrows the set of employers willing to wait for you. Whether a buyout is permitted, and who pays for it, is negotiable when you join and almost never negotiable afterwards.",
+      },
+      {
+        label: "Hike percentage",
+        title: "A ratio, not an outcome",
+        description:
+          "It is measured against your current CTC, so the identical rupee offer is a brilliant hike or an insulting one purely depending on where you started. Compare offers in absolute in-hand terms and real ownership, never in percentages.",
+      },
+    ],
+    footnote:
+      "General mechanics, not tax or legal advice. The specifics of your own offer are exactly what a session is for.",
+  },
+
+  pains: {
+    eyebrow: "Why this keeps happening",
+    title: "The structural reasons nobody tells you any of this",
+    intro:
+      "None of these are personal failings. They are what happens when the people best placed to advise you are the people with the least incentive to.",
+    items: [
+      {
+        title: "Nobody at work is measured on your trajectory",
+        description:
+          "Your manager is assessed on delivery. Senior engineers are assessed on their own scope. Where a formal mentorship programme exists at all, it tends to pair you with whoever had spare capacity that quarter. The most consequential decisions of your twenties end up being made with no counsel at all.",
+      },
+      {
+        title: "Three years of experience, or one year lived three times",
+        description:
+          "Maintenance work, a ticket queue and a stack that has not moved since you joined. It reads as three years on a CV and interviews like one — and the gap only becomes visible at the exact moment it is most expensive, in a room full of strangers.",
+      },
+      {
+        title: "You are negotiating without a second data point",
+        description:
+          "What people are paid reaches you as rumour, and in any appraisal conversation the other side knows the market better than you do. With no independent reference point, you end up negotiating against yourself and calling it realism.",
+      },
+      {
+        title: "Everyone else appears to know exactly what they are doing",
+        description:
+          "They do not, but that is unverifiable from inside your own head. The thing that actually resolves it is one candid conversation with somebody senior enough to describe how uncertain they were at your level, and specific enough to be believed.",
+      },
+    ],
+  },
+
+  sessions: {
+    eyebrow: "What you book",
+    title: "One person, one hour, one decision",
+    intro:
+      "These are the sessions this segment books most, and each one is a defined block of time with a named outcome rather than an open-ended chat.",
+    items: [
+      {
+        icon: "wallet",
+        title: "Offer and counter-offer review",
+        description:
+          "Bring both offers, or the one you are still negotiating. Work through variable pay, clawbacks, equity and notice terms with someone who has sat on the hiring side of those conversations.",
+      },
+      {
+        icon: "chart",
+        title: "An honest read on whether your role is compounding",
+        description:
+          "Whether the work you are doing is building a career or maintaining one, and what specifically would have to change over the next two quarters for the answer to differ.",
+      },
+      {
+        icon: "target",
+        title: "Skill-gap session against a named target role",
+        description:
+          "Not a generic roadmap. Name the role and the kind of company, then work backwards to what is missing from your profile today and in what order to fix it.",
+      },
+      {
+        icon: "message",
+        title: "The conversation you have been avoiding",
+        description:
+          "The raise ask, the team-change ask, the pushback on scope. Rehearse it with someone who has been on the receiving end of that conversation many times and can tell you how it lands.",
+      },
+    ],
+  },
+
+  comparison: {
+    eyebrow: "The honest comparison",
+    title: "Free forums, a monthly retainer, or an hour with one person",
+    intro:
+      "All three are legitimate. They differ in who carries the risk and how much you have to commit before you find out whether it works.",
+    alternatives: [
+      "Anonymous salary forums and cold LinkedIn messages",
+      "A monthly mentorship retainer",
+    ],
+    ourLabel: "Familiarise",
+    rows: [
+      {
+        criterion: "What you get",
+        alternatives: [
+          "Anecdotes from strangers with no context on your situation.",
+          "A recurring relationship, billed whether or not this month needed one.",
+        ],
+        ours: "One expert, for a defined session, on the specific decision in front of you.",
+      },
+      {
+        criterion: "What you commit to",
+        alternatives: [
+          "Nothing, other than the time.",
+          "A monthly fee, usually with a multi-month minimum.",
+        ],
+        ours: "A single booking. Move to a monthly plan later only if you decide you want one.",
+      },
+      {
+        criterion: "Who it comes from",
+        alternatives: [
+          "Unverified, unattributable, and impossible to follow up with.",
+          "Whoever the platform matches or assigns you.",
+        ],
+        ours: "Someone you chose, whose identity and credential documents our staff reviewed.",
+      },
+      {
+        criterion: "Backing out",
+        alternatives: [
+          "Not applicable.",
+          "Notice periods, part-months and partial refunds.",
+        ],
+        ours: "Full refund up to 24 hours before the session, on terms fixed at checkout.",
+      },
+      {
+        criterion: "Paperwork",
+        alternatives: [
+          "None, and nothing you can put through expenses.",
+          "Varies by provider.",
+        ],
+        ours: "A tax invoice, paid in ₹ by UPI, card, net banking or wallet.",
+      },
+    ],
+    footnote:
+      "If ongoing mentorship is genuinely what you want, it exists here too — as a subscription with an agreed number of calls, on the same expert's profile. It simply is not the only way in.",
+  },
+
+  categories: {
+    eyebrow: "Where to start",
+    title: "Find someone who has already done the next bit",
+    intro:
+      "Every listing shows price, session length and reviews from people who actually completed a session.",
+    links: [
+      { label: "System design", href: "/explore/experts?search=System+Design" },
+      { label: "Interview prep", href: "/explore/experts?search=Interview+Prep" },
+      { label: "Machine learning", href: "/explore/experts?search=Machine+Learning" },
+      { label: "Cloud", href: "/explore/experts?search=Cloud" },
+      { label: "DevOps", href: "/explore/experts?search=DevOps" },
+      { label: "Technology", href: "/explore/experts?search=Technology" },
+      { label: "Business", href: "/explore/experts?search=Business" },
+      {
+        label: "Personal development",
+        href: "/explore/experts?search=Personal+Development",
+      },
+    ],
+  },
+
+  faqs: {
+    eyebrow: "Before you book",
+    title: "Fair questions",
+    intro: "None of these require you to speak to a salesperson first.",
+    items: [
+      {
+        question: "I have exactly one question. Is a whole session overkill?",
+        answer:
+          "No, and it is the most common reason people book. Consultations start at 30 minutes, and both the price and the length are on the expert's profile before you commit to anything.",
+      },
+      {
+        question: "Will my employer find out?",
+        answer:
+          "There is nothing for them to find out. You book as an individual and we never contact an employer about a booking.",
+      },
+      {
+        question: "How is this different from a monthly mentorship plan?",
+        answer:
+          "A consultation is a single booking at a fixed price. A subscription is a monthly plan with an agreed number of calls, which some experts offer alongside their one-off sessions. Start with the one-off, and move to a plan only once it has earned its keep.",
+      },
+      {
+        question: "Can I expense it?",
+        answer:
+          "You receive a tax invoice for the booking, with GST charged as Indian law requires for buyers in India. Whether your employer reimburses it is between you and them — but the paperwork will not be the reason they say no.",
+      },
+      {
+        question: "How do I know the price is fair?",
+        answer:
+          "You do not have to take our word for it. Experts set their own prices and you can see them side by side before booking. Our commission is already inside the listed price, so nothing is added at checkout beyond statutory GST.",
+      },
+      {
+        question: "What if I pick the wrong person?",
+        answer:
+          "Cancel at least 24 hours before the start time, get a full refund, and book someone else. If the expert cancels on you, you are refunded in full no matter when it happens.",
+      },
+    ],
+  },
+
+  closing: {
+    title: "Compounding starts with one honest conversation",
+    description:
+      "An hour with someone a few years ahead of you, about the decision actually in front of you. Priced in rupees, on their profile, before you book anything.",
+    primaryCta: { label: "Find an expert", href: "/explore/experts" },
+    secondaryCta: {
+      label: "See top-rated experts",
+      href: "/explore/experts?sort=rating",
     },
-    {
-      title: "Imposter syndrome is real",
-      description:
-        "Everyone around you seems to know what they're doing. You're constantly second-guessing your skills and wondering if you're falling behind your peers.",
-    },
-  ],
-  solutions: [
-    {
-      title: "Career strategy sessions with senior professionals",
-      description:
-        "Book 1-on-1 calls with people 5–10 years ahead of you. Get honest advice on promotions, skill gaps, team dynamics, and when to make your next move.",
-    },
-    {
-      title: "Skill-gap analysis and learning roadmaps",
-      description:
-        "Consultants help you identify exactly what skills you need for your target role — and create a focused plan to build them within 3–6 months.",
-    },
-    {
-      title: "Salary negotiation and offer evaluation",
-      description:
-        "Before you accept that next offer, get it reviewed by someone who understands comp structures, equity, and market rates for your level and location.",
-    },
-    {
-      title: "Ongoing mentorship through subscriptions",
-      description:
-        "Don't limit yourself to one-off calls. Subscribe to a mentor for regular check-ins, accountability, and continuous guidance as your career evolves.",
-    },
-  ],
-  categories: [
-    { label: "Technology", href: "/explore/experts?domain=Technology" },
-    { label: "Business", href: "/explore/experts?domain=Business" },
-    { label: "Creative Arts", href: "/explore/experts?domain=Creative Arts" },
-    {
-      label: "Personal Development",
-      href: "/explore/experts?domain=Personal Development",
-    },
-  ],
-  bottomCtaTitle: "Don't Navigate Your Career Alone",
-  bottomCtaDescription:
-    "The professionals who grow fastest are the ones who ask for help early. One conversation with the right mentor can save you years of guesswork.",
+    reassurance:
+      "No callback. No brochure. Cancel 24 hours ahead for a full refund.",
+  },
+
+  order: ["spine", "pains", "sessions", "comparison", "categories", "faqs"],
 };
 
 export default function EarlyCareerPage() {

--- a/app/use-cases/mentorship/page.tsx
+++ b/app/use-cases/mentorship/page.tsx
@@ -1,66 +1,293 @@
+import type { Metadata } from "next";
+
 import UseCasePageLayout from "../UseCasePageLayout";
 import type { UseCasePageData } from "../UseCasePageLayout";
 
+export const metadata: Metadata = {
+  title: "Long-Term 1:1 Mentorship in India | Familiarise",
+  description:
+    "Monthly mentorship plans set by the expert — one to twenty-four months, an agreed number of calls, chat in between. Try the fit first where a trial is offered. Cancel a session 24 hours ahead for a full refund.",
+};
+
+/**
+ * Segment thesis: this is the only page selling a *commitment*, so it leads with
+ * the comparison rather than the pitch — including the case for not buying it.
+ * The one genuinely citable proof device on any of these pages lives here: the
+ * duration-versus-outcome finding, quoted with its own limitation stated. Every
+ * competitor in this category leans on unsourced outcome percentages instead.
+ *
+ * Sources for the framing:
+ * - Duration drives mentoring outcomes and early-terminating matches can leave
+ *   people worse off — Grossman & Rhodes, "The Test of Time" (2002), n=1,138,
+ *   https://pubmed.ncbi.nlm.nih.gov/12002243/ and
+ *   https://link.springer.com/article/10.1023/A:1014680827552
+ * - Why relationships fail (mismatch, distancing/neglect, insufficient
+ *   expertise) — Eby et al. (2004), https://scse.d.umn.edu/sites/scse.d.umn.edu/files/eby_and_mcmannus_2004.pdf
+ *   and Straus et al. (2013), https://pubmed.ncbi.nlm.nih.gov/23165266/
+ * - Cold outreach is a losing numbers game — Belkins 2025 LinkedIn outreach
+ *   study, 15.1M touchpoints, 7.2% reply / 1.3% meeting:
+ *   https://belkins.io/blog/linkedin-outreach-study (sales outreach, so it is
+ *   used qualitatively here and no figure appears in the copy).
+ */
 const data: UseCasePageData = {
-  title: "Long-Term Mentorship That Actually Works",
-  subtitle:
-    "One-off calls are great for quick answers. But real career transformation happens through ongoing relationships with mentors who know your story.",
-  ctaLabel: "Find a Mentor",
-  ctaHref: "/explore/experts",
-  painPoints: [
-    {
-      title: "One-off advice doesn't stick",
-      description:
-        "You've had great conversations before, but without follow-through, the advice fades. You need someone who tracks your progress and holds you accountable.",
+  hero: {
+    eyebrow: "For ongoing mentorship",
+    titleLead: "Advice fades.",
+    titleAccent: "A relationship compounds.",
+    subtitle:
+      "One call answers the question you have today. A monthly plan is for the year in which the questions keep changing — and someone who already knows your context answers them.",
+    primaryCta: { label: "Find a mentor", href: "/explore/experts" },
+    secondaryCta: {
+      label: "See top-rated experts",
+      href: "/explore/experts?sort=rating",
     },
-    {
-      title: "Hard to find committed mentors",
-      description:
-        "Everyone says 'find a mentor' but no one says how. Cold DMs on LinkedIn rarely work, and workplace mentors don't always have the right expertise.",
+    assurances: [
+      "Where an expert offers a trial session, it is free",
+      "Plans run one to twenty-four months — you choose",
+      "Cancel a session 24 hours ahead for a full refund",
+    ],
+    card: {
+      title: "What ongoing buys that a single call cannot",
+      items: [
+        "No re-explaining. By the third session they know your team, your manager and your constraints.",
+        "Course correction between decisions rather than post-mortems after them.",
+        "Somebody who remembers what you said you would do last month, and asks about it.",
+        "Chat between sessions, so a small blocking question does not have to wait three weeks.",
+      ],
+      footnote:
+        "Each expert sets their own plan: the number of calls, the session length, the term and the monthly price are all on their profile before you commit to anything.",
     },
-    {
-      title: "Your challenges evolve over time",
-      description:
-        "What you need help with in month 1 is different from month 6. A mentor who only knows your surface-level story can't give you the depth of guidance you need.",
+  },
+
+  comparison: {
+    eyebrow: "Read this before the pitch",
+    title: "Ongoing mentorship is not always the right purchase",
+    intro:
+      "It is the most expensive thing on this platform and the one that most often goes unused. Here is the honest comparison, including the cases where you should buy something else.",
+    alternatives: [
+      "A single consultation",
+      "An informal mentor you found yourself",
+    ],
+    ourLabel: "A subscription here",
+    rows: [
+      {
+        criterion: "Best for",
+        alternatives: [
+          "One decision you can name today.",
+          "Occasional generous advice, on their schedule.",
+        ],
+        ours: "A stretch of months in which the questions keep changing.",
+      },
+      {
+        criterion: "Context",
+        alternatives: [
+          "The first ten minutes go on explaining yourself.",
+          "Varies with how much of your situation they retain.",
+        ],
+        ours: "Accumulates across sessions and is carried forward.",
+      },
+      {
+        criterion: "Between sessions",
+        alternatives: ["Nothing.", "Whenever they happen to have time."],
+        ours: "A dedicated chat channel, plus documents and materials shared on the plan.",
+      },
+      {
+        criterion: "What you commit to",
+        alternatives: [
+          "A single booking.",
+          "Nothing — and there is no obligation on their side either.",
+        ],
+        ours: "A term you choose, from one month to twenty-four.",
+      },
+      {
+        criterion: "Cost",
+        alternatives: [
+          "The session price, shown before you book.",
+          "Free, and priced accordingly in reliability.",
+        ],
+        ours: "A monthly price the expert sets, visible before you subscribe.",
+      },
+    ],
+    footnote:
+      "If your question is a single question, book the single session. We would much rather sell you an hour that works than a year that does not.",
+  },
+
+  pains: {
+    eyebrow: "Why mentorship usually fails",
+    title: "The failure modes are well documented, and none of them are effort",
+    intro:
+      "Research on mentoring relationships keeps finding the same causes of breakdown: mismatch, neglect, and a mentor who quietly disengages. Almost none of it is about the mentee not trying.",
+    items: [
+      {
+        title: "Advice without follow-through is entertainment",
+        description:
+          "The insight lands, the week resumes, and nothing actually changes. What converts advice into a different outcome is not a better insight — it is somebody expecting an answer from you next month.",
+      },
+      {
+        title: "Cold outreach is a numbers game you are set up to lose",
+        description:
+          "The senior people you want are precisely the ones with no spare time, and an unpaid request from a stranger sits at the bottom of every inbox. Paying for the time is not a lesser version of a real mentorship; it is the thing that makes the calendar entry exist at all.",
+      },
+      {
+        title: "Informal mentorships expire without anyone deciding to end them",
+        description:
+          "No cadence, no written goal, and a slow drift into we-should-catch-up-sometime. Both sides feel vaguely guilty, and neither of them is the one who reschedules.",
+      },
+      {
+        title: "Your problems move faster than a distant advisor can track",
+        description:
+          "What you need in month one is not what you need in month six. Somebody who only knows the surface of your situation keeps carefully answering the question you have already outgrown.",
+      },
+    ],
+    footnote:
+      "The most rigorous evidence here comes from youth mentoring rather than careers, so treat it as suggestive: tracking 1,138 matched pairs over eighteen months, Grossman and Rhodes found that longer relationships produced the largest gains — and that relationships ending very early left participants measurably worse off than no mentoring at all. It is the strongest argument we know of both for committing properly and for checking the fit before you do.",
+  },
+
+  spine: {
+    variant: "cadence",
+    eyebrow: "How an arc actually runs",
+    title: "The first few months, honestly described",
+    intro:
+      "This is the shape most ongoing engagements take. Your expert sets the actual cadence and session count — what follows is the pattern, not a promise.",
+    items: [
+      {
+        label: "Session zero",
+        title: "The trial, where the expert offers one",
+        description:
+          "A short introductory session so both of you can test the fit before money changes hands. Not every expert enables it; where they do it is free, and it is much the cheapest way to avoid committing to the wrong person.",
+      },
+      {
+        label: "First month",
+        title: "Context in, goals out",
+        description:
+          "You stop explaining and they start noticing. What the first month should produce is two or three concrete goals with dates attached, rather than a pleasant general sense of direction.",
+      },
+      {
+        label: "Middle months",
+        title: "The unglamorous part, where it actually works",
+        description:
+          "Progress reviews, course corrections, and the specific conversations you have been avoiding. Chat between sessions absorbs the small blocking questions so the calls stay on the large ones.",
+      },
+      {
+        label: "Ongoing",
+        title: "Renew, change, or stop",
+        description:
+          "Plans run for the term you chose. If it is not earning its place, stopping is the correct answer — and a mentor worth having will usually say so before you do.",
+      },
+    ],
+  },
+
+  sessions: {
+    eyebrow: "What a plan includes",
+    title: "Everything on one platform, not five",
+    intro:
+      "No Zoom links pasted into a chat you cannot find later, and no documents lost in an email thread.",
+    items: [
+      {
+        icon: "video",
+        title: "Scheduled 1:1 calls",
+        description:
+          "An agreed number of calls at a length the expert defines, on the platform's own video rather than a link posted somewhere and subsequently lost.",
+      },
+      {
+        icon: "message",
+        title: "Chat between sessions",
+        description:
+          "A dedicated channel for the questions that cannot wait three weeks but do not deserve an entire call of their own.",
+      },
+      {
+        icon: "file",
+        title: "Documents and materials",
+        description:
+          "Attach work for review and get it back annotated. Experts can also share materials against the plan, so the useful things accumulate in one place.",
+      },
+      {
+        icon: "users",
+        title: "Their classes and webinars",
+        description:
+          "Many experts also run group programs. Those are separate bookings, but they come from the same person you have already decided to trust.",
+      },
+    ],
+  },
+
+  categories: {
+    eyebrow: "Where to start",
+    title: "Find someone worth a standing calendar entry",
+    intro:
+      "Every profile shows the plan's price, term and session count, plus reviews left only by people who actually completed a session.",
+    links: [
+      { label: "Technology", href: "/explore/experts?search=Technology" },
+      { label: "Business", href: "/explore/experts?search=Business" },
+      { label: "Education", href: "/explore/experts?search=Education" },
+      { label: "Health", href: "/explore/experts?search=Health" },
+      { label: "Creative Arts", href: "/explore/experts?search=Creative+Arts" },
+      {
+        label: "Personal development",
+        href: "/explore/experts?search=Personal+Development",
+      },
+      { label: "System design", href: "/explore/experts?search=System+Design" },
+      { label: "Interview prep", href: "/explore/experts?search=Interview+Prep" },
+    ],
+  },
+
+  faqs: {
+    eyebrow: "Before you subscribe",
+    title: "The questions worth asking first",
+    intro:
+      "Especially the ones about getting out again, which is the part nobody advertises.",
+    items: [
+      {
+        question: "How do I try someone before committing to months?",
+        answer:
+          "Where an expert has enabled a trial session it is free and short — often around half an hour — and its only job is to test the fit. Where they have not, book a single consultation with them first; it does the same work at a price you can see up front.",
+      },
+      {
+        question: "How long do plans run, and who decides?",
+        answer:
+          "The expert does. They set the term — anywhere from one month to twenty-four — along with the number of calls, the session length and the monthly price. All of it is visible on their profile before you subscribe.",
+      },
+      {
+        question: "What if my mentor stops showing up?",
+        answer:
+          "Report it from the booking. Our team reviews the attendance record for that session and can arrange a full refund or a reschedule. If the expert cancels a session outright, that session is refunded in full regardless of when they cancel.",
+      },
+      {
+        question: "Can I change mentors?",
+        answer:
+          "Yes. Plans are per expert, so you end one and start another — there is nothing to transfer and nobody whose permission you need.",
+      },
+      {
+        question: "Are the sessions recorded?",
+        answer:
+          "Not the 1:1 ones. Recording exists only for group formats — webinars and classes — and only when the expert has switched it on for that plan. Nothing about a private mentoring call is recorded by default.",
+      },
+      {
+        question: "Is this cheaper than a course?",
+        answer:
+          "It is a different purchase, so compare it honestly rather than on price. A course sells you a syllabus; a mentor sells you attention on your particular situation. If what you actually need is the syllabus, buy the course — it will be cheaper and it will work.",
+      },
+      {
+        question: "How are experts vetted?",
+        answer:
+          "They submit identity and credential documents, and a member of our staff reviews them individually before the profile is marked Verified. We do not run criminal background checks, and we would rather say so than imply a check we do not perform.",
+      },
+    ],
+  },
+
+  closing: {
+    title: "Start with the fit, not the commitment",
+    description:
+      "Take the trial where it is offered, or book a single session first. Turn it into a plan only once the person has proved they are worth a standing entry in your calendar.",
+    primaryCta: { label: "Find a mentor", href: "/explore/experts" },
+    secondaryCta: {
+      label: "See top-rated experts",
+      href: "/explore/experts?sort=rating",
     },
-    {
-      title: "No structure or accountability",
-      description:
-        "Even when you find a good mentor, the relationship often fizzles out. Without scheduled sessions and clear goals, both sides lose momentum.",
-    },
-  ],
-  solutions: [
-    {
-      title: "Subscription-based mentorship plans",
-      description:
-        "Subscribe to ongoing sessions with your chosen mentor. Get regular check-ins — weekly or biweekly — with someone who understands your full context and career arc.",
-    },
-    {
-      title: "Integrated video calls and chat",
-      description:
-        "No more juggling Zoom links and WhatsApp messages. Everything happens on one platform — scheduled calls, async questions, shared documents and notes.",
-    },
-    {
-      title: "Goal tracking and session continuity",
-      description:
-        "Each session builds on the last. Your mentor knows your history, tracks your goals, and adjusts guidance as your situation changes.",
-    },
-    {
-      title: "Access to classes and webinars",
-      description:
-        "Beyond 1-on-1s, join group webinars and classes hosted by your mentor or other experts. Get broader perspectives while maintaining your core mentoring relationship.",
-    },
-  ],
-  categories: [
-    { label: "Technology", href: "/explore/experts?domain=Technology" },
-    { label: "Business", href: "/explore/experts?domain=Business" },
-    { label: "Creative Arts", href: "/explore/experts?domain=Creative Arts" },
-    { label: "Education", href: "/explore/experts?domain=Education" },
-    { label: "Health", href: "/explore/experts?domain=Health" },
-  ],
-  bottomCtaTitle: "Invest in a Relationship, Not Just a Call",
-  bottomCtaDescription:
-    "The best mentors become career-long allies. Start a mentorship subscription today and build the kind of guidance that compounds over time.",
+    reassurance:
+      "Plans run for a term you choose. Sessions cancel 24 hours ahead for a full refund.",
+  },
+
+  order: ["comparison", "pains", "spine", "sessions", "categories", "faqs"],
 };
 
 export default function MentorshipPage() {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,51 +15,78 @@ import { ArrowUpRight, MessageSquare } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { isChromeHidden } from "@/lib/navigation/public-chrome";
 import familiariseLogoWhite from "@/public/avif/static/assets/logos/images/logos/Familiarise-logos_white.avif";
 
 interface FooterLink {
   label: string;
   href: string;
+  /** Renders the outbound glyph. Flagged explicitly rather than matched on
+   *  display text, which silently breaks the moment the copy is reworded. */
+  external?: boolean;
 }
 
-const FOOTER_LINKS: Record<string, FooterLink[]> = {
-  expertise: [
-    { label: "Technology", href: "/explore/experts?domain=Technology" },
-    { label: "Business", href: "/explore/experts?domain=Business" },
-    { label: "Creative Arts", href: "/explore/experts?domain=Creative Arts" },
-    { label: "Education", href: "/explore/experts?domain=Education" },
-    { label: "Health", href: "/explore/experts?domain=Health" },
-    {
-      label: "Personal Development",
-      href: "/explore/experts?domain=Personal Development",
-    },
-  ],
-  useCases: [
-    { label: "College Students", href: "/use-cases/college-students" },
-    { label: "Early-Career Pros", href: "/use-cases/early-career" },
-    { label: "Career Switchers", href: "/use-cases/career-switchers" },
-    { label: "Long-Term Mentorship", href: "/use-cases/mentorship" },
-  ],
-  company: [
-    { label: "About", href: "/about" },
-    { label: "Contact", href: "/contactus" },
-    { label: "Blog", href: "/blog" },
-    { label: "Pricing", href: "/pricing" },
-  ],
-  resources: [
-    { label: "How It Works", href: "/#how-it-works" },
-    { label: "Become an Expert", href: "/form/onboarding" },
-    {
-      label: "Explore Organisations",
-      href: "/explore/enterprise/organisations",
-    },
-  ],
-  legal: [
-    { label: "Terms of Service", href: "/terms" },
-    { label: "Privacy Policy", href: "/privacy" },
-    { label: "Refund Policy", href: "/refund" },
-  ],
-};
+// Mirrors the Navbar's IA (Explore / Solutions / Company / Legal). Users who
+// miss something in the nav look for it in the footer, so the two disagreeing
+// costs clicks. Programs and Organisations were previously unreachable from
+// here entirely.
+const FOOTER_COLUMNS: { heading: string; links: FooterLink[] }[] = [
+  {
+    heading: "Explore",
+    links: [
+      { label: "Find experts", href: "/explore/experts" },
+      { label: "Programs", href: "/explore/programs" },
+      {
+        label: "Organisations",
+        href: "/explore/enterprise/organisations",
+      },
+      { label: "Community", href: "/explore/community" },
+    ],
+  },
+  {
+    heading: "Solutions",
+    links: [
+      { label: "College students", href: "/use-cases/college-students" },
+      { label: "Early-career pros", href: "/use-cases/early-career" },
+      { label: "Career switchers", href: "/use-cases/career-switchers" },
+      { label: "Long-term mentorship", href: "/use-cases/mentorship" },
+      { label: "For teams", href: "/contactus" },
+    ],
+  },
+  {
+    heading: "Company",
+    links: [
+      { label: "About", href: "/about" },
+      { label: "Contact", href: "/contactus" },
+      { label: "Blog", href: "/blog" },
+      { label: "Pricing", href: "/pricing" },
+      { label: "How it works", href: "/#how-it-works" },
+      { label: "Become an expert", href: "/become-an-expert", external: true },
+    ],
+  },
+  {
+    heading: "Legal",
+    links: [
+      { label: "Terms of Service", href: "/terms" },
+      { label: "Privacy Policy", href: "/privacy" },
+      { label: "Refund Policy", href: "/refund" },
+    ],
+  },
+];
+
+// Internal-linking band. A marketplace's value is its long-tail catalog, so
+// these deep links are worth more here than another column of company pages.
+const EXPERTISE_LINKS: FooterLink[] = [
+  { label: "Technology", href: "/explore/experts?domain=Technology" },
+  { label: "Business", href: "/explore/experts?domain=Business" },
+  { label: "Creative Arts", href: "/explore/experts?domain=Creative Arts" },
+  { label: "Education", href: "/explore/experts?domain=Education" },
+  { label: "Health", href: "/explore/experts?domain=Health" },
+  {
+    label: "Personal Development",
+    href: "/explore/experts?domain=Personal Development",
+  },
+];
 
 const SOCIAL_LINKS = [
   {
@@ -99,23 +126,19 @@ const Footer: React.FC = () => {
   // Check if we're on the home page
   const isHomePage = pathname === "/";
 
-  // Routes where footer should be hidden
-  const excludeFooter =
-    pathname.startsWith("/api/") ||
-    pathname.startsWith("/auth/") ||
-    pathname.startsWith("/form/") ||
-    pathname.startsWith("/checkout/") ||
-    pathname === "/dashboard" ||
-    pathname.startsWith("/dashboard/") ||
-    pathname.startsWith("/meetings/");
+  // Route list lives in lib/navigation/public-chrome.ts — it was duplicated
+  // across Navbar/Footer/HeaderSpacer and had already drifted.
+  if (isChromeHidden(pathname)) return null;
 
-  if (excludeFooter) return null;
-
-  const waitlistButtonLabel = {
-    idle: "Join waitlist",
-    loading: "Signing up...",
+  // The heading says "Stay in the loop" and the copy promises a weekly email,
+  // but the button still said "Join waitlist" — left over from the
+  // waitlist→newsletter rework. The endpoint is unchanged; only the label was
+  // stale.
+  const subscribeButtonLabel = {
+    idle: "Subscribe",
+    loading: "Subscribing...",
     success: "Check your email",
-    error: "Join waitlist",
+    error: "Subscribe",
   }[waitlistStatus];
 
   const handleWaitlistSubmit = async (e: React.FormEvent) => {
@@ -186,7 +209,7 @@ const Footer: React.FC = () => {
                 }
                 className="h-14 bg-white text-zinc-900 hover:bg-zinc-200 px-8 rounded-xl font-medium shrink-0"
               >
-                {waitlistButtonLabel}
+                {subscribeButtonLabel}
               </Button>
             </form>
 
@@ -211,7 +234,7 @@ const Footer: React.FC = () => {
 
       {/* Main Footer Content */}
       <div className="container mx-auto px-4 md:px-6 py-16 md:py-20 relative z-10">
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-8 lg:gap-10">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8 lg:gap-10">
           {/* Brand Column */}
           <div className="col-span-2 md:col-span-3 lg:col-span-2">
             <Link href="/" className="inline-block mb-6">
@@ -247,124 +270,54 @@ const Footer: React.FC = () => {
             </div>
           </div>
 
-          {/* Expertise Column */}
-          <div>
-            <h3 className="font-semibold text-white mb-4">Expertise</h3>
-            <ul className="space-y-3">
-              {FOOTER_LINKS.expertise.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    href={link.href}
-                    className="text-sm text-zinc-400 hover:text-white transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
+          {FOOTER_COLUMNS.map((column) => (
+            <div key={column.heading}>
+              <h3 className="font-semibold text-white mb-4">
+                {column.heading}
+              </h3>
+              <ul className="space-y-3">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      className="text-sm text-zinc-400 hover:text-white transition-colors inline-flex items-center gap-1"
+                    >
+                      {link.label}
+                      {link.external && <ArrowUpRight className="w-3 h-3" />}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
 
-          {/* Use Cases Column */}
-          <div>
-            <h3 className="font-semibold text-white mb-4">Use Cases</h3>
-            <ul className="space-y-3">
-              {FOOTER_LINKS.useCases.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    href={link.href}
-                    className="text-sm text-zinc-400 hover:text-white transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Company Column */}
-          <div>
-            <h3 className="font-semibold text-white mb-4">Company</h3>
-            <ul className="space-y-3">
-              {FOOTER_LINKS.company.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    href={link.href}
-                    className="text-sm text-zinc-400 hover:text-white transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Resources Column */}
-          <div>
-            <h3 className="font-semibold text-white mb-4">Resources</h3>
-            <ul className="space-y-3">
-              {FOOTER_LINKS.resources.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    href={link.href}
-                    className="text-sm text-zinc-400 hover:text-white transition-colors inline-flex items-center gap-1"
-                  >
-                    {link.label}
-                    {link.label === "Become an Expert" && (
-                      <ArrowUpRight className="w-3 h-3" />
-                    )}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Legal Column */}
-          <div>
-            <h3 className="font-semibold text-white mb-4">Legal</h3>
-            <ul className="space-y-3">
-              {FOOTER_LINKS.legal.map((link) => (
-                <li key={link.label}>
-                  <Link
-                    href={link.href}
-                    className="text-sm text-zinc-400 hover:text-white transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+        {/* Expertise band — deep links into the catalog */}
+        <div className="mt-12 pt-8 border-t border-zinc-800">
+          <h3 className="text-[11px] font-medium uppercase tracking-wider text-zinc-500 mb-3">
+            Find an expert in
+          </h3>
+          <div className="flex flex-wrap gap-x-5 gap-y-2">
+            {EXPERTISE_LINKS.map((link) => (
+              <Link
+                key={link.label}
+                href={link.href}
+                className="text-sm text-zinc-400 hover:text-white transition-colors"
+              >
+                {link.label}
+              </Link>
+            ))}
           </div>
         </div>
       </div>
 
-      {/* Bottom Bar */}
+      {/* Bottom Bar — legal lives in its own column above, so this carries
+          only the copyright line. */}
       <div className="border-t border-zinc-800 relative z-10">
         <div className="container mx-auto px-4 md:px-6 py-6">
-          <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-            <p className="text-sm text-zinc-500">
-              © {new Date().getFullYear()} Familiarise. All rights reserved.
-            </p>
-            <div className="flex items-center gap-6">
-              <Link
-                href="/terms"
-                className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
-              >
-                Terms
-              </Link>
-              <Link
-                href="/privacy"
-                className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
-              >
-                Privacy
-              </Link>
-              <Link
-                href="/refund"
-                className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
-              >
-                Refunds
-              </Link>
-            </div>
-          </div>
+          <p className="text-sm text-zinc-500 text-center md:text-left">
+            © {new Date().getFullYear()} Familiarise. All rights reserved.
+          </p>
         </div>
       </div>
     </footer>

--- a/components/HeaderSpacer.tsx
+++ b/components/HeaderSpacer.tsx
@@ -2,6 +2,8 @@
 
 import { usePathname } from "next/navigation";
 
+import { needsHeaderSpacer } from "@/lib/navigation/public-chrome";
+
 /**
  * HeaderSpacer - Creates vertical space to account for fixed Navbar and AnnouncementBar
  *
@@ -13,37 +15,15 @@ import { usePathname } from "next/navigation";
  * - Announcement bar visibility (present, dismissed, wrapping text)
  * - Device safe areas (notch, Dynamic Island)
  *
- * Excludes:
- * - Pages with transparent navbar overlay (home, explore/experts, etc.)
- * - Pages that exclude navbar entirely (checkout, dashboard, meetings, etc.)
+ * Which routes need a spacer is derived in lib/navigation/public-chrome.ts
+ * rather than listed locally — the local list had already drifted from the
+ * Navbar's dark-hero list, which is what put a white spacer band under the
+ * transparent nav on the organisations directory.
  */
 const HeaderSpacer = () => {
   const pathname = usePathname();
 
-  // Routes that don't need the spacer (hero sections, excluded navbar routes)
-  const excludedRoutes = [
-    "/", // Home page (has full-bleed hero)
-    "/explore/experts", // Experts page (has dark hero section)
-    "/explore/programs", // Programs page (has dark hero section)
-    "/explore/community", // Community page (has dark hero section)
-  ];
-
-  // Routes that never show navbar (so no spacer needed)
-  const noNavbarRoutes = [
-    "/api/",
-    "/auth/",
-    "/form/",
-    "/checkout/",
-    "/dashboard",
-    "/meetings/",
-  ];
-
-  // Check if current route should exclude spacer
-  const shouldExclude =
-    excludedRoutes.includes(pathname) ||
-    noNavbarRoutes.some((route) => pathname.startsWith(route));
-
-  if (shouldExclude) {
+  if (!needsHeaderSpacer(pathname)) {
     return null;
   }
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -17,6 +17,8 @@ import {
   Info,
   Mail,
   Presentation,
+  Layers,
+  Star,
 } from "lucide-react";
 import { signOut, useSession } from "@/lib/auth-client";
 // Import the logout helper from the SDK-free module (not @/providers/StreamProvider)
@@ -43,6 +45,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { useCurrency, SUPPORTED_CURRENCIES } from "@/hooks/useCurrency";
+import { hasDarkHero, isChromeHidden } from "@/lib/navigation/public-chrome";
 import { useAnnouncementBar } from "@/providers/AnnouncementBarProvider";
 import familiariseLogoTransparent from "@/public/avif/static/assets/logos/images/logos/Familiarise-logos_transparent.avif";
 import familiariseLogoWhite from "@/public/avif/static/assets/logos/images/logos/Familiarise-logos_white.avif";
@@ -56,8 +59,8 @@ interface NavDropdownItem {
   href: string;
   description: string;
   icon: React.ElementType;
+  /** Not yet available: renders a "Soon" pill and routes to /contactus. */
   disabled?: boolean;
-  comingSoon?: boolean;
 }
 
 interface NavCategoryChip {
@@ -65,30 +68,94 @@ interface NavCategoryChip {
   href: string;
 }
 
+/** A titled column inside a mega-menu panel. */
+interface NavColumn {
+  heading: string;
+  items: NavDropdownItem[];
+}
+
 interface NavDropdownGroup {
   label: string;
-  items: NavDropdownItem[];
+  /** Single-column panel (w-80) vs multi-column mega panel. */
+  variant: "list" | "mega";
+  columns: NavColumn[];
   categoryChips?: NavCategoryChip[];
 }
 
-const EXPLORE_ITEMS: NavDropdownItem[] = [
+// Catalog first: a marketplace's nav should open onto its inventory, the way
+// Toptal leads with "Hire Talent" and Maven with "Courses". "Use Cases" led
+// before, which put marketing ahead of the thing people came to browse.
+const EXPLORE_COLUMNS: NavColumn[] = [
   {
-    label: "Find Experts",
-    href: "/explore/experts",
-    description: "Browse verified consultants across domains",
-    icon: Search,
+    heading: "Experts",
+    items: [
+      {
+        label: "Find experts",
+        href: "/explore/experts",
+        description: "Browse verified consultants across domains",
+        icon: Search,
+      },
+      {
+        label: "Browse by domain",
+        href: "/explore/experts#domains",
+        description: "Technology, business, health, and more",
+        icon: Layers,
+      },
+      {
+        label: "Top rated",
+        // Anchor as well as sort — without it the sort applies but the user
+        // lands at the top of the page and never sees the sorted list.
+        href: "/explore/experts?sort=rating#all-experts",
+        description: "Highest-rated experts on Familiarise",
+        icon: Star,
+      },
+    ],
   },
   {
-    label: "Browse Programs",
-    href: "/explore/programs",
-    description: "Webinars, classes, and group sessions",
-    icon: Presentation,
+    heading: "Programs",
+    items: [
+      {
+        label: "Classes",
+        href: "/explore/programs?tab=class",
+        description: "Multi-session cohorts and courses",
+        icon: GraduationCap,
+      },
+      {
+        label: "Webinars",
+        href: "/explore/programs?tab=webinar",
+        description: "Single live sessions with an expert",
+        icon: Presentation,
+      },
+      {
+        label: "All programs",
+        href: "/explore/programs",
+        description: "Everything on offer right now",
+        icon: Layers,
+      },
+    ],
   },
   {
-    label: "Explore Organisations",
-    href: "/explore/enterprise/organisations",
-    description: "Discover agencies and expert networks",
-    icon: Building2,
+    heading: "Organisations",
+    items: [
+      {
+        label: "All organisations",
+        href: "/explore/enterprise/organisations",
+        description: "Expert networks, agencies, and institutions",
+        icon: Building2,
+      },
+      {
+        label: "Expert networks",
+        href: "/explore/enterprise/organisations?type=EXPERT_NETWORK",
+        description: "Curated panels you can book directly",
+        icon: Users,
+      },
+      {
+        label: "Learning institutions",
+        href: "/explore/enterprise/organisations?type=LEARNING_INSTITUTION",
+        description: "Universities and research institutes",
+        icon: GraduationCap,
+      },
+    ],
   },
 ];
 
@@ -104,133 +171,225 @@ const EXPLORE_CATEGORIES: NavCategoryChip[] = [
   },
 ];
 
-const USE_CASE_ITEMS: NavDropdownItem[] = [
+// "For Businesses" used to be a one-item dropdown whose only item was disabled
+// — a menu that could only ever go to /contactus. Folded in here as a column so
+// the B2B path is visible without spending a top-level slot on it.
+const SOLUTIONS_COLUMNS: NavColumn[] = [
   {
-    label: "For College Students",
-    href: "/use-cases/college-students",
-    description: "Get career guidance before you graduate",
-    icon: GraduationCap,
+    heading: "By goal",
+    items: [
+      {
+        label: "College students",
+        href: "/use-cases/college-students",
+        description: "Get career guidance before you graduate",
+        icon: GraduationCap,
+      },
+      {
+        label: "Early-career professionals",
+        href: "/use-cases/early-career",
+        description: "Accelerate your first 1–5 years",
+        icon: Briefcase,
+      },
+      {
+        label: "Career switchers",
+        href: "/use-cases/career-switchers",
+        description: "Navigate the service-to-product transition",
+        icon: ArrowRightLeft,
+      },
+      {
+        label: "Long-term mentorship",
+        href: "/use-cases/mentorship",
+        description: "Ongoing guidance from industry experts",
+        icon: UserCheck,
+      },
+    ],
   },
   {
-    label: "For Early-Career Professionals",
-    href: "/use-cases/early-career",
-    description: "Accelerate your first 1–5 years",
-    icon: Briefcase,
-  },
-  {
-    label: "For Career Switchers",
-    href: "/use-cases/career-switchers",
-    description: "Navigate the service-to-product transition",
-    icon: ArrowRightLeft,
-  },
-  {
-    label: "For Long-Term Mentorship",
-    href: "/use-cases/mentorship",
-    description: "Ongoing guidance from industry experts",
-    icon: UserCheck,
+    heading: "For teams",
+    items: [
+      {
+        label: "Team training",
+        href: "/contactus",
+        description: "Upskill a whole team with vetted experts",
+        icon: Building2,
+        disabled: true,
+      },
+      {
+        label: "Corporate mentorship",
+        href: "/contactus",
+        description: "Structured mentorship programs for staff",
+        icon: Users,
+        disabled: true,
+      },
+      {
+        label: "Talk to us",
+        href: "/contactus",
+        description: "Tell us what your organisation needs",
+        icon: Mail,
+      },
+    ],
   },
 ];
 
-const BUSINESS_ITEMS: NavDropdownItem[] = [
+// Community and Blog previously rendered a "Soon" pill while linking to live
+// pages — the pill told users not to bother clicking something that worked.
+const RESOURCE_COLUMNS: NavColumn[] = [
   {
-    label: "Team Training & Corporate Mentorship",
-    href: "/contactus",
-    description: "Coming soon — contact us to express interest",
-    icon: Building2,
-    disabled: true,
-  },
-];
-
-const RESOURCE_ITEMS: NavDropdownItem[] = [
-  {
-    label: "Community",
-    href: "/explore/community",
-    description: "Connect with peers and mentors",
-    icon: Users,
-    comingSoon: true,
-  },
-  {
-    label: "Blog",
-    href: "/blog",
-    description: "Insights, tips, and career advice",
-    icon: FileText,
-    comingSoon: true,
-  },
-  {
-    label: "How It Works",
-    href: "/#how-it-works",
-    description: "See how Familiarise works",
-    icon: HelpCircle,
-  },
-  {
-    label: "About",
-    href: "/about",
-    description: "Our mission and story",
-    icon: Info,
-  },
-  {
-    label: "Contact",
-    href: "/contactus",
-    description: "Get in touch with our team",
-    icon: Mail,
+    heading: "Resources",
+    items: [
+      {
+        label: "How it works",
+        href: "/#how-it-works",
+        description: "See how Familiarise works",
+        icon: HelpCircle,
+      },
+      {
+        label: "Community",
+        href: "/explore/community",
+        description: "Connect with peers and mentors",
+        icon: Users,
+      },
+      {
+        label: "Blog",
+        href: "/blog",
+        description: "Insights, tips, and career advice",
+        icon: FileText,
+      },
+      {
+        label: "About",
+        href: "/about",
+        description: "Our mission and story",
+        icon: Info,
+      },
+      {
+        label: "Contact",
+        href: "/contactus",
+        description: "Get in touch with our team",
+        icon: Mail,
+      },
+    ],
   },
 ];
 
 const NAV_GROUPS: NavDropdownGroup[] = [
-  { label: "Use Cases", items: USE_CASE_ITEMS },
-  { label: "Explore", items: EXPLORE_ITEMS, categoryChips: EXPLORE_CATEGORIES },
-  { label: "For Businesses", items: BUSINESS_ITEMS },
-  { label: "Resources", items: RESOURCE_ITEMS },
+  {
+    label: "Explore",
+    variant: "mega",
+    columns: EXPLORE_COLUMNS,
+    categoryChips: EXPLORE_CATEGORIES,
+  },
+  { label: "Solutions", variant: "mega", columns: SOLUTIONS_COLUMNS },
+  { label: "Resources", variant: "list", columns: RESOURCE_COLUMNS },
 ];
 
 // ─── Dropdown Panel (Desktop) ────────────────────────────────────────────────
 
+function DropdownLink({
+  item,
+  onClose,
+}: {
+  item: NavDropdownItem;
+  onClose: () => void;
+}) {
+  const Icon = item.icon;
+  return (
+    <Link
+      href={item.disabled ? "/contactus" : item.href}
+      onClick={onClose}
+      // Not a real `disabled` — these still navigate (to /contactus), so the
+      // "Soon" state has to reach assistive tech through the label rather than
+      // a visual pill alone.
+      aria-label={item.disabled ? `${item.label} — coming soon` : undefined}
+      className={`flex items-start gap-3 px-3 py-2.5 rounded-lg transition-colors ${
+        item.disabled ? "opacity-60" : "hover:bg-muted"
+      }`}
+    >
+      <div className="mt-0.5 w-8 h-8 rounded-lg bg-muted flex items-center justify-center shrink-0">
+        <Icon className="w-4 h-4 text-muted-foreground" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-foreground flex items-center gap-2">
+          {item.label}
+          {item.disabled && (
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+              Soon
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {item.description}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
 function DesktopDropdownPanel({
   group,
   onClose,
+  panelId,
 }: {
   group: NavDropdownGroup;
   onClose: () => void;
+  panelId: string;
 }) {
+  const isMega = group.variant === "mega";
+  const isWide = group.columns.length > 2;
+  const panelWidth = isMega ? (isWide ? "w-[860px]" : "w-[620px]") : "w-80";
+  const panelGrid = isWide ? "grid-cols-3" : "grid-cols-2";
+
   return (
     <motion.div
+      id={panelId}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 8 }}
       transition={{ duration: 0.15 }}
-      className="absolute top-full left-1/2 -translate-x-1/2 mt-2 w-80 bg-popover rounded-xl shadow-xl border border-border overflow-hidden z-[1100]"
+      // Mega panels centre on the VIEWPORT (fixed), list panels on their
+      // trigger (absolute) — an 860px panel hung off a narrow left-side trigger
+      // reads as badly misaligned.
+      //
+      // Centred with `inset-x-0 mx-auto`, never `left-1/2 -translate-x-1/2`:
+      // motion.div writes an inline `transform` for its y animation, which
+      // beats Tailwind's translate class, so the -50% shift was silently
+      // dropped and the panel sat half a viewport to the right. Margin centring
+      // can't be clobbered by a transform.
+      className={`inset-x-0 mx-auto bg-popover rounded-xl shadow-xl border border-border overflow-hidden z-[1100] ${
+        isMega
+          ? `fixed max-w-[calc(100vw-2rem)] ${panelWidth}`
+          : `absolute top-full mt-2 ${panelWidth}`
+      }`}
+      style={
+        isMega
+          ? {
+              top: `calc(var(--maintenance-banner-height, 0px) + var(--announcement-bar-height, 0px) + var(--navbar-height) + 0.5rem)`,
+            }
+          : undefined
+      }
     >
-      <div className="p-2">
-        {group.items.map((item) => {
-          const Icon = item.icon;
-          return (
-            <Link
-              key={item.href + item.label}
-              href={item.disabled ? "/contactus" : item.href}
-              onClick={onClose}
-              className={`flex items-start gap-3 px-3 py-2.5 rounded-lg transition-colors ${
-                item.disabled ? "opacity-60 cursor-default" : "hover:bg-muted"
-              }`}
-            >
-              <div className="mt-0.5 w-8 h-8 rounded-lg bg-muted flex items-center justify-center shrink-0">
-                <Icon className="w-4 h-4 text-muted-foreground" />
-              </div>
-              <div className="min-w-0">
-                <div className="text-sm font-medium text-foreground flex items-center gap-2">
-                  {item.label}
-                  {(item.disabled || item.comingSoon) && (
-                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-                      Soon
-                    </span>
-                  )}
-                </div>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {item.description}
-                </p>
-              </div>
-            </Link>
-          );
-        })}
+      <div
+        className={
+          isMega
+            ? `p-4 grid gap-2 ${panelGrid}`
+            : "p-2"
+        }
+      >
+        {group.columns.map((column) => (
+          <div key={column.heading} className="min-w-0">
+            {isMega && (
+              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground px-3 pb-1.5">
+                {column.heading}
+              </p>
+            )}
+            {column.items.map((item) => (
+              <DropdownLink
+                key={item.href + item.label}
+                item={item}
+                onClose={onClose}
+              />
+            ))}
+          </div>
+        ))}
       </div>
 
       {/* Category chips */}
@@ -269,6 +428,8 @@ function DesktopNavItem({
   const [open, setOpen] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelId = `nav-panel-${group.label.toLowerCase().replace(/\s+/g, "-")}`;
 
   const handleEnter = useCallback(() => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
@@ -285,6 +446,36 @@ function DesktopNavItem({
     };
   }, []);
 
+  // The panel previously closed on mouse-leave only: no Escape, no
+  // outside-click, no focus return — so a keyboard user could open it and had
+  // no way to dismiss it without tabbing through every link inside.
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+
+    // Pointer-down outside and focus leaving the group are the same condition:
+    // the interaction moved somewhere this menu doesn't own.
+    const handleInteractionOutside = (event: Event) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("pointerdown", handleInteractionOutside);
+    document.addEventListener("focusin", handleInteractionOutside);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("pointerdown", handleInteractionOutside);
+      document.removeEventListener("focusin", handleInteractionOutside);
+    };
+  }, [open]);
+
   return (
     <div
       ref={containerRef}
@@ -293,6 +484,7 @@ function DesktopNavItem({
       onMouseLeave={handleLeave}
     >
       <button
+        ref={triggerRef}
         className={`inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
           showDarkStyle
             ? "text-white hover:bg-white/10"
@@ -300,6 +492,8 @@ function DesktopNavItem({
         }`}
         onClick={() => setOpen((prev) => !prev)}
         aria-expanded={open}
+        aria-haspopup="true"
+        aria-controls={open ? panelId : undefined}
       >
         {group.label}
         <ChevronDown
@@ -308,7 +502,11 @@ function DesktopNavItem({
       </button>
       <AnimatePresence>
         {open && (
-          <DesktopDropdownPanel group={group} onClose={() => setOpen(false)} />
+          <DesktopDropdownPanel
+            group={group}
+            panelId={panelId}
+            onClose={() => setOpen(false)}
+          />
         )}
       </AnimatePresence>
     </div>
@@ -329,14 +527,9 @@ const Navbar = () => {
   const { currency, symbol, setCurrency } = useCurrency();
   const { isVisible: isAnnouncementVisible } = useAnnouncementBar();
 
-  const darkHeroPages = [
-    "/",
-    "/explore/experts",
-    "/explore/programs",
-    "/explore/community",
-    "/explore/enterprise/organisations",
-  ];
-  const hasDarkHero = darkHeroPages.includes(pathname);
+  // Route lists live in lib/navigation/public-chrome.ts — they were duplicated
+  // across Navbar/Footer/HeaderSpacer and had already drifted.
+  const darkHero = hasDarkHero(pathname);
 
   const toggleMenu = () => setIsOpen(!isOpen);
   const closeMenu = () => setIsOpen(false);
@@ -352,16 +545,7 @@ const Navbar = () => {
     closeMenu();
   };
 
-  const excludeNavbar =
-    pathname.startsWith("/api/") ||
-    pathname.startsWith("/auth/") ||
-    pathname.startsWith("/form/") ||
-    pathname.startsWith("/checkout/") ||
-    pathname === "/dashboard" ||
-    pathname.startsWith("/dashboard/") ||
-    pathname.startsWith("/meetings/");
-
-  if (excludeNavbar) return null;
+  if (isChromeHidden(pathname)) return null;
 
   const handleSignOut = async () => {
     try {
@@ -385,7 +569,7 @@ const Navbar = () => {
       : defaultUserImage;
   };
 
-  const showDarkStyle = hasDarkHero && !isScrolled;
+  const showDarkStyle = darkHero && !isScrolled;
 
   return (
     <>
@@ -512,25 +696,16 @@ const Navbar = () => {
                   </Button>
                 </div>
               ) : (
-                <>
-                  <Button
-                    variant="ghost"
-                    onClick={() => handleNavigation("/auth/signin")}
-                    className={`font-medium ${showDarkStyle ? "text-white hover:bg-white/10" : "text-foreground hover:bg-muted"}`}
-                  >
-                    Sign in
-                  </Button>
-                  <Button
-                    onClick={() => handleNavigation("/form/onboarding")}
-                    className={
-                      showDarkStyle
-                        ? "bg-white text-zinc-900 hover:bg-zinc-200"
-                        : "bg-primary text-primary-foreground hover:bg-primary/90"
-                    }
-                  >
-                    Become an Expert
-                  </Button>
-                </>
+                /* No marketing CTAs in the bar — discovery is reachable from
+                   the Explore menu, and the supply-side CTA lives in the
+                   landing hero. Sign in is the only action here. */
+                <Button
+                  variant="ghost"
+                  onClick={() => handleNavigation("/auth/signin")}
+                  className={`font-medium ${showDarkStyle ? "text-white hover:bg-white/10" : "text-foreground hover:bg-muted"}`}
+                >
+                  Sign in
+                </Button>
               )}
             </div>
 
@@ -621,29 +796,42 @@ const Navbar = () => {
                       </AccordionTrigger>
                       <AccordionContent className="px-2 pb-2">
                         <div className="space-y-1">
-                          {group.items.map((item) => (
-                            <Link
-                              key={item.href + item.label}
-                              href={item.disabled ? "/contactus" : item.href}
-                              onClick={closeMenu}
-                              className={`block px-4 py-2.5 rounded-lg transition-colors ${
-                                item.disabled
-                                  ? "opacity-50"
-                                  : "hover:bg-zinc-800"
-                              }`}
-                            >
-                              <span className="text-sm font-medium text-white flex items-center gap-2">
-                                {item.label}
-                                {(item.disabled || item.comingSoon) && (
-                                  <span className="text-[10px] uppercase tracking-wider text-zinc-500 bg-zinc-800 px-1.5 py-0.5 rounded">
-                                    Soon
+                          {group.columns.map((column) => (
+                            <div key={column.heading}>
+                              {/* Column headings only earn their space when
+                                  there's more than one column to separate. */}
+                              {group.columns.length > 1 && (
+                                <p className="text-[10px] font-medium uppercase tracking-wider text-zinc-500 px-4 pt-2 pb-1">
+                                  {column.heading}
+                                </p>
+                              )}
+                              {column.items.map((item) => (
+                                <Link
+                                  key={item.href + item.label}
+                                  href={
+                                    item.disabled ? "/contactus" : item.href
+                                  }
+                                  onClick={closeMenu}
+                                  className={`block px-4 py-2.5 rounded-lg transition-colors ${
+                                    item.disabled
+                                      ? "opacity-50"
+                                      : "hover:bg-zinc-800"
+                                  }`}
+                                >
+                                  <span className="text-sm font-medium text-white flex items-center gap-2">
+                                    {item.label}
+                                    {item.disabled && (
+                                      <span className="text-[10px] uppercase tracking-wider text-zinc-500 bg-zinc-800 px-1.5 py-0.5 rounded">
+                                        Soon
+                                      </span>
+                                    )}
                                   </span>
-                                )}
-                              </span>
-                              <span className="text-xs text-zinc-500 mt-0.5 block">
-                                {item.description}
-                              </span>
-                            </Link>
+                                  <span className="text-xs text-zinc-500 mt-0.5 block">
+                                    {item.description}
+                                  </span>
+                                </Link>
+                              ))}
+                            </div>
                           ))}
 
                           {/* Category chips on mobile */}
@@ -734,20 +922,13 @@ const Navbar = () => {
                     </Button>
                   </div>
                 ) : (
-                  <div className="flex flex-col gap-3">
-                    <Button
-                      onClick={() => handleNavigation("/form/onboarding")}
-                      className="w-full bg-white text-zinc-900 hover:bg-zinc-200"
-                    >
-                      Become an Expert
-                    </Button>
-                    <Button
-                      onClick={() => handleNavigation("/auth/signin")}
-                      className="w-full bg-transparent border border-zinc-700 text-white hover:bg-zinc-800"
-                    >
-                      Sign in
-                    </Button>
-                  </div>
+                  /* Mirrors the desktop bar: no marketing CTAs, sign in only. */
+                  <Button
+                    onClick={() => handleNavigation("/auth/signin")}
+                    className="w-full bg-white text-zinc-900 hover:bg-zinc-200"
+                  >
+                    Sign in
+                  </Button>
                 )}
               </div>
             </motion.div>

--- a/components/home/BecomeExpertSection.tsx
+++ b/components/home/BecomeExpertSection.tsx
@@ -63,7 +63,7 @@ export function BecomeExpertSection() {
           </div>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link href="/form/onboarding">
+            <Link href="/become-an-expert">
               <Button
                 size="lg"
                 className="bg-primary hover:bg-primary/90 text-primary-foreground px-8 h-14 text-base rounded-xl shadow-elevation-3"

--- a/components/home/EnterpriseSection.tsx
+++ b/components/home/EnterpriseSection.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ArrowRight, Building2 } from "lucide-react";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+import { ENTERPRISE_FEATURES } from "./data";
+
+/**
+ * The B2C page had no path for the buyer who arrives on behalf of an
+ * organisation — the enterprise subsystem (sponsored bookings, procurement
+ * invoicing, hosted expert networks) was invisible from the landing page.
+ */
+export function EnterpriseSection() {
+  return (
+    <section className="py-20 md:py-28 bg-zinc-950 relative overflow-hidden">
+      <div className="absolute inset-0 grid-pattern opacity-20" />
+      <div className="absolute top-1/3 left-1/4 w-[420px] h-[420px] bg-zinc-800/30 rounded-full blur-[120px] animate-blob" />
+
+      <div className="container mx-auto px-4 md:px-6 relative z-10">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          viewport={{ once: true }}
+          className="max-w-2xl mb-14"
+        >
+          <Badge
+            variant="outline"
+            className="mb-5 border-zinc-700 bg-zinc-800/50 text-zinc-300"
+          >
+            <Building2 className="w-3.5 h-3.5 mr-1.5" />
+            For teams &amp; organisations
+          </Badge>
+          <h2 className="text-fluid-4xl font-bold tracking-tight text-white mb-4">
+            Bring Familiarise to your{" "}
+            <span className="silver-text">whole team</span>
+          </h2>
+          <p className="text-lg text-zinc-400 leading-relaxed">
+            Sponsor sessions for your people, run structured mentorship
+            programs, or host your own experts on the platform — with the
+            billing and compliance your finance team expects.
+          </p>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mb-12">
+          {ENTERPRISE_FEATURES.map((feature, index) => {
+            const Icon = feature.icon;
+            return (
+              <motion.div
+                key={feature.title}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.4, delay: index * 0.08 }}
+                viewport={{ once: true }}
+                className="flex gap-4 p-6 rounded-2xl bg-zinc-900/60 border border-zinc-800 backdrop-blur-sm"
+              >
+                <div className="w-11 h-11 rounded-xl bg-zinc-800 flex items-center justify-center shrink-0">
+                  <Icon className="w-5 h-5 text-zinc-300" />
+                </div>
+                <div className="min-w-0">
+                  <h3 className="font-semibold text-white mb-1.5">
+                    {feature.title}
+                  </h3>
+                  <p className="text-sm text-zinc-400 leading-relaxed">
+                    {feature.description}
+                  </p>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+          viewport={{ once: true }}
+          className="flex flex-col sm:flex-row gap-3"
+        >
+          <Button
+            size="lg"
+            className="w-full sm:w-auto bg-white text-zinc-900 hover:bg-zinc-200"
+            asChild
+          >
+            <Link href="/contactus">
+              Talk to us
+              <ArrowRight className="w-4 h-4 ml-2" />
+            </Link>
+          </Button>
+          <Button
+            size="lg"
+            variant="outline"
+            className="w-full sm:w-auto bg-transparent border-zinc-700 text-white hover:bg-zinc-800 hover:text-white"
+            asChild
+          >
+            <Link href="/explore/enterprise/organisations">
+              Browse organisations
+            </Link>
+          </Button>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { motion, useInView } from "framer-motion";
-import { ArrowRight, Play, Sparkles } from "lucide-react";
+import { ArrowRight, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { useRef, useState, useEffect } from "react";
 
@@ -119,22 +119,29 @@ export function HeroSection() {
             transition={{ duration: 0.6, delay: 0.3 }}
             className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16"
           >
-            <Link href="/explore/experts">
-              <Button
-                size="lg"
-                className="bg-white text-black hover:bg-zinc-200 px-8 h-14 text-base rounded-xl shadow-lg shadow-white/10 group font-medium"
-              >
+            <Button
+              size="lg"
+              className="bg-white text-black hover:bg-zinc-200 px-8 h-14 text-base rounded-xl shadow-lg shadow-white/10 group font-medium"
+              asChild
+            >
+              <Link href="/explore/experts">
                 Find Your Expert
                 <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />
-              </Button>
-            </Link>
+              </Link>
+            </Button>
+            {/* The supply-side CTA lives here now that the navbar carries no
+                CTAs. (It replaces a "Watch Demo" button that had no href and
+                no handler — it did nothing when clicked.) */}
             <Button
               size="lg"
               variant="outline"
               className="border-zinc-700 bg-transparent text-white hover:bg-zinc-900 hover:text-white px-8 h-14 text-base rounded-xl group"
+              asChild
             >
-              <Play className="mr-2 w-5 h-5" />
-              Watch Demo
+              <Link href="/become-an-expert">
+                Become an Expert
+                <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />
+              </Link>
             </Button>
           </motion.div>
 

--- a/components/home/data.ts
+++ b/components/home/data.ts
@@ -357,3 +357,30 @@ export const COMPANY_LOGOS = [
   "Stripe",
   "Airbnb",
 ];
+
+export const ENTERPRISE_FEATURES = [
+  {
+    icon: Users,
+    title: "Team training",
+    description:
+      "Book vetted experts for a whole team, with one plan covering every seat instead of individual expensing.",
+  },
+  {
+    icon: Briefcase,
+    title: "Sponsored sessions",
+    description:
+      "Your organisation pays; your people book. Set a budget or a per-seat allowance and let them choose their own experts.",
+  },
+  {
+    icon: FileCheck,
+    title: "Invoicing built for procurement",
+    description:
+      "Purchase orders, GST-compliant invoices, and Net-60 terms — not a corporate card and a pile of receipts.",
+  },
+  {
+    icon: Shield,
+    title: "Run your own expert network",
+    description:
+      "Agencies and institutions can host their experts on Familiarise and take a share of every booking.",
+  },
+];

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import * as React from "react";
+
+import { cn } from "@/utils/tailwind";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "start", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[1200] w-72 rounded-xl border border-border bg-popover p-1 text-popover-foreground shadow-xl outline-none",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -31,6 +31,10 @@ export type TTrialWithPlan = {
   notes: string | null;
   requestedAt: string;
   completedAt: string | null;
+  /** Live while AWAITING_PAYMENT; drives the "Pay Now to Confirm" affordance. */
+  pendingPaymentUrl: string | null;
+  /** Deadline for that pay-link — 24h from acceptance, or the session start. */
+  paymentDueAt: string | null;
   subscriptionPlan: {
     id: string;
     title: string;

--- a/jobs/trials/expire-unpaid-trials.ts
+++ b/jobs/trials/expire-unpaid-trials.ts
@@ -1,0 +1,97 @@
+/**
+ * Unpaid Trial Expiry Job (GitHub Actions Wrapper)
+ *
+ * Thin wrapper around scripts/trials/expire-unpaid-trials.ts
+ * Adds GitHub Actions-specific outputs and error handling.
+ *
+ * Runs hourly via scheduled workflow.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import fs from "fs";
+
+import { CronLockHeldError } from "../../lib/cron/with-cron-lock";
+import { abortIfMaintenance } from "../../lib/maintenance-cron";
+import {
+  disconnectDatabase,
+  expireUnpaidTrials,
+  type ExpireUnpaidTrialsResult,
+} from "../../scripts/trials/expire-unpaid-trials";
+
+/**
+ * Output results to GitHub Actions
+ */
+function outputToGitHubActions(result: ExpireUnpaidTrialsResult): void {
+  if (!process.env.GITHUB_ACTIONS) return;
+
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    const outputs = [
+      `trials_expired=${result.trialsExpired}`,
+      `success=${result.success}`,
+    ].join("\n");
+
+    fs.appendFileSync(outputFile, outputs + "\n");
+  }
+
+  if (result.trialsExpired > 0) {
+    console.log(
+      `::notice::Expired ${result.trialsExpired} unpaid trial sessions`,
+    );
+  }
+
+  if (!result.success) {
+    console.log(
+      `::warning::Unpaid trial expiry had errors: ${result.errors.join("; ")}`,
+    );
+  }
+}
+
+/**
+ * Main entry point
+ */
+async function main(): Promise<void> {
+  await abortIfMaintenance("expire-unpaid-trials");
+  Sentry.logger.info("job:expire-unpaid-trials started");
+  console.log("🧹 Starting unpaid trial expiry job...");
+  console.log(`Timestamp: ${new Date().toISOString()}`);
+
+  try {
+    const result = await expireUnpaidTrials();
+
+    console.log("\n📊 Job Results:");
+    console.log(`   Trials Expired: ${result.trialsExpired}`);
+    console.log(`   Success: ${result.success}`);
+
+    if (result.errors.length > 0) {
+      console.log("\n⚠️ Errors:");
+      result.errors.forEach((e) => console.log(`   - ${e}`));
+    }
+
+    outputToGitHubActions(result);
+
+    Sentry.logger.info("job:expire-unpaid-trials finished", {
+      trialsExpired: result.trialsExpired,
+    });
+
+    if (!result.success) {
+      process.exit(1);
+    }
+  } catch (error) {
+    // #476 — lock held = another run is live; skip cleanly (exit 0).
+    if (error instanceof CronLockHeldError) {
+      Sentry.logger.info("job:expire-unpaid-trials lock held, skipping");
+      console.log(`⏭️  ${error.message}`);
+      return;
+    }
+    Sentry.captureException(error, {
+      tags: { subsystem: "jobs", job: "expire-unpaid-trials" },
+    });
+    console.error("❌ Fatal error in unpaid trial expiry:", error);
+    process.exit(1);
+  } finally {
+    await disconnectDatabase();
+  }
+}
+
+main();

--- a/lib/appointments/map-consultee.ts
+++ b/lib/appointments/map-consultee.ts
@@ -266,7 +266,8 @@ function mapTrial(t: TTrialWithPlan, now: Date): AppointmentVM {
       t.subscriptionPlan.trialDurationMinutes,
     ),
     organizationId: t.appointment?.organizationId ?? null,
-    pendingPaymentUrl: null,
+    // Paid trials carry a live pay-link while AWAITING_PAYMENT.
+    pendingPaymentUrl: t.pendingPaymentUrl ?? null,
     collaborators: [],
     collaboratorRole: null,
     raw: {

--- a/lib/appointments/status.ts
+++ b/lib/appointments/status.ts
@@ -65,7 +65,15 @@ export function isCompletedLikeStatus(
 export function isPendingPaymentStatus(
   status: string | null | undefined,
 ): boolean {
-  return normalizeStatus(status) === "APPROVED_PENDING_PAYMENT";
+  const normalized = normalizeStatus(status);
+  // AWAITING_PAYMENT is the trial equivalent of APPROVED_PENDING_PAYMENT:
+  // accepted by the provider, slot held, money not yet collected. Both must
+  // bucket as PAY_NOW or the learner never sees the "Pay Now to Confirm"
+  // affordance on the booking itself.
+  return (
+    normalized === "APPROVED_PENDING_PAYMENT" ||
+    normalized === "AWAITING_PAYMENT"
+  );
 }
 
 export function isPendingStatus(status: string | null | undefined): boolean {

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -48,6 +48,10 @@ export const consultantListInclude = {
       callsPerWeek: true,
       emailSupport: true,
       totalSessions: true,
+      // Drive the card's Trial CTA from real data instead of showing it
+      // unconditionally — a plan with no trial had a button that dead-ended.
+      trialEnabled: true,
+      trialPriceInPaise: true,
     },
     take: 5,
   },
@@ -142,6 +146,9 @@ export function toConsultantCard(row: ConsultantCardRow): IConsultantCardData {
       callsPerWeek: p.callsPerWeek,
       emailSupport: p.emailSupport,
       totalSessions: p.totalSessions,
+      trialEnabled: p.trialEnabled,
+      // BigInt (paise) → Number, same as `price` above.
+      trialPriceInPaise: Number(p.trialPriceInPaise),
     })),
     organizationBadge: firstOrg
       ? {

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -69,6 +69,12 @@ export const orgMembershipInclude = {
       organization: {
         canHost: true,
         status: "ACTIVE",
+        // The badge deep-links to /explore/enterprise/organisations/{slug},
+        // which only serves opted-in, non-deleted orgs — without these the card
+        // rendered a link straight to a 404. #781 §B soft-deletes orgs rather
+        // than removing them, so ACTIVE alone doesn't exclude them.
+        isPublic: true,
+        deletedAt: null,
       },
     },
     orderBy: { createdAt: "asc" },

--- a/lib/data/explore-organisations.ts
+++ b/lib/data/explore-organisations.ts
@@ -1,0 +1,304 @@
+/**
+ * Read layer for the public organisations directory.
+ *
+ * Discovery is deliberately NOT gated on `canHost` or on ENABLE_HOST_ORGS. That
+ * flag gates money paths (org creation with canHost, EXPERT memberships, the
+ * 3-way split) — filtering the directory on it made the page structurally
+ * incapable of being non-empty, because the same flag prevents any org from
+ * acquiring canHost in the first place. The single visibility control is the
+ * owner-set `Organization.isPublic` opt-in.
+ */
+
+import type { Prisma } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+import {
+  ORGANISATIONS_PER_PAGE,
+  type IOrganisationFilters,
+  type OrganisationListItem,
+  type OrganisationsMetadata,
+  type OrganisationsPage,
+  type OrgCapabilityFilter,
+  type OrgSortOption,
+} from "@/lib/explore/organisation-types";
+
+// Types and defaults live in lib/explore/organisation-types.ts so client
+// components can import them without pulling prisma into the browser bundle.
+export * from "@/lib/explore/organisation-types";
+
+const EXPERT_MEMBERSHIP_WHERE = {
+  role: "EXPERT",
+  status: "ACTIVE",
+} as const;
+
+/**
+ * Every listed org must be a live, opted-in, non-deleted org. Capability plays
+ * no part here — see the file header.
+ */
+function baseWhere(): Prisma.OrganizationWhereInput {
+  return { isPublic: true, status: "ACTIVE", deletedAt: null };
+}
+
+function whereFromFilters(
+  filters: IOrganisationFilters,
+): Prisma.OrganizationWhereInput {
+  const where: Prisma.OrganizationWhereInput = baseWhere();
+
+  if (filters.search) {
+    // industry/description live on the OrgBrandingProfile satellite since #768.
+    // The previous public API queried them as scalars on Organization, which
+    // made every ?search= request throw a Prisma validation error.
+    where.OR = [
+      { name: { contains: filters.search, mode: "insensitive" } },
+      {
+        brandingProfile: {
+          is: { description: { contains: filters.search, mode: "insensitive" } },
+        },
+      },
+      {
+        brandingProfile: {
+          is: { industry: { contains: filters.search, mode: "insensitive" } },
+        },
+      },
+    ];
+  }
+
+  const branding: Prisma.OrgBrandingProfileWhereInput = {};
+  if (filters.types.length > 0) branding.directoryType = { in: filters.types };
+  if (filters.sizes.length > 0) branding.sizeBucket = { in: filters.sizes };
+  if (filters.industries.length > 0) {
+    branding.industry = { in: filters.industries, mode: "insensitive" };
+  }
+  if (Object.keys(branding).length > 0) {
+    // `is:` — brandingProfile is a nullable 1:1, so the bare-object shorthand
+    // is ambiguous with the relation filter and doesn't typecheck.
+    where.brandingProfile = { is: branding };
+  }
+
+  if (filters.capability === "host") {
+    where.canHost = true;
+    where.canSponsor = false;
+  } else if (filters.capability === "sponsor") {
+    where.canSponsor = true;
+    where.canHost = false;
+  } else if (filters.capability === "hybrid") {
+    where.canHost = true;
+    where.canSponsor = true;
+  }
+
+  if (filters.hasExperts) {
+    where.memberships = { some: EXPERT_MEMBERSHIP_WHERE };
+  }
+
+  return where;
+}
+
+function orderByForSort(
+  sort: OrgSortOption,
+): Prisma.OrganizationOrderByWithRelationInput[] {
+  switch (sort) {
+    case "nameDesc":
+      return [{ name: "desc" }];
+    case "newest":
+      return [{ createdAt: "desc" }, { name: "asc" }];
+    // expertsDesc is not expressible here — see rankByExpertCount.
+    default:
+      return [{ name: "asc" }];
+  }
+}
+
+/**
+ * Page ids ranked by ACTIVE EXPERT membership count, descending.
+ *
+ * Prisma can't order by a *filtered* relation count, and ordering by the raw
+ * `memberships._count` counts learners, owners and support members too — so a
+ * learner-heavy org outranked one with more experts, contradicting the number
+ * rendered on its own card. Ranking here keeps the order and the displayed
+ * count derived from the same predicate.
+ *
+ * Two queries instead of one, over the opt-in directory set only (public,
+ * ACTIVE, non-deleted), which is curated and small by construction.
+ */
+async function rankByExpertCount(
+  where: Prisma.OrganizationWhereInput,
+  skip: number,
+  take: number,
+): Promise<string[]> {
+  const rows = await prisma.organization.findMany({
+    where,
+    select: {
+      id: true,
+      name: true,
+      _count: { select: { memberships: { where: EXPERT_MEMBERSHIP_WHERE } } },
+    },
+  });
+
+  return rows
+    .sort(
+      (a, b) =>
+        b._count.memberships - a._count.memberships ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(skip, skip + take)
+    .map((row) => row.id);
+}
+
+const orgListSelect = {
+  id: true,
+  name: true,
+  slug: true,
+  canSponsor: true,
+  canHost: true,
+  createdAt: true,
+  brandingProfile: {
+    select: {
+      logo: true,
+      bannerImage: true,
+      description: true,
+      industry: true,
+      website: true,
+      sizeBucket: true,
+      directoryType: true,
+    },
+  },
+  kybVerification: { select: { kybVerifiedAt: true } },
+  _count: { select: { memberships: { where: EXPERT_MEMBERSHIP_WHERE } } },
+} satisfies Prisma.OrganizationSelect;
+
+function toListItem(
+  row: Prisma.OrganizationGetPayload<{ select: typeof orgListSelect }>,
+): OrganisationListItem {
+  const capability: OrganisationListItem["capability"] =
+    row.canHost && row.canSponsor
+      ? "hybrid"
+      : row.canHost
+        ? "host"
+        : row.canSponsor
+          ? "sponsor"
+          : "inert";
+
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    logo: row.brandingProfile?.logo ?? null,
+    bannerImage: row.brandingProfile?.bannerImage ?? null,
+    description: row.brandingProfile?.description ?? null,
+    industry: row.brandingProfile?.industry ?? null,
+    website: row.brandingProfile?.website ?? null,
+    sizeBucket: row.brandingProfile?.sizeBucket ?? null,
+    directoryType: row.brandingProfile?.directoryType ?? null,
+    capability,
+    // There is no `verified` boolean on Organization — KYB sign-off is the
+    // only durable verification signal, and ACTIVE status is already implied.
+    isVerified: Boolean(row.kybVerification?.kybVerifiedAt),
+    expertCount: row._count.memberships,
+  };
+}
+
+export async function getOrganisationsPage(
+  filters: IOrganisationFilters,
+  page = 1,
+  perPage = ORGANISATIONS_PER_PAGE,
+): Promise<OrganisationsPage> {
+  const where = whereFromFilters(filters);
+  const safePage = Math.max(1, page);
+  const skip = (safePage - 1) * perPage;
+
+  let rows: Prisma.OrganizationGetPayload<{ select: typeof orgListSelect }>[];
+  let total: number;
+
+  if (filters.sort === "expertsDesc") {
+    const [rankedIds, count] = await Promise.all([
+      rankByExpertCount(where, skip, perPage),
+      prisma.organization.count({ where }),
+    ]);
+    total = count;
+    // Named `pageRows`, not `page` — that would shadow the `page` parameter.
+    const pageRows = await prisma.organization.findMany({
+      where: { id: { in: rankedIds } },
+      select: orgListSelect,
+    });
+    // findMany ignores the id order, so restore the ranking.
+    const order = new Map(rankedIds.map((id, index) => [id, index]));
+    rows = pageRows.sort(
+      (a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0),
+    );
+  } else {
+    [rows, total] = await Promise.all([
+      prisma.organization.findMany({
+        where,
+        select: orgListSelect,
+        orderBy: orderByForSort(filters.sort),
+        skip,
+        take: perPage,
+      }),
+      prisma.organization.count({ where }),
+    ]);
+  }
+
+  return {
+    items: rows.map(toListItem),
+    total,
+    page: safePage,
+    totalPages: Math.max(1, Math.ceil(total / perPage)),
+  };
+}
+
+/**
+ * Facet counts for the filter rail. Computed over the full visible set (not the
+ * current filter), so a facet never renders a count the user can't reach.
+ */
+export async function getOrganisationsMetadata(): Promise<OrganisationsMetadata> {
+  const where = baseWhere();
+
+  const [total, brandingRows, capabilityRows] = await Promise.all([
+    prisma.organization.count({ where }),
+    prisma.orgBrandingProfile.findMany({
+      where: { organization: where },
+      select: { industry: true, directoryType: true, sizeBucket: true },
+    }),
+    prisma.organization.findMany({
+      where,
+      select: { canHost: true, canSponsor: true },
+    }),
+  ]);
+
+  const tally = <T extends string>(values: (T | null)[]) => {
+    const counts = new Map<T, number>();
+    for (const value of values) {
+      if (value === null) continue;
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+  };
+
+  const capabilityCounts = { host: 0, sponsor: 0, hybrid: 0 };
+  for (const row of capabilityRows) {
+    if (row.canHost && row.canSponsor) capabilityCounts.hybrid += 1;
+    else if (row.canHost) capabilityCounts.host += 1;
+    else if (row.canSponsor) capabilityCounts.sponsor += 1;
+  }
+
+  return {
+    industries: tally(brandingRows.map((r) => r.industry)),
+    types: tally(brandingRows.map((r) => r.directoryType)),
+    sizes: tally(brandingRows.map((r) => r.sizeBucket)),
+    capabilities: (
+      Object.entries(capabilityCounts) as [OrgCapabilityFilter, number][]
+    )
+      .filter(([, count]) => count > 0)
+      .map(([value, count]) => ({ value, count })),
+    total,
+  };
+}
+
+/** Public org profile, used by /explore/enterprise/organisations/[orgSlug]. */
+export async function getPublicOrgBySlug(slug: string) {
+  return prisma.organization.findFirst({
+    where: { slug, ...baseWhere() },
+    select: orgListSelect,
+  });
+}

--- a/lib/data/home.ts
+++ b/lib/data/home.ts
@@ -50,6 +50,10 @@ export const getHomeExperts = unstable_cache(
             callsPerWeek: true,
             emailSupport: true,
             totalSessions: true,
+            // Same shape as lib/data/explore-experts.ts — both feed
+            // IConsultantCardData, so both must carry the trial fields.
+            trialEnabled: true,
+            trialPriceInPaise: true,
           },
           take: 5,
         },

--- a/lib/explore/filter-codec.ts
+++ b/lib/explore/filter-codec.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared URL <-> filter-state codec for the explore surfaces.
+ *
+ * Generalised out of app/explore/experts/utils.ts, which was the only surface
+ * with bookmarkable filters. Two behaviours from that implementation are load-
+ * bearing and preserved here:
+ *
+ *   1. Multi-value filters use REPEATED params (?tags=a&tags=b), never a
+ *      comma-joined string — a literal comma inside a tag/company/industry name
+ *      would otherwise split one value into two bogus filter terms.
+ *   2. `0` is a legitimate numeric filter value (the price slider's "Free"
+ *      state writes minPrice=0&maxPrice=0), so numbers are parsed with an
+ *      explicit null check rather than `|| undefined`.
+ */
+
+export interface ReadonlyParams {
+  get(name: string): string | null;
+  getAll(name: string): string[];
+}
+
+export function parseIntegerParam(raw: string | null): number | undefined {
+  if (raw === null || raw.trim() === "") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+export function parseNumberParam(raw: string | null): number | undefined {
+  if (raw === null || raw.trim() === "") return undefined;
+  const parsed = Number(raw);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+export function parseBooleanParam(raw: string | null): boolean {
+  return raw === "true" || raw === "1";
+}
+
+/** Narrow a raw param to a known option, falling back when unrecognised. */
+export function parseEnumParam<T extends string>(
+  raw: string | null,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return raw !== null && (allowed as readonly string[]).includes(raw)
+    ? (raw as T)
+    : fallback;
+}
+
+/** Same, but for a nullable filter with no default selection. */
+export function parseNullableEnumParam<T extends string>(
+  raw: string | null,
+  allowed: readonly T[],
+): T | null {
+  return raw !== null && (allowed as readonly string[]).includes(raw)
+    ? (raw as T)
+    : null;
+}
+
+/** Repeated params, filtered to the known option set. */
+export function parseEnumListParam<T extends string>(
+  raws: string[],
+  allowed: readonly T[],
+): T[] {
+  return raws.filter((raw): raw is T =>
+    (allowed as readonly string[]).includes(raw),
+  );
+}
+
+/**
+ * Append a multi-value filter as repeated params. No-op when empty so default
+ * state produces a clean URL.
+ */
+export function appendList(
+  params: URLSearchParams,
+  key: string,
+  values: readonly string[],
+): void {
+  for (const value of values) params.append(key, value);
+}
+
+/** Set a param only when the value differs from its default. */
+export function setIfChanged<T>(
+  params: URLSearchParams,
+  key: string,
+  value: T,
+  defaultValue: T,
+): void {
+  if (value === defaultValue) return;
+  if (value === undefined || value === null || value === "") return;
+  params.set(key, String(value));
+}

--- a/lib/explore/organisation-filters.ts
+++ b/lib/explore/organisation-filters.ts
@@ -1,0 +1,100 @@
+import type { OrgDirectoryType, OrgSizeBucket } from "@prisma/client";
+
+import {
+  appendList,
+  parseBooleanParam,
+  parseEnumListParam,
+  parseEnumParam,
+  parseNullableEnumParam,
+  setIfChanged,
+  type ReadonlyParams,
+} from "@/lib/explore/filter-codec";
+import {
+  DEFAULT_ORGANISATION_FILTERS,
+  type IOrganisationFilters,
+  type OrgCapabilityFilter,
+  type OrgSortOption,
+} from "@/lib/explore/organisation-types";
+
+export const ORG_DIRECTORY_TYPES = [
+  "EXPERT_NETWORK",
+  "CONSULTING_AGENCY",
+  "LEARNING_INSTITUTION",
+  "CORPORATE_ACADEMY",
+  "OTHER",
+] as const satisfies readonly OrgDirectoryType[];
+
+export const ORG_SIZE_BUCKETS = [
+  "SMALL_1_50",
+  "MEDIUM_51_200",
+  "LARGE_201_1000",
+  "ENTERPRISE_1000_PLUS",
+] as const satisfies readonly OrgSizeBucket[];
+
+export const ORG_CAPABILITIES = [
+  "host",
+  "sponsor",
+  "hybrid",
+] as const satisfies readonly OrgCapabilityFilter[];
+
+export const ORG_SORT_OPTIONS = [
+  "nameAsc",
+  "nameDesc",
+  "expertsDesc",
+  "newest",
+] as const satisfies readonly OrgSortOption[];
+
+export const ORG_SORT_LABEL: Record<OrgSortOption, string> = {
+  nameAsc: "Name (A–Z)",
+  nameDesc: "Name (Z–A)",
+  expertsDesc: "Most experts",
+  newest: "Newest",
+};
+
+export function orgFiltersFromSearchParams(
+  params: ReadonlyParams,
+): IOrganisationFilters {
+  return {
+    search: params.get("search") || "",
+    types: parseEnumListParam(params.getAll("type"), ORG_DIRECTORY_TYPES),
+    industries: params.getAll("industry").filter(Boolean),
+    sizes: parseEnumListParam(params.getAll("size"), ORG_SIZE_BUCKETS),
+    capability: parseNullableEnumParam(
+      params.get("capability"),
+      ORG_CAPABILITIES,
+    ),
+    hasExperts: parseBooleanParam(params.get("hasExperts")),
+    sort: parseEnumParam(params.get("sort"), ORG_SORT_OPTIONS, "nameAsc"),
+  };
+}
+
+export function orgFiltersToSearchParams(
+  filters: IOrganisationFilters,
+): string {
+  const params = new URLSearchParams();
+  setIfChanged(params, "search", filters.search, "");
+  appendList(params, "type", filters.types);
+  appendList(params, "industry", filters.industries);
+  appendList(params, "size", filters.sizes);
+  if (filters.capability) params.set("capability", filters.capability);
+  if (filters.hasExperts) params.set("hasExperts", "true");
+  setIfChanged(
+    params,
+    "sort",
+    filters.sort,
+    DEFAULT_ORGANISATION_FILTERS.sort,
+  );
+  return params.toString();
+}
+
+export function hasActiveOrgFilters(filters: IOrganisationFilters): boolean {
+  return (
+    filters.search !== "" ||
+    filters.types.length > 0 ||
+    filters.industries.length > 0 ||
+    filters.sizes.length > 0 ||
+    filters.capability !== null ||
+    filters.hasExperts ||
+    filters.sort !== DEFAULT_ORGANISATION_FILTERS.sort
+  );
+}

--- a/lib/explore/organisation-types.ts
+++ b/lib/explore/organisation-types.ts
@@ -1,0 +1,69 @@
+import type { OrgDirectoryType, OrgSizeBucket } from "@prisma/client";
+
+/**
+ * Client-safe types and constants for the organisations directory.
+ *
+ * Deliberately separate from `lib/data/explore-organisations.ts`: that module
+ * imports `@/lib/prisma`, so importing any *value* from it in a client
+ * component (`DEFAULT_ORGANISATION_FILTERS`, for instance) drags the pg driver
+ * into the browser bundle and the build fails on `Can't resolve 'fs'`. Type-only
+ * imports are erased and would be fine; values are not. Keeping them here makes
+ * the boundary impossible to get wrong by accident.
+ */
+
+export const ORGANISATIONS_PER_PAGE = 24;
+
+export type OrgCapabilityFilter = "host" | "sponsor" | "hybrid";
+
+export type OrgSortOption = "nameAsc" | "nameDesc" | "expertsDesc" | "newest";
+
+export interface IOrganisationFilters {
+  search: string;
+  types: OrgDirectoryType[];
+  industries: string[];
+  sizes: OrgSizeBucket[];
+  capability: OrgCapabilityFilter | null;
+  hasExperts: boolean;
+  sort: OrgSortOption;
+}
+
+export const DEFAULT_ORGANISATION_FILTERS: IOrganisationFilters = {
+  search: "",
+  types: [],
+  industries: [],
+  sizes: [],
+  capability: null,
+  hasExperts: false,
+  sort: "nameAsc",
+};
+
+export interface OrganisationListItem {
+  id: string;
+  name: string;
+  slug: string;
+  logo: string | null;
+  bannerImage: string | null;
+  description: string | null;
+  industry: string | null;
+  website: string | null;
+  sizeBucket: OrgSizeBucket | null;
+  directoryType: OrgDirectoryType | null;
+  capability: OrgCapabilityFilter | "inert";
+  isVerified: boolean;
+  expertCount: number;
+}
+
+export interface OrganisationsMetadata {
+  industries: { value: string; count: number }[];
+  types: { value: OrgDirectoryType; count: number }[];
+  sizes: { value: OrgSizeBucket; count: number }[];
+  capabilities: { value: OrgCapabilityFilter; count: number }[];
+  total: number;
+}
+
+export interface OrganisationsPage {
+  items: OrganisationListItem[];
+  total: number;
+  page: number;
+  totalPages: number;
+}

--- a/lib/explore/programs.ts
+++ b/lib/explore/programs.ts
@@ -109,6 +109,8 @@ export interface ProgramFilters {
   minPrice?: number;
   maxPrice?: number;
   search?: string;
+  /** "all" is the UI sentinel for "no level filter" and is never sent. */
+  level?: string;
 }
 
 // Generate program image URL based on ID with dimensions, using DB image if available
@@ -126,26 +128,9 @@ export function isClassProgram(program: Program): program is ClassPlanProgram {
   return program.type === "class";
 }
 
-// Client-side filtering for search term and level only.
-// Sort is handled server-side via API params — no need to re-sort here.
-export function filterAndSortPrograms(
-  programs: Program[],
-  searchTerm: string,
-  selectedLevel: string,
-): Program[] {
-  return programs.filter((program) => {
-    const matchesSearch =
-      !searchTerm ||
-      program.title.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesLevel =
-      selectedLevel === "all" || program.level === selectedLevel;
-    return matchesSearch && matchesLevel;
-  });
-}
-
-export function getUniqueLevels(programs: Program[]): string[] {
-  const levels = programs
-    .map((program) => program.level)
-    .filter((level): level is string => level !== null);
-  return Array.from(new Set(levels));
-}
+// `filterAndSortPrograms` and `getUniqueLevels` used to re-filter search/level
+// on the client over the already-loaded infinite-scroll page, which meant a
+// matching program on a later page never appeared and the level dropdown could
+// only offer levels that happened to be loaded. Both are now server-side:
+// `level` joins the shared where-builder in app/api/plans/shared/plan-filters.ts,
+// and the level list comes from `getCachedProgramLevels` in the RSC.

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -22,8 +22,13 @@
  *   - The org-create wizard hides the "host consultants" capability checkbox
  *     (the render sites read this server flag and pass hostOrgsEnabled to the
  *     wizard; the 400 gate above stays as the server-side backstop) — #863
- *   - The public /explore/enterprise/organisations directory shows an honest
- *     "coming soon" state instead of a silently-empty grid — #863
+ *
+ * NOT gated by this flag: the public /explore/enterprise/organisations
+ * directory. It used to be, which was a category error — this is a payments
+ * flag, and because the create gate above also blocks `canHost=true`, a
+ * directory filtered on canHost could never be non-empty while the flag was
+ * off. Discovery is now controlled solely by the owner-set
+ * `Organization.isPublic` opt-in; orgs of every capability can be listed.
  *   - The host earnings/payout surfaces stay gated
  *   - The Experts tab and the Payouts nav item are hidden — but note those
  *     are gated on the org's own `canHost`, not on this flag; an org can

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,16 @@
+import { Sora } from "next/font/google";
+
+/**
+ * The app's single font instance.
+ *
+ * `next/font` generates a separately-hashed family per call site, so calling
+ * `Sora()` in more than one module yields two different families (and two
+ * fallback-metric faces) that render subtly differently. Every surface that
+ * owns an `<html>/<body>` pair — the root layout and `global-error` — imports
+ * this one instance instead of declaring its own.
+ */
+export const sora = Sora({
+  subsets: ["latin"],
+  variable: "--font-sora",
+  display: "swap",
+});

--- a/lib/labels/org-labels.ts
+++ b/lib/labels/org-labels.ts
@@ -20,7 +20,13 @@
  *   - License:  green  (fully paid, no per-session billing)
  */
 
-import type { FundingSource, MemberRole, MemberStatus } from "@prisma/client";
+import type {
+  FundingSource,
+  MemberRole,
+  MemberStatus,
+  OrgDirectoryType,
+  OrgSizeBucket,
+} from "@prisma/client";
 
 // ───────────────────────────── Capability ─────────────────────────────
 
@@ -296,3 +302,58 @@ export function narrowSelfServiceRole(
   const parsed = SelfServiceMemberRoleSchema.safeParse(v);
   return parsed.success ? parsed.data : fallback;
 }
+
+// ───────────────────────── Public directory taxonomy ─────────────────────────
+
+/**
+ * What kind of organisation a visitor is looking at, for the public directory.
+ * Distinct from CapabilityKind above: "Hybrid" is billing vocabulary that means
+ * nothing to a marketplace visitor, whereas these are the categories the
+ * marketing copy has always promised.
+ *
+ * No badge-class map — directory type is a neutral taxonomy, so it renders
+ * monochrome (filled vs muted) like every other non-status categorical here.
+ */
+export const ORG_DIRECTORY_TYPE_LABEL: Record<OrgDirectoryType, string> = {
+  EXPERT_NETWORK: "Expert network",
+  CONSULTING_AGENCY: "Consulting agency",
+  LEARNING_INSTITUTION: "Learning institution",
+  CORPORATE_ACADEMY: "Corporate academy",
+  OTHER: "Organisation",
+};
+
+export const ORG_DIRECTORY_TYPE_DESCRIPTION: Record<OrgDirectoryType, string> =
+  {
+    EXPERT_NETWORK:
+      "Curates a panel of independent experts you can book directly.",
+    CONSULTING_AGENCY:
+      "A consulting firm offering its consultants through the platform.",
+    LEARNING_INSTITUTION:
+      "A university, school, or research institute running programs.",
+    CORPORATE_ACADEMY:
+      "A company's internal learning arm, open to external learners.",
+    OTHER: "An organisation on Familiarise.",
+  };
+
+/**
+ * Visitor-facing phrasing for the capability pair, for the public directory.
+ * Distinct from CAPABILITY_LABEL above, which is the dashboard's internal
+ * vocabulary ("Host" / "Hybrid") and means nothing to a marketplace visitor.
+ * `inert` renders nothing rather than the internal "Inactive".
+ */
+export const ORG_PUBLIC_CAPABILITY_LABEL: Record<
+  "host" | "sponsor" | "hybrid" | "inert",
+  string
+> = {
+  host: "Hosts experts",
+  sponsor: "Sponsors members",
+  hybrid: "Hosts & sponsors",
+  inert: "",
+};
+
+export const ORG_SIZE_BUCKET_LABEL: Record<OrgSizeBucket, string> = {
+  SMALL_1_50: "1–50 people",
+  MEDIUM_51_200: "51–200 people",
+  LARGE_201_1000: "201–1,000 people",
+  ENTERPRISE_1000_PLUS: "1,000+ people",
+};

--- a/lib/labels/session-labels.ts
+++ b/lib/labels/session-labels.ts
@@ -136,6 +136,14 @@ export const TRIAL_STATUS_BADGE: Record<TrialSessionStatus, StatusBadgeStyle> =
       className: "bg-amber-100 text-amber-900 border-amber-200",
       dotClassName: "bg-amber-500",
     },
+    // Accepted by the consultant, waiting on the learner to pay. Amber like
+    // PENDING because both are "waiting", but the label names who we're
+    // waiting on — that distinction is the whole reason this status exists.
+    AWAITING_PAYMENT: {
+      label: "Awaiting payment",
+      className: "bg-amber-100 text-amber-900 border-amber-200",
+      dotClassName: "bg-amber-500",
+    },
     SCHEDULED: {
       label: "Scheduled",
       className: "bg-emerald-100 text-emerald-900 border-emerald-200",

--- a/lib/navigation/public-chrome.ts
+++ b/lib/navigation/public-chrome.ts
@@ -1,0 +1,80 @@
+/**
+ * Single source of truth for which public chrome (Navbar / Footer /
+ * HeaderSpacer) renders on a given route.
+ *
+ * These three lists used to be copy-pasted into all three components and had
+ * already drifted: `/explore/enterprise/organisations` was treated as a
+ * dark-hero page by the Navbar but was missing from HeaderSpacer's exclusions,
+ * so a transparent white-text nav rendered on top of a full-height white
+ * spacer band instead of the page's dark hero.
+ *
+ * The fix that keeps it fixed is making the spacer *derived* rather than
+ * independently listed — see `needsHeaderSpacer`.
+ */
+
+/** Routes that render their own shell and never show the public chrome. */
+export const NO_CHROME_PREFIXES = [
+  "/api/",
+  "/auth/",
+  "/form/",
+  "/checkout/",
+  "/dashboard",
+  "/meetings/",
+  // Middleware can rewrite any URL here; it has its own standalone shell.
+  "/maintenance",
+] as const;
+
+/**
+ * Routes whose page begins with a full-bleed dark hero that the nav overlays.
+ * On these the nav is transparent with white text until the user scrolls, and
+ * the page supplies its own top padding — so no spacer.
+ */
+export const TRANSPARENT_HERO_ROUTES = [
+  "/",
+  "/explore/experts",
+  "/explore/programs",
+  "/explore/community",
+  "/explore/enterprise/organisations",
+  // The four persona pages open on the same full-bleed dark hero.
+  "/use-cases/college-students",
+  "/use-cases/early-career",
+  "/use-cases/career-switchers",
+  "/use-cases/mentorship",
+] as const;
+
+/**
+ * Segment-aware prefix match. A bare `startsWith` would treat `/dashboardfoo`
+ * or `/maintenance-notes` as matching `/dashboard` / `/maintenance` and strip
+ * the chrome from an unrelated page.
+ */
+function matchesPrefix(pathname: string, prefix: string): boolean {
+  const normalised = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+  return pathname === normalised || pathname.startsWith(`${normalised}/`);
+}
+
+export function isChromeHidden(pathname: string): boolean {
+  return NO_CHROME_PREFIXES.some((prefix) => matchesPrefix(pathname, prefix));
+}
+
+/**
+ * Exact match, not prefix: `/explore/experts` has a dark hero but its detail
+ * page `/explore/experts/[consultantId]` does not. Query strings never reach
+ * here — callers pass `usePathname()`.
+ */
+export function hasDarkHero(pathname: string): boolean {
+  // Tolerate a trailing slash; still an exact-route match otherwise, because
+  // `/explore/experts` has a dark hero but `/explore/experts/[id]` does not.
+  const normalised =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+  return (TRANSPARENT_HERO_ROUTES as readonly string[]).includes(normalised);
+}
+
+/**
+ * Derived, so it can't drift from the other two: a spacer is needed exactly
+ * when the nav is rendered AND is not overlaying a hero.
+ */
+export function needsHeaderSpacer(pathname: string): boolean {
+  return !isChromeHidden(pathname) && !hasDarkHero(pathname);
+}

--- a/lib/payments/operations/approval-payment.ts
+++ b/lib/payments/operations/approval-payment.ts
@@ -24,10 +24,19 @@ import { acquireLock, releaseLock } from "@/lib/redis";
 
 export interface CreateApprovalPaymentParams {
   userId: string;
-  appointmentType: "CONSULTATION" | "SUBSCRIPTION";
+  appointmentType: "CONSULTATION" | "SUBSCRIPTION" | "TRIAL";
   consultationId?: string;
   subscriptionId?: string;
   planId: string;
+  /** Required when appointmentType is TRIAL. */
+  trialId?: string;
+  /**
+   * Link the intent to an appointment that ALREADY exists. Trials create the
+   * appointment when the consultant accepts (to hold the slot), so the webhook
+   * should confirm it rather than build a new one. Consultations and
+   * subscriptions leave this unset — their appointment is made on capture.
+   */
+  appointmentId?: string;
   paymentGateway: PaymentGateway;
   startsAt?: string;
   endsAt?: string;
@@ -75,9 +84,13 @@ export async function createApprovalPaymentIntent(
       "subscriptionId required for SUBSCRIPTION appointment type",
     );
   }
+  if (params.appointmentType === "TRIAL" && !params.trialId) {
+    throw new Error("trialId required for TRIAL appointment type");
+  }
 
   // H3 FIX: Acquire distributed lock keyed on the resource
-  const resourceId = params.consultationId || params.subscriptionId;
+  const resourceId =
+    params.consultationId || params.subscriptionId || params.trialId;
   const lockKey = `lock:approval_payment:${resourceId}`;
   const lockToken = await acquireLock(lockKey, APPROVAL_PAYMENT_LOCK_TTL);
 
@@ -92,6 +105,7 @@ export async function createApprovalPaymentIntent(
     const hasExistingPayment = await checkExistingPayment({
       consultationId: params.consultationId,
       subscriptionId: params.subscriptionId,
+      trialId: params.trialId,
     });
 
     if (hasExistingPayment) {
@@ -145,6 +159,9 @@ export async function createApprovalPaymentIntent(
         userId: params.userId,
         expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000), // 48 hours expiration
         isMockPayment: false,
+        // Null for consultations/subscriptions, whose appointment is created
+        // on capture; trials pass the appointment they already hold.
+        appointmentId: params.appointmentId ?? null,
       },
     });
 
@@ -171,6 +188,41 @@ async function calculateAmount(params: CreateApprovalPaymentParams): Promise<{
   currency: Currency;
   plan: { title: string };
 }> {
+  if (params.appointmentType === "TRIAL") {
+    // A trial is priced by its parent subscription plan's trialPriceInPaise,
+    // NOT the plan price — the trial is a taster of that plan, not the plan.
+    const plan = await prisma.subscriptionPlan.findUnique({
+      where: { id: params.planId },
+      select: {
+        title: true,
+        trialPriceInPaise: true,
+        trialEnabled: true,
+        priceCurrency: true,
+      },
+    });
+
+    if (!plan) {
+      throw new Error("Subscription plan not found");
+    }
+    if (!plan.trialEnabled) {
+      throw new Error("This plan does not offer trials");
+    }
+    if (plan.trialPriceInPaise <= 0) {
+      // Free trials never reach a payment intent — the accept path schedules
+      // them directly. Reaching here means the caller mis-routed.
+      throw new Error("Cannot create a payment intent for a free trial");
+    }
+
+    const currency = plan.priceCurrency;
+    validatePlanCurrency(currency); // see the note on the CONSULTATION branch
+
+    return {
+      amount: Number(plan.trialPriceInPaise),
+      currency,
+      plan: { title: `${plan.title} — trial` },
+    };
+  }
+
   if (params.appointmentType === "CONSULTATION") {
     const plan = await prisma.consultationPlan.findUnique({
       where: { id: params.planId },
@@ -240,7 +292,9 @@ function buildApprovalMetadata(params: CreateApprovalPaymentParams): {
   [key: string]: string;
 } {
   const metadata: Record<string, string> = {
-    appointmentId: "pending", // Will be linked after payment success
+    // Trials pass a real id (their appointment exists before the intent);
+    // everything else links after capture.
+    appointmentId: params.appointmentId ?? "pending",
     appointmentType: params.appointmentType,
     userId: params.userId,
     planId: params.planId,
@@ -256,6 +310,11 @@ function buildApprovalMetadata(params: CreateApprovalPaymentParams): {
   // Add subscription-specific fields
   if (params.subscriptionId) {
     metadata.subscriptionId = params.subscriptionId;
+  }
+
+  // Add trial-specific fields — the webhook resolves the TrialSession from this.
+  if (params.trialId) {
+    metadata.trialId = params.trialId;
   }
 
   // Add slot times if provided
@@ -284,7 +343,23 @@ function buildApprovalMetadata(params: CreateApprovalPaymentParams): {
 export async function checkExistingPayment(params: {
   consultationId?: string;
   subscriptionId?: string;
+  trialId?: string;
 }): Promise<boolean> {
+  if (params.trialId) {
+    // A trial owns its Payment directly (TrialSession.paymentId), so unlike the
+    // consultation/subscription arms there is no appointment to walk through —
+    // the appointment doesn't exist until the trial is paid and scheduled.
+    const trial = await prisma.trialSession.findUnique({
+      where: { id: params.trialId },
+      select: { payment: { select: { paymentStatus: true } } },
+    });
+
+    const status = trial?.payment?.paymentStatus;
+    return (
+      status === PaymentStatus.SUCCEEDED || status === PaymentStatus.PENDING
+    );
+  }
+
   if (params.consultationId) {
     const consultation = await prisma.consultation.findUnique({
       where: { id: params.consultationId },

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -11,6 +11,7 @@ import {
   PaymentStatus,
   Prisma,
   AppointmentStatus,
+  TrialSessionStatus,
 } from "@prisma/client";
 import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
 import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
@@ -392,6 +393,36 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
           appointment.id,
           payment.userId,
         );
+
+        // TRIAL: the session is AWAITING_PAYMENT with its slot already held, so
+        // capture is what schedules it. Scoped to AWAITING_PAYMENT via
+        // updateMany so a re-delivered webhook is a no-op rather than
+        // resurrecting a trial the learner cancelled or the expiry job closed.
+        if (metadata.trialId) {
+          const scheduled = await tx.trialSession.updateMany({
+            where: {
+              id: metadata.trialId,
+              status: TrialSessionStatus.AWAITING_PAYMENT,
+            },
+            data: {
+              status: TrialSessionStatus.SCHEDULED,
+              paymentId: payment.id,
+              pendingPaymentUrl: null,
+              paymentDueAt: null,
+            },
+          });
+
+          console.log(
+            JSON.stringify({
+              event: scheduled.count
+                ? "webhook_trial_scheduled"
+                : "webhook_trial_not_awaiting_payment",
+              paymentIntent: paymentIntentId,
+              trialId: metadata.trialId,
+              timestamp: new Date().toISOString(),
+            }),
+          );
+        }
 
         console.log(
           `✅ Payment ${paymentIntentId} processed successfully. Appointment ID: ${appointment.id}`,

--- a/lib/trials/eligibility.ts
+++ b/lib/trials/eligibility.ts
@@ -1,0 +1,56 @@
+import type { TrialSessionStatus } from "@prisma/client";
+
+/**
+ * Which existing trial statuses block a fresh trial request.
+ *
+ * `TrialSession` is `@@unique([consulteeProfileId, consultantProfileId])`, so
+ * exactly one row can exist per learner–consultant pair. Eligibility used to be
+ * "no row at all", which meant ANY prior trial — including one the consultant
+ * declined, one the learner cancelled, or (once paid trials landed) one that
+ * simply lapsed unpaid — barred that learner from ever trialling that
+ * consultant again. Never paying isn't the same as having used your trial.
+ *
+ * So only trials that are live or already delivered block a re-request. The
+ * terminal-without-delivery outcomes below free the pair, and the old row is
+ * deleted when the new request is made (the unique constraint leaves no other
+ * option).
+ *
+ * NOTE ON ABUSE: this is deliberately the permissive setting. It does allow
+ * someone to repeatedly request → get declined → request again, which could be
+ * used to pester a consultant, and to repeatedly hold slots without paying. If
+ * that shows up in practice, tighten by moving REJECTED (pestering) and/or
+ * CANCELLED (slot-holding) back into the blocking set — that single change
+ * restores the old one-shot behaviour without touching any call site.
+ */
+export const TRIAL_REQUEST_BLOCKING_STATUSES: TrialSessionStatus[] = [
+  "PENDING", // awaiting the consultant
+  "AWAITING_PAYMENT", // accepted, pay-link live and not yet lapsed
+  "SCHEDULED", // confirmed, upcoming
+  "COMPLETED", // trial actually delivered — this is the real one-per-pair rule
+  "CONVERTED", // delivered and subscribed
+];
+
+/** Terminal outcomes where the learner never received a trial. */
+export const TRIAL_REQUEST_FREEING_STATUSES: TrialSessionStatus[] = [
+  "CANCELLED", // withdrawn by the learner, or lapsed unpaid
+  "REJECTED", // declined by the consultant
+];
+
+export function blocksNewTrialRequest(status: TrialSessionStatus): boolean {
+  return TRIAL_REQUEST_BLOCKING_STATUSES.includes(status);
+}
+
+/**
+ * Paid-trial payment window: 24h from acceptance, clamped to the session start.
+ * A slot three hours out must not stay payable past the slot itself.
+ */
+export const TRIAL_PAYMENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export function computeTrialPaymentDueAt(
+  acceptedAt: Date,
+  sessionStartsAt: Date | null | undefined,
+): Date {
+  const window = new Date(acceptedAt.getTime() + TRIAL_PAYMENT_WINDOW_MS);
+  if (sessionStartsAt && sessionStartsAt < window) return sessionStartsAt;
+  return window;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -84,6 +84,7 @@ const ROUTE_PATTERNS = {
   PUBLIC_API_PREFIXES: [
     "/api/auth/", // BetterAuth core + SSO endpoints (including /api/auth/sso/domain-check)
     "/api/health/",
+    "/api/organizations/public", // Public: explore organisations directory (shadows the private /api/organizations/ parent)
     "/api/user/consultants", // Public: explore experts list and individual profiles
     "/api/user/reviews", // Public: consultant reviews
     "/api/plans/classes", // Public: browse and view class plans (sub-routes enforce their own auth)
@@ -100,8 +101,13 @@ const ROUTE_PATTERNS = {
  */
 const matchesAnyPrefix = (pathname: string, prefixes: string[]): boolean => {
   for (const prefix of prefixes) {
-    if (pathname.startsWith(prefix)) return true;
-    if (prefix.endsWith("/") && pathname === prefix.slice(0, -1)) return true;
+    // Match on SEGMENT boundaries. A bare startsWith let a prefix without a
+    // trailing slash leak across the boundary — "/api/organizations/public"
+    // would also match "/api/organizations/publicfoo", handing an unintended
+    // route the public exemption. Intended matches (exact path, or any deeper
+    // segment) are unchanged.
+    const base = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+    if (pathname === base || pathname.startsWith(`${base}/`)) return true;
   }
   return false;
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -683,8 +683,10 @@ model Organization {
   defaultCancellationPolicy String? @db.Text
   defaultRefundPolicy       String? @db.Text
 
-  // Marketplace visibility — HOST/HYBRID orgs can opt in to appear on
-  // /explore/enterprise/organisations. SPONSOR-only orgs stay private.
+  // Marketplace visibility — any ACTIVE org can opt in to appear on
+  // /explore/enterprise/organisations, regardless of capability. Discovery is
+  // deliberately not gated on canHost: that would make the directory
+  // structurally empty while ENABLE_HOST_ORGS blocks canHost from being set.
   isPublic Boolean @default(false)
 
   // Sponsorship side — one BillingAccount per org when canSponsor=true
@@ -788,6 +790,9 @@ model Organization {
   @@index([status])
   @@index([canSponsor, canHost])
   @@index([canHost, isPublic, status])
+  // Directory listing filters on isPublic+status only; the index above can't
+  // serve it because its leading column (canHost) is no longer in the predicate.
+  @@index([isPublic, status])
   @@index([dataResidencyRegion])
   @@map("organizations")
 }
@@ -1692,9 +1697,9 @@ model OrganizationPayout {
   // Left unbounded these are Postgres `numeric` with arbitrary precision, so the
   // same FX rate could round differently on the payment and the payout sides of
   // one booking and the reconciler would report drift that isn't real.
-  dtaaRateApplied   Decimal?           @db.Decimal(18, 6)
+  dtaaRateApplied   Decimal?            @db.Decimal(18, 6)
   rbiPurposeCode    String? // P0802 | P0807
-  fxRateUsed        Decimal?           @db.Decimal(18, 6)
+  fxRateUsed        Decimal?            @db.Decimal(18, 6)
   firceRef          String?
 
   payoutReference String?
@@ -4535,11 +4540,11 @@ model GstTcsAdjustment {
 /// response. The stored response is replayed verbatim on a repeat, so the
 /// caller sees the original outcome rather than a confusing 409.
 model IdempotencyRecord {
-  id    String @id @default(cuid())
+  id     String @id @default(cuid())
   /// Route-owned namespace, e.g. "admin.refund" or "org.payout.create".
-  scope String
+  scope  String
   /// Caller-supplied `Idempotency-Key` header value.
-  key   String
+  key    String
   /// Who the key belongs to — a key from one user must never replay another's
   /// response, even within the same scope.
   userId String
@@ -5447,8 +5452,25 @@ model OrgBrandingProfile {
   website        String?
   sizeBucket     OrgSizeBucket?
 
+  /// What kind of organisation this is, for the public directory. Deliberately
+  /// separate from the canSponsor/canHost capability pair: capability is a
+  /// commercial fact (who may host experts, who may pay for members), while
+  /// this is market identity a visitor understands. Null = untyped, still listed.
+  directoryType OrgDirectoryType?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+/// Public-directory taxonomy for organisations. Replaces nothing — the deleted
+/// `OrganizationKind` described billing capability, which now lives on
+/// Organization.canSponsor/canHost.
+enum OrgDirectoryType {
+  EXPERT_NETWORK
+  CONSULTING_AGENCY
+  LEARNING_INSTITUTION
+  CORPORATE_ACADEMY
+  OTHER
 }
 
 /// #768 lockdown #14 — append-only OverageEvent table (Stripe Meter

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3050,22 +3050,33 @@ model TrialSession {
   requestedAt DateTime  @default(now())
   completedAt DateTime?
 
+  /// Deadline for a paid trial's pay-link, set when the consultant accepts.
+  /// 24h from acceptance, or the session start if that comes first — a slot
+  /// three hours out must not stay payable past the slot itself. The expiry
+  /// job cancels AWAITING_PAYMENT trials past this and frees the slot.
+  paymentDueAt DateTime?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  // One trial per consultant
+  // One LIVE trial per consultant. The pair is unique, so re-requesting after
+  // a terminal outcome requires clearing the old row — see
+  // `TRIAL_REQUEST_BLOCKING_STATUSES` in lib/trials/eligibility.ts.
   @@unique([consulteeProfileId, consultantProfileId])
   @@index([consultantProfileId])
   @@index([subscriptionPlanId])
   @@index([organizationId])
+  // Expiry job scans for overdue unpaid trials.
+  @@index([status, paymentDueAt])
 }
 
 enum TrialSessionStatus {
   PENDING // Requested, awaiting consultant action
+  AWAITING_PAYMENT // Consultant accepted a PAID trial; pay-link issued, unpaid
   SCHEDULED // Time slot confirmed
   COMPLETED // Trial session completed
   CONVERTED // Consultee subscribed after trial
-  CANCELLED // Cancelled by consultee
+  CANCELLED // Cancelled by consultee, or lapsed unpaid past paymentDueAt
   REJECTED // Declined by consultant
 }
 

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -49,6 +49,8 @@ import {
   MsmeStatus,
   PoStatus,
   UserRole,
+  OrgDirectoryType,
+  OrgSizeBucket,
 } from "@prisma/client";
 import prisma from "../../lib/prisma";
 import { buildConsentArtifact } from "../../lib/compliance/dpdp";
@@ -86,6 +88,10 @@ async function createRootOrg(params: {
   industry?: string;
   website?: string;
   description?: string;
+  /** Opt in to the public /explore/enterprise/organisations directory. */
+  isPublic?: boolean;
+  directoryType?: OrgDirectoryType;
+  sizeBucket?: OrgSizeBucket;
 }) {
   // #768 lockdown — branding fields live on OrgBrandingProfile (1:1).
   // PAN at rest is encrypted; the plaintext column was dropped.
@@ -97,13 +103,19 @@ async function createRootOrg(params: {
       })()
     : {};
   const brandingFields =
-    params.industry || params.website || params.description
+    params.industry ||
+    params.website ||
+    params.description ||
+    params.directoryType ||
+    params.sizeBucket
       ? {
           brandingProfile: {
             create: {
               industry: params.industry ?? null,
               website: params.website ?? null,
               description: params.description ?? null,
+              directoryType: params.directoryType ?? null,
+              sizeBucket: params.sizeBucket ?? null,
             },
           },
         }
@@ -115,6 +127,7 @@ async function createRootOrg(params: {
       canSponsor: params.canSponsor,
       canHost: params.canHost,
       status: params.status ?? OrgStatus.ACTIVE,
+      isPublic: params.isPublic ?? false,
       // #771 D10 — tax identity on the OrganizationTaxInfo satellite.
       taxInfo: {
         create: {
@@ -418,6 +431,9 @@ async function seedLearnPro(owner: UserWithProfiles, agencyConsultants: UserWith
     industry: "Education Services",
     website: "https://learnpro.example",
     description: "Coaching agency aggregating independent experts.",
+    isPublic: true,
+    directoryType: OrgDirectoryType.CONSULTING_AGENCY,
+    sizeBucket: OrgSizeBucket.SMALL_1_50,
   });
 
   const rateCard = await prisma.rateCard.create({
@@ -526,6 +542,9 @@ async function seedIit(params: {
     industry: "Higher Education",
     website: "https://iitm.ac.in",
     description: "Public research university; hybrid buyer+provider.",
+    isPublic: true,
+    directoryType: OrgDirectoryType.LEARNING_INSTITUTION,
+    sizeBucket: OrgSizeBucket.ENTERPRISE_1000_PLUS,
   });
 
   // BillingAccount with WALLET funding (GLG-style)

--- a/schemas/enums.ts
+++ b/schemas/enums.ts
@@ -53,6 +53,18 @@ export const SupportIssueTypeEnum = z.enum([
   "OTHER",
 ]);
 
+/**
+ * Statuses a CLIENT may request via PATCH /api/trials/[trialId].
+ *
+ * Deliberately narrower than the Prisma `TrialSessionStatus` enum:
+ * AWAITING_PAYMENT is server-set only — the accept handler assigns it and the
+ * Razorpay webhook clears it — so accepting it from a request body would let a
+ * caller mark their own trial as awaiting payment, or worse, sidestep the pay
+ * step. Cancelling one still works, because CANCELLED is listed.
+ *
+ * This list is hand-maintained rather than z.nativeEnum(TrialSessionStatus)
+ * precisely so the omission is a decision instead of drift.
+ */
 export const TrialSessionStatusEnum = z.enum([
   "PENDING",
   "SCHEDULED",

--- a/schemas/webhooks/metadata.ts
+++ b/schemas/webhooks/metadata.ts
@@ -76,6 +76,26 @@ export const classMetadataSchema = baseMetadataSchema.extend({
 });
 
 /**
+ * Trial metadata schema
+ *
+ * A paid trial's appointment already exists when the intent is created (the
+ * consultant accepted and the slot is held), so `trialId` is what the handler
+ * needs to move the session out of AWAITING_PAYMENT. `planId` is the parent
+ * subscription plan the trial belongs to.
+ *
+ * Without this arm the switch below threw "Unsupported appointment type", which
+ * routes to CRITICAL_PAYMENT_WITHOUT_APPOINTMENT — the learner charged and the
+ * trial never scheduled.
+ */
+export const trialMetadataSchema = baseMetadataSchema.extend({
+  appointmentType: z.literal(AppointmentsType.TRIAL),
+  planId: z.string().cuid(),
+  trialId: z.string().cuid(),
+  startsAt: z.string().datetime(),
+  endsAt: z.string().datetime(),
+});
+
+/**
  * #679 transition dual-read — REMOVE after 2026-07-12.
  *
  * Razorpay persists checkout metadata as order `notes`; orders created
@@ -124,6 +144,8 @@ export function validateWebhookMetadata(rawMetadata: Record<string, string>) {
       return webinarMetadataSchema.parse(metadata);
     case AppointmentsType.CLASS:
       return classMetadataSchema.parse(metadata);
+    case AppointmentsType.TRIAL:
+      return trialMetadataSchema.parse(metadata);
     default:
       throw new Error(`Unsupported appointment type: ${appointmentType}`);
   }

--- a/scripts/trials/expire-unpaid-trials.ts
+++ b/scripts/trials/expire-unpaid-trials.ts
@@ -1,0 +1,91 @@
+/**
+ * Unpaid Trial Expiry - Core Logic
+ *
+ * Cancels paid trials the consultant accepted but the learner never paid for,
+ * once `paymentDueAt` has passed. Without this an AWAITING_PAYMENT trial holds
+ * a consultant's slot indefinitely: it counts as occupied in
+ * `buildOccupiedAppointmentFilter`, so the consultant can neither deliver it
+ * nor rebook the time.
+ *
+ * Releasing the slot needs no slot surgery — occupancy is derived from the
+ * trial's status, so moving it to CANCELLED drops it out of that filter.
+ *
+ * The learner is not penalised: a cancelled trial frees the
+ * learner-consultant pair, so they can request again. See
+ * lib/trials/eligibility.ts.
+ *
+ * This module exports the core function. It is imported by:
+ * - jobs/trials/expire-unpaid-trials.ts (GitHub Actions)
+ * - app/api/cleanup/expire-unpaid-trials/route.ts (API endpoint)
+ *
+ * Schedule: Hourly
+ */
+
+import { TrialSessionStatus } from "@prisma/client";
+
+import { withCronLock } from "@/lib/cron/with-cron-lock";
+import prisma from "../../lib/prisma";
+
+export interface ExpireUnpaidTrialsResult {
+  success: boolean;
+  trialsExpired: number;
+  errors: string[];
+  timestamp: string;
+}
+
+/**
+ * Expire unpaid trial sessions.
+ */
+// #476 — locked at the core so every entry (GH Actions / HTTP) shares one
+// mutual exclusion; fail-open: the updateMany is idempotent, lock is
+// belt-and-braces.
+export async function expireUnpaidTrials(): Promise<ExpireUnpaidTrialsResult> {
+  return withCronLock("expire-unpaid-trials", { failMode: "open" }, () =>
+    expireUnpaidTrialsUnlocked(),
+  );
+}
+
+async function expireUnpaidTrialsUnlocked(): Promise<ExpireUnpaidTrialsResult> {
+  const errors: string[] = [];
+  let trialsExpired = 0;
+  const now = new Date();
+
+  console.log("🧹 Starting unpaid trial expiry...");
+
+  try {
+    const result = await prisma.trialSession.updateMany({
+      where: {
+        status: TrialSessionStatus.AWAITING_PAYMENT,
+        // A null paymentDueAt means the pay-link was never minted — the gateway
+        // call failed after acceptance. Sweep those too: holding a slot for a
+        // trial nobody can pay for is the worst case of all.
+        OR: [{ paymentDueAt: { lt: now } }, { paymentDueAt: null }],
+      },
+      data: {
+        status: TrialSessionStatus.CANCELLED,
+        // The link is dead once cancelled; leaving it would let a stale
+        // dashboard row send someone to a checkout for a released slot.
+        pendingPaymentUrl: null,
+        paymentDueAt: null,
+      },
+    });
+
+    trialsExpired = result.count;
+    console.log(`   Trials expired: ${trialsExpired}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(message);
+    console.error("❌ Failed to expire unpaid trials:", message);
+  }
+
+  return {
+    success: errors.length === 0,
+    trialsExpired,
+    errors,
+    timestamp: now.toISOString(),
+  };
+}
+
+export async function disconnectDatabase(): Promise<void> {
+  await prisma.$disconnect();
+}

--- a/types/consultant.ts
+++ b/types/consultant.ts
@@ -79,5 +79,9 @@ export interface IConsultantCardData {
     callsPerWeek: number | null;
     emailSupport: string | null;
     totalSessions: number | null;
+    /** Whether this plan offers a trial at all. */
+    trialEnabled: boolean;
+    /** 0 = free intro call; >0 = paid trial. Drives the card's Trial CTA. */
+    trialPriceInPaise: number;
   }>;
 }

--- a/utils/slotAllocation/occupancyPolicy.ts
+++ b/utils/slotAllocation/occupancyPolicy.ts
@@ -77,13 +77,25 @@ export function buildOccupiedAppointmentFilter(
     },
   ];
 
-  // Add trial session filter
+  // Add trial session filter.
+  //
+  // AWAITING_PAYMENT occupies too: a paid trial's slot is reserved the moment
+  // the consultant accepts, and stays reserved while the learner pays. Counting
+  // only SCHEDULED would let someone else book the same slot during the payment
+  // window, and the capture webhook would then confirm a trial into a
+  // double-booked slot. The expiry job releases it by moving the trial to
+  // CANCELLED, which drops out of this filter automatically.
+  const OCCUPYING_TRIAL_STATUSES = [
+    TrialSessionStatus.SCHEDULED,
+    TrialSessionStatus.AWAITING_PAYMENT,
+  ];
+
   if (consultantProfileId) {
     filters.push({
       trialSession: {
         is: {
           consultantProfileId,
-          status: TrialSessionStatus.SCHEDULED,
+          status: { in: OCCUPYING_TRIAL_STATUSES },
         },
       },
     });
@@ -91,7 +103,7 @@ export function buildOccupiedAppointmentFilter(
     filters.push({
       trialSession: {
         is: {
-          status: TrialSessionStatus.SCHEDULED,
+          status: { in: OCCUPYING_TRIAL_STATUSES },
         },
       },
     });


### PR DESCRIPTION
Release `dev` → `prod`. Two PRs, both already merged to `dev` and green on CI.

| PR | What |
|---|---|
| #1044 | Catalog-first public IA, the organisations directory, and a set of chrome/font defects |
| #1046 | Paid trials wired through the approval-payment flow |

## Schema — already applied, no action needed

Both migrations were applied ahead of this release and verified. Note this project has **one active Supabase database shared by dev and prod**, so these are already live:

- `OrgDirectoryType` enum + `OrgBrandingProfile.directoryType` + `organizations(isPublic, status)` index
- `AWAITING_PAYMENT` on `TrialSessionStatus`, `TrialSession.paymentDueAt`, `(status, paymentDueAt)` index

All additive — no drops, no rewrites, no backfill.

## What actually changes for users

**Public IA.** Nav leads with the catalog rather than "Use Cases", the primary CTA is demand-side, and the footer mirrors the nav. The organisations directory is open for the first time: it was gated behind `ENABLE_HOST_ORGS`, a payments flag, *and* filtered on `canHost` — which the same flag prevents any org from having, so it could never have been non-empty. Discovery is now controlled solely by the owner-set `isPublic` opt-in; every money path stays gated exactly as before.

**Four use-case pages** rebuilt for the Indian market, and a new `/become-an-expert` page. The old expert CTA pointed at `/form/onboarding`, which is auth-protected and calls `requireNotOnboarded` — logged-out visitors hit a sign-in wall, already-onboarded users were silently bounced to `/dashboard`.

**Paid trials.** Previously blocked by a deliberate 400. Now: consultant accepts → pay-link issued → `AWAITING_PAYMENT` with the slot held → payment captured → `SCHEDULED`. No money moves at request time, so a declined trial never needs a refund. Unpaid trials expire after 24h (clamped to the session start) and release the slot.

## Exposure on the trials path

**Currently dormant.** Zero subscription plans have `trialEnabled = true` and none is priced, so no paid trial can be triggered until a consultant turns one on.

**When one is:** there is no feature flag, and this path has never processed a real gateway payment. The first live paid trial will be the first end-to-end test. Recommended before enabling one: a Razorpay test-mode run — request → accept → pay → confirm `SCHEDULED` → re-deliver the same webhook and confirm no duplicate appointment → let one lapse and confirm the slot frees.

## Bugs fixed along the way

Several were pre-existing and unrelated to the new features:

- `/api/organizations/public` filtered `industry`/`description` as columns on `Organization`, but both moved to `OrgBrandingProfile` in #768 — every `?search=` request threw a Prisma validation error. The route was also shadowed by the private `/api/organizations/` middleware prefix, so it was unreachable.
- `?domain=<name>` matched nothing sitewide: the API compared it against `domainId` (a cuid), so every human-authored category link returned zero experts.
- Programs applied `search` and `level` client-side over the already-loaded infinite-scroll page, silently dropping matches on later pages.
- `AWAITING_PAYMENT` didn't hold its slot, so a paid trial mid-payment could be double-booked and the capture webhook would confirm into the conflict.
- `validateWebhookMetadata` had no `TRIAL` arm — it would have routed to `CRITICAL_PAYMENT_WITHOUT_APPOINTMENT`, charging the learner without scheduling the trial.
- Nav/Footer/HeaderSpacer carried three copy-pasted route lists that had already drifted; `maintenance/layout.tsx` declared a second font instance inside a nested `<html>`.

## Known, accepted

SonarCloud fails on both PRs. #1044: `new_duplicated_lines_density` 14.6% against a 3% threshold. #1046: `new_security_rating` 3, entirely from the new workflow file using bare `npm ci` and `npx --yes tsx@4.23.1` — the same pattern as 58 and 57 existing workflows respectively, with no application code involved. Neither is a required check, and #1042/#1043 merged through the same gate. The duplication figure is roughly double recent precedent and is worth a follow-up.

CodeRabbit did not review #1046 ("reviews are disabled for this base branch"), so the payments code has had no automated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
