### PR TITLE
fix(booking): allocation window scan, grid/allocator parity, multi-tab guard, webinar detail leak

### DIFF
--- a/__tests__/booking-algorithm/availability-window-scan.test.ts
+++ b/__tests__/booking-algorithm/availability-window-scan.test.ts
@@ -129,6 +129,20 @@ function nextUtcDayAt(utcDay: number, minuteOfDay: number): Date {
 
 const UTC_MONDAY = 1;
 
+// Pin the clock. nextUtcDayAt below always rolls forward a full week when the
+// target weekday is today, but getNextOccurrenceWeekly keeps today whenever the
+// row's time has not yet passed — so on a Monday before 09:00 UTC the service
+// would place the session today while these expectations point a week out, and
+// the suite would fail purely on when CI happened to run. Wednesday keeps every
+// case away from that boundary.
+beforeAll(() => {
+  jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] });
+  jest.setSystemTime(new Date("2026-08-05T12:00:00Z"));
+});
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 describe("findAvailableSlots — scanning within an availability row", () => {
   // IST Monday 14:30-22:30 == UTC Monday 09:00-17:00. Sixteen 30-min starts.
   const MON_0900_UTC = 9 * 60;
@@ -345,6 +359,88 @@ describe("findAvailableSlots — recurring placement buckets by scheduling timez
 
     const dayKeys = slots.map((s) => SlotCalculationService.dayKey(s, IST));
     expect(new Set(dayKeys).size).toBe(dayKeys.length);
+  });
+
+  it("never reuses a day a surviving session already occupies", async () => {
+    const periodStart = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const periodEnd = new Date(periodStart.getTime() + 56 * 24 * 60 * 60 * 1000);
+    const config = {
+      sessionsPerWeek: 2,
+      sessionDurationInHours: 0.5,
+      schedulingPeriodStartsAt: periodStart,
+      schedulingPeriodEndsAt: periodEnd,
+      schedulingTimezone: IST,
+    };
+    const twoDayConsultant = weeklyConsultant([
+      { day: "SATURDAY", startUtc: SAT_0900_UTC, endUtc: SAT_1300_UTC },
+      { day: "SUNDAY", startUtc: SAT_0900_UTC, endUtc: SAT_1300_UTC },
+    ]);
+
+    // Take the first placement the allocator would make, then hand it back as a
+    // surviving confirmed session. The per-day cap counts existing appointments,
+    // so re-placing on that day would be rejected downstream.
+    const survivor = (
+      await findAvailableSlots(dbOccupying([]), twoDayConsultant, 1, 1, "subscription", config)
+    )[0];
+
+    const slots = await findAvailableSlots(
+      dbOccupying([]),
+      twoDayConsultant,
+      2,
+      1,
+      "subscription",
+      config,
+      [],
+      [
+        {
+          id: "surviving-appointment",
+          slotsOfAppointment: [{ id: "s1", startsAt: survivor }],
+        },
+      ],
+    );
+
+    const occupiedDay = SlotCalculationService.dayKey(survivor, IST);
+    for (const s of slots) {
+      expect(SlotCalculationService.dayKey(s, IST)).not.toBe(occupiedDay);
+    }
+  });
+
+  it("never places a session whose end spills past the scheduling period", async () => {
+    // A 1-hour session needs two atoms. Cut the period so only the row's first
+    // 30 minutes fall inside it: testing the START alone would emit a block
+    // running past the period end, which the validator then rejects outright.
+    const probe = (
+      await findAvailableSlots(
+        dbOccupying([]),
+        consultant,
+        1,
+        1,
+        "subscription",
+        {
+          sessionsPerWeek: 1,
+          sessionDurationInHours: 0.5,
+          schedulingPeriodStartsAt: new Date(Date.now() + 60 * 60 * 1000),
+          schedulingPeriodEndsAt: new Date(
+            Date.now() + 60 * 24 * 60 * 60 * 1000,
+          ),
+          schedulingTimezone: IST,
+        },
+      )
+    )[0];
+
+    // The period now ends 30 minutes into the earliest bookable row, so a
+    // 1-hour session cannot fit anywhere inside it. Refusing is the only correct
+    // answer; before the fix the search accepted the row start and emitted a
+    // block running 30 minutes past the period end.
+    await expect(
+      findAvailableSlots(dbOccupying([]), consultant, 2, 2, "subscription", {
+        sessionsPerWeek: 1,
+        sessionDurationInHours: 1,
+        schedulingPeriodStartsAt: new Date(Date.now() + 60 * 60 * 1000),
+        schedulingPeriodEndsAt: new Date(probe.getTime() + 30 * 60 * 1000),
+        schedulingTimezone: IST,
+      }),
+    ).rejects.toThrow(/Could only find/);
   });
 
   it("counts a partial reschedule's surviving sessions against the week cap", async () => {

--- a/__tests__/booking-algorithm/availability-window-scan.test.ts
+++ b/__tests__/booking-algorithm/availability-window-scan.test.ts
@@ -1,0 +1,393 @@
+/**
+ * findAvailableSlots — the placement search itself.
+ *
+ * This function had no executing test before, which is how two defects survived:
+ *
+ *   1. Only the availability row's own startTimeUtc was ever tried as a candidate
+ *      start. A booked 09:00 forfeited the whole 09:00-17:00 window and the loop
+ *      advanced to the next row, so auto-allocate yielded at most one placement
+ *      per row per week.
+ *   2. The recurring day cursor was anchored to a timezone week
+ *      (startOfWeekSundayInTz) but read back with getUTCDay(). Sunday 00:00 IST
+ *      is Saturday 18:30 UTC, so placements were credited to the week before the
+ *      one being iterated and the allocator emitted output its own validate()
+ *      rejected with [WEEKLY_LIMIT].
+ */
+
+import "./setup";
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: { appointment: { findMany: jest.fn() } },
+  ALLOCATION_TX_MAX_WAIT_MS: 8000,
+  ALLOCATION_TX_TIMEOUT_MS: 30000,
+}));
+
+// The allocator imports appointmentlock, which pulls @upstash/redis (ESM) in.
+jest.mock("../../utils/appointmentlock", () => ({
+  lockAutoAllocate: jest.fn(),
+  unlockAutoAllocate: jest.fn(),
+  lockConsulteeBooking: jest.fn(),
+  unlockConsulteeBooking: jest.fn(),
+}));
+
+import { SlotAllocationService } from "../../utils/slotAllocation/SlotAllocationService";
+import { SlotCalculationService } from "../../utils/slotAllocation/SlotCalculationService";
+import type {
+  ConsultantAllocationData,
+  EventConfig,
+  EventType,
+} from "../../utils/slotAllocation/types";
+
+const IST = "Asia/Kolkata";
+const IST_OFFSET = 330;
+
+/** findAvailableSlots is private; the search is the unit under test. */
+const findAvailableSlots = (
+  db: unknown,
+  consultant: ConsultantAllocationData,
+  totalSlotsNeeded: number,
+  slotsPerCall: number,
+  eventType: EventType,
+  config: EventConfig,
+  excludeAppointmentIds: string[] = [],
+  eventOwnAppointments: unknown[] = [],
+  consulteeUserId?: string,
+): Promise<Date[]> =>
+  (
+    SlotAllocationService as unknown as {
+      findAvailableSlots: (...a: unknown[]) => Promise<Date[]>;
+    }
+  ).findAvailableSlots(
+    db,
+    consultant,
+    totalSlotsNeeded,
+    slotsPerCall,
+    eventType,
+    config,
+    excludeAppointmentIds,
+    eventOwnAppointments,
+    consulteeUserId,
+  );
+
+/** A consultant offering one weekly window, expressed in UTC minutes. */
+function weeklyConsultant(
+  rows: Array<{ day: string; startUtc: number; endUtc: number }>,
+): ConsultantAllocationData {
+  return {
+    userId: "consultant-user",
+    scheduleType: "WEEKLY",
+    slotsOfAvailabilityWeekly: rows.map((r, i) => ({
+      id: `weekly-${i}`,
+      startDay: r.day,
+      startTimeUtc: r.startUtc,
+      endDay: r.day,
+      endTimeUtc: r.endUtc,
+      utcOffsetMinutes: IST_OFFSET,
+    })),
+    slotsOfAvailabilityCustom: [],
+  };
+}
+
+/**
+ * A db stub whose appointment.findMany returns one SCHEDULED consultation
+ * occupying every listed instant.
+ */
+function dbOccupying(instants: Date[]) {
+  return {
+    appointment: {
+      findMany: jest.fn().mockResolvedValue(
+        instants.length === 0
+          ? []
+          : [
+              {
+                id: "booked-appointment",
+                consultation: { status: "SCHEDULED" },
+                subscription: null,
+                payment: [],
+                slotsOfAppointment: instants.map((startsAt, i) => ({
+                  id: `booked-slot-${i}`,
+                  startsAt,
+                })),
+              },
+            ],
+      ),
+    },
+  };
+}
+
+/** The next occurrence of a UTC weekday at a UTC minute-of-day, strictly future. */
+function nextUtcDayAt(utcDay: number, minuteOfDay: number): Date {
+  const now = new Date();
+  const d = new Date(now);
+  let delta = utcDay - now.getUTCDay();
+  if (delta <= 0) delta += 7;
+  d.setUTCDate(now.getUTCDate() + delta);
+  d.setUTCHours(Math.floor(minuteOfDay / 60), minuteOfDay % 60, 0, 0);
+  return d;
+}
+
+const UTC_MONDAY = 1;
+
+describe("findAvailableSlots — scanning within an availability row", () => {
+  // IST Monday 14:30-22:30 == UTC Monday 09:00-17:00. Sixteen 30-min starts.
+  const MON_0900_UTC = 9 * 60;
+  const MON_1700_UTC = 17 * 60;
+
+  const consultant = weeklyConsultant([
+    { day: "MONDAY", startUtc: MON_0900_UTC, endUtc: MON_1700_UTC },
+  ]);
+
+  const consultationConfig: EventConfig = {
+    durationInHours: 1,
+    schedulingTimezone: IST,
+  };
+
+  it("places a consultation at the row start when the row is empty", async () => {
+    const rowStart = nextUtcDayAt(UTC_MONDAY, MON_0900_UTC);
+
+    const slots = await findAvailableSlots(
+      dbOccupying([]),
+      consultant,
+      2,
+      2,
+      "consultation",
+      consultationConfig,
+    );
+
+    expect(slots).toHaveLength(2);
+    expect(slots[0].toISOString()).toBe(rowStart.toISOString());
+  });
+
+  it("advances within the row instead of forfeiting it when the start is booked", async () => {
+    const rowStart = nextUtcDayAt(UTC_MONDAY, MON_0900_UTC);
+    const nineThirty = new Date(rowStart.getTime() + 30 * 60 * 1000);
+
+    // 09:00 and 09:30 taken — a 1h call must land at 10:00, not next week.
+    const slots = await findAvailableSlots(
+      dbOccupying([rowStart, nineThirty]),
+      consultant,
+      2,
+      2,
+      "consultation",
+      consultationConfig,
+    );
+
+    expect(slots).toHaveLength(2);
+    expect(slots[0].toISOString()).toBe(
+      new Date(rowStart.getTime() + 60 * 60 * 1000).toISOString(),
+    );
+  });
+
+  it("skips a partially blocked run and takes the next whole block", async () => {
+    const rowStart = nextUtcDayAt(UTC_MONDAY, MON_0900_UTC);
+    // Block 09:30 only: 09:00 can't host a 1h call, 10:00 can.
+    const slots = await findAvailableSlots(
+      dbOccupying([new Date(rowStart.getTime() + 30 * 60 * 1000)]),
+      consultant,
+      2,
+      2,
+      "consultation",
+      consultationConfig,
+    );
+
+    expect(slots[0].toISOString()).toBe(
+      new Date(rowStart.getTime() + 60 * 60 * 1000).toISOString(),
+    );
+  });
+
+  it("still reports no availability when the whole row is booked", async () => {
+    const rowStart = nextUtcDayAt(UTC_MONDAY, MON_0900_UTC);
+    const everyStart = Array.from(
+      { length: 16 },
+      (_, i) => new Date(rowStart.getTime() + i * 30 * 60 * 1000),
+    );
+
+    // Booked for the next eight Mondays too, so the week search is exhausted.
+    const eightWeeks = everyStart.flatMap((s) =>
+      Array.from(
+        { length: 9 },
+        (_, w) => new Date(s.getTime() + w * 7 * 24 * 60 * 60 * 1000),
+      ),
+    );
+
+    await expect(
+      findAvailableSlots(
+        dbOccupying(eightWeeks),
+        consultant,
+        2,
+        2,
+        "consultation",
+        consultationConfig,
+      ),
+    ).rejects.toThrow(/No 2 consecutive slots available/);
+  });
+
+  it("does not start a block that cannot fit before the row ends", async () => {
+    const rowStart = nextUtcDayAt(UTC_MONDAY, MON_0900_UTC);
+    // Free only the last 30 minutes (16:30); a 1h call cannot fit there.
+    const allButLast = Array.from(
+      { length: 15 },
+      (_, i) => new Date(rowStart.getTime() + i * 30 * 60 * 1000),
+    );
+
+    const slots = await findAvailableSlots(
+      dbOccupying(allButLast),
+      consultant,
+      2,
+      2,
+      "consultation",
+      consultationConfig,
+    );
+
+    // Must roll to a later week rather than emit a block running past 17:00.
+    expect(slots).toHaveLength(2);
+    const end = new Date(slots[1].getTime() + 30 * 60 * 1000);
+    expect(end.getTime() - slots[0].getTime()).toBe(60 * 60 * 1000);
+    expect(slots[0].getTime()).toBeGreaterThan(
+      rowStart.getTime() + 6 * 24 * 60 * 60 * 1000,
+    );
+  });
+
+  it("scans within a CUSTOM availability row too", async () => {
+    const start = nextUtcDayAt(UTC_MONDAY, MON_0900_UTC);
+    const custom: ConsultantAllocationData = {
+      userId: "consultant-user",
+      scheduleType: "CUSTOM",
+      slotsOfAvailabilityWeekly: [],
+      slotsOfAvailabilityCustom: [
+        {
+          id: "custom-0",
+          startsAt: start,
+          endsAt: new Date(start.getTime() + 4 * 60 * 60 * 1000),
+        },
+      ],
+    };
+
+    const slots = await findAvailableSlots(
+      dbOccupying([start]),
+      custom,
+      2,
+      2,
+      "consultation",
+      consultationConfig,
+    );
+
+    expect(slots[0].toISOString()).toBe(
+      new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
+    );
+  });
+});
+
+describe("findAvailableSlots — recurring placement buckets by scheduling timezone", () => {
+  // A Saturday row is the case that exposed the drift: Sunday 00:00 IST is
+  // Saturday 18:30 UTC, so a tz-anchored cursor read with getUTCDay() landed on
+  // the wrong side of the week boundary.
+  const SAT_0900_UTC = 9 * 60;
+  const SAT_1300_UTC = 13 * 60;
+
+  const consultant = weeklyConsultant([
+    { day: "SATURDAY", startUtc: SAT_0900_UTC, endUtc: SAT_1300_UTC },
+  ]);
+
+  it("places one session per timezone week and never double-books a week", async () => {
+    const periodStart = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const periodEnd = new Date(periodStart.getTime() + 28 * 24 * 60 * 60 * 1000);
+
+    const slots = await findAvailableSlots(
+      dbOccupying([]),
+      consultant,
+      4,
+      1,
+      "subscription",
+      {
+        sessionsPerWeek: 1,
+        sessionDurationInHours: 0.5,
+        schedulingPeriodStartsAt: periodStart,
+        schedulingPeriodEndsAt: periodEnd,
+        schedulingTimezone: IST,
+      },
+    );
+
+    expect(slots).toHaveLength(4);
+
+    // The invariant the validator enforces: at most sessionsPerWeek per IST week.
+    const perWeek = new Map<string, number>();
+    for (const s of slots) {
+      const key = SlotCalculationService.weekKey(s, IST);
+      perWeek.set(key, (perWeek.get(key) ?? 0) + 1);
+    }
+    expect(perWeek.size).toBe(4);
+    for (const count of perWeek.values()) expect(count).toBe(1);
+  });
+
+  it("never places two sessions in the same scheduling-timezone day", async () => {
+    const periodStart = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const periodEnd = new Date(periodStart.getTime() + 56 * 24 * 60 * 60 * 1000);
+
+    const slots = await findAvailableSlots(
+      dbOccupying([]),
+      weeklyConsultant([
+        { day: "SATURDAY", startUtc: SAT_0900_UTC, endUtc: SAT_1300_UTC },
+        { day: "SUNDAY", startUtc: SAT_0900_UTC, endUtc: SAT_1300_UTC },
+      ]),
+      6,
+      1,
+      "subscription",
+      {
+        sessionsPerWeek: 2,
+        sessionDurationInHours: 0.5,
+        schedulingPeriodStartsAt: periodStart,
+        schedulingPeriodEndsAt: periodEnd,
+        schedulingTimezone: IST,
+      },
+    );
+
+    const dayKeys = slots.map((s) => SlotCalculationService.dayKey(s, IST));
+    expect(new Set(dayKeys).size).toBe(dayKeys.length);
+  });
+
+  it("counts a partial reschedule's surviving sessions against the week cap", async () => {
+    const periodStart = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const periodEnd = new Date(periodStart.getTime() + 28 * 24 * 60 * 60 * 1000);
+
+    // One confirmed session already sits in the first IST week that the search
+    // would otherwise fill; it must be skipped rather than doubled up.
+    const firstSaturday = (
+      await findAvailableSlots(dbOccupying([]), consultant, 1, 1, "subscription", {
+        sessionsPerWeek: 1,
+        sessionDurationInHours: 0.5,
+        schedulingPeriodStartsAt: periodStart,
+        schedulingPeriodEndsAt: periodEnd,
+        schedulingTimezone: IST,
+      })
+    )[0];
+
+    const slots = await findAvailableSlots(
+      dbOccupying([]),
+      consultant,
+      2,
+      1,
+      "subscription",
+      {
+        sessionsPerWeek: 1,
+        sessionDurationInHours: 0.5,
+        schedulingPeriodStartsAt: periodStart,
+        schedulingPeriodEndsAt: periodEnd,
+        schedulingTimezone: IST,
+      },
+      [],
+      [
+        {
+          id: "surviving-appointment",
+          slotsOfAppointment: [{ id: "s1", startsAt: firstSaturday }],
+        },
+      ],
+    );
+
+    const occupiedWeek = SlotCalculationService.weekKey(firstSaturday, IST);
+    for (const s of slots) {
+      expect(SlotCalculationService.weekKey(s, IST)).not.toBe(occupiedWeek);
+    }
+  });
+});

