### PR TITLE
fix(nav): derive the light-on-dark treatment from the DOM, not a route list

### DIFF
--- a/app/explore/community/page.tsx
+++ b/app/explore/community/page.tsx
@@ -134,6 +134,9 @@ export default function CommunityPage() {
     <div className="w-full">
       {/* Hero */}
       <section className="bg-zinc-950 text-white py-20 md:py-28">
+        {/* Top of the dark full-bleed hero. The navbar observes this to decide
+          its light-on-dark treatment — see components/Navbar.tsx. */}
+        <div data-nav-sentinel aria-hidden="true" />
         <div className="container mx-auto px-4 md:px-6 text-center max-w-3xl">
           <Badge
             variant="outline"
@@ -246,8 +249,12 @@ export default function CommunityPage() {
                 className="flex items-center justify-between gap-3 p-5 rounded-2xl border border-border bg-muted"
               >
                 <div className="min-w-0">
-                  <h3 className="font-semibold text-foreground">{event.title}</h3>
-                  <p className="text-sm text-muted-foreground mt-0.5">{event.host}</p>
+                  <h3 className="font-semibold text-foreground">
+                    {event.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    {event.host}
+                  </p>
                 </div>
                 <Badge
                   variant="outline"

--- a/app/explore/enterprise/organisations/loading.tsx
+++ b/app/explore/enterprise/organisations/loading.tsx
@@ -1,13 +1,46 @@
+/**
+ * Loading skeleton for the organisations directory.
+ *
+ * Renders the dark hero band the real page renders, for two reasons:
+ *
+ *  1. HeaderSpacer decides at SSR whether this route needs top padding, and it
+ *     treats this route as having a full-bleed hero. A skeleton without one
+ *     therefore started underneath the fixed navbar.
+ *  2. The skeleton painted a light surface under a bar this route promises will
+ *     be dark, so the nav's white text sat on white and vanished. The navbar now
+ *     derives its treatment from `[data-nav-sentinel]`, so carrying the sentinel
+ *     here keeps the loading and loaded states consistent by construction.
+ */
 export default function Loading() {
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-4 p-6">
-      <div className="h-8 w-1/3 animate-pulse rounded-md bg-muted" />
-      <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="h-40 animate-pulse rounded-xl bg-muted" />
-        ))}
-      </div>
-    </div>
+    <main className="min-h-screen bg-background">
+      <div data-nav-sentinel aria-hidden="true" />
+      <section className="relative overflow-hidden bg-zinc-950 pt-32 pb-16">
+        <div className="grid-pattern absolute inset-0 opacity-20" />
+        <div className="relative z-10 mx-auto max-w-[1400px] px-4 md:px-8">
+          <div className="mx-auto flex max-w-3xl flex-col items-center gap-6">
+            <div className="h-9 w-56 animate-pulse rounded-full bg-zinc-800" />
+            <div className="h-12 w-80 animate-pulse rounded-lg bg-zinc-800" />
+            <div className="h-5 w-full max-w-xl animate-pulse rounded bg-zinc-900" />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-10 md:py-16">
+        <div className="mx-auto max-w-[1400px] px-4 md:px-8">
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-[260px_1fr]">
+            <div className="hidden h-96 animate-pulse rounded-2xl bg-muted lg:block" />
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-56 animate-pulse rounded-2xl bg-muted"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/app/explore/enterprise/organisations/page.tsx
+++ b/app/explore/enterprise/organisations/page.tsx
@@ -62,6 +62,9 @@ export default function ExploreOrganisationsPage() {
     <main className="min-h-screen bg-background">
       {/* Hero */}
       <section className="relative overflow-hidden bg-zinc-950 pt-32 pb-16">
+        {/* Top of the dark full-bleed hero. The navbar observes this to decide
+          its light-on-dark treatment — see components/Navbar.tsx. */}
+        <div data-nav-sentinel aria-hidden="true" />
         <div className="absolute inset-0">
           <div className="animate-blob absolute left-1/4 top-1/4 h-[500px] w-[500px] rounded-full bg-zinc-800/30 blur-[120px]" />
           <div className="animate-blob animation-delay-2000 absolute bottom-1/4 right-1/4 h-[400px] w-[400px] rounded-full bg-zinc-700/20 blur-[100px]" />

--- a/app/explore/experts/page.tsx
+++ b/app/explore/experts/page.tsx
@@ -38,6 +38,9 @@ function HeroSection({
 
   return (
     <section className="relative pt-32 pb-20 bg-zinc-950 overflow-hidden">
+      {/* Top of the dark full-bleed hero. The navbar observes this to decide
+          its light-on-dark treatment — see components/Navbar.tsx. */}
+      <div data-nav-sentinel aria-hidden="true" />
       <div className="absolute inset-0">
         <div className="absolute top-1/4 left-1/4 w-[600px] h-[600px] bg-zinc-800/30 rounded-full blur-[120px] animate-blob" />
         <div className="absolute bottom-1/4 right-1/4 w-[500px] h-[500px] bg-zinc-700/20 rounded-full blur-[100px] animate-blob animation-delay-2000" />

--- a/app/explore/programs/ProgramsInteractiveContent.tsx
+++ b/app/explore/programs/ProgramsInteractiveContent.tsx
@@ -135,7 +135,11 @@ export default function ProgramsInteractiveContent({
     onLocalSearchChange("");
   }, [onLocalSearchChange]);
 
-  const { chips, removeChip, clearAll: clearAllChips } = useProgramFilterChips({
+  const {
+    chips,
+    removeChip,
+    clearAll: clearAllChips,
+  } = useProgramFilterChips({
     filters,
     topics: topicsWithCount,
     selectedLevel,
@@ -178,6 +182,9 @@ export default function ProgramsInteractiveContent({
     <main className="min-h-screen bg-background">
       {/* Hero Section */}
       <section className="relative pt-32 pb-20 bg-zinc-950 overflow-hidden">
+        {/* Top of the dark full-bleed hero. The navbar observes this to decide
+          its light-on-dark treatment — see components/Navbar.tsx. */}
+        <div data-nav-sentinel aria-hidden="true" />
         <div className="absolute inset-0">
           <div className="absolute top-1/4 left-1/4 w-[600px] h-[600px] bg-zinc-800/30 rounded-full blur-[120px] animate-blob" />
           <div className="absolute bottom-1/4 right-1/4 w-[500px] h-[500px] bg-zinc-700/20 rounded-full blur-[100px] animate-blob animation-delay-2000" />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -45,7 +45,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { useCurrency, SUPPORTED_CURRENCIES } from "@/hooks/useCurrency";
-import { hasDarkHero, isChromeHidden } from "@/lib/navigation/public-chrome";
+import { isChromeHidden } from "@/lib/navigation/public-chrome";
 import { useAnnouncementBar } from "@/providers/AnnouncementBarProvider";
 import familiariseLogoTransparent from "@/public/avif/static/assets/logos/images/logos/Familiarise-logos_transparent.avif";
 import familiariseLogoWhite from "@/public/avif/static/assets/logos/images/logos/Familiarise-logos_white.avif";
@@ -367,13 +367,7 @@ function DesktopDropdownPanel({
           : undefined
       }
     >
-      <div
-        className={
-          isMega
-            ? `p-4 grid gap-2 ${panelGrid}`
-            : "p-2"
-        }
-      >
+      <div className={isMega ? `p-4 grid gap-2 ${panelGrid}` : "p-2"}>
         {group.columns.map((column) => (
           <div key={column.heading} className="min-w-0">
             {isMega && (
@@ -523,22 +517,49 @@ const Navbar = () => {
   // logged-in user doesn't flash the signed-out CTA on first paint.
   const { data: session, isPending } = useSession();
   const [isOpen, setIsOpen] = useState(false);
-  const [isScrolled, setIsScrolled] = useState(false);
+  // Whether a dark full-bleed hero is currently sitting under the bar. Driven
+  // by what is ACTUALLY rendered (see the effect below), not by a route list.
+  const [overDarkHero, setOverDarkHero] = useState(false);
   const { currency, symbol, setCurrency } = useCurrency();
   const { isVisible: isAnnouncementVisible } = useAnnouncementBar();
-
-  // Route lists live in lib/navigation/public-chrome.ts — they were duplicated
-  // across Navbar/Footer/HeaderSpacer and had already drifted.
-  const darkHero = hasDarkHero(pathname);
 
   const toggleMenu = () => setIsOpen(!isOpen);
   const closeMenu = () => setIsOpen(false);
 
+  /**
+   * Derive the light-on-dark treatment from the DOM instead of a route list.
+   *
+   * A page with a dark hero renders `<div data-nav-sentinel />` at the very top
+   * of it. While that sentinel is still under the bar, the bar is transparent
+   * with white text; once it scrolls past — or was never there — the bar is
+   * solid with foreground text.
+   *
+   * The route list this replaces (`TRANSPARENT_HERO_ROUTES`) could only ever
+   * describe the FINISHED page, so during a route's loading.tsx — a light
+   * skeleton with no hero — the bar still went white and became invisible on
+   * white. Detail pages and any new hero drifted for the same reason. Observing
+   * the sentinel makes disagreement impossible: no hero rendered, no sentinel,
+   * solid bar.
+   *
+   * `rootMargin` shifts the viewport's top edge down by the bar's height so the
+   * flip happens exactly as the hero's top passes underneath, replacing the old
+   * scrollY > 50 guess.
+   */
   useEffect(() => {
-    const checkScroll = () => setIsScrolled(window.scrollY > 50);
-    window.addEventListener("scroll", checkScroll);
-    return () => window.removeEventListener("scroll", checkScroll);
-  }, []);
+    const sentinel = document.querySelector("[data-nav-sentinel]");
+    if (!sentinel) {
+      setOverDarkHero(false);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setOverDarkHero(entry.isIntersecting),
+      { rootMargin: "-72px 0px 0px 0px", threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+    // Re-run per navigation: the sentinel belongs to the page, not the bar.
+  }, [pathname]);
 
   const handleNavigation = (path: string) => {
     router.push(path);
@@ -569,7 +590,7 @@ const Navbar = () => {
       : defaultUserImage;
   };
 
-  const showDarkStyle = darkHero && !isScrolled;
+  const showDarkStyle = overDarkHero;
 
   return (
     <>

--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -59,6 +59,9 @@ function AnimatedNumber({
 export function HeroSection() {
   return (
     <section className="relative min-h-[95vh] flex items-center bg-black overflow-hidden">
+      {/* Top of the dark full-bleed hero. The navbar observes this to decide
+          its light-on-dark treatment — see components/Navbar.tsx. */}
+      <div data-nav-sentinel aria-hidden="true" />
       {/* Animated gradient orbs */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute top-1/4 left-1/4 w-[600px] h-[600px] rounded-full bg-gradient-to-br from-zinc-800/50 to-transparent blur-[50px] animate-blob" />

--- a/lib/navigation/public-chrome.ts
+++ b/lib/navigation/public-chrome.ts
@@ -25,9 +25,17 @@ export const NO_CHROME_PREFIXES = [
 ] as const;
 
 /**
- * Routes whose page begins with a full-bleed dark hero that the nav overlays.
- * On these the nav is transparent with white text until the user scrolls, and
- * the page supplies its own top padding — so no spacer.
+ * Routes whose page begins with a full-bleed dark hero that the nav overlays,
+ * and which therefore supply their own top padding — so no spacer.
+ *
+ * SPACING ONLY. The navbar no longer reads this to choose its colour: it
+ * observes a `[data-nav-sentinel]` element rendered at the top of the actual
+ * hero, so its treatment can never disagree with what is painted. This list
+ * survives because HeaderSpacer runs during SSR and must reserve layout before
+ * any observer exists — deriving it on the client would land as a visible jump.
+ *
+ * A route listed here MUST render a full-bleed hero in its `loading.tsx` too,
+ * or its skeleton starts underneath the fixed navbar.
  */
 export const TRANSPARENT_HERO_ROUTES = [
   "/",


### PR DESCRIPTION
The navbar's text turns white and disappears against light backgrounds — most visibly during the organisations page's loading state, where the bar reads as blank.

## Why it keeps happening

The bar chose its colour from `TRANSPARENT_HERO_ROUTES`, a hardcoded route list. **A route list can only describe the finished page.** So while a route's `loading.tsx` is on screen — a light skeleton with no hero — the bar still believed it was over a dark hero, went white, and vanished.

That's the same root cause behind the earlier drift on this list: it went stale for detail pages, and a `/explore/enterprise/organisations` entry disagreed with `HeaderSpacer`. Fixing the entries treats symptoms; the list itself is the defect, because it is a *guess about what is painted* maintained by hand.

## The fix

A page with a dark hero renders a sentinel as the first child of that hero:

```tsx
<section className="… bg-zinc-950 …">
  <div data-nav-sentinel aria-hidden="true" />
```

The navbar observes it. Sentinel under the bar → transparent, white text. Scrolled past, or never rendered → solid, foreground text. **Disagreement becomes impossible**: no hero, no sentinel, solid bar. Applied to all five dark heroes (landing, experts, programs, community, organisations).

The observer's `rootMargin` also replaces the `scrollY > 50` guess with the exact point the hero passes under the bar, so the window scroll listener is deleted.

## What the observer could NOT replace, and why

`TRANSPARENT_HERO_ROUTES` survives — but for **spacing only**, and it now says so in its docstring.

`HeaderSpacer` runs during SSR and must reserve layout before any observer exists. Deriving it on the client would land as a visible jump on every page load, which is worse than the bug being fixed. The invariant is now written down: a route listed there must render a full-bleed hero in its `loading.tsx` too.

`app/explore/enterprise/organisations/loading.tsx` did not, which is why the reported skeleton also started underneath the fixed bar. It now renders the same dark hero band.

## Verification

Cold `tsc --noEmit` clean, ESLint clean on changed files, **172 suites / 1943 tests passing**.

Not verifiable locally: this is a scroll-and-paint behaviour, so the real check is the deploy preview. Worth looking at the landing page (tall hero, scroll past it), the organisations page **during** its loading flash, and a `/explore/experts/[id]` detail page, which previously drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
