### PR TITLE
release: dev → prod (organisation experts + directory cache fix)

### DIFF
--- a/app/explore/enterprise/organisations/OrganisationsInteractiveContent.tsx
+++ b/app/explore/enterprise/organisations/OrganisationsInteractiveContent.tsx
@@ -84,17 +84,27 @@ export default function OrganisationsInteractiveContent({
       return res.json();
     },
     // The RSC already rendered the unfiltered first page; don't refetch it.
-    initialData: isDefaultView
-      ? {
-          data: initialItems,
-          meta: {
-            total: initialTotal,
-            page: 1,
-            limit: initialItems.length,
-            totalPages: 1,
-          },
-        }
-      : undefined,
+    //
+    // Seeded ONLY when the server actually returned rows. The RSC read is
+    // wrapped in fallbackOnTransientDbError, so a cold-connect timeout (#932)
+    // degrades to an EMPTY page rather than throwing — and seeding that as
+    // initialData marks it fresh for staleTime, so the client never refetches
+    // and the user is stuck on "No organisations match these filters"
+    // indefinitely, even though the API answers correctly on the next call.
+    // Falling through to a normal fetch costs one request in the genuinely
+    // empty case and repairs the degraded case.
+    initialData:
+      isDefaultView && initialItems.length > 0
+        ? {
+            data: initialItems,
+            meta: {
+              total: initialTotal,
+              page: 1,
+              limit: initialItems.length,
+              totalPages: 1,
+            },
+          }
+        : undefined,
     placeholderData: keepPreviousData,
     staleTime: 2 * 60 * 1000,
   });