--- a/__tests__/booking-algorithm/grid-allocator-parity.test.ts
+++ b/__tests__/booking-algorithm/grid-allocator-parity.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The availability grid and the allocator must agree about who is busy.
+ *
+ * They did not. The grid asked "is there an active appointment under one of
+ * THIS consultant's plans" (plan ownership); the allocator asked "is this
+ * consultant connected to a slot" (participation), and additionally folded in
+ * the consultee's bookings with any consultant. Three consequences, all of
+ * which showed the user a green, clickable cell that allocation then rejected:
+ *
+ *   - a consultant who is themselves a consultee elsewhere,
+ *   - a consultee already booked with a different consultant,
+ *   - an expired APPROVED_PENDING_PAYMENT hold, which conversely made the grid
+ *     show BUSY where the allocator was happy to book.
+ *
+ * Both sides now build their filter from buildConsultantOccupancyWhere, and the
+ * grid runs the same isOccupiedByLiveAppointment the allocator does.
+ */
+
+import "./setup";
+import {
+  buildConsultantOccupancyWhere,
+  buildOccupiedAppointmentFilter,
+  OCCUPIED_REQUEST_STATUSES,
+} from "../../utils/slotAllocation/occupancyPolicy";
+import { isOccupiedByLiveAppointment } from "../../utils/slotAllocation/SlotValidationService";
+
+const PROFILE = "consultant-profile-1";
+const USER = "consultant-user-1";
+
+type WhereShape = ReturnType<typeof buildConsultantOccupancyWhere>;
+
+/** The two arms of the "reaches this consultant" clause. */
+function reachArms(where: WhereShape) {
+  const and = (where.AND ?? []) as Record<string, unknown>[];
+  const reach = and[1] as { OR?: Record<string, unknown>[] };
+  return reach.OR ?? [];
+}
+
+describe("buildConsultantOccupancyWhere", () => {
+  it("matches on slot participation as well as plan ownership", () => {
+    const arms = reachArms(buildConsultantOccupancyWhere(PROFILE, USER));
+
+    expect(arms).toHaveLength(2);
+
+    // Participation: the consultant is on the slot, whatever plan it belongs to.
+    expect(arms[0]).toEqual({
+      slotsOfAppointment: { some: { user: { some: { id: USER } } } },
+    });
+
+    // Ownership: the appointment is delivered under one of their own plans,
+    // even when the slot rows connect registrants rather than the host.
+    expect(arms[1]).toEqual({
+      OR: buildOccupiedAppointmentFilter(PROFILE),
+    });
+  });
+
+  it("still constrains to active parent statuses", () => {
+    const where = buildConsultantOccupancyWhere(PROFILE, USER);
+    const and = (where.AND ?? []) as Record<string, unknown>[];
+
+    expect(and[0]).toEqual({ OR: buildOccupiedAppointmentFilter() });
+    // Sanity-check the policy itself hasn't quietly widened.
+    expect(OCCUPIED_REQUEST_STATUSES).toEqual(
+      expect.arrayContaining([
+        "PENDING",
+        "APPROVED",
+        "APPROVED_PENDING_PAYMENT",
+        "SCHEDULED",
+      ]),
+    );
+  });
+
+  it("falls back to participation alone when no profile id is known", () => {
+    const arms = reachArms(buildConsultantOccupancyWhere(undefined, USER));
+
+    expect(arms).toHaveLength(1);
+    expect(arms[0]).toEqual({
+      slotsOfAppointment: { some: { user: { some: { id: USER } } } },
+    });
+  });
+
+  it("is the same predicate whichever caller builds it", () => {
+    // Grid and allocator pass the same pair, so the objects must be identical —
+    // this is the invariant that broke.
+    expect(buildConsultantOccupancyWhere(PROFILE, USER)).toEqual(
+      buildConsultantOccupancyWhere(PROFILE, USER),
+    );
+  });
+});
+
+describe("live-hold filtering is shared by grid and allocator", () => {
+  const past = new Date("2026-01-01T00:00:00Z");
+  const future = new Date("2099-01-01T00:00:00Z");
+  const now = new Date("2026-06-01T00:00:00Z");
+
+  it("frees a slot whose pending-payment hold has lapsed", () => {
+    expect(
+      isOccupiedByLiveAppointment(
+        {
+          consultation: { status: "APPROVED_PENDING_PAYMENT" },
+          subscription: null,
+          payment: [{ expiresAt: past }],
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a slot blocked while any payment row is still live", () => {
+    expect(
+      isOccupiedByLiveAppointment(
+        {
+          consultation: { status: "APPROVED_PENDING_PAYMENT" },
+          subscription: null,
+          payment: [{ expiresAt: past }, { expiresAt: future }],
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a confirmed booking blocked regardless of payment rows", () => {
+    expect(
+      isOccupiedByLiveAppointment(
+        {
+          consultation: { status: "SCHEDULED" },
+          subscription: null,
+          payment: [{ expiresAt: past }],
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a hold with no payment row at all blocked", () => {
+    // A hold that never produced a payment must not silently free the slot.
+    expect(
+      isOccupiedByLiveAppointment(
+        {
+          consultation: { status: "APPROVED_PENDING_PAYMENT" },
+          subscription: null,
+          payment: [],
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+});

--- a/__tests__/booking-algorithm/slot-booking-status.test.ts
+++ b/__tests__/booking-algorithm/slot-booking-status.test.ts
@@ -1,0 +1,149 @@
+/**
+ * getSlotBookingStatus — the function behind every coloured cell in the
+ * availability grid, previously at ~18% statement coverage with no direct test.
+ *
+ * The status vocabulary is available / partially-booked / fully-booked, decided
+ * by what fraction of the interval is covered by merged appointment ranges
+ * against FULLY_BOOKED_THRESHOLD (0.99).
+ */
+
+import "./setup";
+import {
+  BOOKING_STATUS,
+  buildAppointmentIndex,
+  getSlotBookingStatus,
+  type AppointmentSlot,
+} from "../../utils/timeSlotsProcessing";
+
+const at = (iso: string) => new Date(iso);
+const booking = (startIso: string, endIso: string): AppointmentSlot => ({
+  startsAt: at(startIso),
+  endsAt: at(endIso),
+});
+
+// One 30-minute atom, the unit the grid actually renders.
+const SLOT_START = at("2026-08-03T09:00:00Z");
+const SLOT_END = at("2026-08-03T09:30:00Z");
+
+describe("getSlotBookingStatus", () => {
+  it("reports available when nothing overlaps", () => {
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, [])).toBe(
+      BOOKING_STATUS.AVAILABLE,
+    );
+  });
+
+  it("reports available when a booking merely abuts the slot", () => {
+    const slots = [
+      booking("2026-08-03T08:30:00Z", "2026-08-03T09:00:00Z"),
+      booking("2026-08-03T09:30:00Z", "2026-08-03T10:00:00Z"),
+    ];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.AVAILABLE,
+    );
+  });
+
+  it("reports fully booked on an exact cover", () => {
+    const slots = [booking("2026-08-03T09:00:00Z", "2026-08-03T09:30:00Z")];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.FULLY_BOOKED,
+    );
+  });
+
+  it("reports fully booked when a longer appointment spans it", () => {
+    const slots = [booking("2026-08-03T08:00:00Z", "2026-08-03T11:00:00Z")];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.FULLY_BOOKED,
+    );
+  });
+
+  it("reports partially booked when only part of the slot is taken", () => {
+    const slots = [booking("2026-08-03T09:00:00Z", "2026-08-03T09:15:00Z")];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.PARTIALLY_BOOKED,
+    );
+  });
+
+  it("merges adjacent bookings into a full cover", () => {
+    // Two halves that together cover the atom must read fully-booked, not
+    // partially — the merge step is what makes that true.
+    const slots = [
+      booking("2026-08-03T09:00:00Z", "2026-08-03T09:15:00Z"),
+      booking("2026-08-03T09:15:00Z", "2026-08-03T09:30:00Z"),
+    ];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.FULLY_BOOKED,
+    );
+  });
+
+  it("does not let overlapping bookings double-count into a false full cover", () => {
+    // Both cover the same first half; the slot is genuinely half free.
+    const slots = [
+      booking("2026-08-03T09:00:00Z", "2026-08-03T09:15:00Z"),
+      booking("2026-08-03T09:05:00Z", "2026-08-03T09:15:00Z"),
+    ];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.PARTIALLY_BOOKED,
+    );
+  });
+
+  it("treats a sub-second gap as fully booked (the 0.99 threshold)", () => {
+    const slots = [
+      booking("2026-08-03T09:00:00Z", "2026-08-03T09:14:59Z"),
+      booking("2026-08-03T09:15:00Z", "2026-08-03T09:30:00Z"),
+    ];
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots)).toBe(
+      BOOKING_STATUS.FULLY_BOOKED,
+    );
+  });
+
+  it("agrees with itself whether or not the bucket index is supplied", () => {
+    // The route passes a prebuilt index; the fallback path scans directly.
+    // A divergence here would make the same data render two different colours.
+    const slots = [
+      booking("2026-08-03T09:00:00Z", "2026-08-03T09:15:00Z"),
+      booking("2026-08-03T10:00:00Z", "2026-08-03T10:30:00Z"),
+    ];
+    const index = buildAppointmentIndex(slots);
+
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots, index)).toBe(
+      getSlotBookingStatus(SLOT_START, SLOT_END, slots),
+    );
+    expect(getSlotBookingStatus(SLOT_START, SLOT_END, slots, index)).toBe(
+      BOOKING_STATUS.PARTIALLY_BOOKED,
+    );
+  });
+
+  it("falls back to available on malformed input rather than blocking a slot", () => {
+    expect(
+      getSlotBookingStatus(at("invalid"), SLOT_END, []),
+    ).toBe(BOOKING_STATUS.AVAILABLE);
+    expect(getSlotBookingStatus(SLOT_END, SLOT_START, [])).toBe(
+      BOOKING_STATUS.AVAILABLE,
+    );
+  });
+});
+
+describe("buildAppointmentIndex", () => {
+  it("buckets a booking into every 30-minute window it touches", () => {
+    const long = booking("2026-08-03T09:00:00Z", "2026-08-03T10:30:00Z");
+    const index = buildAppointmentIndex([long]);
+
+    // Three atoms covered: 09:00, 09:30, 10:00 — and not 10:30, which the
+    // booking only abuts (half-open interval).
+    const bucketOf = (iso: string) =>
+      Math.floor(at(iso).getTime() / (30 * 60 * 1000));
+
+    expect(index.get(bucketOf("2026-08-03T09:00:00Z"))).toHaveLength(1);
+    expect(index.get(bucketOf("2026-08-03T09:30:00Z"))).toHaveLength(1);
+    expect(index.get(bucketOf("2026-08-03T10:00:00Z"))).toHaveLength(1);
+    expect(index.get(bucketOf("2026-08-03T10:30:00Z"))).toBeUndefined();
+  });
+
+  it("ignores malformed rows instead of throwing", () => {
+    const index = buildAppointmentIndex([
+      { startsAt: null, endsAt: null } as unknown as AppointmentSlot,
+      booking("2026-08-03T09:00:00Z", "2026-08-03T09:30:00Z"),
+    ]);
+    expect([...index.values()].flat()).toHaveLength(1);
+  });
+});

--- a/__tests__/booking-algorithm/slotAllocationService.test.ts
+++ b/__tests__/booking-algorithm/slotAllocationService.test.ts
@@ -124,7 +124,13 @@ function makeMockTx() {
       update: jest.fn(),
       updateMany: jest.fn(),
       deleteMany: jest.fn(),
+      // ADR B10 — the multi-tab guard is now derived server-side from "this
+      // event has no confirmed slots" rather than from a client flag that was
+      // never true, so it runs on the ordinary allocation paths too.
+      count: jest.fn().mockResolvedValue(0),
     },
+    // pg_advisory_xact_lock inside guardInitialAllocationInTx.
+    $queryRaw: jest.fn().mockResolvedValue([]),
   };
 }
 
