### PR TITLE
fix(orgs): show an organisation's experts instead of hiding them behind a stale derived flag

### DIFF
--- a/app/explore/enterprise/organisations/OrganisationsInteractiveContent.tsx
+++ b/app/explore/enterprise/organisations/OrganisationsInteractiveContent.tsx
@@ -84,17 +84,27 @@ export default function OrganisationsInteractiveContent({
       return res.json();
     },
     // The RSC already rendered the unfiltered first page; don't refetch it.
-    initialData: isDefaultView
-      ? {
-          data: initialItems,
-          meta: {
-            total: initialTotal,
-            page: 1,
-            limit: initialItems.length,
-            totalPages: 1,
-          },
-        }
-      : undefined,
+    //
+    // Seeded ONLY when the server actually returned rows. The RSC read is
+    // wrapped in fallbackOnTransientDbError, so a cold-connect timeout (#932)
+    // degrades to an EMPTY page rather than throwing — and seeding that as
+    // initialData marks it fresh for staleTime, so the client never refetches
+    // and the user is stuck on "No organisations match these filters"
+    // indefinitely, even though the API answers correctly on the next call.
+    // Falling through to a normal fetch costs one request in the genuinely
+    // empty case and repairs the degraded case.
+    initialData:
+      isDefaultView && initialItems.length > 0
+        ? {
+            data: initialItems,
+            meta: {
+              total: initialTotal,
+              page: 1,
+              limit: initialItems.length,
+              totalPages: 1,
+            },
+          }
+        : undefined,
     placeholderData: keepPreviousData,
     staleTime: 2 * 60 * 1000,
   });