--- a/app/explore/enterprise/organisations/[orgSlug]/page.tsx
+++ b/app/explore/enterprise/organisations/[orgSlug]/page.tsx
@@ -103,7 +103,15 @@ const fetchOrgBySlug = cache(async (slug: string) => {
           status: "ACTIVE",
           consultantProfile: {
             verificationStatus: "VERIFIED",
-            isIndependent: false,
+            // NOT filtered on `isIndependent: false`. That column is derived —
+            // "true iff zero ACTIVE EXPERT memberships at canHost orgs" — and is
+            // only recomputed by recomputeConsultantIsIndependent() after a
+            // membership mutation. Anything that writes memberships directly
+            // (the seed, a backfill, a manual fix) leaves it stale, and a stale
+            // `true` hid every expert on this page even though the membership
+            // being selected here is itself the proof they aren't independent.
+            // The join is the source of truth; the flag is a cache of it.
+            deletedAt: null,
           },
         },
         select: {
@@ -392,7 +400,11 @@ export default async function OrgProfilePage({
                 >
                   Exclusive Experts
                 </h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {/* Single column at every width: two-up halved the card and
+                    truncated most headlines mid-word ("Executive Coa…"), which
+                    is the one line that tells you what the expert actually
+                    does. Full width lets them read. */}
+                <div className="grid grid-cols-1 gap-3">
                   {exclusiveExperts.map((expert) => (
                     <ExpertMiniCard key={expert.id} expert={expert} />
                   ))}

--- a/lib/data/explore-organisations.ts
+++ b/lib/data/explore-organisations.ts
@@ -26,9 +26,23 @@ import {
 // components can import them without pulling prisma into the browser bundle.
 export * from "@/lib/explore/organisation-types";
 
+/**
+ * Which memberships count as "an expert of this org".
+ *
+ * Must stay identical to the roster query on the org detail page — the card's
+ * "N experts" is a promise about what you'll see after clicking through, so a
+ * looser predicate here means the count over-reports and the page looks broken.
+ * Deliberately keyed on the membership + profile state, never on
+ * `ConsultantProfile.isIndependent`, which is a derived cache that goes stale
+ * whenever memberships are written without recomputing it.
+ */
 const EXPERT_MEMBERSHIP_WHERE = {
   role: "EXPERT",
   status: "ACTIVE",
+  consultantProfile: {
+    verificationStatus: "VERIFIED",
+    deletedAt: null,
+  },
 } as const;
 
 /**

--- a/prisma/seedFiles/15a-create-organizations.ts
+++ b/prisma/seedFiles/15a-create-organizations.ts
@@ -212,6 +212,15 @@ export async function createOrganizations(
   // dup. Adopts the canonical Wipro org as its OWNER membership.
   await seedTourOwner();
 
+  // ---------------------------------------------- DERIVED FLAG RECONCILE
+  // ConsultantProfile.isIndependent is derived ("true iff zero ACTIVE EXPERT
+  // memberships at canHost orgs") and is normally maintained by
+  // recomputeConsultantIsIndependent() on every membership mutation. This seed
+  // writes memberships straight through prisma.membership.create(), which
+  // bypasses that — leaving every hosted expert flagged independent and
+  // invisible on their org's public page. Reconcile once at the end.
+  await reconcileSeededIsIndependent();
+
   console.log("[15a] ✓ Enterprise seed complete");
 }
 
@@ -907,5 +916,37 @@ async function seedTourOwner(): Promise<void> {
 
   console.log(
     `[15a]   ✓ Tour owner seeded: ${TOUR_OWNER_EMAIL} (password: ${SEED_PASSWORD}) — OWNER of ${wipro.name}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Derived-flag reconcile
+// ---------------------------------------------------------------------------
+
+async function reconcileSeededIsIndependent(): Promise<void> {
+  const hosted = await prisma.membership.findMany({
+    where: {
+      role: MemberRole.EXPERT,
+      status: MemberStatus.ACTIVE,
+      organization: { canHost: true },
+      consultantProfileId: { not: null },
+    },
+    select: { consultantProfileId: true },
+    distinct: ["consultantProfileId"],
+  });
+
+  const ids = hosted
+    .map((m) => m.consultantProfileId)
+    .filter((id): id is string => Boolean(id));
+
+  if (ids.length === 0) return;
+
+  const { count } = await prisma.consultantProfile.updateMany({
+    where: { id: { in: ids }, isIndependent: true },
+    data: { isIndependent: false },
+  });
+
+  console.log(
+    `[15a]   ✓ isIndependent reconciled for ${count} hosted consultant(s)`,
   );
 }


### PR DESCRIPTION
Release `dev` → `prod`. One PR since the last release.

| PR | What |
|---|---|
| #1048 | Organisation pages show their experts again, plus a directory caching regression |

## What changes for users

**Organisation rosters were empty everywhere.** `/explore/enterprise/organisations/<slug>` reported "0 exclusive experts" while the directory card for the same org said 5.

The roster filtered on `ConsultantProfile.isIndependent = false`. That column is **derived** — its own helper documents it as *"true iff the consultant has ZERO active EXPERT memberships at HOST-capable orgs"* — and is only recomputed after a membership mutation that goes through the API. The seed writes memberships directly, so the flag stayed `true` for every hosted expert and the roster was empty for **every** organisation, permanently.

The page no longer consults the flag. The membership being selected is itself the proof the consultant isn't independent of that org: the join is the source of truth and the flag is a cache of it. It filters on the profile's own state (`VERIFIED`, not soft-deleted) instead.

**The directory's expert count now matches the page it links to.** It counted `role + status` only, so it could over-report against the roster — which is exactly the 5-vs-0 contradiction above.

**A directory caching regression, introduced earlier in this stack and fixed here.** The RSC read is wrapped in `fallbackOnTransientDbError`, so a cold-connect timeout (#932) degrades to an empty page rather than throwing. That empty page was handed to React Query as `initialData`, which marks it fresh for `staleTime` — so the client never refetched and the page showed "No organisations match these filters" for two minutes even though the API answered correctly on the next call. The facet rail went blank at the same time for the same reason. `initialData` is now seeded only when the server actually returned rows.

**Exclusive-experts list is single column.** Two-up halved each card and truncated most headlines mid-word.

## Data already repaired

The stored flag was reconciled to its documented rule via Supabase before this release: **10 `ConsultantProfile` rows** disagreed — both public orgs were affected, not just one. Zero remain stale, and both now report 5 visible experts. No schema change; only rows contradicting the rule the application itself enforces were rewritten.

The seed now reconciles the flag after creating memberships, so re-seeding cannot reintroduce this.

## Schema

No migration in this release. The two additive migrations from the previous release (`OrgDirectoryType`, `AWAITING_PAYMENT` / `paymentDueAt`) are already applied — note dev and prod share one Supabase project.

## Known, not fixed here

The navbar still turns white against light backgrounds during the loading flash on routes listed in `TRANSPARENT_HERO_ROUTES`, because those routes' `loading.tsx` render a light skeleton with no hero. A fix was prepared and withdrawn for rework, so this ships unchanged rather than regressed.

## Verification

CI green on the merged commit — Lint, TypeScript/Tests/Build, **and SonarCloud**, which the previous two PRs did not clear. 172 suites / 1943 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