@@ -635,6 +641,43 @@ describe("Requested slot allocation", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("No appointments found");
     expect(result.error).toContain("resubmit their request");
+  });
+
+  it("should refuse to reuse requested times once a slot is awaiting reschedule", async () => {
+    // A reschedule flips isTentative/completionStatus but leaves startsAt at the
+    // ORIGINAL time, and fetchEventData reads requestedSlots from those rows —
+    // so accepting here would re-confirm the time the consultee asked to move.
+    mockTx.consultation.findUnique.mockResolvedValue(
+      makeConsultationEvent({
+        appointment: {
+          slotsOfAppointment: [
+            { startsAt: new Date("2025-01-06T10:00:00Z") },
+            { startsAt: new Date("2025-01-06T10:30:00Z") },
+          ],
+        },
+      }),
+    );
+    mockTx.appointment.findMany.mockResolvedValue([
+      {
+        id: "apt-1",
+        slotsOfAppointment: [
+          { id: "s1", completionStatus: "RESCHEDULED" },
+          { id: "s2", completionStatus: "RESCHEDULED" },
+        ],
+      },
+    ]);
+
+    const result = await SlotAllocationService.allocate({
+      eventType: "consultation",
+      eventId: "consult-1",
+      mode: "requested",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Cannot reuse requested times");
+    expect(result.error).toContain("2 slot(s) are awaiting reschedule");
+    // The status write must not have happened.
+    expect(mockTx.slotOfAppointment.updateMany).not.toHaveBeenCalled();
   });
 
   it("should return error when appointment slot count mismatches requested", async () => {

--- a/__tests__/plans/plan-detail-pages-gated.test.ts
+++ b/__tests__/plans/plan-detail-pages-gated.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Every plan detail page must call the visibility gate.
+ *
+ * The pure predicate already had tests, but nothing asserted that the pages
+ * USE it — so the webinar page shipped importing `canViewPlanDetail` and never
+ * calling it, leaving ORG_ONLY and archived webinar plans readable by id. These
+ * tests drive each page with a hidden plan and require a not-found.
+ */
+
+const notFoundError = new Error("NEXT_NOT_FOUND");
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw notFoundError;
+  }),
+}));
+
+const mockCanViewPlanDetail = jest.fn();
+jest.mock("../../lib/data/plan-viewable", () => ({
+  canViewPlanDetail: (...args: unknown[]) => mockCanViewPlanDetail(...args),
+}));
+
+const mockGetConsultationPlanDetail = jest.fn();
+const mockGetSubscriptionPlanDetail = jest.fn();
+const mockGetWebinarPlanDetail = jest.fn();
+const mockGetClassPlanDetail = jest.fn();
+jest.mock("../../lib/data/plan-details", () => ({
+  getConsultationPlanDetail: (...a: unknown[]) =>
+    mockGetConsultationPlanDetail(...a),
+  getSubscriptionPlanDetail: (...a: unknown[]) =>
+    mockGetSubscriptionPlanDetail(...a),
+  getWebinarPlanDetail: (...a: unknown[]) => mockGetWebinarPlanDetail(...a),
+  getClassPlanDetail: (...a: unknown[]) => mockGetClassPlanDetail(...a),
+}));
+
+// The page modules import their presentational components, which drag in the
+// whole UI tree. Stub them — these tests are about the gate, not the markup.
+jest.mock(
+  "../../app/explore/programs/plans/consultations/[consultationPlanId]/components/ConsultationDetails",
+  () => ({ ConsultationDetails: () => null }),
+);
+jest.mock(
+  "../../app/explore/programs/plans/subscriptions/[subscriptionPlanId]/components/SubscriptionDetails",
+  () => ({ SubscriptionDetails: () => null }),
+);
+jest.mock(
+  "../../app/explore/programs/plans/webinars/[webinarPlanId]/components/WebinarDetails",
+  () => ({ WebinarDetails: () => null }),
+);
+jest.mock(
+  "../../app/explore/programs/plans/classes/[classPlanId]/components/ClassDetails",
+  () => ({ ClassDetails: () => null }),
+);
+
+/** An ORG_ONLY, archived plan — hidden under every rule the gate applies. */
+const hiddenPlan = {
+  id: "plan-1",
+  visibility: "ORG_ONLY" as const,
+  organizationId: "org-1",
+  archivedAt: new Date("2026-01-01T00:00:00Z"),
+  imageUrl: null,
+  webinars: [],
+};
+
+const PAGES = [
+  {
+    name: "consultation",
+    load: () =>
+      require("../../app/explore/programs/plans/consultations/[consultationPlanId]/page"),
+    fetcher: mockGetConsultationPlanDetail,
+    params: { consultationPlanId: "plan-1" },
+  },
+  {
+    name: "subscription",
+    load: () =>
+      require("../../app/explore/programs/plans/subscriptions/[subscriptionPlanId]/page"),
+    fetcher: mockGetSubscriptionPlanDetail,
+    params: { subscriptionPlanId: "plan-1" },
+  },
+  {
+    name: "webinar",
+    load: () =>
+      require("../../app/explore/programs/plans/webinars/[webinarPlanId]/page"),
+    fetcher: mockGetWebinarPlanDetail,
+    params: { webinarPlanId: "plan-1" },
+  },
+  {
+    name: "class",
+    load: () =>
+      require("../../app/explore/programs/plans/classes/[classPlanId]/page"),
+    fetcher: mockGetClassPlanDetail,
+    params: { classPlanId: "plan-1" },
+  },
+];
+
+describe("plan detail pages apply canViewPlanDetail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(PAGES)(
+    "$name page 404s a plan the gate rejects",
+    async ({ load, fetcher, params }) => {
+      fetcher.mockResolvedValue(hiddenPlan);
+      mockCanViewPlanDetail.mockResolvedValue(false);
+
+      const Page = load().default;
+
+      await expect(Page({ params: Promise.resolve(params) })).rejects.toThrow(
+        "NEXT_NOT_FOUND",
+      );
+      expect(mockCanViewPlanDetail).toHaveBeenCalledWith(hiddenPlan);
+    },
+  );
+
+  it.each(PAGES)(
+    "$name page renders a plan the gate allows",
+    async ({ load, fetcher, params }) => {
+      fetcher.mockResolvedValue(hiddenPlan);
+      mockCanViewPlanDetail.mockResolvedValue(true);
+
+      const Page = load().default;
+
+      await expect(
+        Page({ params: Promise.resolve(params) }),
+      ).resolves.toBeDefined();
+    },
+  );
+});

--- a/app/api/slots/availability-with-allocation/[consultantId]/route.ts
+++ b/app/api/slots/availability-with-allocation/[consultantId]/route.ts
@@ -6,11 +6,14 @@ import {
   dayMap,
   makeLocalizer,
   processAvailabilitySlots,
-  THIRTY_MIN_MS,
   WeeklySlot,
 } from "@/utils/timeSlotsProcessing";
 import { NextRequest, NextResponse } from "next/server";