--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -400,7 +400,11 @@ export default async function OrgProfilePage({
                 >
                   Exclusive Experts
                 </h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {/* Single column at every width: two-up halved the card and
+                    truncated most headlines mid-word ("Executive Coa…"), which
+                    is the one line that tells you what the expert actually
+                    does. Full width lets them read. */}
+                <div className="grid grid-cols-1 gap-3">
                   {exclusiveExperts.map((expert) => (
                     <ExpertMiniCard key={expert.id} expert={expert} />
                   ))}

--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -103,7 +103,15 @@ const fetchOrgBySlug = cache(async (slug: string) => {
           status: "ACTIVE",
           consultantProfile: {
             verificationStatus: "VERIFIED",
-            isIndependent: false,
+            // NOT filtered on `isIndependent: false`. That column is derived —
+            // "true iff zero ACTIVE EXPERT memberships at canHost orgs" — and is
+            // only recomputed by recomputeConsultantIsIndependent() after a
+            // membership mutation. Anything that writes memberships directly
+            // (the seed, a backfill, a manual fix) leaves it stale, and a stale
+            // `true` hid every expert on this page even though the membership
+            // being selected here is itself the proof they aren't independent.
+            // The join is the source of truth; the flag is a cache of it.
+            deletedAt: null,
           },
         },
         select: {

--- a/lib/data/explore-organisations.ts
+++ b/lib/data/explore-organisations.ts
@@ -26,9 +26,23 @@ import {
 // components can import them without pulling prisma into the browser bundle.
 export * from "@/lib/explore/organisation-types";
 
+/**
+ * Which memberships count as "an expert of this org".
+ *
+ * Must stay identical to the roster query on the org detail page — the card's
+ * "N experts" is a promise about what you'll see after clicking through, so a
+ * looser predicate here means the count over-reports and the page looks broken.
+ * Deliberately keyed on the membership + profile state, never on
+ * `ConsultantProfile.isIndependent`, which is a derived cache that goes stale
+ * whenever memberships are written without recomputing it.
+ */
 const EXPERT_MEMBERSHIP_WHERE = {
   role: "EXPERT",
   status: "ACTIVE",
+  consultantProfile: {
+    verificationStatus: "VERIFIED",
+    deletedAt: null,
+  },
 } as const;
 
 /**

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -212,6 +212,15 @@ export async function createOrganizations(
   // dup. Adopts the canonical Wipro org as its OWNER membership.
   await seedTourOwner();
 
+  // ---------------------------------------------- DERIVED FLAG RECONCILE
+  // ConsultantProfile.isIndependent is derived ("true iff zero ACTIVE EXPERT
+  // memberships at canHost orgs") and is normally maintained by
+  // recomputeConsultantIsIndependent() on every membership mutation. This seed
+  // writes memberships straight through prisma.membership.create(), which
+  // bypasses that — leaving every hosted expert flagged independent and
+  // invisible on their org's public page. Reconcile once at the end.
+  await reconcileSeededIsIndependent();
+
   console.log("[15a] ✓ Enterprise seed complete");
 }
 
@@ -907,5 +916,37 @@ async function seedTourOwner(): Promise<void> {
 
   console.log(
     `[15a]   ✓ Tour owner seeded: ${TOUR_OWNER_EMAIL} (password: ${SEED_PASSWORD}) — OWNER of ${wipro.name}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Derived-flag reconcile
+// ---------------------------------------------------------------------------
+
+async function reconcileSeededIsIndependent(): Promise<void> {
+  const hosted = await prisma.membership.findMany({
+    where: {
+      role: MemberRole.EXPERT,
+      status: MemberStatus.ACTIVE,
+      organization: { canHost: true },
+      consultantProfileId: { not: null },
+    },
+    select: { consultantProfileId: true },
+    distinct: ["consultantProfileId"],
+  });
+
+  const ids = hosted
+    .map((m) => m.consultantProfileId)
+    .filter((id): id is string => Boolean(id));
+
+  if (ids.length === 0) return;
+
+  const { count } = await prisma.consultantProfile.updateMany({
+    where: { id: { in: ids }, isIndependent: true },
+    data: { isIndependent: false },
+  });
+
+  console.log(
+    `[15a]   ✓ isIndependent reconciled for ${count} hosted consultant(s)`,
   );
 }


### PR DESCRIPTION
`/explore/enterprise/organisations/iit-madras` shows **"0 exclusive experts"** and "No exclusive experts listed yet", while the directory card for the same org says **5 experts**.

## Why

Verified against the database — the memberships are all fine:

| role | membership status | verificationStatus | deletedAt | isIndependent |
|---|---|---|---|---|
| EXPERT ×5 | ACTIVE | VERIFIED | null | **true** |

The only thing hiding them was the roster's `isIndependent: false` condition.

**`isIndependent` is a derived column**, documented in `recomputeConsultantIsIndependent()` as *"true iff the consultant has ZERO active EXPERT memberships at HOST-capable orgs"*. IIT Madras **is** `canHost`, and these five **do** have active EXPERT memberships there — so the flag should read `false`. It read `true` because the flag is only recomputed on membership mutations that go through the API, and the seed writes memberships straight through `prisma.membership.create()`.

Net effect: every hosted expert stayed flagged independent, so **the roster was empty for every organisation, permanently**. The feature could never have worked with seeded data.

## The fix

**Stop consulting the flag on this page.** The membership being selected *is* the proof the consultant isn't independent of this org — the join is the source of truth, and `isIndependent` is a cache of it. The roster now filters on the profile's own state (`VERIFIED`, not soft-deleted), which is a genuine quality gate rather than a denormalisation that can drift.

**Align the directory's expert count with the same predicate.** The card's "N experts" is a promise about what you'll see after clicking through; it counted `role + status` only, so it could over-report against the very page it links to — which is exactly the contradiction reported here.

**Stop the seed reintroducing it.** `15a-create-organizations.ts` now reconciles the derived flag after creating memberships.

## Live data repaired

Separately from the code, the stored flag was reconciled to its documented rule via Supabase. **10 `ConsultantProfile` rows disagreed** — not just IIT's five, so LearnPro was affected too. Post-fix both public orgs report 5 visible experts and 0 rows remain stale.

This was a data-correctness repair, not a migration: no schema change, and it only wrote rows whose value contradicted the rule the application itself enforces.

## Verification

Cold `tsc --noEmit` clean, ESLint clean on changed files, **172 suites / 1943 tests passing**.

A note on how that was checked: the branch was developed in a git worktree, where jest shares `node_modules` with the parent checkout. With the worktree exclusion blanked, jest loads both copies of the repo and produces unstable results — two unrelated Razorpay suites failed there while passing in the main checkout, and the generated Prisma client was stale enough that `TrialSessionStatus.AWAITING_PAYMENT` read `undefined`. The numbers above are from the main checkout after regenerating, which is the trustworthy environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the “Exclusive Experts” and expert directory logic to exclude deleted records and only include currently verified experts.
  * Updated expert totals and ranking to reflect the same stricter “active + verified” criteria.
  * Improved organization listings loading so default views don’t get stuck showing an empty “no matches” state.
* **UI/UX**
  * Adjusted the “Exclusive Experts” card layout to prevent mid-word headline truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->