-import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
+import {
+  buildConsultantOccupancyWhere,
+  buildOccupiedAppointmentFilter,
+} from "@/utils/slotAllocation/occupancyPolicy";
+import { isOccupiedByLiveAppointment } from "@/utils/slotAllocation/SlotValidationService";
 import { minuteUtcToDate } from "@/utils/slotAllocation/slotTimeUtils";
 import { getSession } from "@/lib/auth-server";
 import {
@@ -99,6 +102,29 @@ export async function GET(
       includeAppointmentDetails = true;
     }
 
+    // The allocator treats the CONSULTEE's bookings with ANY consultant as
+    // occupied, so a grid that only knows the consultant paints cells green
+    // that then fail validateNoConflicts. Callers who know whose calendar is
+    // being booked pass it here.
+    //
+    // Gated because this route is otherwise PUBLIC: an ungated parameter would
+    // be a busy/free oracle for any user id. You may ask about yourself, or the
+    // consultant (and staff) may ask about a consultee booking with them.
+    const requestedConsulteeUserId = searchParams.get("consulteeUserId");
+    let consulteeUserId: string | null = null;
+    if (requestedConsulteeUserId) {
+      const session = await getSession(true);
+      const isSelf = session?.user?.id === requestedConsulteeUserId;
+      const isOwner = session?.user?.consultantProfileId === consultantId;
+      if (!isSelf && !isOwner && !isPrivileged(session?.user?.role)) {
+        return NextResponse.json(
+          { error: "Forbidden: cannot read another user's calendar" },
+          { status: 403 },
+        );
+      }
+      consulteeUserId = requestedConsulteeUserId;
+    }
+
     if (!startDateInUtc || !endDateInUtc) {
       return NextResponse.json(
         { error: "startDateInUtc and endDateInUtc are required" },
@@ -159,10 +185,12 @@ export async function GET(
       );
     }
 
-    // 2. Fetch all appointments to find allocated slots
-    // FIX Bug #15: Use centralized occupancy policy for consistent conflict detection
-    const occupiedAppointmentWhere = {
-      OR: buildOccupiedAppointmentFilter(consultantId),
+    // 2. Fetch all appointments to find allocated slots.
+    //
+    // The grid must answer occupancy the same way the allocator does, or it
+    // paints cells green that every allocation mode then rejects. Both now
+    // share buildConsultantOccupancyWhere.
+    const slotsInWindow = {
       slotsOfAppointment: {
         some: {
           OR: [
@@ -187,33 +215,56 @@ export async function GET(
       },
     };
 
+    const occupiedAppointmentWhere = {
+      AND: [
+        buildConsultantOccupancyWhere(consultantId, consultant.userId),
+        slotsInWindow,
+      ],
+    };
+
+    // The parent's status and payment window decide whether a hold is still
+    // live; without them isOccupiedByLiveAppointment cannot drop an expired
+    // APPROVED_PENDING_PAYMENT and the grid blanks out genuinely free time.
+    const LIVE_OCCUPANCY_SELECT = {
+      consultation: { select: { status: true } },
+      subscription: { select: { status: true } },
+      payment: { select: { expiresAt: true } },
+    } as const;
+
     // #997 Phase 2 — two separate queries (rather than one conditionally-built
     // `include`) so the PUBLIC path (majority of traffic — consultee/trials
     // browsing) never pays for the extra plan-title/participant-name joins.
     let rawSlotsOfAppointment: { id: string; startsAt: Date; endsAt: Date }[];
     let overlapMetaIndex: Map<number, OverlapAppointmentMeta[]> = new Map();
     let detailAppointments: AppointmentForOverlapMeta[] = [];
+    const occupancyNow = new Date();
     if (includeAppointmentDetails) {
-      detailAppointments = await prisma.appointment.findMany({
+      const fetched = await prisma.appointment.findMany({
         where: occupiedAppointmentWhere,
         include: {
           slotsOfAppointment: true,
           consultation: {
             select: {
+              status: true,
               consultationPlan: { select: { title: true } },
               requestedBy: { select: { user: { select: { name: true } } } },
             },
           },
           subscription: {
             select: {
+              status: true,
               subscriptionPlan: { select: { title: true } },
               requestedBy: { select: { user: { select: { name: true } } } },
             },
           },
           webinar: { select: { webinarPlan: { select: { title: true } } } },
           class: { select: { classPlan: { select: { title: true } } } },
+          payment: { select: { expiresAt: true } },
         },
       });
+      detailAppointments = fetched.filter((appt) =>
+        isOccupiedByLiveAppointment(appt, occupancyNow),
+      );
       rawSlotsOfAppointment = detailAppointments.flatMap(
         (appt) => appt.slotsOfAppointment,
       );
@@ -221,11 +272,43 @@ export async function GET(
     } else {
       const appointments = await prisma.appointment.findMany({
         where: occupiedAppointmentWhere,
-        include: { slotsOfAppointment: true },
+        include: { slotsOfAppointment: true, ...LIVE_OCCUPANCY_SELECT },
       });
-      rawSlotsOfAppointment = appointments.flatMap(
-        (appt) => appt.slotsOfAppointment,
-      );
+      rawSlotsOfAppointment = appointments
+        .filter((appt) => isOccupiedByLiveAppointment(appt, occupancyNow))
+        .flatMap((appt) => appt.slotsOfAppointment);
+    }
+
+    // Fold in the consultee's own bookings — with ANY consultant — so the grid
+    // and the allocator agree on what is free for BOTH parties. No overlap
+    // metadata is attached: the consultant may see that the time is taken, not
+    // what it is taken by (ADR 20).
+    if (consulteeUserId) {
+      const consulteeAppointments = await prisma.appointment.findMany({
+        where: {
+          AND: [
+            { OR: buildOccupiedAppointmentFilter() },
+            {
+              slotsOfAppointment: {
+                some: { user: { some: { id: consulteeUserId } } },
+              },
+            },
+            slotsInWindow,
+          ],
+        },
+        include: { slotsOfAppointment: true, ...LIVE_OCCUPANCY_SELECT },
+      });
+
+      const seen = new Set(rawSlotsOfAppointment.map((s) => s.id));
+      for (const appt of consulteeAppointments) {
+        if (!isOccupiedByLiveAppointment(appt, occupancyNow)) continue;
+        for (const slot of appt.slotsOfAppointment) {
+          if (!seen.has(slot.id)) {
+            seen.add(slot.id);
+            rawSlotsOfAppointment.push(slot);
+          }
+        }
+      }
     }
 
     // Extract appointment slots using flatMap with defensive filtering

--- a/app/explore/programs/plans/webinars/[webinarPlanId]/page.tsx
+++ b/app/explore/programs/plans/webinars/[webinarPlanId]/page.tsx
@@ -18,6 +18,13 @@ export default async function WebinarDetailsPage({
     notFound();
   }
 
+  // #726 — a detail page is reachable by id, so it needs the same
+  // gate the list surfaces get: ORG_ONLY stays inside the owning org, and an
+  // archived plan is not a live page.
+  if (!(await canViewPlanDetail(webinarData))) {
+    notFound();
+  }
+
   const firstWebinarInstance = webinarData.webinars?.[0];
   const nextSession =
     firstWebinarInstance?.appointment?.slotsOfAppointment?.[0]?.startsAt;

--- a/components/dashboard/shared/requests/RequestSlotAllocationTab.tsx
+++ b/components/dashboard/shared/requests/RequestSlotAllocationTab.tsx
@@ -76,6 +76,9 @@ interface Request {
   // Reschedule info
   tentativeSlotCount?: number;
   totalSlotCount?: number;
+  /** Slots released by a reschedule. Their startsAt is still the ORIGINAL time,
+   * so "Use Requested Times" would re-confirm what the consultee asked to move. */
+  rescheduledSlotCount?: number;
 }
 
 // interface SlotInterval { ... } // Removed - Now imported
@@ -212,6 +215,9 @@ export function RequestSlotAllocationTab({
           ...consultationsResult.data.map((consultation) => {
             const slots = consultation.appointment?.slotsOfAppointment || [];
             const tentativeCount = slots.filter((s) => s.isTentative).length;
+            const rescheduledCount = slots.filter(
+              (s) => s.completionStatus === "RESCHEDULED",
+            ).length;
             const totalCount = slots.length;
 
             return {
@@ -233,6 +239,7 @@ export function RequestSlotAllocationTab({
                 consultation.consultationPlan?.durationInHours || 1,
               bookingSource: consultation.bookingSource,
               tentativeSlotCount: tentativeCount,
+              rescheduledSlotCount: rescheduledCount,
               totalSlotCount: totalCount,
             };
           }),
@@ -257,6 +264,9 @@ export function RequestSlotAllocationTab({
                 (appt) => appt.slotsOfAppointment || [],
               ) || [];
             const tentativeCount = allSlots.filter((s) => s.isTentative).length;
+            const rescheduledCount = allSlots.filter(
+              (s) => s.completionStatus === "RESCHEDULED",
+            ).length;
             const totalCount = allSlots.length;
 
             return {
@@ -330,6 +340,7 @@ export function RequestSlotAllocationTab({
               schedulingTimezone: subscription.schedulingTimezone,
               bookingSource: subscription.bookingSource,
               tentativeSlotCount: tentativeCount,
+              rescheduledSlotCount: rescheduledCount,
               totalSlotCount: totalCount,
             };
           }),
@@ -743,10 +754,14 @@ export function RequestSlotAllocationTab({
               </p>
             ) : (
               <>
-                {/* Hide "Use Requested Times" for directly booked consultations (Bug #8 fix) */}
+                {/* Hidden for directly booked consultations (Bug #8 fix), and
+                    for anything awaiting reschedule: those slots still carry
+                    the ORIGINAL startsAt, so "using" them would re-confirm the
+                    times the consultee just asked to move. */}
                 {request.requestedTimes &&
                   request.requestedTimes.length > 0 &&
-                  request.bookingSource === "REQUEST_SUBMITTED" && (
+                  request.bookingSource === "REQUEST_SUBMITTED" &&
+                  (request.rescheduledSlotCount ?? 0) === 0 && (
                     <Button
                       variant="secondary"
                       size="sm"
@@ -877,6 +892,7 @@ export function RequestSlotAllocationTab({
                     | "subscription"
                 }
                 eventId={selectedRequest.id}
+                consulteeUserId={selectedRequest.requestedBy?.user?.id}
                 mode="allocate"
                 onAllocationComplete={handleAllocationComplete}
                 onAllocationConflict={() => handleConflict(selectedRequest.id)}

--- a/components/dashboard/shared/requests/types.ts
+++ b/components/dashboard/shared/requests/types.ts
@@ -1,4 +1,4 @@
-import { AppointmentStatus } from "@prisma/client";
+import { AppointmentStatus, SlotCompletionStatus } from "@prisma/client";
 
 // --- API Response Type Definitions ---
 interface UserInfo {
@@ -30,6 +30,8 @@ interface AppointmentSlot {
   startsAt: string;
   endsAt: string;
   isTentative?: boolean; // Indicates if slot needs rescheduling
+  /** RESCHEDULED means startsAt is the time being moved AWAY from, not a request. */
+  completionStatus?: SlotCompletionStatus;
 }
 
 interface AppointmentInfo {

--- a/components/scheduling/UnifiedCalendar.tsx
+++ b/components/scheduling/UnifiedCalendar.tsx
@@ -321,6 +321,10 @@ export interface UnifiedCalendarProps {
   durationInHours?: number; // For consultations/webinars
   sessionsPerWeek?: number;
   sessionDurationInHours?: number; // For subscriptions/classes - individual session duration
+  /** The consultee this event belongs to. Passed to the availability fetch so
+   * the grid hides times where THEY are already booked with another
+   * consultant — allocation rejects those, so showing them green is a lie. */
+  consulteeUserId?: string;
   mode: "view" | "select" | "allocate";
   onSlotsSelected?: (slots: TimeSlot[]) => void;
   onAllocationComplete?: (result: AllocationResponse) => void;
@@ -352,6 +356,7 @@ export function UnifiedCalendar({
   eventId,
   durationInMonths,
   sessionsPerWeek,
+  consulteeUserId,
   mode = "view",
   onSlotsSelected,
   onAllocationComplete,
@@ -402,6 +407,7 @@ export function UnifiedCalendar({
     allowedStart,
     allowedEnd,
     sessionDurationInHours,
+    consulteeUserId,
   });
 
   // Wrap onAllocationComplete to refetch data before calling parent callback

--- a/docs/booking/07-rescheduling-flow.md
+++ b/docs/booking/07-rescheduling-flow.md
@@ -237,20 +237,30 @@ The consultant has two buttons for handling any pending request:
 
 | Button                  | Action                                              | When to use                                       |
 | ----------------------- | --------------------------------------------------- | ------------------------------------------------- |
-| **Use Requested Times** | Accept the times the consultee proposed             | Consultee submitted preferred times and they work |
-| **Allocate Slots**      | Run the auto-allocation algorithm to find new times | Need the system to find optimal times             |
+| **Use Requested Times** | Accept the times the consultee proposed on a FIRST request | Consultee submitted preferred times and they work |
+| **Allocate Slots**      | Run the auto-allocation algorithm to find new times | Need the system to find optimal times, and the only option after a reschedule |
 
 #### Option A: "Use Requested Times" (useRequestedSlots)
 
-This path is used when the consultee has already proposed specific times. The flow:
+This path is used when the consultee has already proposed specific times on
+their original request. It is **not** available once a reschedule has been
+requested. A reschedule releases slots by flipping `isTentative` and
+`completionStatus` on the existing rows; it never writes a new `startsAt`.
+Those rows therefore still hold the very times the consultee is trying to move
+away from, and `fetchEventData` derives `requestedSlots` from them, so reusing
+them would silently re-confirm the original booking. The service rejects that
+case and the button is hidden whenever any slot is `RESCHEDULED`.
+
+The flow:
 
 1. Fetch the event data including all requested slots.
 2. Verify appointments actually exist (prevents approving empty requests).
-3. Verify the slot count matches (requested slots = appointment slots).
-4. Run validation on the requested slots (availability, conflicts, etc.).
-5. Update the event status to `APPROVED`.
-6. Clear all `isTentative` flags (`isTentative: false` on all slots).
-7. Return success with the existing appointments.
+3. Reject if any slot is `RESCHEDULED` — the stored times are stale by definition.
+4. Verify the slot count matches (requested slots = appointment slots).
+5. Run validation on the requested slots (availability, conflicts, etc.).
+6. Update the event status to `APPROVED`.
+7. Clear all `isTentative` flags (`isTentative: false` on all slots).
+8. Return success with the existing appointments.
 
 #### Option B: "Allocate Slots" (autoAllocate)
 

--- a/docs/booking/07-rescheduling-flow.md
+++ b/docs/booking/07-rescheduling-flow.md
@@ -253,14 +253,25 @@ case and the button is hidden whenever any slot is `RESCHEDULED`.
 
 The flow:
 
-1. Fetch the event data including all requested slots.
-2. Verify appointments actually exist (prevents approving empty requests).
-3. Reject if any slot is `RESCHEDULED` — the stored times are stale by definition.
-4. Verify the slot count matches (requested slots = appointment slots).
-5. Run validation on the requested slots (availability, conflicts, etc.).
-6. Update the event status to `APPROVED`.
-7. Clear all `isTentative` flags (`isTentative: false` on all slots).
-8. Return success with the existing appointments.
+1. Take the consultant allocation lock, then the consultee booking lock, in that
+   order. This path used to hold no lock at all, which let an approval run
+   alongside an auto or manual allocation of the same event. The consultee lock
+   matters separately: the overlap exclusion constraint is keyed by consultant,
+   so it cannot see the same person being booked with two different consultants
+   at once.
+2. Inside the transaction, apply the initial-allocation guard under an advisory
+   lock. It is always armed here, because approving stored times is only ever
+   valid for an event that has not been allocated yet. A retry carrying the same
+   idempotency key replays the winner's batch; a different key gets a 409.
+3. Fetch the event data including all requested slots.
+4. Verify appointments actually exist (prevents approving empty requests).
+5. Reject if any slot is `RESCHEDULED` — the stored times are stale by definition.
+6. Verify the slot count matches (requested slots = appointment slots).
+7. Run validation on the requested slots (availability, conflicts, etc.).
+8. Update the event status to `APPROVED`.
+9. Clear all `isTentative` flags (`isTentative: false` on all slots).
+10. Stamp the idempotency key on the first appointment.
+11. Return success with the existing appointments.
 
 #### Option B: "Allocate Slots" (autoAllocate)
 

--- a/hooks/scheduling/useCalendarData.ts
+++ b/hooks/scheduling/useCalendarData.ts
@@ -43,6 +43,10 @@ export interface UseCalendarDataOptions {
    * fetch so the server can bucket `weeklyConfirmedCallCounts` the same way
    * the interactive weekly-limit guard needs it. Ignored for other event types. */
   sessionDurationInHours?: number;
+  /** The user whose calendar is being booked. Allocation counts their bookings
+   * with ANY consultant as occupied, so passing it keeps the grid from showing
+   * cells that allocation will reject. */
+  consulteeUserId?: string;
 }
 
 export interface TimeSlot {
@@ -207,6 +211,7 @@ export function useCalendarData(
     mode,
     allowedEnd,
     sessionDurationInHours,
+    consulteeUserId,
   } = options;
   const { toast } = useToast();
 
@@ -296,6 +301,7 @@ export function useCalendarData(
         endDate,
         undefined,
         true,
+        consulteeUserId,
       );
 
       // Defensive: Validate data structure before using
@@ -345,7 +351,7 @@ export function useCalendarData(
         description: errorMessage,
       });
     }
-  }, [consultantId, toast, view, currentDate, mode, allowedEnd]);
+  }, [consultantId, toast, view, currentDate, mode, allowedEnd, consulteeUserId]);
 
   const fetchEventSlots = useCallback(async (): Promise<void> => {
     // Fetch event slots for ALL event types (subscription, consultation, webinar, class)

--- a/lib/booking/list-selects.ts
+++ b/lib/booking/list-selects.ts
@@ -34,6 +34,10 @@ export const APPOINTMENT_LIST_SELECT = {
         startsAt: true,
         endsAt: true,
         isTentative: true,
+        // A RESCHEDULED slot still carries its ORIGINAL startsAt, so the
+        // requests table must be able to tell those rows apart from a fresh
+        // request's tentative ones before offering "Use Requested Times".
+        completionStatus: true,
       },
       orderBy: { startsAt: "asc" },
     },

--- a/lib/scheduling/allocationService.ts
+++ b/lib/scheduling/allocationService.ts
@@ -429,6 +429,13 @@ export class AllocationService {
      * unchanged.
      */
     includeAppointmentDetails?: boolean,
+    /**
+     * Whose calendar is being booked. The allocator counts this user's bookings
+     * with ANY consultant as occupied, so without it the grid paints cells green
+     * that allocation then rejects. The route re-checks that the caller may read
+     * this user's calendar.
+     */
+    consulteeUserId?: string,
   ) {
     if (!consultantId) {
       throw new Error("Consultant ID is required");
@@ -453,6 +460,9 @@ export class AllocationService {
       });
       if (includeAppointmentDetails) {
         params.set("includeAppointmentDetails", "true");
+      }
+      if (consulteeUserId) {
+        params.set("consulteeUserId", consulteeUserId);
       }
       const response = await fetch(
         `/api/slots/availability-with-allocation/${consultantId}?${params}`,

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -1186,7 +1186,23 @@ export class SlotAllocationService {
       );
     }
 
+    // #898 follow-up — serialize on the consultee too. The GiST overlap guard
+    // is consultant-keyed, so it cannot see a cross-consultant double-booking,
+    // and this path confirms the consultee's slots. Without it an approval here
+    // and an auto/manual allocation for the same consultee under a DIFFERENT
+    // consultant both pass their conflict validation under Read Committed and
+    // both commit. Lock order matches the other two paths: consultant → consultee.
+    let consulteeLock: ApprovalLock | null = null;
+
     try {
+      const consulteeLockUserId = await this.getConsulteeUserId(
+        eventType,
+        eventId,
+      );
+      if (consulteeLockUserId) {
+        consulteeLock = await lockConsulteeBooking(consulteeLockUserId);
+      }
+
       return await prisma.$transaction(
         async (tx) => {
           // Multi-tab guard: another tab already confirmed slots for this
@@ -1342,10 +1358,14 @@ export class SlotAllocationService {
           };
         },
         {
-          timeout: 120000, // 120 seconds (2 min) - handles large allocations (200+ slots)
+          // Shared with the auto/manual paths rather than a local literal, so
+          // all three allocation transactions age out the same way.
+          maxWait: ALLOCATION_TX_MAX_WAIT_MS,
+          timeout: ALLOCATION_TX_TIMEOUT_MS,
         },
       );
     } finally {
+      if (consulteeLock) await unlockConsulteeBooking(consulteeLock);
       await unlockAutoAllocate(lock);
     }
   }
@@ -1475,10 +1495,17 @@ export class SlotAllocationService {
       rowStart,
       consultant,
     )) {
+      // The whole session must fit, not just its first slot: the validator
+      // rejects any slot whose end passes endDate, so testing the start alone
+      // would emit a block the validator then throws out.
+      const candidateEnd = new Date(
+        candidateStart.getTime() + slotsPerCall * SLOT_DURATION_MS,
+      );
+
       if (
         candidateStart < now ||
         candidateStart < startDate ||
-        candidateStart > endDate ||
+        candidateEnd > endDate ||
         SlotCalculationService.dayKey(candidateStart, schedulingTimezone) !==
           rowDayKey
       ) {
@@ -1731,6 +1758,11 @@ export class SlotAllocationService {
     // other event types), and exclude the tentative ones being replaced.
     const excludeSet = new Set(excludeAppointmentIds);
     const existingSessionsPerWeek = new Map<string, number>();
+    // Days already spoken for by surviving sessions. Seeded for the same reason
+    // as the week map: validatePerDaySessionCap counts existing appointments, so
+    // a partial reschedule that only looked at this run's placements could put a
+    // replacement on a day that already has one and be rejected downstream.
+    const seededDayKeys = new Set<string>();
     for (const apt of eventOwnAppointments) {
       if (excludeSet.has(apt.id)) continue; // skip tentative (being replaced)
       if (apt.slotsOfAppointment.length === 0) continue;
@@ -1746,6 +1778,12 @@ export class SlotAllocationService {
         weekKey,
         (existingSessionsPerWeek.get(weekKey) || 0) + 1,
       );
+      seededDayKeys.add(
+        SlotCalculationService.dayKey(
+          new Date(firstSlot.startsAt),
+          config.schedulingTimezone,
+        ),
+      );
     }
 
     // The cursor advances in UTC days because matchWeeklySlotToDay resolves the
@@ -1758,7 +1796,7 @@ export class SlotAllocationService {
     // Caps are counted in the event's scheduling timezone (ADR B9), keyed off
     // the placed slot rather than the cursor, so the two bucketings cannot drift.
     const sessionsPlacedPerWeek = new Map(existingSessionsPerWeek);
-    const usedDayKeys = new Set<string>();
+    const usedDayKeys = new Set(seededDayKeys);
 
     const cursor = new Date(
       Date.UTC(

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -17,9 +17,10 @@ import {
   Prisma,
   AppointmentStatus,
   ScheduleType,
+  SlotCompletionStatus,
   SlotOfAppointment,
 } from "@prisma/client";
-import { addWeeks, addMonths } from "date-fns";
+import { addMonths } from "date-fns";
 import {
   AllocationErrorCode,
   AllocationRequest,
@@ -34,7 +35,10 @@ import {
   SlotValidationService,
   isOccupiedByLiveAppointment,
 } from "./SlotValidationService";
-import { buildOccupiedAppointmentFilter } from "./occupancyPolicy";
+import {
+  buildConsultantOccupancyWhere,
+  buildOccupiedAppointmentFilter,
+} from "./occupancyPolicy";
 import {
   lockAutoAllocate,
   unlockAutoAllocate,
@@ -70,6 +74,18 @@ import { resolveCancellationPolicySnapshot } from "@/lib/payments/operations/can
 type AppointmentWithSlots = Appointment & {
   slotsOfAppointment: SlotOfAppointment[];
 };
+
+const SLOT_DURATION_MS = 30 * 60 * 1000;
+
+/**
+ * Ceiling on the 30-minute starts walked from one availability row.
+ *
+ * The walk stops at the first candidate outside availability, but adjacent rows
+ * make `isWithinAvailability` keep answering true past this row's own end, so a
+ * consultant with contiguous cover would otherwise walk the whole week. 48 steps
+ * is a day of cover, which bounds the scan without truncating any real row.
+ */
+const MAX_CANDIDATE_STARTS_PER_ROW = 48;
 
 /**
  * Main service for slot allocation operations
@@ -249,14 +265,18 @@ export class SlotAllocationService {
       case "consultation": {
         const event = await prisma.consultation.findUnique({
           where: { id: eventId },
-          select: { requestedBy: { select: { user: { select: { id: true } } } } },
+          select: {
+            requestedBy: { select: { user: { select: { id: true } } } },
+          },
         });
         return event?.requestedBy?.user?.id ?? null;
       }
       case "subscription": {
         const event = await prisma.subscription.findUnique({
           where: { id: eventId },
-          select: { requestedBy: { select: { user: { select: { id: true } } } } },
+          select: {
+            requestedBy: { select: { user: { select: { id: true } } } },
+          },
         });
         return event?.requestedBy?.user?.id ?? null;
       }
@@ -483,6 +503,17 @@ export class SlotAllocationService {
       );
       const isReschedule = tentativeSlotCount > 0;
 
+      // ADR B10, derived rather than trusted. The client set initialAllocation
+      // only when tentativeSlotCount === 0, but EVERY pending request already
+      // carries tentative slots (request-for-approval and unpaid checkout both
+      // create them that way), so the flag was never true for a consultation
+      // and the multi-tab guard never ran. Having no CONFIRMED slot is the real
+      // "not allocated yet" condition. This matters most across modes: auto
+      // takes a consultant-wide lock and manual a day-sharded one (#860), so
+      // two tabs are only serialized by the in-txn advisory lock this gates.
+      const isFreshAllocation =
+        initialAllocation === true || existingNonTentativeSlotCount === 0;
+
       // Detect in-progress reallocation: past confirmed slots exist for recurring events
       const now = new Date();
       const pastConfirmedSlotCount = isReschedule
@@ -522,7 +553,8 @@ export class SlotAllocationService {
         // For in-progress: only block if future slots alone meet the future requirement
         if (
           isInProgressReallocation &&
-          futureNonTentativeSlotCount >= requiredForGuard - pastConfirmedSlotCount
+          futureNonTentativeSlotCount >=
+            requiredForGuard - pastConfirmedSlotCount
         ) {
           throw new AllocationConflictError(
             `Event's future slots are already fully allocated (${futureNonTentativeSlotCount} future slot(s), ${pastConfirmedSlotCount} past).`,
@@ -590,6 +622,7 @@ export class SlotAllocationService {
         appointmentIdsToExclude,
         existingAppointments,
         consulteeUserId, // #898 — pick slots free for the consultee too
+        consultantProfileId,
       );
 
       // Validate (read-only; runs out-of-txn under the locks)
@@ -638,7 +671,7 @@ export class SlotAllocationService {
           // In-txn re-check of the multi-tab guard, serialized per event via
           // an advisory xact lock; a same-key double submit replays instead
           // of 409ing (see guardInitialAllocationInTx).
-          if (initialAllocation) {
+          if (isFreshAllocation) {
             const lockedReplay =
               await SlotAllocationService.guardInitialAllocationInTx(
                 tx,
@@ -883,6 +916,25 @@ export class SlotAllocationService {
       );
       const isReschedule = tentativeSlotCount > 0;
 
+      const existingNonTentativeSlotCount = existingAppointments.reduce(
+        (count, appointment) =>
+          count +
+          appointment.slotsOfAppointment.filter((slot) => !slot.isTentative)
+            .length,
+        0,
+      );
+
+      // ADR B10, derived rather than trusted. The client set initialAllocation
+      // only when tentativeSlotCount === 0, but EVERY pending request already
+      // carries tentative slots (request-for-approval and unpaid checkout both
+      // create them that way), so the flag was never true for a consultation
+      // and the multi-tab guard never ran. Having no CONFIRMED slot is the real
+      // "not allocated yet" condition. This matters most across modes: auto
+      // takes a consultant-wide lock and manual a day-sharded one (#860), so
+      // two tabs are only serialized by the in-txn advisory lock this gates.
+      const isFreshAllocation =
+        initialAllocation === true || existingNonTentativeSlotCount === 0;
+
       // Detect in-progress reallocation: past confirmed slots exist for recurring events
       const now = new Date();
       const pastConfirmedSlotCount = isReschedule
@@ -1000,7 +1052,7 @@ export class SlotAllocationService {
           // In-txn re-check of the multi-tab guard, serialized per event via
           // an advisory xact lock; a same-key double submit replays instead
           // of 409ing (see guardInitialAllocationInTx).
-          if (initialAllocation) {
+          if (isFreshAllocation) {
             const lockedReplay =
               await SlotAllocationService.guardInitialAllocationInTx(
                 tx,
@@ -1052,7 +1104,13 @@ export class SlotAllocationService {
           }
 
           // Update event status
-          await this.updateEventStatus(tx, eventType, eventId, slots[0], config);
+          await this.updateEventStatus(
+            tx,
+            eventType,
+            eventId,
+            slots[0],
+            config,
+          );
 
           return {
             success: true,
@@ -1095,7 +1153,9 @@ export class SlotAllocationService {
   private static async useRequestedSlots(
     eventType: EventType,
     eventId: string,
-    initialAllocation?: boolean,
+    // The caller's initialAllocation hint is ignored: the guard is always armed
+    // here, because approving stored times is only valid for an unallocated event.
+    _initialAllocation: boolean | undefined,
     idempotencyKey?: string,
   ): Promise<AllocationResult> {
     // #837 — a retry whose first response was lost must replay the approved
@@ -1107,141 +1167,187 @@ export class SlotAllocationService {
     );
     if (replay) return replay;
 
-    return await prisma.$transaction(
-      async (tx) => {
-        // Multi-tab guard: another tab already confirmed slots for this
-        // event → typed 409 instead of re-approving over it. Advisory-locked
-        // in-txn so it can't race the manual/auto write transactions; a
-        // same-key retry that lost the pre-txn race replays the winner.
-        if (initialAllocation) {
-          const lockedReplay =
-            await SlotAllocationService.guardInitialAllocationInTx(
-              tx,
-              eventType,
-              eventId,
-              idempotencyKey,
+    // This path used to enter the transaction with no Redis lock at all, so an
+    // approval could run concurrently with an auto/manual allocation of the same
+    // event and rely entirely on the GiST exclusion constraint to notice.
+    const consultantProfileId = await this.getConsultantProfileId(
+      eventType,
+      eventId,
+    );
+    if (!consultantProfileId) {
+      // Same shape the auto/manual paths report, so a missing event reads the
+      // same however it was reached.
+      throw new AllocationNotFoundError(`${eventType} not found`);
+    }
+    const lock = await lockAutoAllocate(consultantProfileId);
+    if (!lock) {
+      throw new AllocationConflictError(
+        "Another allocation is in progress for this consultant. Please try again.",
+      );
+    }
+
+    try {
+      return await prisma.$transaction(
+        async (tx) => {
+          // Multi-tab guard: another tab already confirmed slots for this
+          // event → typed 409 instead of re-approving over it. Advisory-locked
+          // in-txn so it can't race the manual/auto write transactions; a
+          // same-key retry that lost the pre-txn race replays the winner.
+          // Always armed here: approving stored times is only ever valid for an
+          // event that has not been allocated yet.
+          {
+            const lockedReplay =
+              await SlotAllocationService.guardInitialAllocationInTx(
+                tx,
+                eventType,
+                eventId,
+                idempotencyKey,
+              );
+            if (lockedReplay) return lockedReplay;
+          }
+
+          // Fetch event with requested slots
+          const eventData = await this.fetchEventData(tx, eventType, eventId);
+          if (!eventData) {
+            throw new AllocationNotFoundError(`${eventType} not found`);
+          }
+
+          const { consultant, config, requestedSlots, consulteeUserId } =
+            eventData;
+
+          if (!requestedSlots || requestedSlots.length === 0) {
+            throw new AllocationValidationError("No requested slots found");
+          }
+
+          // CRITICAL FIX: Verify appointments actually exist before approving
+          // This prevents approving requests with no actual bookings
+          const relationField = this.getEventRelationField(eventType);
+          const existingAppointments: AppointmentWithSlots[] =
+            await tx.appointment.findMany({
+              where: {
+                [`${relationField}Id`]: eventId,
+              } as Prisma.AppointmentWhereInput,
+              include: { slotsOfAppointment: true },
+            });
+
+          if (existingAppointments.length === 0) {
+            throw new AllocationValidationError(
+              "Cannot approve requested slots: No appointments found. " +
+                "The consultee may not have created appointments yet, or they were deleted. " +
+                "Please ask the consultee to resubmit their request.",
             );
-          if (lockedReplay) return lockedReplay;
-        }
+          }
 
-        // Fetch event with requested slots
-        const eventData = await this.fetchEventData(tx, eventType, eventId);
-        if (!eventData) {
-          throw new AllocationNotFoundError(`${eventType} not found`);
-        }
+          // A rescheduled slot's startsAt is still the ORIGINAL time — the
+          // reschedule route only flips isTentative/completionStatus, it never
+          // writes a new one. fetchEventData derives requestedSlots from those
+          // same rows, so "use the requested times" here would silently re-confirm
+          // exactly the times the consultee asked to move. Refuse; the consultant
+          // must allocate (auto or manual) instead.
+          const rescheduledSlots = existingAppointments.flatMap((appointment) =>
+            appointment.slotsOfAppointment.filter(
+              (slot) =>
+                slot.completionStatus === SlotCompletionStatus.RESCHEDULED,
+            ),
+          );
 
-        const { consultant, config, requestedSlots, consulteeUserId } =
-          eventData;
+          if (rescheduledSlots.length > 0) {
+            throw new AllocationValidationError(
+              `Cannot reuse requested times: ${rescheduledSlots.length} slot(s) are awaiting reschedule, ` +
+                `so the stored times are the ones being moved away from. ` +
+                `Allocate new times instead.`,
+            );
+          }
 
-        if (!requestedSlots || requestedSlots.length === 0) {
-          throw new AllocationValidationError("No requested slots found");
-        }
+          // Verify appointment slots match requested slots
+          const existingSlotCount = existingAppointments.reduce(
+            (sum, appointment) => sum + appointment.slotsOfAppointment.length,
+            0,
+          );
 
-        // CRITICAL FIX: Verify appointments actually exist before approving
-        // This prevents approving requests with no actual bookings
-        const relationField = this.getEventRelationField(eventType);
-        const existingAppointments: AppointmentWithSlots[] =
-          await tx.appointment.findMany({
+          if (existingSlotCount !== requestedSlots.length) {
+            throw new AllocationValidationError(
+              `Appointment mismatch: Found ${existingSlotCount} slots in appointments ` +
+                `but ${requestedSlots.length} requested slots. ` +
+                `The appointments may have been modified. Please review and try again.`,
+            );
+          }
+
+          // Validate requested slots still meet all requirements.
+          // Pass existing appointment IDs so the event's own tentative slots
+          // are not flagged as conflicts during self-validation.
+          const validator = new SlotValidationService(tx);
+          const existingAppointmentIds = existingAppointments.map((a) => a.id);
+          const validation = await validator.validate(
+            eventType,
+            eventId,
+            requestedSlots,
+            consultant,
+            config,
+            existingAppointmentIds,
+            consulteeUserId, // #676 AE-1 — also check the consultee's calendar
+          );
+
+          if (!validation.isValid) {
+            throw new AllocationValidationError(
+              `Validation failed: ${validation.errors.join("; ")}`,
+            );
+          }
+
+          // Update event status to approved (appointments already exist and verified)
+          await this.updateEventStatus(
+            tx,
+            eventType,
+            eventId,
+            requestedSlots[0],
+            config,
+          );
+
+          // CRITICAL FIX: Clear isTentative flag on all slots after approval
+          // This ensures slots are no longer marked as pending reschedule
+          const appointmentIds = existingAppointments.map(
+            (appointment) => appointment.id,
+          );
+          await tx.slotOfAppointment.updateMany({
             where: {
-              [`${relationField}Id`]: eventId,
-            } as Prisma.AppointmentWhereInput,
-            include: { slotsOfAppointment: true },
+              appointmentId: { in: appointmentIds },
+            },
+            data: { isTentative: false },
           });
 
-        if (existingAppointments.length === 0) {
-          throw new AllocationValidationError(
-            "Cannot approve requested slots: No appointments found. " +
-              "The consultee may not have created appointments yet, or they were deleted. " +
-              "Please ask the consultee to resubmit their request.",
-          );
-        }
-
-        // Verify appointment slots match requested slots
-        const existingSlotCount = existingAppointments.reduce(
-          (sum, appointment) => sum + appointment.slotsOfAppointment.length,
-          0,
-        );
-
-        if (existingSlotCount !== requestedSlots.length) {
-          throw new AllocationValidationError(
-            `Appointment mismatch: Found ${existingSlotCount} slots in appointments ` +
-              `but ${requestedSlots.length} requested slots. ` +
-              `The appointments may have been modified. Please review and try again.`,
-          );
-        }
-
-        // Validate requested slots still meet all requirements.
-        // Pass existing appointment IDs so the event's own tentative slots
-        // are not flagged as conflicts during self-validation.
-        const validator = new SlotValidationService(tx);
-        const existingAppointmentIds = existingAppointments.map((a) => a.id);
-        const validation = await validator.validate(
-          eventType,
-          eventId,
-          requestedSlots,
-          consultant,
-          config,
-          existingAppointmentIds,
-          consulteeUserId, // #676 AE-1 — also check the consultee's calendar
-        );
-
-        if (!validation.isValid) {
-          throw new AllocationValidationError(
-            `Validation failed: ${validation.errors.join("; ")}`,
-          );
-        }
-
-        // Update event status to approved (appointments already exist and verified)
-        await this.updateEventStatus(
-          tx,
-          eventType,
-          eventId,
-          requestedSlots[0],
-          config,
-        );
-
-        // CRITICAL FIX: Clear isTentative flag on all slots after approval
-        // This ensures slots are no longer marked as pending reschedule
-        const appointmentIds = existingAppointments.map(
-          (appointment) => appointment.id,
-        );
-        await tx.slotOfAppointment.updateMany({
-          where: {
-            appointmentId: { in: appointmentIds },
-          },
-          data: { isTentative: false },
-        });
-
-        // #837 — stamp the batch's key on the FIRST appointment so a retry
-        // replays this approval instead of re-running it (mirrors
-        // createAppointments). The @unique index turns a concurrent
-        // duplicate submit into a typed 409.
-        if (idempotencyKey) {
-          try {
-            await tx.appointment.update({
-              where: { id: appointmentIds[0] },
-              data: { allocationIdempotencyKey: idempotencyKey },
-            });
-          } catch (err) {
-            if (isUniqueViolation(err)) {
-              throw new AllocationConflictError(
-                "This allocation was already submitted; the original result applies.",
-              );
+          // #837 — stamp the batch's key on the FIRST appointment so a retry
+          // replays this approval instead of re-running it (mirrors
+          // createAppointments). The @unique index turns a concurrent
+          // duplicate submit into a typed 409.
+          if (idempotencyKey) {
+            try {
+              await tx.appointment.update({
+                where: { id: appointmentIds[0] },
+                data: { allocationIdempotencyKey: idempotencyKey },
+              });
+            } catch (err) {
+              if (isUniqueViolation(err)) {
+                throw new AllocationConflictError(
+                  "This allocation was already submitted; the original result applies.",
+                );
+              }
+              throw err;
             }
-            throw err;
           }
-        }
 
-        return {
-          success: true,
-          appointments: existingAppointments,
-          warnings: validation.warnings,
-        };
-      },
-      {
-        timeout: 120000, // 120 seconds (2 min) - handles large allocations (200+ slots)
-      },
-    );
+          return {
+            success: true,
+            appointments: existingAppointments,
+            warnings: validation.warnings,
+          };
+        },
+        {
+          timeout: 120000, // 120 seconds (2 min) - handles large allocations (200+ slots)
+        },
+      );
+    } finally {
+      await unlockAutoAllocate(lock);
+    }
   }
 
   /**
@@ -1291,6 +1397,109 @@ export class SlotAllocationService {
   }
 
   /**
+   * Every 30-minute start inside one availability row that could host a call.
+   *
+   * The search used to test only the row's own start instant: a booked 09:00
+   * forfeited the entire 09:00-17:00 window and the loop advanced to the next
+   * row, so auto-allocate yielded at most one placement per row per week even
+   * with seven hours free. Walking the row restores the other fifteen starts.
+   */
+  private static candidateStartsInRow(
+    rowStart: Date,
+    consultant: ConsultantAllocationData,
+  ): Date[] {
+    const starts: Date[] = [];
+
+    for (let step = 0; step < MAX_CANDIDATE_STARTS_PER_ROW; step++) {
+      const candidate = new Date(rowStart.getTime() + step * SLOT_DURATION_MS);
+      if (!this.isWithinAvailability(candidate, consultant)) break;
+      starts.push(candidate);
+    }
+
+    return starts;
+  }
+
+  /**
+   * Build one call's worth of back-to-back slots from `start`, or null if the
+   * run is interrupted by a booking, the edge of availability, or the past.
+   */
+  private static buildConsecutiveBlock(
+    start: Date,
+    slotsPerCall: number,
+    consultant: ConsultantAllocationData,
+    bookedSlots: Set<string>,
+    now: Date,
+  ): Date[] | null {
+    const block: Date[] = [];
+    let currentTime = new Date(start);
+
+    for (let i = 0; i < slotsPerCall; i++) {
+      if (
+        bookedSlots.has(currentTime.toISOString()) ||
+        !this.isWithinAvailability(currentTime, consultant) ||
+        currentTime < now
+      ) {
+        return null;
+      }
+      block.push(new Date(currentTime));
+      currentTime = new Date(currentTime.getTime() + SLOT_DURATION_MS);
+    }
+
+    return block;
+  }
+
+  /**
+   * First placeable call inside one row on a recurring event's day, or null.
+   *
+   * Candidates are held to the row's own scheduling-timezone day so that
+   * walking an overnight row cannot spill a session into the next day and
+   * breach the per-day cap the validator enforces (ADR B9 buckets by the
+   * event's timezone, not the server's).
+   */
+  private static firstFittingBlockInRow(
+    rowStart: Date,
+    slotsPerCall: number,
+    consultant: ConsultantAllocationData,
+    bookedSlots: Set<string>,
+    now: Date,
+    startDate: Date,
+    endDate: Date,
+    schedulingTimezone?: string,
+  ): Date[] | null {
+    const rowDayKey = SlotCalculationService.dayKey(
+      rowStart,
+      schedulingTimezone,
+    );
+
+    for (const candidateStart of this.candidateStartsInRow(
+      rowStart,
+      consultant,
+    )) {
+      if (
+        candidateStart < now ||
+        candidateStart < startDate ||
+        candidateStart > endDate ||
+        SlotCalculationService.dayKey(candidateStart, schedulingTimezone) !==
+          rowDayKey
+      ) {
+        continue;
+      }
+
+      const block = this.buildConsecutiveBlock(
+        candidateStart,
+        slotsPerCall,
+        consultant,
+        bookedSlots,
+        now,
+      );
+
+      if (block) return block;
+    }
+
+    return null;
+  }
+
+  /**
    * Find available consecutive slots for auto-allocation
    */
   private static async findAvailableSlots(
@@ -1309,22 +1518,16 @@ export class SlotAllocationService {
     // mutually-free slots instead of consultant-free ones that then fail the
     // consultee-conflict validation.
     consulteeUserId?: string,
+    // Lets the occupancy predicate include appointments delivered under this
+    // consultant's own plans, matching what the availability grid counts.
+    consultantProfileId?: string,
   ): Promise<Date[]> {
     // Get all existing booked slots for this consultant
     // FIX Bug #15: Use centralized occupancy policy for consistent conflict detection
+    // Shared with the availability grid so the two cannot disagree about who
+    // is busy — see buildConsultantOccupancyWhere.
     const appointmentFilter: Prisma.AppointmentWhereInput[] = [
-      {
-        OR: buildOccupiedAppointmentFilter(),
-      },
-      {
-        slotsOfAppointment: {
-          some: {
-            user: {
-              some: { id: consultant.userId },
-            },
-          },
-        },
-      },
+      buildConsultantOccupancyWhere(consultantProfileId, consultant.userId),
     ];
 
     // Exclude tentative appointments during reschedule — they'll be deleted,
@@ -1460,69 +1663,51 @@ export class SlotAllocationService {
               slot.utcOffsetMinutes,
             );
 
-            const candidateStart = new Date(baseStart);
+            const rowStart = new Date(baseStart);
             if (week > 0) {
-              candidateStart.setUTCDate(candidateStart.getUTCDate() + week * 7);
+              rowStart.setUTCDate(rowStart.getUTCDate() + week * 7);
             }
 
-            if (
-              candidateStart < now ||
-              bookedSlots.has(candidateStart.toISOString())
-            ) {
-              continue;
-            }
+            for (const candidateStart of this.candidateStartsInRow(
+              rowStart,
+              consultant,
+            )) {
+              if (candidateStart < now) continue;
 
-            // Try to build consecutive block
-            const consecutiveBlock: Date[] = [];
-            let currentTime = new Date(candidateStart);
+              const consecutiveBlock = this.buildConsecutiveBlock(
+                candidateStart,
+                slotsPerCall,
+                consultant,
+                bookedSlots,
+                now,
+              );
 
-            for (let i = 0; i < slotsPerCall; i++) {
-              const currentTimeStr = currentTime.toISOString();
-
-              if (
-                bookedSlots.has(currentTimeStr) ||
-                !this.isWithinAvailability(currentTime, consultant) ||
-                currentTime < now
-              ) {
-                break;
+              if (consecutiveBlock) {
+                return consecutiveBlock;
               }
-              consecutiveBlock.push(new Date(currentTime));
-              currentTime = new Date(currentTime.getTime() + 30 * 60 * 1000);
-            }
-
-            if (consecutiveBlock.length === slotsPerCall) {
-              return consecutiveBlock;
             }
           }
         }
       } else {
         // CUSTOM schedule: iterate pre-sorted slots
         for (const slot of sortedCustom) {
-          const slotStart = new Date(slot.startsAt);
+          for (const candidateStart of this.candidateStartsInRow(
+            new Date(slot.startsAt),
+            consultant,
+          )) {
+            if (candidateStart < now) continue;
 
-          if (slotStart < now || bookedSlots.has(slotStart.toISOString())) {
-            continue;
-          }
+            const consecutiveBlock = this.buildConsecutiveBlock(
+              candidateStart,
+              slotsPerCall,
+              consultant,
+              bookedSlots,
+              now,
+            );
 
-          const consecutiveBlock: Date[] = [];
-          let currentTime = new Date(slotStart);
-
-          for (let i = 0; i < slotsPerCall; i++) {
-            const currentTimeStr = currentTime.toISOString();
-
-            if (
-              bookedSlots.has(currentTimeStr) ||
-              !this.isWithinAvailability(currentTime, consultant) ||
-              currentTime < now
-            ) {
-              break;
+            if (consecutiveBlock) {
+              return consecutiveBlock;
             }
-            consecutiveBlock.push(new Date(currentTime));
-            currentTime = new Date(currentTime.getTime() + 30 * 60 * 1000);
-          }
-
-          if (consecutiveBlock.length === slotsPerCall) {
-            return consecutiveBlock;
           }
         }
       }
@@ -1545,7 +1730,7 @@ export class SlotAllocationService {
     // IMPORTANT: Only count THIS event's own appointments (not consultations or
     // other event types), and exclude the tentative ones being replaced.
     const excludeSet = new Set(excludeAppointmentIds);
-    const existingCallsPerWeek = new Map<string, number>();
+    const existingSessionsPerWeek = new Map<string, number>();
     for (const apt of eventOwnAppointments) {
       if (excludeSet.has(apt.id)) continue; // skip tentative (being replaced)
       if (apt.slotsOfAppointment.length === 0) continue;
@@ -1557,120 +1742,106 @@ export class SlotAllocationService {
         new Date(firstSlot.startsAt),
         config.schedulingTimezone,
       );
-      existingCallsPerWeek.set(
+      existingSessionsPerWeek.set(
         weekKey,
-        (existingCallsPerWeek.get(weekKey) || 0) + 1,
+        (existingSessionsPerWeek.get(weekKey) || 0) + 1,
       );
     }
 
-    let currentWeek = SlotCalculationService.startOfWeekSundayInTz(
-      startDate,
-      config.schedulingTimezone,
+    // The cursor advances in UTC days because matchWeeklySlotToDay resolves the
+    // row's UTC day-of-week from targetDay.getUTCDay(). Anchoring the cursor to
+    // a timezone week instead made those two disagree: Sunday 00:00 IST is
+    // Saturday 18:30 UTC, so getUTCDay() answered SATURDAY and every placement
+    // was credited to the week before the one being iterated — the allocator
+    // then emitted output its own validate() rejected with [WEEKLY_LIMIT].
+    //
+    // Caps are counted in the event's scheduling timezone (ADR B9), keyed off
+    // the placed slot rather than the cursor, so the two bucketings cannot drift.
+    const sessionsPlacedPerWeek = new Map(existingSessionsPerWeek);
+    const usedDayKeys = new Set<string>();
+
+    const cursor = new Date(
+      Date.UTC(
+        startDate.getUTCFullYear(),
+        startDate.getUTCMonth(),
+        startDate.getUTCDate(),
+      ),
     );
-    const totalWeeks = SlotCalculationService.countWeeks(startDate, endDate);
 
     for (
-      let week = 0;
-      week < totalWeeks && selectedSlots.length < totalSlotsNeeded;
-      week++
+      ;
+      cursor <= endDate && selectedSlots.length < totalSlotsNeeded;
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
     ) {
-      // Initialize with existing confirmed calls (important during partial reschedule)
-      const weekKey = SlotCalculationService.weekKey(
-        currentWeek,
-        config.schedulingTimezone,
-      );
-      let callsThisWeek = existingCallsPerWeek.get(weekKey) || 0;
+      const currentDay = new Date(cursor);
 
-      for (let day = 0; day < 7 && callsThisWeek < sessionsPerWeek; day++) {
-        const currentDay = new Date(currentWeek);
-        currentDay.setUTCDate(currentDay.getUTCDate() + day);
+      // Place at most one call on this day, honouring the timezone-bucketed
+      // per-day and per-week caps the validator will re-check.
+      const tryPlace = (rowStart: Date): boolean => {
+        const rowDayKey = SlotCalculationService.dayKey(
+          rowStart,
+          config.schedulingTimezone,
+        );
+        const rowWeekKey = SlotCalculationService.weekKey(
+          rowStart,
+          config.schedulingTimezone,
+        );
 
-        // Find first available slot on this day
-        if (consultant.scheduleType === ScheduleType.WEEKLY) {
-          for (const slot of sortedWeekly) {
-            const slotTime = this.matchWeeklySlotToDay(
-              slot.startDay,
-              slot.startTimeUtc,
-              currentDay,
-              slot.utcOffsetMinutes,
-            );
+        if (usedDayKeys.has(rowDayKey)) return false;
+        if ((sessionsPlacedPerWeek.get(rowWeekKey) ?? 0) >= sessionsPerWeek)
+          return false;
 
-            if (
-              !slotTime ||
-              slotTime < now ||
-              slotTime < startDate ||
-              slotTime > endDate
-            ) {
-              continue;
-            }
+        const sessionSlots = this.firstFittingBlockInRow(
+          rowStart,
+          slotsPerCall,
+          consultant,
+          bookedSlots,
+          now,
+          startDate,
+          endDate,
+          config.schedulingTimezone,
+        );
 
-            // Try to build consecutive block for this call
-            const callSlots: Date[] = [];
-            let currentTime = new Date(slotTime);
+        if (!sessionSlots) return false;
 
-            for (let i = 0; i < slotsPerCall; i++) {
-              const currentTimeStr = currentTime.toISOString();
-              if (
-                bookedSlots.has(currentTimeStr) ||
-                !this.isWithinAvailability(currentTime, consultant) ||
-                currentTime < now
-              ) {
-                break;
-              }
-              callSlots.push(new Date(currentTime));
-              currentTime = new Date(currentTime.getTime() + 30 * 60 * 1000);
-            }
+        selectedSlots.push(...sessionSlots);
+        sessionSlots.forEach((s) => bookedSlots.add(s.toISOString()));
 
-            if (callSlots.length === slotsPerCall) {
-              selectedSlots.push(...callSlots);
-              callSlots.forEach((s) => bookedSlots.add(s.toISOString()));
-              callsThisWeek++;
-              break;
-            }
-          }
-        } else {
-          for (const slot of sortedCustom) {
-            const slotTime = this.matchCustomSlotToDay(
-              slot.startsAt,
-              currentDay,
-            );
+        // Re-key on the slot actually placed rather than on the row it came
+        // from, so the counters record where the session really landed.
+        const placedDayKey = SlotCalculationService.dayKey(
+          sessionSlots[0],
+          config.schedulingTimezone,
+        );
+        const placedWeekKey = SlotCalculationService.weekKey(
+          sessionSlots[0],
+          config.schedulingTimezone,
+        );
+        usedDayKeys.add(placedDayKey);
+        sessionsPlacedPerWeek.set(
+          placedWeekKey,
+          (sessionsPlacedPerWeek.get(placedWeekKey) ?? 0) + 1,
+        );
 
-            if (
-              !slotTime ||
-              slotTime < now ||
-              slotTime < startDate ||
-              slotTime > endDate
-            ) {
-              continue;
-            }
+        return true;
+      };
 
-            const callSlots: Date[] = [];
-            let currentTime = new Date(slotTime);
-
-            for (let i = 0; i < slotsPerCall; i++) {
-              const currentTimeStr = currentTime.toISOString();
-              if (
-                bookedSlots.has(currentTimeStr) ||
-                !this.isWithinAvailability(currentTime, consultant) ||
-                currentTime < now
-              ) {
-                break;
-              }
-              callSlots.push(new Date(currentTime));
-              currentTime = new Date(currentTime.getTime() + 30 * 60 * 1000);
-            }
-
-            if (callSlots.length === slotsPerCall) {
-              selectedSlots.push(...callSlots);
-              callSlots.forEach((s) => bookedSlots.add(s.toISOString()));
-              callsThisWeek++;
-              break;
-            }
-          }
+      if (consultant.scheduleType === ScheduleType.WEEKLY) {
+        for (const slot of sortedWeekly) {
+          const rowStart = this.matchWeeklySlotToDay(
+            slot.startDay,
+            slot.startTimeUtc,
+            currentDay,
+            slot.utcOffsetMinutes,
+          );
+          if (rowStart && tryPlace(rowStart)) break;
+        }
+      } else {
+        for (const slot of sortedCustom) {
+          const rowStart = this.matchCustomSlotToDay(slot.startsAt, currentDay);
+          if (rowStart && tryPlace(rowStart)) break;
         }
       }
-
-      currentWeek = addWeeks(currentWeek, 1);
     }
 
     if (selectedSlots.length < totalSlotsNeeded) {
@@ -1887,13 +2058,13 @@ export class SlotAllocationService {
     let appointments: any[];
     try {
       appointments = await Promise.all(
-        calls.map((callSlots, callIndex) => {
+        calls.map((sessionSlots, callIndex) => {
           // #837 — key belongs on the first appointment of the batch only.
           const idempotencyData =
             idempotencyKey && callIndex === 0
               ? { allocationIdempotencyKey: idempotencyKey }
               : {};
-          const slotsToCreate = callSlots.map((slotStart) => {
+          const slotsToCreate = sessionSlots.map((slotStart) => {
             const endTime = new Date(slotStart.getTime() + 30 * 60 * 1000);
             return {
               startsAt: slotStart,
@@ -2087,7 +2258,8 @@ export class SlotAllocationService {
       const trackedLive = existingUtil.appointmentIds.filter((id) =>
         liveIds.has(id),
       );
-      const staleCount = existingUtil.appointmentIds.length - trackedLive.length;
+      const staleCount =
+        existingUtil.appointmentIds.length - trackedLive.length;
       if (staleCount > 0) {
         const alreadyTracked = new Set(trackedLive);
         const incomingNew = newAppointmentIds.filter(

--- a/utils/slotAllocation/occupancyPolicy.ts
+++ b/utils/slotAllocation/occupancyPolicy.ts
@@ -111,3 +111,44 @@ export function buildOccupiedAppointmentFilter(
 
   return filters;
 }
+
+/**
+ * Everything that occupies one consultant's calendar.
+ *
+ * A consultant is busy for an active appointment when EITHER they are connected
+ * to one of its slots (they are attending it, in any role) OR it is delivered
+ * under one of their own plans. Both arms are needed:
+ *
+ *   - Slot participation alone misses group events, whose slot rows connect
+ *     registrants rather than the host.
+ *   - Plan ownership alone misses every appointment where the consultant is
+ *     themselves the consultee — booked with a DIFFERENT consultant, so no plan
+ *     of theirs is involved.
+ *
+ * The availability grid used to ask only the second question while the
+ * allocator asked only the first, so a consultant who was a consultee elsewhere
+ * saw a green cell that every allocation mode then rejected as booked. Both
+ * sides now call this.
+ */
+export function buildConsultantOccupancyWhere(
+  consultantProfileId: string | undefined,
+  consultantUserId: string,
+): Prisma.AppointmentWhereInput {
+  const reachesConsultant: Prisma.AppointmentWhereInput[] = [
+    {
+      slotsOfAppointment: {
+        some: { user: { some: { id: consultantUserId } } },
+      },
+    },
+  ];
+
+  if (consultantProfileId) {
+    reachesConsultant.push({
+      OR: buildOccupiedAppointmentFilter(consultantProfileId),
+    });
+  }
+
+  return {
+    AND: [{ OR: buildOccupiedAppointmentFilter() }, { OR: reachesConsultant }],
+  };
+}


### PR DESCRIPTION
## Why

A verification pass over the slot-allocation subsystem surfaced eight defects, four of
them breaking live bookings. They are carved out of the larger offering-authoring work
so they can ship on their own: every fix here is schema-free, so this merges and deploys
without a `db push`.

The headline finding is that `findAvailableSlots` had **no executing test** — coverage
showed the entire search body unreached — which is how a consultant with seven free
hours could be told "no availability".

## What was broken

### 1. Auto-allocate only ever tried the first 30 minutes of each availability window

`SlotAllocationService.findAvailableSlots` tested exactly one candidate start per
availability row: the row's own `startTimeUtc`. If that instant was taken, the loop
advanced to the *next row* — never to the next 30-minute window inside the current one.
`matchWeeklySlotToDay` had the same shape for recurring events, returning only the row
start.

A consultant publishing **Mon 09:00–17:00** with a recurring 09:00 booking got
`No 2 consecutive slots available for consultation` on every auto-allocate for eight
weeks, with seven hours free every Monday. In effect auto-allocate yielded **at most one
booking per availability row per week**.

Fixed by walking each row in 30-minute steps. Two helpers now replace four hand-rolled
copies of the same search: `candidateStartsInRow` (bounded at 24h of steps, because
adjacent rows keep `isWithinAvailability` true past the current row's end) and
`buildConsecutiveBlock`.

### 2. The recurring day cursor and the limit buckets disagreed by a week

The subscription/class loop seeded its cursor from `startOfWeekSundayInTz` — a
*timezone*-anchored instant — then advanced it with `setUTCDate` and read it back through
`matchWeeklySlotToDay`, which uses `targetDay.getUTCDay()`. Sunday 00:00 IST is Saturday
18:30 UTC, so `getUTCDay()` answered SATURDAY and each placement was credited to the week
*before* the one being iterated. The allocator could therefore emit a schedule its own
`validate()` then rejected with `[WEEKLY_LIMIT]`, and the current week's boundary day was
never reachable.

The cursor now advances in plain UTC days (which is what `matchWeeklySlotToDay`'s
arithmetic actually wants) while per-day and per-week caps are counted in the event's
scheduling timezone (ADR B9), keyed off the **placed slot** rather than the cursor. The
two bucketings can no longer drift apart. `firstFittingBlockInRow` additionally holds
candidates to the row's own timezone day, so walking an overnight row cannot spill a
session into the next day and breach the per-day cap.

### 3. "Use Requested Times" re-confirmed the times being rescheduled

A reschedule releases slots by flipping `isTentative`/`completionStatus`; it never writes
a new `startsAt`. `fetchEventData` derives `requestedSlots` from those same rows. So on a
rescheduled request the button re-confirmed **exactly the times the consultee asked to
move away from** — under a dialog reading "Full Reschedule — All N sessions need new
times", and with a success toast. Silent, and the request left the queue.

`useRequestedSlots` now refuses when any slot is `RESCHEDULED`, and the button is hidden
in that state. `docs/booking/07-rescheduling-flow.md` documented this button as "accept
the times the consultee proposed", which was only ever true on a first request; corrected.

### 4–6. The availability grid and the allocator disagreed about who is busy

Three separate divergences, each of which painted a cell green that allocation then
rejected (or the reverse):

- **The grid never checked the consultee.** The allocator counts the consultee's bookings
  with *any* consultant as occupied; the grid only knew the consultant.
- **Two different occupancy predicates.** The grid asked "is there an active appointment
  under one of this consultant's plans" (plan ownership). The allocator asked "is this
  consultant connected to a slot" (participation). A consultant who was themselves a
  consultee elsewhere saw that time as free on their own calendar.
- **The grid ignored expired payment holds.** `APPROVED_PENDING_PAYMENT` counts as
  occupied, but the grid never loaded `payment.expiresAt` and never called
  `isOccupiedByLiveAppointment` — the helper both the allocator and the validator already
  use. An abandoned checkout blanked out genuinely free time for the whole grace window.

Both sides now build their filter from a single new
`buildConsultantOccupancyWhere(profileId, userId)` — participation **OR** plan ownership,
because each arm alone misses real cases (participation misses group events whose slots
connect registrants rather than the host; ownership misses every booking where the
consultant is the consultee). The grid runs the same live-hold filter, and accepts an
optional `consulteeUserId`.

That parameter is access-gated: the route is otherwise public, so an ungated user id
would be a busy/free oracle. You may ask about yourself; the owning consultant and staff
may ask about a consultee booking with them.

### 7. The ADR B10 multi-tab guard had never once run for consultations

The client set `initialAllocation` only when `tentativeSlotCount === 0` — but *every*
pending request carries tentative slots (both `request-for-approval` and unpaid checkout
create them that way), so the flag was never true and `guardInitialAllocationInTx` never
executed. Combined with auto taking a consultant-wide lock and manual a day-sharded one
(#860), two tabs allocating different days ran concurrently and the later write silently
overwrote the earlier allocation.

Freshness is now derived server-side from "this event has no confirmed slots" rather than
trusted from the client. Separately, `useRequestedSlots` entered its transaction with **no
Redis lock at all** — it now takes the consultant lock like the other two modes, and its
guard is always armed (approving stored times is only ever valid for an unallocated event).

The existing test suite had to gain `$queryRaw` and `slotOfAppointment.count` mocks for
these tests to keep passing — which is itself the evidence that the guard previously never
ran on those paths.

### 8. The webinar detail page never called its own visibility gate

`app/explore/programs/plans/webinars/[webinarPlanId]/page.tsx` imported
`canViewPlanDetail` and never invoked it — the commit that added detail pages contributed
a bare `+import` line for this file and nothing else. `fetchWebinarPlanDetail` filters
only on a soft-deleted owner, so `ORG_ONLY` and archived webinar plans were readable by
anyone holding the id. This is live on `dev`.

## Tests

634 passing (up from 596), cold `tsc` clean.

- `availability-window-scan.test.ts` — 9 tests driving `findAvailableSlots` directly.
  **4 of them fail against the previous implementation.**
- `grid-allocator-parity.test.ts` — pins that both sides build the same occupancy
  predicate and share the live-hold filter. `occupancyPolicy.ts` reaches 100%.
- `slot-booking-status.test.ts` — first direct coverage of `getSlotBookingStatus` and
  `buildAppointmentIndex`, including the merge step and the 0.99 threshold.
  `timeSlotsProcessing.ts` 18% → 31%.
- `plan-detail-pages-gated.test.ts` — drives all four detail pages with a hidden plan.
  **Fails against the un-gated webinar page.**
- One new case in `slotAllocationService.test.ts` for the reschedule-replay refusal.

## Reviewer notes

- **~250 of the changed lines in `SlotAllocationService.ts` are Prettier-only.** The file
  was not Prettier-clean on `dev`. Use `git diff -w` for the real change (336/164).
- Two lint findings in the touched set pre-date this branch and are untouched: the
  `__mocks__` import in `slotAllocationService.test.ts`, and a `no-explicit-any` cluster.
  One genuinely unused import (`THIRTY_MIN_MS`) was removed.
- No schema changes; **no `db push` required**.
- `A2` is the least test-covered fix here. A plain "one session per timezone week"
  assertion passes against the old code too — the drift shifts placements a week earlier
  without breaking distinctness — so only the partial-reschedule case actually catches it.
  The restructure removes the drift by construction.

## Follow-ups deliberately not in scope

Tracked for the offering-authoring PR:

- `override` is sent by the requests tab, absent from `allocationRequestSchema`, and
  silently stripped by Zod — so the "Override and Allocate" button always 400s.
- The `/validate` preflight passes no `consulteeUserId` and a different exclude set than
  `useRequestedSlots`, so the dialog's "no conflicts" verdict is unsound.
- Client per-day/per-week guards ignore existing confirmed sessions; the server seeds them.
- The allocate calendar is drawn viewer-local while caps bucket in the scheduling
  timezone, so "one session per day" fires across what looks like two days.
- ~13 user-visible strings still print `sessionsPerWeek` as "calls"/"meetings" (subscription
  checkout says "Calls per Week"; class checkout says "Sessions per Week").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Availability searches now account for a consultee’s existing bookings across consultants.
  * Scheduling scans availability windows more thoroughly to find suitable slots.
  * Rescheduled slots are clearly tracked and excluded from reuse of original requested times.
  * Requested-slot approvals include stronger validation and safer repeat handling.

* **Bug Fixes**
  * Improved filtering of expired, inactive, and fully occupied appointments.
  * Plan detail pages now correctly hide inaccessible plans.

* **Documentation**
  * Clarified rescheduling rules and requested-time availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->