### PR TITLE
feat(observability): Sentry coverage across the booking engine, money paths and reads

### DIFF
--- a/hooks/scheduling/useCalendarData.ts
+++ b/hooks/scheduling/useCalendarData.ts
@@ -269,10 +269,10 @@ export function useCalendarData(
       setConsultantDetails(data);
     } catch (error) {
       console.error("Error fetching consultant details:", error);
-      reportSentryError(error, {
-        subsystem: "client",
-        tags: { feature: "scheduling-calendar" },
-      });
+      // Not captured here — AllocationService.fetchConsultantData already
+      // reports this exact error (with httpStatus-based expected
+      // classification) before rethrowing; a second capture here would only
+      // add a worse, always-unexpected duplicate.
       const errorMessage =
         error instanceof Error
           ? error.message
@@ -355,10 +355,8 @@ export function useCalendarData(
       setRawAvailabilitySlots(validatedData);
     } catch (error) {
       console.error("Error fetching availability slots:", error);
-      reportSentryError(error, {
-        subsystem: "client",
-        tags: { feature: "scheduling-calendar" },
-      });
+      // Not captured here — AllocationService.fetchAvailabilitySlots already
+      // reports this exact error (see fetchConsultantDetails above).
       const errorMessage =
         error instanceof Error ? error.message : "Failed to fetch availability";
       setError(errorMessage);
@@ -477,11 +475,8 @@ export function useCalendarData(
       console.error("Error fetching event slots:", error);
       // Silent degrade to empty (no toast/setError, unlike the two siblings
       // above) — the calendar just shows no "This Event" slots, which reads
-      // as "nothing booked yet" rather than "the fetch broke".
-      reportSentryError(error, {
-        subsystem: "client",
-        tags: { feature: "scheduling-calendar" },
-      });
+      // as "nothing booked yet" rather than "the fetch broke". Not captured
+      // here either — AllocationService.fetchEventSlots already reports it.
       setEventSlots([]);
       setEventTentativeSlots([]);
       setWeeklyConfirmedCallCounts({});

--- a/hooks/scheduling/useCalendarData.ts
+++ b/hooks/scheduling/useCalendarData.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import {
   startOfWeek,
   endOfWeek,
@@ -269,16 +269,10 @@ export function useCalendarData(
       setConsultantDetails(data);
     } catch (error) {
       console.error("Error fetching consultant details:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            feature: "scheduling-calendar",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        tags: { feature: "scheduling-calendar" },
+      });
       const errorMessage =
         error instanceof Error
           ? error.message
@@ -361,16 +355,10 @@ export function useCalendarData(
       setRawAvailabilitySlots(validatedData);
     } catch (error) {
       console.error("Error fetching availability slots:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            feature: "scheduling-calendar",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        tags: { feature: "scheduling-calendar" },
+      });
       const errorMessage =
         error instanceof Error ? error.message : "Failed to fetch availability";
       setError(errorMessage);
@@ -490,16 +478,10 @@ export function useCalendarData(
       // Silent degrade to empty (no toast/setError, unlike the two siblings
       // above) — the calendar just shows no "This Event" slots, which reads
       // as "nothing booked yet" rather than "the fetch broke".
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            feature: "scheduling-calendar",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        tags: { feature: "scheduling-calendar" },
+      });
       setEventSlots([]);
       setEventTentativeSlots([]);
       setWeeklyConfirmedCallCounts({});
@@ -676,16 +658,10 @@ export function useCalendarData(
       // Believed unreachable: the three awaited fetchers each self-catch and
       // never reject, so Promise.all here shouldn't throw. Capturing anyway
       // (not tagged expected) — if this ever fires, that invariant broke.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            feature: "scheduling-calendar",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        tags: { feature: "scheduling-calendar" },
+      });
       const errorMessage =
         error instanceof Error
           ? error.message
@@ -705,16 +681,10 @@ export function useCalendarData(
         (error) => {
           console.error("Error fetching date-independent data:", error);
           // Believed unreachable — see fetchAllData's identical comment.
-          Sentry.captureException(
-            error instanceof Error ? error : new Error(String(error)),
-            {
-              tags: {
-                subsystem: "client",
-                feature: "scheduling-calendar",
-                expected: "false",
-              },
-            },
-          );
+          reportError(error, {
+            subsystem: "client",
+            tags: { feature: "scheduling-calendar" },
+          });
           setError(
             error instanceof Error
               ? error.message
@@ -741,16 +711,10 @@ export function useCalendarData(
         .catch((error) => {
           console.error("Error fetching date-dependent data:", error);
           // Believed unreachable — see fetchAllData's identical comment.
-          Sentry.captureException(
-            error instanceof Error ? error : new Error(String(error)),
-            {
-              tags: {
-                subsystem: "client",
-                feature: "scheduling-calendar",
-                expected: "false",
-              },
-            },
-          );
+          reportError(error, {
+            subsystem: "client",
+            tags: { feature: "scheduling-calendar" },
+          });
           setError(
             error instanceof Error
               ? error.message

--- a/hooks/scheduling/useCalendarData.ts
+++ b/hooks/scheduling/useCalendarData.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
 import {
   startOfWeek,
   endOfWeek,
@@ -268,6 +269,16 @@ export function useCalendarData(
       setConsultantDetails(data);
     } catch (error) {
       console.error("Error fetching consultant details:", error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            feature: "scheduling-calendar",
+            expected: "false",
+          },
+        },
+      );
       const errorMessage =
         error instanceof Error
           ? error.message
@@ -350,6 +361,16 @@ export function useCalendarData(
       setRawAvailabilitySlots(validatedData);
     } catch (error) {
       console.error("Error fetching availability slots:", error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            feature: "scheduling-calendar",
+            expected: "false",
+          },
+        },
+      );
       const errorMessage =
         error instanceof Error ? error.message : "Failed to fetch availability";
       setError(errorMessage);
@@ -466,6 +487,19 @@ export function useCalendarData(
       }
     } catch (error) {
       console.error("Error fetching event slots:", error);
+      // Silent degrade to empty (no toast/setError, unlike the two siblings
+      // above) — the calendar just shows no "This Event" slots, which reads
+      // as "nothing booked yet" rather than "the fetch broke".
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            feature: "scheduling-calendar",
+            expected: "false",
+          },
+        },
+      );
       setEventSlots([]);
       setEventTentativeSlots([]);
       setWeeklyConfirmedCallCounts({});
@@ -639,6 +673,19 @@ export function useCalendarData(
       ]);
     } catch (error) {
       console.error("Error fetching calendar data:", error);
+      // Believed unreachable: the three awaited fetchers each self-catch and
+      // never reject, so Promise.all here shouldn't throw. Capturing anyway
+      // (not tagged expected) — if this ever fires, that invariant broke.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            feature: "scheduling-calendar",
+            expected: "false",
+          },
+        },
+      );
       const errorMessage =
         error instanceof Error
           ? error.message
@@ -657,6 +704,17 @@ export function useCalendarData(
       Promise.all([fetchConsultantDetails(), fetchEventSlots()]).catch(
         (error) => {
           console.error("Error fetching date-independent data:", error);
+          // Believed unreachable — see fetchAllData's identical comment.
+          Sentry.captureException(
+            error instanceof Error ? error : new Error(String(error)),
+            {
+              tags: {
+                subsystem: "client",
+                feature: "scheduling-calendar",
+                expected: "false",
+              },
+            },
+          );
           setError(
             error instanceof Error
               ? error.message
@@ -682,6 +740,17 @@ export function useCalendarData(
       fetchAvailabilitySlots()
         .catch((error) => {
           console.error("Error fetching date-dependent data:", error);
+          // Believed unreachable — see fetchAllData's identical comment.
+          Sentry.captureException(
+            error instanceof Error ? error : new Error(String(error)),
+            {
+              tags: {
+                subsystem: "client",
+                feature: "scheduling-calendar",
+                expected: "false",
+              },
+            },
+          );
           setError(
             error instanceof Error
               ? error.message

--- a/hooks/scheduling/useCalendarData.ts
+++ b/hooks/scheduling/useCalendarData.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import {
   startOfWeek,
   endOfWeek,
@@ -269,7 +269,7 @@ export function useCalendarData(
       setConsultantDetails(data);
     } catch (error) {
       console.error("Error fetching consultant details:", error);
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         tags: { feature: "scheduling-calendar" },
       });
@@ -355,7 +355,7 @@ export function useCalendarData(
       setRawAvailabilitySlots(validatedData);
     } catch (error) {
       console.error("Error fetching availability slots:", error);
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         tags: { feature: "scheduling-calendar" },
       });
@@ -478,7 +478,7 @@ export function useCalendarData(
       // Silent degrade to empty (no toast/setError, unlike the two siblings
       // above) — the calendar just shows no "This Event" slots, which reads
       // as "nothing booked yet" rather than "the fetch broke".
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         tags: { feature: "scheduling-calendar" },
       });
@@ -658,7 +658,7 @@ export function useCalendarData(
       // Believed unreachable: the three awaited fetchers each self-catch and
       // never reject, so Promise.all here shouldn't throw. Capturing anyway
       // (not tagged expected) — if this ever fires, that invariant broke.
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         tags: { feature: "scheduling-calendar" },
       });
@@ -681,7 +681,7 @@ export function useCalendarData(
         (error) => {
           console.error("Error fetching date-independent data:", error);
           // Believed unreachable — see fetchAllData's identical comment.
-          reportError(error, {
+          reportSentryError(error, {
             subsystem: "client",
             tags: { feature: "scheduling-calendar" },
           });
@@ -711,7 +711,7 @@ export function useCalendarData(
         .catch((error) => {
           console.error("Error fetching date-dependent data:", error);
           // Believed unreachable — see fetchAllData's identical comment.
-          reportError(error, {
+          reportSentryError(error, {
             subsystem: "client",
             tags: { feature: "scheduling-calendar" },
           });

--- a/hooks/useChatUnreadCount.ts
+++ b/hooks/useChatUnreadCount.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { StreamChat } from "stream-chat";
 
 const apiKey = process.env.NEXT_PUBLIC_STREAM_API_KEY;
@@ -59,10 +59,7 @@ export function useChatUnreadCount(): number {
         // A failed recount leaves the previous number in place — a stale badge
         // beats one that drops to zero on a transient error. Reported for
         // visibility only; the degrade itself is unchanged.
-        Sentry.captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          { tags: { subsystem: "client", expected: "true" }, level: "info" },
-        );
+        reportError(error, { subsystem: "client", expected: true });
       }
     };
 

--- a/hooks/useChatUnreadCount.ts
+++ b/hooks/useChatUnreadCount.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { StreamChat } from "stream-chat";
 
 const apiKey = process.env.NEXT_PUBLIC_STREAM_API_KEY;
@@ -59,7 +59,7 @@ export function useChatUnreadCount(): number {
         // A failed recount leaves the previous number in place — a stale badge
         // beats one that drops to zero on a transient error. Reported for
         // visibility only; the degrade itself is unchanged.
-        reportError(error, { subsystem: "client", expected: true });
+        reportSentryError(error, { subsystem: "client", expected: true });
       }
     };
 

--- a/hooks/useChatUnreadCount.ts
+++ b/hooks/useChatUnreadCount.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { StreamChat } from "stream-chat";
 
 const apiKey = process.env.NEXT_PUBLIC_STREAM_API_KEY;
@@ -54,9 +55,14 @@ export function useChatUnreadCount(): number {
         setUnreadCount(
           channels.reduce((sum, channel) => sum + channel.countUnread(), 0),
         );
-      } catch {
+      } catch (error) {
         // A failed recount leaves the previous number in place — a stale badge
-        // beats one that drops to zero on a transient error.
+        // beats one that drops to zero on a transient error. Reported for
+        // visibility only; the degrade itself is unchanged.
+        Sentry.captureException(
+          error instanceof Error ? error : new Error(String(error)),
+          { tags: { subsystem: "client", expected: "true" }, level: "info" },
+        );
       }
     };
 

--- a/hooks/useConsultantPrefetchDashboard.ts
+++ b/hooks/useConsultantPrefetchDashboard.ts
@@ -2,6 +2,7 @@
 
 import { useQueryClient, type FetchQueryOptions } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
+import * as Sentry from "@sentry/nextjs";
 
 import {
   createConsultantQueries,
@@ -107,6 +108,12 @@ export function usePrefetchDashboard({
       safePrefetch([queries.planner], "medium");
     } catch (error) {
       console.warn("Consultant data prefetching failed:", error);
+      // Best-effort dashboard prefetch — the real useQuery on the actual
+      // tab still fetches on demand. Reported for volume visibility only.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        { tags: { subsystem: "client", expected: "true" }, level: "info" },
+      );
     }
   }, [consultantId, safePrefetch]);
 
@@ -127,6 +134,11 @@ export function usePrefetchDashboard({
       );
     } catch (error) {
       console.warn("Consultee data prefetching failed:", error);
+      // Best-effort dashboard prefetch — see the consultant twin above.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        { tags: { subsystem: "client", expected: "true" }, level: "info" },
+      );
     }
   }, [consulteeId, safePrefetch]);
 
@@ -205,8 +217,9 @@ export function usePrefetchDashboard({
 
   // Cleanup function to clear prefetch tracking on unmount
   useEffect(() => {
+    const trackedSet = prefetchedRef.current;
     return () => {
-      prefetchedRef.current.clear();
+      trackedSet.clear();
     };
   }, []);
 

--- a/hooks/useConsultantPrefetchDashboard.ts
+++ b/hooks/useConsultantPrefetchDashboard.ts
@@ -2,7 +2,7 @@
 
 import { useQueryClient, type FetchQueryOptions } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 
 import {
   createConsultantQueries,
@@ -110,7 +110,7 @@ export function usePrefetchDashboard({
       console.warn("Consultant data prefetching failed:", error);
       // Best-effort dashboard prefetch — the real useQuery on the actual
       // tab still fetches on demand. Reported for volume visibility only.
-      reportError(error, { subsystem: "client", expected: true });
+      reportSentryError(error, { subsystem: "client", expected: true });
     }
   }, [consultantId, safePrefetch]);
 
@@ -132,7 +132,7 @@ export function usePrefetchDashboard({
     } catch (error) {
       console.warn("Consultee data prefetching failed:", error);
       // Best-effort dashboard prefetch — see the consultant twin above.
-      reportError(error, { subsystem: "client", expected: true });
+      reportSentryError(error, { subsystem: "client", expected: true });
     }
   }, [consulteeId, safePrefetch]);
 

--- a/hooks/useConsultantPrefetchDashboard.ts
+++ b/hooks/useConsultantPrefetchDashboard.ts
@@ -55,24 +55,41 @@ export function usePrefetchDashboard({
           queries.map((query) => queryClient.prefetchQuery(query)),
         );
 
-        // Log failures in development
-        if (process.env.NODE_ENV === "development") {
-          results.forEach((result, index) => {
-            if (result.status === "rejected") {
+        // allSettled swallows rejections — the outer try/catch below never
+        // sees these, so they must be captured here or they vanish entirely.
+        results.forEach((result, index) => {
+          if (result.status === "rejected") {
+            if (process.env.NODE_ENV === "development") {
               console.warn(
                 `Prefetch failed for query:`,
                 queries[index].queryKey,
                 result.reason,
               );
             }
-          });
-        }
+            reportSentryError(result.reason, {
+              subsystem: "client",
+              expected: true,
+              extra: { queryKey: queries[index].queryKey },
+            });
+          }
+        });
       };
 
+      // executePrefetch itself shouldn't throw (allSettled never rejects),
+      // but the delayed branch is fire-and-forget, so guard against an
+      // unhandled rejection if that assumption is ever wrong.
+      const runPrefetch = () =>
+        executePrefetch().catch((error) => {
+          reportSentryError(error, {
+            subsystem: "client",
+            op: "safe-prefetch-unexpected",
+          });
+        });
+
       if (delay > 0) {
-        setTimeout(executePrefetch, delay);
+        setTimeout(runPrefetch, delay);
       } else {
-        executePrefetch();
+        runPrefetch();
       }
     },
     [queryClient],

--- a/hooks/useConsultantPrefetchDashboard.ts
+++ b/hooks/useConsultantPrefetchDashboard.ts
@@ -2,7 +2,7 @@
 
 import { useQueryClient, type FetchQueryOptions } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 
 import {
   createConsultantQueries,
@@ -110,10 +110,7 @@ export function usePrefetchDashboard({
       console.warn("Consultant data prefetching failed:", error);
       // Best-effort dashboard prefetch — the real useQuery on the actual
       // tab still fetches on demand. Reported for volume visibility only.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        { tags: { subsystem: "client", expected: "true" }, level: "info" },
-      );
+      reportError(error, { subsystem: "client", expected: true });
     }
   }, [consultantId, safePrefetch]);
 
@@ -135,10 +132,7 @@ export function usePrefetchDashboard({
     } catch (error) {
       console.warn("Consultee data prefetching failed:", error);
       // Best-effort dashboard prefetch — see the consultant twin above.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        { tags: { subsystem: "client", expected: "true" }, level: "info" },
-      );
+      reportError(error, { subsystem: "client", expected: true });
     }
   }, [consulteeId, safePrefetch]);
 

--- a/hooks/useCurrency.ts
+++ b/hooks/useCurrency.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useSyncExternalStore } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { CURRENCY_LOCALE_MAP } from "@/utils/formatting";
 
 const STORAGE_KEY = "preferred-currency";
@@ -84,7 +84,7 @@ export function useCurrency() {
         // React Query retries this (retry: 2) and formatPrice already has an
         // honest INR fallback while rate is null — captured for visibility
         // into retry volume, not because the degrade itself needs fixing.
-        reportError(error, { subsystem: "client", expected: true });
+        reportSentryError(error, { subsystem: "client", expected: true });
         throw error;
       }
     },
@@ -138,7 +138,7 @@ export function useCurrency() {
       } catch (error) {
         // Only throws on a malformed currency code (e.g. a bad value from
         // /api/currency) \u2014 a real data bug, not the "still loading" case.
-        reportError(error, {
+        reportSentryError(error, {
           subsystem: "client",
           extra: { displayCurrency },
         });

--- a/hooks/useCurrency.ts
+++ b/hooks/useCurrency.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useSyncExternalStore } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { CURRENCY_LOCALE_MAP } from "@/utils/formatting";
 
 const STORAGE_KEY = "preferred-currency";
@@ -73,11 +74,22 @@ export function useCurrency() {
   const { data, isLoading } = useQuery<CurrencyData>({
     queryKey: ["currency-rate", selectedCurrency],
     queryFn: async () => {
-      const res = await fetch(
-        `/api/currency?to=${encodeURIComponent(selectedCurrency)}`,
-      );
-      if (!res.ok) throw new Error("Failed to fetch currency rate");
-      return res.json();
+      try {
+        const res = await fetch(
+          `/api/currency?to=${encodeURIComponent(selectedCurrency)}`,
+        );
+        if (!res.ok) throw new Error("Failed to fetch currency rate");
+        return await res.json();
+      } catch (error) {
+        // React Query retries this (retry: 2) and formatPrice already has an
+        // honest INR fallback while rate is null — captured for visibility
+        // into retry volume, not because the degrade itself needs fixing.
+        Sentry.captureException(
+          error instanceof Error ? error : new Error(String(error)),
+          { tags: { subsystem: "client", expected: "true" }, level: "info" },
+        );
+        throw error;
+      }
     },
     enabled: !isINR,
     staleTime: 60 * 60 * 1000, // 1 hour
@@ -126,7 +138,16 @@ export function useCurrency() {
           minimumFractionDigits: 0,
           maximumFractionDigits: 0,
         }).format(converted);
-      } catch {
+      } catch (error) {
+        // Only throws on a malformed currency code (e.g. a bad value from
+        // /api/currency) \u2014 a real data bug, not the "still loading" case.
+        Sentry.captureException(
+          error instanceof Error ? error : new Error(String(error)),
+          {
+            tags: { subsystem: "client", expected: "false" },
+            extra: { displayCurrency },
+          },
+        );
         return `${rate === null ? "\u20B9" : symbol}${Math.round(converted).toLocaleString()}`;
       }
     },

--- a/hooks/useCurrency.ts
+++ b/hooks/useCurrency.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useSyncExternalStore } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { CURRENCY_LOCALE_MAP } from "@/utils/formatting";
 
 const STORAGE_KEY = "preferred-currency";
@@ -84,10 +84,7 @@ export function useCurrency() {
         // React Query retries this (retry: 2) and formatPrice already has an
         // honest INR fallback while rate is null — captured for visibility
         // into retry volume, not because the degrade itself needs fixing.
-        Sentry.captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          { tags: { subsystem: "client", expected: "true" }, level: "info" },
-        );
+        reportError(error, { subsystem: "client", expected: true });
         throw error;
       }
     },
@@ -141,13 +138,10 @@ export function useCurrency() {
       } catch (error) {
         // Only throws on a malformed currency code (e.g. a bad value from
         // /api/currency) \u2014 a real data bug, not the "still loading" case.
-        Sentry.captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: { subsystem: "client", expected: "false" },
-            extra: { displayCurrency },
-          },
-        );
+        reportError(error, {
+          subsystem: "client",
+          extra: { displayCurrency },
+        });
         return `${rate === null ? "\u20B9" : symbol}${Math.round(converted).toLocaleString()}`;
       }
     },

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { useToast } from "@/components/ui/use-toast";
 import {
   TConsultation,
@@ -170,9 +170,7 @@ function useEventsInternal(mode: TEventQueryMode): IEventsResult {
         setError(normalizedErr);
         // Falls through to an empty-list render otherwise — indistinguishable
         // from "this consultee genuinely has no bookings" without this.
-        Sentry.captureException(normalizedErr, {
-          tags: { subsystem: "client", expected: "false" },
-        });
+        reportError(normalizedErr, { subsystem: "client" });
         toast({
           title: "Error fetching events",
           description: message,

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { useToast } from "@/components/ui/use-toast";
 import {
   TConsultation,
@@ -165,7 +166,13 @@ function useEventsInternal(mode: TEventQueryMode): IEventsResult {
       } catch (err: unknown) {
         console.error("Error fetching events:", err);
         const message = err instanceof Error ? err.message : "Unknown error";
-        setError(err instanceof Error ? err : new Error(message));
+        const normalizedErr = err instanceof Error ? err : new Error(message);
+        setError(normalizedErr);
+        // Falls through to an empty-list render otherwise — indistinguishable
+        // from "this consultee genuinely has no bookings" without this.
+        Sentry.captureException(normalizedErr, {
+          tags: { subsystem: "client", expected: "false" },
+        });
         toast({
           title: "Error fetching events",
           description: message,

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { useToast } from "@/components/ui/use-toast";
 import {
   TConsultation,
@@ -170,7 +170,7 @@ function useEventsInternal(mode: TEventQueryMode): IEventsResult {
         setError(normalizedErr);
         // Falls through to an empty-list render otherwise — indistinguishable
         // from "this consultee genuinely has no bookings" without this.
-        reportError(normalizedErr, { subsystem: "client" });
+        reportSentryError(normalizedErr, { subsystem: "client" });
         toast({
           title: "Error fetching events",
           description: message,

--- a/hooks/useNovuSubscriberSync.ts
+++ b/hooks/useNovuSubscriberSync.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { useSession } from "@/lib/auth-client";
 
 /**
@@ -24,7 +24,7 @@ export function useNovuSubscriberSync() {
         // React Query retries this (retry: 1); a failed sync just delays
         // the subscriber row, nothing user-visible breaks. Captured for
         // retry-volume visibility only.
-        reportError(error, { subsystem: "novu", expected: true });
+        reportSentryError(error, { subsystem: "novu", expected: true });
         throw error;
       }
     },

--- a/hooks/useNovuSubscriberSync.ts
+++ b/hooks/useNovuSubscriberSync.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { useSession } from "@/lib/auth-client";
 
 /**
@@ -24,10 +24,7 @@ export function useNovuSubscriberSync() {
         // React Query retries this (retry: 1); a failed sync just delays
         // the subscriber row, nothing user-visible breaks. Captured for
         // retry-volume visibility only.
-        Sentry.captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          { tags: { subsystem: "novu", expected: "true" }, level: "info" },
-        );
+        reportError(error, { subsystem: "novu", expected: true });
         throw error;
       }
     },

--- a/hooks/useNovuSubscriberSync.ts
+++ b/hooks/useNovuSubscriberSync.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import * as Sentry from "@sentry/nextjs";
 import { useSession } from "@/lib/auth-client";
 
 /**
@@ -13,11 +14,22 @@ export function useNovuSubscriberSync() {
   return useQuery({
     queryKey: ["novu-subscriber-sync", session?.user?.id],
     queryFn: async () => {
-      const res = await fetch("/api/novu/subscriber", { method: "POST" });
-      if (!res.ok) {
-        throw new Error("Failed to sync Novu subscriber");
+      try {
+        const res = await fetch("/api/novu/subscriber", { method: "POST" });
+        if (!res.ok) {
+          throw new Error("Failed to sync Novu subscriber");
+        }
+        return await res.json();
+      } catch (error) {
+        // React Query retries this (retry: 1); a failed sync just delays
+        // the subscriber row, nothing user-visible breaks. Captured for
+        // retry-volume visibility only.
+        Sentry.captureException(
+          error instanceof Error ? error : new Error(String(error)),
+          { tags: { subsystem: "novu", expected: "true" }, level: "info" },
+        );
+        throw error;
       }
-      return res.json();
     },
     enabled: !!session?.user?.id && !!process.env.NEXT_PUBLIC_NOVU_APP_ID,
     staleTime: 30 * 60 * 1000, // 30 minutes

--- a/hooks/useNovuSubscriberSync.ts
+++ b/hooks/useNovuSubscriberSync.ts
@@ -17,14 +17,28 @@ export function useNovuSubscriberSync() {
       try {
         const res = await fetch("/api/novu/subscriber", { method: "POST" });
         if (!res.ok) {
-          throw new Error("Failed to sync Novu subscriber");
+          // Carry the status so the catch can tell a 4xx business answer from
+          // a real 5xx/network fault instead of tagging every failure expected.
+          throw Object.assign(new Error("Failed to sync Novu subscriber"), {
+            httpStatus: res.status,
+          });
         }
         return await res.json();
       } catch (error) {
+        const httpStatus =
+          error && typeof error === "object" && "httpStatus" in error
+            ? (error as { httpStatus?: number }).httpStatus
+            : undefined;
+        const expected =
+          typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
         // React Query retries this (retry: 1); a failed sync just delays
-        // the subscriber row, nothing user-visible breaks. Captured for
-        // retry-volume visibility only.
-        reportSentryError(error, { subsystem: "novu", expected: true });
+        // the subscriber row, nothing user-visible breaks. A 5xx/network
+        // fault is still worth alerting on even though retry papers over it.
+        reportSentryError(error, {
+          subsystem: "novu",
+          expected,
+          extra: { httpStatus },
+        });
         throw error;
       }
     },

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { useToast } from "@/components/ui/use-toast";
 import { TConsultantProfile } from "@/types/consultant";
 import { TConsulteeProfile } from "@/types/consultee";
@@ -69,7 +70,8 @@ export const useUserData = (userId: string) => {
         const error = err instanceof Error ? err : new Error(String(err));
         setError(error);
         // 401 is expected after sign-out (session cleared before component unmounts)
-        if (err != null && typeof err === "object" && "status" in err && (err as { status: number }).status === 401) return;
+        if (err !== null && err !== undefined && typeof err === "object" && "status" in err && (err as { status: number }).status === 401) return;
+        Sentry.captureException(error, { tags: { subsystem: "client", expected: "false" } });
         console.error("Error fetching user details:", err);
         toast({
           title: "Error fetching user details",

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { useToast } from "@/components/ui/use-toast";
 import { TConsultantProfile } from "@/types/consultant";
 import { TConsulteeProfile } from "@/types/consultee";
@@ -71,7 +71,7 @@ export const useUserData = (userId: string) => {
         setError(error);
         // 401 is expected after sign-out (session cleared before component unmounts)
         if (err !== null && err !== undefined && typeof err === "object" && "status" in err && (err as { status: number }).status === 401) return;
-        reportError(error, { subsystem: "client" });
+        reportSentryError(error, { subsystem: "client" });
         console.error("Error fetching user details:", err);
         toast({
           title: "Error fetching user details",

--- a/hooks/useUserData.ts
+++ b/hooks/useUserData.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { useToast } from "@/components/ui/use-toast";
 import { TConsultantProfile } from "@/types/consultant";
 import { TConsulteeProfile } from "@/types/consultee";
@@ -71,7 +71,7 @@ export const useUserData = (userId: string) => {
         setError(error);
         // 401 is expected after sign-out (session cleared before component unmounts)
         if (err !== null && err !== undefined && typeof err === "object" && "status" in err && (err as { status: number }).status === 401) return;
-        Sentry.captureException(error, { tags: { subsystem: "client", expected: "false" } });
+        reportError(error, { subsystem: "client" });
         console.error("Error fetching user details:", err);
         toast({
           title: "Error fetching user details",

--- a/lib/booking/reschedule-auto-confirm.ts
+++ b/lib/booking/reschedule-auto-confirm.ts
@@ -110,7 +110,11 @@ export async function tryAutoConfirmProposal(
     Sentry.captureException(
       err instanceof Error ? err : new Error(String(err)),
       {
-        tags: { subsystem: "bookings", op: "reschedule-auto-confirm" },
+        tags: {
+          subsystem: "bookings",
+          op: "reschedule-auto-confirm",
+          expected: "false",
+        },
         extra: {
           phase: "stamp",
           rescheduleRequestId,
@@ -151,7 +155,11 @@ export async function tryAutoConfirmProposal(
       Sentry.captureException(
         err instanceof Error ? err : new Error(String(err)),
         {
-          tags: { subsystem: "bookings", op: "reschedule-auto-confirm" },
+          tags: {
+            subsystem: "bookings",
+            op: "reschedule-auto-confirm",
+            expected: "false",
+          },
           level: "fatal",
           extra: {
             phase: "restore",
@@ -163,7 +171,10 @@ export async function tryAutoConfirmProposal(
       );
       throw err;
     }
-    return { confirmed: false, reason: result.errorCode ?? "VALIDATION_FAILED" };
+    return {
+      confirmed: false,
+      reason: result.errorCode ?? "VALIDATION_FAILED",
+    };
   }
 
   try {
@@ -179,18 +190,24 @@ export async function tryAutoConfirmProposal(
     });
   } catch (err) {
     // A lost race (the proposal was answered or expired concurrently) is the
-    // ordinary outcome this CAS guard models by throwing — not an error.
-    // Anything else means the reallocation above already succeeded but the
-    // proposal's own bookkeeping never caught up, which is worth knowing.
-    if (!(err instanceof IllegalTransitionError)) {
-      Sentry.captureException(
-        err instanceof Error ? err : new Error(String(err)),
-        {
-          tags: { subsystem: "bookings", op: "reschedule-auto-confirm" },
-          extra: { phase: "finalize", rescheduleRequestId, eventType, eventId },
+    // ordinary outcome this CAS guard models by throwing — not an error, but
+    // still reported at info/expected so its rate is visible (full-coverage
+    // policy). Anything else means the reallocation above already succeeded
+    // but the proposal's own bookkeeping never caught up, which is worth
+    // knowing at the default fault level.
+    const isLostRace = err instanceof IllegalTransitionError;
+    Sentry.captureException(
+      err instanceof Error ? err : new Error(String(err)),
+      {
+        tags: {
+          subsystem: "bookings",
+          op: "reschedule-auto-confirm",
+          ...(isLostRace ? { expected: "true" } : {}),
         },
-      );
-    }
+        extra: { phase: "finalize", rescheduleRequestId, eventType, eventId },
+        ...(isLostRace ? { level: "info" as const } : {}),
+      },
+    );
     throw err;
   }
 

--- a/lib/booking/reschedule-auto-confirm.ts
+++ b/lib/booking/reschedule-auto-confirm.ts
@@ -17,7 +17,7 @@
  * outcome, not an error.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import type { EventType } from "@/utils/slotAllocation/types";
 import { SlotAllocationService } from "@/utils/slotAllocation/SlotAllocationService";
@@ -107,21 +107,15 @@ export async function tryAutoConfirmProposal(
       }
     });
   } catch (err) {
-    Sentry.captureException(
-      err instanceof Error ? err : new Error(String(err)),
-      {
-        tags: {
-          subsystem: "bookings",
-          op: "reschedule-auto-confirm",
-          expected: "false",
-        },
-        extra: {
-          phase: "stamp",
-          rescheduleRequestId,
-          releasedSlotIds: request.releasedSlotIds,
-        },
+    reportError(err, {
+      subsystem: "bookings",
+      op: "reschedule-auto-confirm",
+      extra: {
+        phase: "stamp",
+        rescheduleRequestId,
+        releasedSlotIds: request.releasedSlotIds,
       },
-    );
+    });
     throw err;
   }
 
@@ -152,23 +146,17 @@ export async function tryAutoConfirmProposal(
         }
       });
     } catch (err) {
-      Sentry.captureException(
-        err instanceof Error ? err : new Error(String(err)),
-        {
-          tags: {
-            subsystem: "bookings",
-            op: "reschedule-auto-confirm",
-            expected: "false",
-          },
-          level: "fatal",
-          extra: {
-            phase: "restore",
-            rescheduleRequestId,
-            releasedSlotIds: request.releasedSlotIds,
-            originalSlotIds: pairs.map((p) => p.slot.id),
-          },
+      reportError(err, {
+        subsystem: "bookings",
+        op: "reschedule-auto-confirm",
+        level: "fatal",
+        extra: {
+          phase: "restore",
+          rescheduleRequestId,
+          releasedSlotIds: request.releasedSlotIds,
+          originalSlotIds: pairs.map((p) => p.slot.id),
         },
-      );
+      });
       throw err;
     }
     return {
@@ -196,18 +184,12 @@ export async function tryAutoConfirmProposal(
     // but the proposal's own bookkeeping never caught up, which is worth
     // knowing at the default fault level.
     const isLostRace = err instanceof IllegalTransitionError;
-    Sentry.captureException(
-      err instanceof Error ? err : new Error(String(err)),
-      {
-        tags: {
-          subsystem: "bookings",
-          op: "reschedule-auto-confirm",
-          ...(isLostRace ? { expected: "true" } : {}),
-        },
-        extra: { phase: "finalize", rescheduleRequestId, eventType, eventId },
-        ...(isLostRace ? { level: "info" as const } : {}),
-      },
-    );
+    reportError(err, {
+      subsystem: "bookings",
+      op: "reschedule-auto-confirm",
+      expected: isLostRace,
+      extra: { phase: "finalize", rescheduleRequestId, eventType, eventId },
+    });
     throw err;
   }
 

--- a/lib/booking/reschedule-auto-confirm.ts
+++ b/lib/booking/reschedule-auto-confirm.ts
@@ -17,7 +17,7 @@
  * outcome, not an error.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import type { EventType } from "@/utils/slotAllocation/types";
 import { SlotAllocationService } from "@/utils/slotAllocation/SlotAllocationService";
@@ -107,7 +107,7 @@ export async function tryAutoConfirmProposal(
       }
     });
   } catch (err) {
-    reportError(err, {
+    reportSentryError(err, {
       subsystem: "bookings",
       op: "reschedule-auto-confirm",
       extra: {
@@ -146,7 +146,7 @@ export async function tryAutoConfirmProposal(
         }
       });
     } catch (err) {
-      reportError(err, {
+      reportSentryError(err, {
         subsystem: "bookings",
         op: "reschedule-auto-confirm",
         level: "fatal",
@@ -184,7 +184,7 @@ export async function tryAutoConfirmProposal(
     // but the proposal's own bookkeeping never caught up, which is worth
     // knowing at the default fault level.
     const isLostRace = err instanceof IllegalTransitionError;
-    reportError(err, {
+    reportSentryError(err, {
       subsystem: "bookings",
       op: "reschedule-auto-confirm",
       expected: isLostRace,

--- a/lib/data/consultant-detail.ts
+++ b/lib/data/consultant-detail.ts
@@ -1,5 +1,5 @@
 import { cache } from "react";
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import { consultantPublicScalars } from "@/lib/data/consultant-public";
 
@@ -105,10 +105,7 @@ export const getConsultantDetail = cache(async (consultantId: string) => {
     // A throw here means the row picked up something non-JSON-safe (a
     // serialization regression, not a missing/empty result) — the public
     // detail page would otherwise 500 with no trace of why.
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "consultant", expected: "false" } },
-    );
+    reportError(error, { subsystem: "consultant" });
     throw error;
   }
 });

--- a/lib/data/consultant-detail.ts
+++ b/lib/data/consultant-detail.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
 import { consultantPublicScalars } from "@/lib/data/consultant-public";
 
@@ -98,7 +99,18 @@ export const getConsultantDetail = cache(async (consultantId: string) => {
   // symbols, methods) and yields true plain objects. Dates become ISO
   // strings — downstream client components already format them via
   // formatInTimeZone / date-fns, so this is safe here.
-  return JSON.parse(JSON.stringify(consultant)) as typeof consultant;
+  try {
+    return JSON.parse(JSON.stringify(consultant)) as typeof consultant;
+  } catch (error) {
+    // A throw here means the row picked up something non-JSON-safe (a
+    // serialization regression, not a missing/empty result) — the public
+    // detail page would otherwise 500 with no trace of why.
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "consultant", expected: "false" } },
+    );
+    throw error;
+  }
 });
 
 export const getConsultantReviews = cache(

--- a/lib/data/consultant-detail.ts
+++ b/lib/data/consultant-detail.ts
@@ -1,5 +1,5 @@
 import { cache } from "react";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import { consultantPublicScalars } from "@/lib/data/consultant-public";
 
@@ -105,7 +105,7 @@ export const getConsultantDetail = cache(async (consultantId: string) => {
     // A throw here means the row picked up something non-JSON-safe (a
     // serialization regression, not a missing/empty result) — the public
     // detail page would otherwise 500 with no trace of why.
-    reportError(error, { subsystem: "consultant" });
+    reportSentryError(error, { subsystem: "consultant" });
     throw error;
   }
 });

--- a/lib/data/consultee-events-read.ts
+++ b/lib/data/consultee-events-read.ts
@@ -14,6 +14,7 @@
  * and is callable from a Server Component.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
 import type { Scope } from "@/lib/api/scope/parse";
@@ -44,7 +45,15 @@ export async function readConsulteeEvents(
   });
 
   if (!consulteeProfile) {
-    throw new ConsulteeProfileNotFoundError(consulteeId);
+    // Modelled: the route maps this to a 404 (see class docstring) —
+    // captured for visibility only (stale link / deleted profile), not a
+    // fault in this read.
+    const notFoundErr = new ConsulteeProfileNotFoundError(consulteeId);
+    Sentry.captureException(notFoundErr, {
+      tags: { subsystem: "consultees", expected: "true" },
+      level: "info",
+    });
+    throw notFoundErr;
   }
 
   const userId = consulteeProfile.userId;

--- a/lib/data/consultee-events-read.ts
+++ b/lib/data/consultee-events-read.ts
@@ -14,7 +14,7 @@
  * and is callable from a Server Component.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
 import type { Scope } from "@/lib/api/scope/parse";
@@ -49,10 +49,7 @@ export async function readConsulteeEvents(
     // captured for visibility only (stale link / deleted profile), not a
     // fault in this read.
     const notFoundErr = new ConsulteeProfileNotFoundError(consulteeId);
-    Sentry.captureException(notFoundErr, {
-      tags: { subsystem: "consultees", expected: "true" },
-      level: "info",
-    });
+    reportError(notFoundErr, { subsystem: "consultees", expected: true });
     throw notFoundErr;
   }
 

--- a/lib/data/consultee-events-read.ts
+++ b/lib/data/consultee-events-read.ts
@@ -14,7 +14,7 @@
  * and is callable from a Server Component.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
 import type { Scope } from "@/lib/api/scope/parse";
@@ -49,7 +49,7 @@ export async function readConsulteeEvents(
     // captured for visibility only (stale link / deleted profile), not a
     // fault in this read.
     const notFoundErr = new ConsulteeProfileNotFoundError(consulteeId);
-    reportError(notFoundErr, { subsystem: "consultees", expected: true });
+    reportSentryError(notFoundErr, { subsystem: "consultees", expected: true });
     throw notFoundErr;
   }
 

--- a/lib/data/org-workspace.ts
+++ b/lib/data/org-workspace.ts
@@ -14,7 +14,7 @@
  * verbatim against the client query keys.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import type { FundingSource, MemberRole, OrgStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { sumPaise } from "@/lib/payments/utils/money";
@@ -394,7 +394,7 @@ export async function getWorkspaceSettings(
     // client-side fetch (see docstring above) — captured for visibility
     // into how often the IDOR-checked id resolves to no row.
     const notFoundErr = new Error("OrgWorkspaceProfile not found");
-    reportError(notFoundErr, { subsystem: "organizations", expected: true });
+    reportSentryError(notFoundErr, { subsystem: "organizations", expected: true });
     throw notFoundErr;
   }
 

--- a/lib/data/org-workspace.ts
+++ b/lib/data/org-workspace.ts
@@ -14,6 +14,7 @@
  * verbatim against the client query keys.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import type { FundingSource, MemberRole, OrgStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { sumPaise } from "@/lib/payments/utils/money";
@@ -389,7 +390,15 @@ export async function getWorkspaceSettings(
   });
 
   if (!profile) {
-    throw new Error("OrgWorkspaceProfile not found");
+    // Modelled: the caller's Promise.allSettled degrades this to a
+    // client-side fetch (see docstring above) — captured for visibility
+    // into how often the IDOR-checked id resolves to no row.
+    const notFoundErr = new Error("OrgWorkspaceProfile not found");
+    Sentry.captureException(notFoundErr, {
+      tags: { subsystem: "organizations", expected: "true" },
+      level: "info",
+    });
+    throw notFoundErr;
   }
 
   const ownedOrgs = await prisma.membership.findMany({

--- a/lib/data/org-workspace.ts
+++ b/lib/data/org-workspace.ts
@@ -14,7 +14,7 @@
  * verbatim against the client query keys.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import type { FundingSource, MemberRole, OrgStatus } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { sumPaise } from "@/lib/payments/utils/money";
@@ -394,10 +394,7 @@ export async function getWorkspaceSettings(
     // client-side fetch (see docstring above) — captured for visibility
     // into how often the IDOR-checked id resolves to no row.
     const notFoundErr = new Error("OrgWorkspaceProfile not found");
-    Sentry.captureException(notFoundErr, {
-      tags: { subsystem: "organizations", expected: "true" },
-      level: "info",
-    });
+    reportError(notFoundErr, { subsystem: "organizations", expected: true });
     throw notFoundErr;
   }
 

--- a/lib/data/plan-viewable.ts
+++ b/lib/data/plan-viewable.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
 import { isPlanViewable } from "@/lib/api/plans/visibility";
@@ -17,7 +18,16 @@ export async function canViewPlanDetail(
     archivedAt?: Date | null;
   } | null,
 ): Promise<boolean> {
-  const session = await getSession().catch(() => null);
+  // A session-lookup failure is treated as anonymous by design (matches
+  // app/api/waitlist/route.ts's identical fallback) — captured for
+  // visibility only; the anonymous-fallback outcome itself is unchanged.
+  const session = await getSession().catch((error) => {
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      { tags: { subsystem: "plans", expected: "true" }, level: "info" },
+    );
+    return null;
+  });
   return isPlanViewable(
     plan,
     session?.user?.id ?? null,

--- a/lib/data/plan-viewable.ts
+++ b/lib/data/plan-viewable.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
 import { isPlanViewable } from "@/lib/api/plans/visibility";
@@ -22,10 +22,7 @@ export async function canViewPlanDetail(
   // app/api/waitlist/route.ts's identical fallback) — captured for
   // visibility only; the anonymous-fallback outcome itself is unchanged.
   const session = await getSession().catch((error) => {
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "plans", expected: "true" }, level: "info" },
-    );
+    reportError(error, { subsystem: "plans", expected: true });
     return null;
   });
   return isPlanViewable(

--- a/lib/data/plan-viewable.ts
+++ b/lib/data/plan-viewable.ts
@@ -1,4 +1,4 @@
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import { getSession } from "@/lib/auth-server";
 import { isPlanViewable } from "@/lib/api/plans/visibility";
@@ -22,7 +22,7 @@ export async function canViewPlanDetail(
   // app/api/waitlist/route.ts's identical fallback) — captured for
   // visibility only; the anonymous-fallback outcome itself is unchanged.
   const session = await getSession().catch((error) => {
-    reportError(error, { subsystem: "plans", expected: true });
+    reportSentryError(error, { subsystem: "plans", expected: true });
     return null;
   });
   return isPlanViewable(

--- a/lib/observability/report.ts
+++ b/lib/observability/report.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared Sentry capture helper — every call site in the codebase used to
+ * repeat "normalize to Error, stamp subsystem/op/expected tags, pick a level"
+ * inline (~80 sites, see PR #1062). Extracted once so that shape lives here.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import type { SeverityLevel } from "@sentry/nextjs";
+
+export interface ReportOpts {
+  subsystem: string;
+  op?: string;
+  /** true = a modelled outcome (an ANSWER, not a fault). Defaults to false. */
+  expected?: boolean;
+  /** Overrides the level derived from `expected`. */
+  level?: SeverityLevel;
+  extra?: Record<string, unknown>;
+  /** Merged over the derived subsystem/op/expected tags — can override any of them. */
+  tags?: Record<string, string>;
+  contexts?: Record<string, Record<string, unknown>>;
+}
+
+function captureContext(opts: ReportOpts) {
+  const expected = opts.expected ?? false;
+  // expected:true defaults to "info"; expected:false leaves level unset so
+  // Sentry's own default ("error") applies. An explicit opts.level always wins.
+  const level = opts.level ?? (expected ? "info" : undefined);
+  return {
+    tags: {
+      subsystem: opts.subsystem,
+      ...(opts.op ? { op: opts.op } : {}),
+      expected: String(expected),
+      ...opts.tags,
+    },
+    ...(level ? { level } : {}),
+    ...(opts.extra ? { extra: opts.extra } : {}),
+    ...(opts.contexts ? { contexts: opts.contexts } : {}),
+  };
+}
+
+/** Report a caught fault or modelled outcome. Normalises non-Error throws. */
+export function reportError(error: unknown, opts: ReportOpts): void {
+  Sentry.captureException(
+    error instanceof Error ? error : new Error(String(error)),
+    captureContext(opts),
+  );
+}
+
+/** Sibling of `reportError` for sites with no exception object to attach — idempotency short-circuits, race-losses, malformed-input rejections. */
+export function reportMessage(message: string, opts: ReportOpts): void {
+  Sentry.captureMessage(message, captureContext(opts));
+}

--- a/lib/observability/report.ts
+++ b/lib/observability/report.ts
@@ -20,7 +20,7 @@ export interface ReportOpts {
   contexts?: Record<string, Record<string, unknown>>;
 }
 
-function captureContext(opts: ReportOpts) {
+function buildSentryCaptureContext(opts: ReportOpts) {
   const expected = opts.expected ?? false;
   // expected:true defaults to "info"; expected:false leaves level unset so
   // Sentry's own default ("error") applies. An explicit opts.level always wins.
@@ -39,14 +39,14 @@ function captureContext(opts: ReportOpts) {
 }
 
 /** Report a caught fault or modelled outcome. Normalises non-Error throws. */
-export function reportError(error: unknown, opts: ReportOpts): void {
+export function reportSentryError(error: unknown, opts: ReportOpts): void {
   Sentry.captureException(
     error instanceof Error ? error : new Error(String(error)),
-    captureContext(opts),
+    buildSentryCaptureContext(opts),
   );
 }
 
-/** Sibling of `reportError` for sites with no exception object to attach — idempotency short-circuits, race-losses, malformed-input rejections. */
-export function reportMessage(message: string, opts: ReportOpts): void {
-  Sentry.captureMessage(message, captureContext(opts));
+/** Sibling of `reportSentryError` for sites with no exception object to attach — idempotency short-circuits, race-losses, malformed-input rejections. */
+export function reportSentryMessage(message: string, opts: ReportOpts): void {
+  Sentry.captureMessage(message, buildSentryCaptureContext(opts));
 }

--- a/lib/payments/billing/overage-settlement.ts
+++ b/lib/payments/billing/overage-settlement.ts
@@ -5,7 +5,7 @@
  * dependency-light); this module carries the heavier graph (computeOverage +
  * the Novu member-due notification).
  */
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import {
   PaymentStatus,
@@ -146,10 +146,7 @@ export async function recordOverageAtCheckout(
     );
     // Modelled outcome (the circuit breaker working as designed), not a
     // fault — captured for volume/pattern visibility only.
-    Sentry.captureException(capExhaustedErr, {
-      tags: { subsystem: "payments", expected: "true" },
-      level: "info",
-    });
+    reportError(capExhaustedErr, { subsystem: "payments", expected: true });
     throw capExhaustedErr;
   }
 
@@ -226,8 +223,8 @@ export async function recordOverageAtCheckout(
         );
         // A genuine coverage gap (#715), not a modelled outcome — this aborts
         // a booking with real money on the line.
-        Sentry.captureException(carveErr, {
-          tags: { subsystem: "payments", expected: "false" },
+        reportError(carveErr, {
+          subsystem: "payments",
           contexts: { overage: { paymentId, basePaise } },
         });
         throw carveErr;
@@ -270,13 +267,7 @@ export async function recordOverageAtCheckout(
       })
       .catch((notifyErr) => {
         console.error("[notifyOrgProgramOverageDue] failed:", notifyErr);
-        Sentry.captureException(
-          notifyErr instanceof Error ? notifyErr : new Error(String(notifyErr)),
-          {
-            tags: { subsystem: "payments", expected: "false" },
-            level: "warning",
-          },
-        );
+        reportError(notifyErr, { subsystem: "payments", level: "warning" });
       });
     return;
   }

--- a/lib/payments/billing/overage-settlement.ts
+++ b/lib/payments/billing/overage-settlement.ts
@@ -5,11 +5,11 @@
  * dependency-light); this module carries the heavier graph (computeOverage +
  * the Novu member-due notification).
  */
+import * as Sentry from "@sentry/nextjs";
 import prisma from "@/lib/prisma";
 import {
   PaymentStatus,
   type Currency,
-  type Prisma,
   type PaymentGateway,
   type ProgramType,
 } from "@prisma/client";
@@ -138,12 +138,19 @@ export async function recordOverageAtCheckout(
   // Circuit breaker: ceiling exceeded → reject the booking like BLOCK. Distinct
   // code so the dashboard can explain it's the cycle cap, not the allocation.
   if (overage.decision === "BLOCK" && overage.chargeTo === null) {
-    throw Object.assign(
+    const capExhaustedErr = Object.assign(
       new Error(
         "PROGRAM_CAP_EXHAUSTED: This booking would exceed the program's per-cycle overage ceiling. Contact your organization administrator to raise the ceiling or wait for the next cycle.",
       ),
       { httpStatus: 402, code: "PROGRAM_CAP_EXHAUSTED" },
     );
+    // Modelled outcome (the circuit breaker working as designed), not a
+    // fault — captured for volume/pattern visibility only.
+    Sentry.captureException(capExhaustedErr, {
+      tags: { subsystem: "payments", expected: "true" },
+      level: "info",
+    });
+    throw capExhaustedErr;
   }
 
   if (marginalPaise <= 0) return;
@@ -212,11 +219,18 @@ export async function recordOverageAtCheckout(
       // tx rather than silently double-collect basePaise. Reachable today because
       // isReachableOrgFundingPath doesn't constrain overageBehavior by funding.
       if (!parentBase || parentBase.amountPaise < basePaise) {
-        throw new Error(
+        const carveErr = new Error(
           `CHARGE_MEMBER overage on payment ${paymentId}: cannot carve basePaise=${basePaise} ` +
             `from parent INVOICE_ACCRUAL leg (${parentBase ? parentBase.amountPaise : "absent"}); ` +
             `non-invoice-funded member-overage credit-back not implemented (#715) — refusing to double-collect`,
         );
+        // A genuine coverage gap (#715), not a modelled outcome — this aborts
+        // a booking with real money on the line.
+        Sentry.captureException(carveErr, {
+          tags: { subsystem: "payments", expected: "false" },
+          contexts: { overage: { paymentId, basePaise } },
+        });
+        throw carveErr;
       }
       await tx.paymentLeg.update({
         where: { paymentId_source: { paymentId, source: "INVOICE_ACCRUAL" } },
@@ -254,9 +268,16 @@ export async function recordOverageAtCheckout(
           payUrl: `/dashboard/overage?charge=${memberOverageEvent.id}`,
         });
       })
-      .catch((notifyErr) =>
-        console.error("[notifyOrgProgramOverageDue] failed:", notifyErr),
-      );
+      .catch((notifyErr) => {
+        console.error("[notifyOrgProgramOverageDue] failed:", notifyErr);
+        Sentry.captureException(
+          notifyErr instanceof Error ? notifyErr : new Error(String(notifyErr)),
+          {
+            tags: { subsystem: "payments", expected: "false" },
+            level: "warning",
+          },
+        );
+      });
     return;
   }
 

--- a/lib/payments/billing/overage-settlement.ts
+++ b/lib/payments/billing/overage-settlement.ts
@@ -5,7 +5,7 @@
  * dependency-light); this module carries the heavier graph (computeOverage +
  * the Novu member-due notification).
  */
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import {
   PaymentStatus,
@@ -146,7 +146,7 @@ export async function recordOverageAtCheckout(
     );
     // Modelled outcome (the circuit breaker working as designed), not a
     // fault — captured for volume/pattern visibility only.
-    reportError(capExhaustedErr, { subsystem: "payments", expected: true });
+    reportSentryError(capExhaustedErr, { subsystem: "payments", expected: true });
     throw capExhaustedErr;
   }
 
@@ -223,7 +223,7 @@ export async function recordOverageAtCheckout(
         );
         // A genuine coverage gap (#715), not a modelled outcome — this aborts
         // a booking with real money on the line.
-        reportError(carveErr, {
+        reportSentryError(carveErr, {
           subsystem: "payments",
           contexts: { overage: { paymentId, basePaise } },
         });
@@ -267,7 +267,7 @@ export async function recordOverageAtCheckout(
       })
       .catch((notifyErr) => {
         console.error("[notifyOrgProgramOverageDue] failed:", notifyErr);
-        reportError(notifyErr, { subsystem: "payments", level: "warning" });
+        reportSentryError(notifyErr, { subsystem: "payments", level: "warning" });
       });
     return;
   }

--- a/lib/payments/core/razorpay.ts
+++ b/lib/payments/core/razorpay.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import Razorpay from "razorpay";
 import {
   PaymentIntentParams,
@@ -88,8 +89,9 @@ export async function createRazorpayOrder({
     };
   } catch (error) {
     console.error("Razorpay order creation failed:", error);
-    Sentry.captureException(error, {
-      tags: { subsystem: "payments", provider: "razorpay", expected: "false" },
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "razorpay" },
       contexts: { payment: { amount, currency } },
     });
     throw handleRazorpayError(error);
@@ -123,13 +125,11 @@ export async function cancelRazorpayOrder(orderId: string): Promise<void> {
     console.log(
       `✅ Razorpay order fetch failed (likely safe to ignore): ${orderId}`,
     );
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: { subsystem: "payments", provider: "razorpay", expected: "true" },
-        level: "info",
-      },
-    );
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "razorpay" },
+      expected: true,
+    });
   }
 }
 
@@ -311,13 +311,10 @@ export async function createRazorpayRefund({
     // doesn't conflate "Razorpay is down" with "this order has no payment".
     const isModelledValidation =
       error instanceof RefundError && error.code !== "UNKNOWN_ERROR";
-    Sentry.captureException(error, {
-      tags: {
-        subsystem: "payments",
-        provider: "razorpay",
-        expected: isModelledValidation ? "true" : "false",
-      },
-      level: isModelledValidation ? "info" : "error",
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "razorpay" },
+      expected: isModelledValidation,
     });
     throw handleRazorpayRefundError(error);
   }
@@ -351,12 +348,10 @@ export async function getRazorpayRefund(
     };
   } catch (error) {
     console.error("Razorpay refund retrieval failed:", error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: { subsystem: "payments", provider: "razorpay", expected: "false" },
-      },
-    );
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "razorpay" },
+    });
     throw handleRazorpayRefundError(error);
   }
 }
@@ -405,12 +400,10 @@ export async function listRazorpayRefunds(
     }));
   } catch (error) {
     console.error("Razorpay refunds list failed:", error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: { subsystem: "payments", provider: "razorpay", expected: "false" },
-      },
-    );
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "razorpay" },
+    });
     throw handleRazorpayRefundError(error);
   }
 }

--- a/lib/payments/core/razorpay.ts
+++ b/lib/payments/core/razorpay.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import Razorpay from "razorpay";
 import {
   PaymentIntentParams,
@@ -89,7 +89,7 @@ export async function createRazorpayOrder({
     };
   } catch (error) {
     console.error("Razorpay order creation failed:", error);
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "razorpay" },
       contexts: { payment: { amount, currency } },
@@ -125,7 +125,7 @@ export async function cancelRazorpayOrder(orderId: string): Promise<void> {
     console.log(
       `✅ Razorpay order fetch failed (likely safe to ignore): ${orderId}`,
     );
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "razorpay" },
       expected: true,
@@ -311,7 +311,7 @@ export async function createRazorpayRefund({
     // doesn't conflate "Razorpay is down" with "this order has no payment".
     const isModelledValidation =
       error instanceof RefundError && error.code !== "UNKNOWN_ERROR";
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "razorpay" },
       expected: isModelledValidation,
@@ -348,7 +348,7 @@ export async function getRazorpayRefund(
     };
   } catch (error) {
     console.error("Razorpay refund retrieval failed:", error);
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "razorpay" },
     });
@@ -400,7 +400,7 @@ export async function listRazorpayRefunds(
     }));
   } catch (error) {
     console.error("Razorpay refunds list failed:", error);
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "razorpay" },
     });

--- a/lib/payments/core/razorpay.ts
+++ b/lib/payments/core/razorpay.ts
@@ -8,7 +8,6 @@ import {
   PaymentError,
   RefundError,
 } from "./types";
-import { RefundStatus } from "@prisma/client";
 import { mapGatewayRefundStatus } from "@/lib/payments/refund-status";
 
 // ============================================================================
@@ -90,7 +89,7 @@ export async function createRazorpayOrder({
   } catch (error) {
     console.error("Razorpay order creation failed:", error);
     Sentry.captureException(error, {
-      tags: { subsystem: "payments", provider: "razorpay" },
+      tags: { subsystem: "payments", provider: "razorpay", expected: "false" },
       contexts: { payment: { amount, currency } },
     });
     throw handleRazorpayError(error);
@@ -118,10 +117,18 @@ export async function cancelRazorpayOrder(orderId: string): Promise<void> {
     console.warn(
       `⚠️ Cannot cancel Razorpay order with existing payments: ${orderId}`,
     );
-  } catch {
-    // If we can't fetch payments, assume it's safe to ignore
+  } catch (error) {
+    // If we can't fetch payments, assume it's safe to ignore — best-effort
+    // cancel, and a stray order with no payment costs nothing.
     console.log(
       `✅ Razorpay order fetch failed (likely safe to ignore): ${orderId}`,
+    );
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        tags: { subsystem: "payments", provider: "razorpay", expected: "true" },
+        level: "info",
+      },
     );
   }
 }
@@ -299,8 +306,18 @@ export async function createRazorpayRefund({
     };
   } catch (error) {
     console.error("Razorpay refund creation failed:", error);
+    // NO_PAYMENT_FOUND/etc are our own pre-gateway validation (thrown above in
+    // this same try), not a gateway fault — tag by origin so the dashboard
+    // doesn't conflate "Razorpay is down" with "this order has no payment".
+    const isModelledValidation =
+      error instanceof RefundError && error.code !== "UNKNOWN_ERROR";
     Sentry.captureException(error, {
-      tags: { subsystem: "payments", provider: "razorpay" },
+      tags: {
+        subsystem: "payments",
+        provider: "razorpay",
+        expected: isModelledValidation ? "true" : "false",
+      },
+      level: isModelledValidation ? "info" : "error",
     });
     throw handleRazorpayRefundError(error);
   }
@@ -337,7 +354,7 @@ export async function getRazorpayRefund(
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
       {
-        tags: { subsystem: "payments", provider: "razorpay" },
+        tags: { subsystem: "payments", provider: "razorpay", expected: "false" },
       },
     );
     throw handleRazorpayRefundError(error);
@@ -391,7 +408,7 @@ export async function listRazorpayRefunds(
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
       {
-        tags: { subsystem: "payments", provider: "razorpay" },
+        tags: { subsystem: "payments", provider: "razorpay", expected: "false" },
       },
     );
     throw handleRazorpayRefundError(error);

--- a/lib/payments/core/stripe.ts
+++ b/lib/payments/core/stripe.ts
@@ -1,4 +1,4 @@
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import Stripe from "stripe";
 import {
   PaymentIntentParams,
@@ -123,7 +123,7 @@ export async function createStripeCheckoutSession({
     const isCardDecline =
       error instanceof Stripe.errors.StripeError &&
       error.type === "StripeCardError";
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "stripe" },
       expected: isCardDecline,
@@ -170,7 +170,7 @@ export async function cancelStripePayment(
         console.log(
           `✅ Payment was already expired/cancelled: ${paymentIntentId}`,
         );
-        reportError(error, {
+        reportSentryError(error, {
           subsystem: "payments",
           tags: { provider: "stripe" },
           expected: true,
@@ -179,7 +179,7 @@ export async function cancelStripePayment(
       }
     }
     console.error(`Failed to cancel Stripe payment ${paymentIntentId}:`, error);
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
   }
 }
 
@@ -226,7 +226,7 @@ export async function createStripeRefund({
     };
   } catch (error) {
     console.error("Stripe refund creation failed:", error);
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeRefundError(error);
   }
 }
@@ -255,7 +255,7 @@ export async function getStripeRefund(refundId: string): Promise<RefundResult> {
     };
   } catch (error) {
     console.error("Stripe refund retrieval failed:", error);
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeRefundError(error);
   }
 }
@@ -290,7 +290,7 @@ export async function listStripeRefunds(
     }));
   } catch (error) {
     console.error("Stripe refunds list failed:", error);
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeRefundError(error);
   }
 }
@@ -334,7 +334,7 @@ export async function getStripeDispute(
     } else {
       console.error("Stripe dispute retrieval failed:", error);
     }
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeDisputeError(error);
   }
 }
@@ -388,7 +388,7 @@ export async function submitStripeDisputeEvidence({
     };
   } catch (error) {
     console.error("Stripe dispute evidence submission failed:", error);
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeDisputeError(error);
   }
 }
@@ -421,7 +421,7 @@ export async function listStripeDisputes(
     }));
   } catch (error) {
     console.error("Stripe disputes list failed:", error);
-    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
+    reportSentryError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeDisputeError(error);
   }
 }

--- a/lib/payments/core/stripe.ts
+++ b/lib/payments/core/stripe.ts
@@ -117,8 +117,19 @@ export async function createStripeCheckoutSession({
     };
   } catch (error) {
     console.error("Stripe checkout session creation failed:", error);
+    // A declined/invalid card is an ANSWER the gateway gave us, not a fault —
+    // tag it separately so the dashboard doesn't read "Stripe is down" for
+    // routine card declines.
+    const isCardDecline =
+      error instanceof Stripe.errors.StripeError &&
+      error.type === "StripeCardError";
     Sentry.captureException(error, {
-      tags: { subsystem: "payments", provider: "stripe" },
+      tags: {
+        subsystem: "payments",
+        provider: "stripe",
+        expected: isCardDecline ? "true" : "false",
+      },
+      level: isCardDecline ? "info" : "error",
       contexts: { payment: { amount, currency } },
     });
     throw handleStripeError(error);
@@ -162,13 +173,23 @@ export async function cancelStripePayment(
         console.log(
           `✅ Payment was already expired/cancelled: ${paymentIntentId}`,
         );
+        Sentry.captureException(error, {
+          tags: {
+            subsystem: "payments",
+            provider: "stripe",
+            expected: "true",
+          },
+          level: "info",
+        });
         return;
       }
     }
     console.error(`Failed to cancel Stripe payment ${paymentIntentId}:`, error);
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe" } },
+      {
+        tags: { subsystem: "payments", provider: "stripe", expected: "false" },
+      },
     );
   }
 }
@@ -217,7 +238,7 @@ export async function createStripeRefund({
   } catch (error) {
     console.error("Stripe refund creation failed:", error);
     Sentry.captureException(error, {
-      tags: { subsystem: "payments", provider: "stripe" },
+      tags: { subsystem: "payments", provider: "stripe", expected: "false" },
     });
     throw handleStripeRefundError(error);
   }
@@ -249,7 +270,7 @@ export async function getStripeRefund(refundId: string): Promise<RefundResult> {
     console.error("Stripe refund retrieval failed:", error);
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe" } },
+      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
     );
     throw handleStripeRefundError(error);
   }
@@ -287,7 +308,7 @@ export async function listStripeRefunds(
     console.error("Stripe refunds list failed:", error);
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe" } },
+      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
     );
     throw handleStripeRefundError(error);
   }
@@ -334,7 +355,7 @@ export async function getStripeDispute(
     }
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe" } },
+      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
     );
     throw handleStripeDisputeError(error);
   }
@@ -391,7 +412,7 @@ export async function submitStripeDisputeEvidence({
     console.error("Stripe dispute evidence submission failed:", error);
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe" } },
+      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
     );
     throw handleStripeDisputeError(error);
   }
@@ -427,7 +448,7 @@ export async function listStripeDisputes(
     console.error("Stripe disputes list failed:", error);
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe" } },
+      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
     );
     throw handleStripeDisputeError(error);
   }

--- a/lib/payments/core/stripe.ts
+++ b/lib/payments/core/stripe.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import Stripe from "stripe";
 import {
   PaymentIntentParams,
@@ -123,13 +123,10 @@ export async function createStripeCheckoutSession({
     const isCardDecline =
       error instanceof Stripe.errors.StripeError &&
       error.type === "StripeCardError";
-    Sentry.captureException(error, {
-      tags: {
-        subsystem: "payments",
-        provider: "stripe",
-        expected: isCardDecline ? "true" : "false",
-      },
-      level: isCardDecline ? "info" : "error",
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "stripe" },
+      expected: isCardDecline,
       contexts: { payment: { amount, currency } },
     });
     throw handleStripeError(error);
@@ -173,24 +170,16 @@ export async function cancelStripePayment(
         console.log(
           `✅ Payment was already expired/cancelled: ${paymentIntentId}`,
         );
-        Sentry.captureException(error, {
-          tags: {
-            subsystem: "payments",
-            provider: "stripe",
-            expected: "true",
-          },
-          level: "info",
+        reportError(error, {
+          subsystem: "payments",
+          tags: { provider: "stripe" },
+          expected: true,
         });
         return;
       }
     }
     console.error(`Failed to cancel Stripe payment ${paymentIntentId}:`, error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: { subsystem: "payments", provider: "stripe", expected: "false" },
-      },
-    );
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
   }
 }
 
@@ -237,9 +226,7 @@ export async function createStripeRefund({
     };
   } catch (error) {
     console.error("Stripe refund creation failed:", error);
-    Sentry.captureException(error, {
-      tags: { subsystem: "payments", provider: "stripe", expected: "false" },
-    });
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeRefundError(error);
   }
 }
@@ -268,10 +255,7 @@ export async function getStripeRefund(refundId: string): Promise<RefundResult> {
     };
   } catch (error) {
     console.error("Stripe refund retrieval failed:", error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
-    );
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeRefundError(error);
   }
 }
@@ -306,10 +290,7 @@ export async function listStripeRefunds(
     }));
   } catch (error) {
     console.error("Stripe refunds list failed:", error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
-    );
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeRefundError(error);
   }
 }
@@ -353,10 +334,7 @@ export async function getStripeDispute(
     } else {
       console.error("Stripe dispute retrieval failed:", error);
     }
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
-    );
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeDisputeError(error);
   }
 }
@@ -410,10 +388,7 @@ export async function submitStripeDisputeEvidence({
     };
   } catch (error) {
     console.error("Stripe dispute evidence submission failed:", error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
-    );
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeDisputeError(error);
   }
 }
@@ -446,10 +421,7 @@ export async function listStripeDisputes(
     }));
   } catch (error) {
     console.error("Stripe disputes list failed:", error);
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", provider: "stripe", expected: "false" } },
-    );
+    reportError(error, { subsystem: "payments", tags: { provider: "stripe" } });
     throw handleStripeDisputeError(error);
   }
 }

--- a/lib/payments/ledger/post.ts
+++ b/lib/payments/ledger/post.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import type { PrismaLike } from "@/lib/prisma";
 /**
  * #771 D1/D5 — double-entry posting helper (Batch 2 foundation).
@@ -22,8 +23,6 @@ import type {
   LedgerAccountKind,
   LedgerDirection,
   LedgerTransactionKind,
-  Prisma,
-  PrismaClient,
 } from "@prisma/client";
 import { sumPaise } from "@/lib/payments/utils/money";
 
@@ -112,21 +111,35 @@ export async function postLedgerTxn(
   input: PostLedgerTxnInput,
 ): Promise<{ transactionId: string; created: boolean }> {
   if (input.postings.length === 0) {
-    throw new Error(`postLedgerTxn "${input.idempotencyKey}": no postings`);
+    const err = new Error(
+      `postLedgerTxn "${input.idempotencyKey}": no postings`,
+    );
+    Sentry.captureException(err, {
+      tags: { subsystem: "payments", expected: "false" },
+    });
+    throw err;
   }
   let debit = 0;
   let credit = 0;
   for (const p of input.postings) {
     if (!Number.isInteger(p.amountPaise) || p.amountPaise <= 0) {
-      throw new Error(
+      const err = new Error(
         `postLedgerTxn "${input.idempotencyKey}": each posting must be a positive integer paise (got ${p.amountPaise})`,
       );
+      Sentry.captureException(err, {
+        tags: { subsystem: "payments", expected: "false" },
+      });
+      throw err;
     }
     if (p.direction === "DEBIT") debit += p.amountPaise;
     else credit += p.amountPaise;
   }
   if (debit !== credit) {
-    throw new LedgerImbalanceError(input.idempotencyKey, debit, credit);
+    const err = new LedgerImbalanceError(input.idempotencyKey, debit, credit);
+    Sentry.captureException(err, {
+      tags: { subsystem: "payments", expected: "false" },
+    });
+    throw err;
   }
 
   // Idempotency fast-path. `idempotencyKey @unique` is the hard guard: if two
@@ -136,7 +149,16 @@ export async function postLedgerTxn(
     where: { idempotencyKey: input.idempotencyKey },
     select: { id: true },
   });
-  if (existing) return { transactionId: existing.id, created: false };
+  if (existing) {
+    // Idempotency short-circuit — a retried/replayed caller hit an
+    // already-posted key. The system working as designed.
+    Sentry.captureMessage("Ledger posting idempotency short-circuit", {
+      level: "info",
+      tags: { subsystem: "payments", expected: "true" },
+      extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
+    });
+    return { transactionId: existing.id, created: false };
+  }
 
   const accountIds = await Promise.all(
     input.postings.map((p) => resolveAccountId(db, p.account)),
@@ -198,11 +220,39 @@ export async function postLedgerTxn(
           where: { idempotencyKey: input.idempotencyKey },
           select: { id: true },
         });
-        if (winner) return { transactionId: winner.id, created: false };
-      } catch {
+        if (winner) {
+          // Lost-race rescue succeeded — a concurrent poster with the same
+          // key committed first. Modelled outcome, not a fault.
+          Sentry.captureMessage("Ledger posting P2002 race rescued", {
+            level: "info",
+            tags: { subsystem: "payments", expected: "true" },
+            extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
+          });
+          return { transactionId: winner.id, created: false };
+        }
+      } catch (rescueErr) {
         // Aborted transaction — fall through and rethrow the original P2002.
+        // This inner failure is itself expected inside a tx (Postgres already
+        // aborted it, so ANY further read throws 25P02) — captured for
+        // pattern visibility only, not as a new fault.
+        Sentry.captureException(
+          rescueErr instanceof Error ? rescueErr : new Error(String(rescueErr)),
+          {
+            tags: { subsystem: "payments", expected: "true" },
+            level: "info",
+            extra: { idempotencyKey: input.idempotencyKey },
+          },
+        );
       }
     }
+    // Genuine, unrecovered ledger-write failure — every caller must see this;
+    // captured here so callers that don't wrap postLedgerTxn in their own
+    // try/catch (some do, redundantly capturing the same error again) still
+    // get visibility.
+    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
+      tags: { subsystem: "payments", expected: "false" },
+      extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
+    });
     throw err;
   }
 

--- a/lib/payments/ledger/post.ts
+++ b/lib/payments/ledger/post.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import type { PrismaLike } from "@/lib/prisma";
 /**
  * #771 D1/D5 — double-entry posting helper (Batch 2 foundation).
@@ -114,9 +114,7 @@ export async function postLedgerTxn(
     const err = new Error(
       `postLedgerTxn "${input.idempotencyKey}": no postings`,
     );
-    Sentry.captureException(err, {
-      tags: { subsystem: "payments", expected: "false" },
-    });
+    reportError(err, { subsystem: "payments" });
     throw err;
   }
   let debit = 0;
@@ -126,9 +124,7 @@ export async function postLedgerTxn(
       const err = new Error(
         `postLedgerTxn "${input.idempotencyKey}": each posting must be a positive integer paise (got ${p.amountPaise})`,
       );
-      Sentry.captureException(err, {
-        tags: { subsystem: "payments", expected: "false" },
-      });
+      reportError(err, { subsystem: "payments" });
       throw err;
     }
     if (p.direction === "DEBIT") debit += p.amountPaise;
@@ -136,9 +132,7 @@ export async function postLedgerTxn(
   }
   if (debit !== credit) {
     const err = new LedgerImbalanceError(input.idempotencyKey, debit, credit);
-    Sentry.captureException(err, {
-      tags: { subsystem: "payments", expected: "false" },
-    });
+    reportError(err, { subsystem: "payments" });
     throw err;
   }
 
@@ -152,9 +146,9 @@ export async function postLedgerTxn(
   if (existing) {
     // Idempotency short-circuit — a retried/replayed caller hit an
     // already-posted key. The system working as designed.
-    Sentry.captureMessage("Ledger posting idempotency short-circuit", {
-      level: "info",
-      tags: { subsystem: "payments", expected: "true" },
+    reportMessage("Ledger posting idempotency short-circuit", {
+      subsystem: "payments",
+      expected: true,
       extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
     });
     return { transactionId: existing.id, created: false };
@@ -223,9 +217,9 @@ export async function postLedgerTxn(
         if (winner) {
           // Lost-race rescue succeeded — a concurrent poster with the same
           // key committed first. Modelled outcome, not a fault.
-          Sentry.captureMessage("Ledger posting P2002 race rescued", {
-            level: "info",
-            tags: { subsystem: "payments", expected: "true" },
+          reportMessage("Ledger posting P2002 race rescued", {
+            subsystem: "payments",
+            expected: true,
             extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
           });
           return { transactionId: winner.id, created: false };
@@ -235,22 +229,19 @@ export async function postLedgerTxn(
         // This inner failure is itself expected inside a tx (Postgres already
         // aborted it, so ANY further read throws 25P02) — captured for
         // pattern visibility only, not as a new fault.
-        Sentry.captureException(
-          rescueErr instanceof Error ? rescueErr : new Error(String(rescueErr)),
-          {
-            tags: { subsystem: "payments", expected: "true" },
-            level: "info",
-            extra: { idempotencyKey: input.idempotencyKey },
-          },
-        );
+        reportError(rescueErr, {
+          subsystem: "payments",
+          expected: true,
+          extra: { idempotencyKey: input.idempotencyKey },
+        });
       }
     }
     // Genuine, unrecovered ledger-write failure — every caller must see this;
     // captured here so callers that don't wrap postLedgerTxn in their own
     // try/catch (some do, redundantly capturing the same error again) still
     // get visibility.
-    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-      tags: { subsystem: "payments", expected: "false" },
+    reportError(err, {
+      subsystem: "payments",
       extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
     });
     throw err;

--- a/lib/payments/ledger/post.ts
+++ b/lib/payments/ledger/post.ts
@@ -1,4 +1,4 @@
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import type { PrismaLike } from "@/lib/prisma";
 /**
  * #771 D1/D5 — double-entry posting helper (Batch 2 foundation).
@@ -114,7 +114,7 @@ export async function postLedgerTxn(
     const err = new Error(
       `postLedgerTxn "${input.idempotencyKey}": no postings`,
     );
-    reportError(err, { subsystem: "payments" });
+    reportSentryError(err, { subsystem: "payments" });
     throw err;
   }
   let debit = 0;
@@ -124,7 +124,7 @@ export async function postLedgerTxn(
       const err = new Error(
         `postLedgerTxn "${input.idempotencyKey}": each posting must be a positive integer paise (got ${p.amountPaise})`,
       );
-      reportError(err, { subsystem: "payments" });
+      reportSentryError(err, { subsystem: "payments" });
       throw err;
     }
     if (p.direction === "DEBIT") debit += p.amountPaise;
@@ -132,7 +132,7 @@ export async function postLedgerTxn(
   }
   if (debit !== credit) {
     const err = new LedgerImbalanceError(input.idempotencyKey, debit, credit);
-    reportError(err, { subsystem: "payments" });
+    reportSentryError(err, { subsystem: "payments" });
     throw err;
   }
 
@@ -146,7 +146,7 @@ export async function postLedgerTxn(
   if (existing) {
     // Idempotency short-circuit — a retried/replayed caller hit an
     // already-posted key. The system working as designed.
-    reportMessage("Ledger posting idempotency short-circuit", {
+    reportSentryMessage("Ledger posting idempotency short-circuit", {
       subsystem: "payments",
       expected: true,
       extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
@@ -217,7 +217,7 @@ export async function postLedgerTxn(
         if (winner) {
           // Lost-race rescue succeeded — a concurrent poster with the same
           // key committed first. Modelled outcome, not a fault.
-          reportMessage("Ledger posting P2002 race rescued", {
+          reportSentryMessage("Ledger posting P2002 race rescued", {
             subsystem: "payments",
             expected: true,
             extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
@@ -229,7 +229,7 @@ export async function postLedgerTxn(
         // This inner failure is itself expected inside a tx (Postgres already
         // aborted it, so ANY further read throws 25P02) — captured for
         // pattern visibility only, not as a new fault.
-        reportError(rescueErr, {
+        reportSentryError(rescueErr, {
           subsystem: "payments",
           expected: true,
           extra: { idempotencyKey: input.idempotencyKey },
@@ -240,7 +240,7 @@ export async function postLedgerTxn(
     // captured here so callers that don't wrap postLedgerTxn in their own
     // try/catch (some do, redundantly capturing the same error again) still
     // get visibility.
-    reportError(err, {
+    reportSentryError(err, {
       subsystem: "payments",
       extra: { idempotencyKey: input.idempotencyKey, kind: input.kind },
     });

--- a/lib/payments/operations/cancel-pending.ts
+++ b/lib/payments/operations/cancel-pending.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import type { Tx } from "@/lib/prisma";
 import { Prisma, type PaymentGateway } from "@prisma/client";
@@ -125,14 +125,11 @@ export async function cancelPendingCheckout(args: {
         if (!payment || payment.userId !== args.userId) {
           // Authorization-denial-shaped outcome (or a genuinely missing
           // payment) — modelled, reported for visibility only.
-          Sentry.captureMessage(
-            "cancelPendingCheckout: not found / not owned by caller",
-            {
-              level: "info",
-              tags: { subsystem: "payments", expected: "true" },
-              extra: { paymentId: args.paymentId },
-            },
-          );
+          reportMessage("cancelPendingCheckout: not found / not owned by caller", {
+            subsystem: "payments",
+            expected: true,
+            extra: { paymentId: args.paymentId },
+          });
           return {
             outcome: { ok: false, code: "NOT_FOUND" },
             gatewayCancel: null,
@@ -152,14 +149,11 @@ export async function cancelPendingCheckout(args: {
         if (claimed.count === 0) {
           // Lost CAS race — the webhook/cron/a parallel cancel already won.
           // The system working as designed.
-          Sentry.captureMessage(
-            "cancelPendingCheckout: lost CAS race (already terminal)",
-            {
-              level: "info",
-              tags: { subsystem: "payments", expected: "true" },
-              extra: { paymentId: args.paymentId },
-            },
-          );
+          reportMessage("cancelPendingCheckout: lost CAS race (already terminal)", {
+            subsystem: "payments",
+            expected: true,
+            extra: { paymentId: args.paymentId },
+          });
           return {
             outcome: { ok: false, code: "NOT_PENDING" },
             gatewayCancel: null,
@@ -226,10 +220,7 @@ export async function cancelPendingCheckout(args: {
         gatewayCancel.gateway,
       );
     } catch (error) {
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        { tags: { subsystem: "payments", expected: "false" } },
-      );
+      reportError(error, { subsystem: "payments" });
       console.warn(
         JSON.stringify({
           event: "cancel_pending_gateway_cancel_failed",

--- a/lib/payments/operations/cancel-pending.ts
+++ b/lib/payments/operations/cancel-pending.ts
@@ -1,4 +1,4 @@
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import type { Tx } from "@/lib/prisma";
 import { Prisma, type PaymentGateway } from "@prisma/client";
@@ -125,7 +125,7 @@ export async function cancelPendingCheckout(args: {
         if (!payment || payment.userId !== args.userId) {
           // Authorization-denial-shaped outcome (or a genuinely missing
           // payment) — modelled, reported for visibility only.
-          reportMessage("cancelPendingCheckout: not found / not owned by caller", {
+          reportSentryMessage("cancelPendingCheckout: not found / not owned by caller", {
             subsystem: "payments",
             expected: true,
             extra: { paymentId: args.paymentId },
@@ -149,7 +149,7 @@ export async function cancelPendingCheckout(args: {
         if (claimed.count === 0) {
           // Lost CAS race — the webhook/cron/a parallel cancel already won.
           // The system working as designed.
-          reportMessage("cancelPendingCheckout: lost CAS race (already terminal)", {
+          reportSentryMessage("cancelPendingCheckout: lost CAS race (already terminal)", {
             subsystem: "payments",
             expected: true,
             extra: { paymentId: args.paymentId },
@@ -220,7 +220,7 @@ export async function cancelPendingCheckout(args: {
         gatewayCancel.gateway,
       );
     } catch (error) {
-      reportError(error, { subsystem: "payments" });
+      reportSentryError(error, { subsystem: "payments" });
       console.warn(
         JSON.stringify({
           event: "cancel_pending_gateway_cancel_failed",

--- a/lib/payments/operations/cancel-pending.ts
+++ b/lib/payments/operations/cancel-pending.ts
@@ -123,6 +123,16 @@ export async function cancelPendingCheckout(args: {
         });
         // Foreign payments 404 like missing ones — don't leak existence.
         if (!payment || payment.userId !== args.userId) {
+          // Authorization-denial-shaped outcome (or a genuinely missing
+          // payment) — modelled, reported for visibility only.
+          Sentry.captureMessage(
+            "cancelPendingCheckout: not found / not owned by caller",
+            {
+              level: "info",
+              tags: { subsystem: "payments", expected: "true" },
+              extra: { paymentId: args.paymentId },
+            },
+          );
           return {
             outcome: { ok: false, code: "NOT_FOUND" },
             gatewayCancel: null,
@@ -140,6 +150,16 @@ export async function cancelPendingCheckout(args: {
           data: { paymentStatus: "EXPIRED" },
         });
         if (claimed.count === 0) {
+          // Lost CAS race — the webhook/cron/a parallel cancel already won.
+          // The system working as designed.
+          Sentry.captureMessage(
+            "cancelPendingCheckout: lost CAS race (already terminal)",
+            {
+              level: "info",
+              tags: { subsystem: "payments", expected: "true" },
+              extra: { paymentId: args.paymentId },
+            },
+          );
           return {
             outcome: { ok: false, code: "NOT_PENDING" },
             gatewayCancel: null,
@@ -208,7 +228,7 @@ export async function cancelPendingCheckout(args: {
     } catch (error) {
       Sentry.captureException(
         error instanceof Error ? error : new Error(String(error)),
-        { tags: { subsystem: "payments" } },
+        { tags: { subsystem: "payments", expected: "false" } },
       );
       console.warn(
         JSON.stringify({

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -197,7 +197,7 @@ export class PaymentIntentManager {
       Sentry.captureException(
         error instanceof Error ? error : new Error(String(error)),
         {
-          tags: { subsystem: "payments" },
+          tags: { subsystem: "payments", expected: "false" },
         },
       );
       throw new Error(
@@ -221,7 +221,7 @@ export class PaymentIntentManager {
       Sentry.captureException(
         error instanceof Error ? error : new Error(String(error)),
         {
-          tags: { subsystem: "payments" },
+          tags: { subsystem: "payments", expected: "false" },
           level: "warning",
         },
       );
@@ -2251,7 +2251,7 @@ export async function handleCheckout(
             ? paymentError
             : new Error(String(paymentError)),
           {
-            tags: { subsystem: "payments" },
+            tags: { subsystem: "payments", expected: "false" },
           },
         );
         throw new Error(
@@ -2546,7 +2546,7 @@ export async function handleCheckout(
                         ? notifyErr
                         : new Error(String(notifyErr)),
                       {
-                        tags: { subsystem: "payments" },
+                        tags: { subsystem: "payments", expected: "false" },
                         level: "warning",
                       },
                     );
@@ -2659,7 +2659,7 @@ export async function handleCheckout(
                         ? notifyErr
                         : new Error(String(notifyErr)),
                       {
-                        tags: { subsystem: "payments" },
+                        tags: { subsystem: "payments", expected: "false" },
                         level: "warning",
                       },
                     );
@@ -2880,7 +2880,7 @@ export async function handleCheckout(
               ? referralError
               : new Error(String(referralError)),
             {
-              tags: { subsystem: "payments" },
+              tags: { subsystem: "payments", expected: "false" },
               level: "warning",
             },
           );
@@ -3028,7 +3028,7 @@ export async function handleCheckout(
               ? consultantRefError
               : new Error(String(consultantRefError)),
             {
-              tags: { subsystem: "payments" },
+              tags: { subsystem: "payments", expected: "false" },
               level: "warning",
             },
           );
@@ -3050,10 +3050,36 @@ export async function handleCheckout(
       };
     } catch (dbError) {
       console.error("Failed to create payment record:", dbError);
+      // Classification for Sentry tagging ONLY — deliberately NOT the same
+      // list `preservedMessages` below uses for the rethrow decision, so
+      // adding a tagging-only pattern here can never change which message
+      // reaches the caller.
+      const modelledOutcomePatterns = [
+        "already registered",
+        "already enrolled",
+        "full",
+        "cancelled",
+        "ended",
+        "not been scheduled",
+        "already have a pending or active subscription",
+        "overlapping dates",
+        "insufficient credits",
+        "session cap", // ProgramAssignmentLimitError-derived message, above
+      ];
+      const isModelledOutcome =
+        dbError instanceof WalletFrozenError ||
+        (dbError instanceof Error &&
+          modelledOutcomePatterns.some((msg) =>
+            dbError.message.toLowerCase().includes(msg),
+          ));
       Sentry.captureException(
         dbError instanceof Error ? dbError : new Error(String(dbError)),
         {
-          tags: { subsystem: "payments" },
+          tags: {
+            subsystem: "payments",
+            expected: isModelledOutcome ? "true" : "false",
+          },
+          level: isModelledOutcome ? "info" : "error",
         },
       );
 
@@ -3100,16 +3126,31 @@ export async function handleCheckout(
       );
     }
   } catch (error) {
+    // Outermost boundary — also catches validation errors from
+    // calculateAmountAndValidate/acquireCheckoutLock/revalidateInsideLock
+    // (steps 1-3, above the STEP-5 try/catch that already reports) which
+    // otherwise reach here uncaptured. Lock contention is a modelled,
+    // expected race between two concurrent checkouts; anything else here is
+    // unclassified and reported as a fault by default.
+    const isLockContention =
+      error instanceof Error &&
+      (error.message.includes("currently checking out") ||
+        error.message.includes("currently being booked"));
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        tags: {
+          subsystem: "payments",
+          expected: isLockContention ? "true" : "false",
+        },
+        level: isLockContention ? "info" : "error",
+      },
+    );
     // Enhanced error handling with lock-specific errors
-    if (error instanceof Error) {
-      if (
-        error.message.includes("currently checking out") ||
-        error.message.includes("currently being booked")
-      ) {
-        throw new Error(
-          "Another user is currently booking this slot. Please wait a few seconds and try again.",
-        );
-      }
+    if (isLockContention) {
+      throw new Error(
+        "Another user is currently booking this slot. Please wait a few seconds and try again.",
+      );
     }
     throw error;
   } finally {

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -3,7 +3,7 @@
  * Handles the complete checkout flow for all appointment types
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import { CheckoutInput, checkoutSchema } from "@/schemas/checkout";
 import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
@@ -194,12 +194,7 @@ export class PaymentIntentManager {
       return paymentResponse;
     } catch (error) {
       console.error("Payment intent creation failed:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: { subsystem: "payments", expected: "false" },
-        },
-      );
+      reportError(error, { subsystem: "payments" });
       throw new Error(
         "Failed to create payment intent. Please try again later.",
       );
@@ -218,13 +213,7 @@ export class PaymentIntentManager {
       this.activeIntents.delete(intentId);
     } catch (error) {
       console.error(`Failed to cancel payment intent ${intentId}:`, error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: { subsystem: "payments", expected: "false" },
-          level: "warning",
-        },
-      );
+      reportError(error, { subsystem: "payments", level: "warning" });
       // Don't throw - cleanup should be best-effort
     }
   }
@@ -2246,14 +2235,7 @@ export async function handleCheckout(
         });
       } catch (paymentError) {
         console.error("Payment intent creation failed:", paymentError);
-        Sentry.captureException(
-          paymentError instanceof Error
-            ? paymentError
-            : new Error(String(paymentError)),
-          {
-            tags: { subsystem: "payments", expected: "false" },
-          },
-        );
+        reportError(paymentError, { subsystem: "payments" });
         throw new Error(
           "Failed to create payment intent. Please try again later.",
         );
@@ -2541,15 +2523,10 @@ export async function handleCheckout(
                       "[notifyOrgProgramExhausted] failed:",
                       notifyErr,
                     );
-                    Sentry.captureException(
-                      notifyErr instanceof Error
-                        ? notifyErr
-                        : new Error(String(notifyErr)),
-                      {
-                        tags: { subsystem: "payments", expected: "false" },
-                        level: "warning",
-                      },
-                    );
+                    reportError(notifyErr, {
+                      subsystem: "payments",
+                      level: "warning",
+                    });
                   });
 
                 throw new Error(
@@ -2654,15 +2631,10 @@ export async function handleCheckout(
                       "[notifyOrgProgramCapNear] failed:",
                       notifyErr,
                     );
-                    Sentry.captureException(
-                      notifyErr instanceof Error
-                        ? notifyErr
-                        : new Error(String(notifyErr)),
-                      {
-                        tags: { subsystem: "payments", expected: "false" },
-                        level: "warning",
-                      },
-                    );
+                    reportError(notifyErr, {
+                      subsystem: "payments",
+                      level: "warning",
+                    });
                   });
               }
             }
@@ -2875,15 +2847,7 @@ export async function handleCheckout(
             `⚠️ Failed to process referral qualifying action for user ${userId}:`,
             referralError,
           );
-          Sentry.captureException(
-            referralError instanceof Error
-              ? referralError
-              : new Error(String(referralError)),
-            {
-              tags: { subsystem: "payments", expected: "false" },
-              level: "warning",
-            },
-          );
+          reportError(referralError, { subsystem: "payments", level: "warning" });
         }
 
         // Create consultant earnings (mock payments bypass webhooks, so earnings must be created here)
@@ -3023,15 +2987,10 @@ export async function handleCheckout(
             `⚠️ Failed to process consultant referral qualifying action:`,
             consultantRefError,
           );
-          Sentry.captureException(
-            consultantRefError instanceof Error
-              ? consultantRefError
-              : new Error(String(consultantRefError)),
-            {
-              tags: { subsystem: "payments", expected: "false" },
-              level: "warning",
-            },
-          );
+          reportError(consultantRefError, {
+            subsystem: "payments",
+            level: "warning",
+          });
         }
       }
 
@@ -3072,16 +3031,7 @@ export async function handleCheckout(
           modelledOutcomePatterns.some((msg) =>
             dbError.message.toLowerCase().includes(msg),
           ));
-      Sentry.captureException(
-        dbError instanceof Error ? dbError : new Error(String(dbError)),
-        {
-          tags: {
-            subsystem: "payments",
-            expected: isModelledOutcome ? "true" : "false",
-          },
-          level: isModelledOutcome ? "info" : "error",
-        },
-      );
+      reportError(dbError, { subsystem: "payments", expected: isModelledOutcome });
 
       // CRITICAL: Cancel payment intent since DB operation failed
       // (Skip cleanup for zero-amount payments — they have no real gateway intent)
@@ -3136,16 +3086,7 @@ export async function handleCheckout(
       error instanceof Error &&
       (error.message.includes("currently checking out") ||
         error.message.includes("currently being booked"));
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: {
-          subsystem: "payments",
-          expected: isLockContention ? "true" : "false",
-        },
-        level: isLockContention ? "info" : "error",
-      },
-    );
+    reportError(error, { subsystem: "payments", expected: isLockContention });
     // Enhanced error handling with lock-specific errors
     if (isLockContention) {
       throw new Error(

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -3095,7 +3095,16 @@ export async function handleCheckout(
       error instanceof Error &&
       (error.message.includes("currently checking out") ||
         error.message.includes("currently being booked"));
-    reportSentryError(error, { subsystem: "payments", expected: isLockContention });
+    // Tag-only: the explicit lock-expiry throw above ("...already in
+    // progress...") is the same modelled race, but is NOT folded into
+    // isLockContention — that variable also picks the rethrow message below,
+    // and this message already classifies correctly downstream (LOCK_CONTENTION
+    // via payment-error-classification.ts), so changing it would misroute it
+    // to AVAILABILITY instead.
+    const isModeledLockRace =
+      isLockContention ||
+      (error instanceof Error && error.message.includes("already in progress"));
+    reportSentryError(error, { subsystem: "payments", expected: isModeledLockRace });
     // Enhanced error handling with lock-specific errors
     if (isLockContention) {
       throw new Error(

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -3,7 +3,7 @@
  * Handles the complete checkout flow for all appointment types
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import { CheckoutInput, checkoutSchema } from "@/schemas/checkout";
 import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
@@ -194,7 +194,7 @@ export class PaymentIntentManager {
       return paymentResponse;
     } catch (error) {
       console.error("Payment intent creation failed:", error);
-      reportError(error, { subsystem: "payments" });
+      reportSentryError(error, { subsystem: "payments" });
       throw new Error(
         "Failed to create payment intent. Please try again later.",
       );
@@ -213,7 +213,7 @@ export class PaymentIntentManager {
       this.activeIntents.delete(intentId);
     } catch (error) {
       console.error(`Failed to cancel payment intent ${intentId}:`, error);
-      reportError(error, { subsystem: "payments", level: "warning" });
+      reportSentryError(error, { subsystem: "payments", level: "warning" });
       // Don't throw - cleanup should be best-effort
     }
   }
@@ -2235,7 +2235,7 @@ export async function handleCheckout(
         });
       } catch (paymentError) {
         console.error("Payment intent creation failed:", paymentError);
-        reportError(paymentError, { subsystem: "payments" });
+        reportSentryError(paymentError, { subsystem: "payments" });
         throw new Error(
           "Failed to create payment intent. Please try again later.",
         );
@@ -2523,7 +2523,7 @@ export async function handleCheckout(
                       "[notifyOrgProgramExhausted] failed:",
                       notifyErr,
                     );
-                    reportError(notifyErr, {
+                    reportSentryError(notifyErr, {
                       subsystem: "payments",
                       level: "warning",
                     });
@@ -2631,7 +2631,7 @@ export async function handleCheckout(
                       "[notifyOrgProgramCapNear] failed:",
                       notifyErr,
                     );
-                    reportError(notifyErr, {
+                    reportSentryError(notifyErr, {
                       subsystem: "payments",
                       level: "warning",
                     });
@@ -2847,7 +2847,7 @@ export async function handleCheckout(
             `⚠️ Failed to process referral qualifying action for user ${userId}:`,
             referralError,
           );
-          reportError(referralError, { subsystem: "payments", level: "warning" });
+          reportSentryError(referralError, { subsystem: "payments", level: "warning" });
         }
 
         // Create consultant earnings (mock payments bypass webhooks, so earnings must be created here)
@@ -2987,7 +2987,7 @@ export async function handleCheckout(
             `⚠️ Failed to process consultant referral qualifying action:`,
             consultantRefError,
           );
-          reportError(consultantRefError, {
+          reportSentryError(consultantRefError, {
             subsystem: "payments",
             level: "warning",
           });
@@ -3025,13 +3025,22 @@ export async function handleCheckout(
         "insufficient credits",
         "session cap", // ProgramAssignmentLimitError-derived message, above
       ];
+      // Typed errors and stable codes first — a substring is a last resort,
+      // not the mechanism. recordOverageAtCheckout stamps
+      // code: "PROGRAM_CAP_EXHAUSTED" on its 402, which this used to miss
+      // entirely and report as a fault.
+      const dbErrorCode = (dbError as { code?: unknown } | null)?.code;
       const isModelledOutcome =
         dbError instanceof WalletFrozenError ||
+        dbError instanceof ProgramAssignmentLimitError ||
+        dbErrorCode === "PROGRAM_CAP_EXHAUSTED" ||
         (dbError instanceof Error &&
           modelledOutcomePatterns.some((msg) =>
-            dbError.message.toLowerCase().includes(msg),
+            // Word-bounded: bare `includes` let "full" match "successful" and
+            // "ended" match "unintended", tagging real faults as routine.
+            new RegExp(`\\b${msg}\\b`, "i").test(dbError.message),
           ));
-      reportError(dbError, { subsystem: "payments", expected: isModelledOutcome });
+      reportSentryError(dbError, { subsystem: "payments", expected: isModelledOutcome });
 
       // CRITICAL: Cancel payment intent since DB operation failed
       // (Skip cleanup for zero-amount payments — they have no real gateway intent)
@@ -3086,7 +3095,7 @@ export async function handleCheckout(
       error instanceof Error &&
       (error.message.includes("currently checking out") ||
         error.message.includes("currently being booked"));
-    reportError(error, { subsystem: "payments", expected: isLockContention });
+    reportSentryError(error, { subsystem: "payments", expected: isLockContention });
     // Enhanced error handling with lock-specific errors
     if (isLockContention) {
       throw new Error(

--- a/lib/payments/operations/event-refunds.ts
+++ b/lib/payments/operations/event-refunds.ts
@@ -1,4 +1,4 @@
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { withSerializableRetry } from "@/lib/db/serializable-retry";
@@ -82,7 +82,7 @@ export async function refundWholeEventPayments(
       summary.childRefundIds.push(r.refundId);
     } catch (err) {
       summary.failures.push({ paymentId: p.id, error: errMsg(err) });
-      reportError(err, {
+      reportSentryError(err, {
         subsystem: "payments",
         tags: { feature: "whole-event-refund" },
         extra: { paymentId: p.id, eventId, kind },
@@ -127,7 +127,7 @@ export async function refundWholeEventPayments(
       for (const p of internal) {
         summary.failures.push({ paymentId: p.id, error: errMsg(err) });
       }
-      reportError(err, {
+      reportSentryError(err, {
         subsystem: "payments",
         tags: { feature: "whole-event-refund" },
         extra: { eventId, kind, internalCount: internal.length },

--- a/lib/payments/operations/event-refunds.ts
+++ b/lib/payments/operations/event-refunds.ts
@@ -83,7 +83,7 @@ export async function refundWholeEventPayments(
     } catch (err) {
       summary.failures.push({ paymentId: p.id, error: errMsg(err) });
       Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-        tags: { subsystem: "payments", feature: "whole-event-refund" },
+        tags: { subsystem: "payments", feature: "whole-event-refund", expected: "false" },
         extra: { paymentId: p.id, eventId, kind },
       });
     }
@@ -127,7 +127,7 @@ export async function refundWholeEventPayments(
         summary.failures.push({ paymentId: p.id, error: errMsg(err) });
       }
       Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-        tags: { subsystem: "payments", feature: "whole-event-refund" },
+        tags: { subsystem: "payments", feature: "whole-event-refund", expected: "false" },
         extra: { eventId, kind, internalCount: internal.length },
       });
     }

--- a/lib/payments/operations/event-refunds.ts
+++ b/lib/payments/operations/event-refunds.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { withSerializableRetry } from "@/lib/db/serializable-retry";
@@ -82,8 +82,9 @@ export async function refundWholeEventPayments(
       summary.childRefundIds.push(r.refundId);
     } catch (err) {
       summary.failures.push({ paymentId: p.id, error: errMsg(err) });
-      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-        tags: { subsystem: "payments", feature: "whole-event-refund", expected: "false" },
+      reportError(err, {
+        subsystem: "payments",
+        tags: { feature: "whole-event-refund" },
         extra: { paymentId: p.id, eventId, kind },
       });
     }
@@ -126,8 +127,9 @@ export async function refundWholeEventPayments(
       for (const p of internal) {
         summary.failures.push({ paymentId: p.id, error: errMsg(err) });
       }
-      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-        tags: { subsystem: "payments", feature: "whole-event-refund", expected: "false" },
+      reportError(err, {
+        subsystem: "payments",
+        tags: { feature: "whole-event-refund" },
         extra: { eventId, kind, internalCount: internal.length },
       });
     }

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -104,6 +104,18 @@ export class RefundValidationError extends Error {
   }
 }
 
+/**
+ * Report a modelled refund-validation outcome (already-refunded, race-loss,
+ * blocked-by-dispute, etc.) for visibility only. Never changes control flow —
+ * every call site still throws the same error object right after this.
+ */
+function reportModelledRefundOutcome(err: RefundValidationError): void {
+  Sentry.captureException(err, {
+    tags: { subsystem: "payments", feature: "refund", expected: "true" },
+    level: "info",
+  });
+}
+
 /** Gateway rejected or errored on the refund call. The Refund row is kept
  * (PENDING with a `pending_` placeholder, or FAILED when the gateway
  * definitively declined) so the reconcile cron / failed-refund notifier own
@@ -151,16 +163,20 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
   });
 
   if (!payment) {
-    throw new RefundValidationError(
+    const err = new RefundValidationError(
       `Payment ${input.paymentId} not found`,
       "PAYMENT_NOT_FOUND",
     );
+    reportModelledRefundOutcome(err);
+    throw err;
   }
   if (payment.paymentStatus !== PaymentStatus.SUCCEEDED) {
-    throw new RefundValidationError(
+    const err = new RefundValidationError(
       `Payment ${input.paymentId} is not SUCCEEDED (status=${payment.paymentStatus}); cannot refund`,
       "PAYMENT_NOT_SUCCEEDED",
     );
+    reportModelledRefundOutcome(err);
+    throw err;
   }
 
   // Sum already-refunded across non-FAILED, non-CANCELLED refunds. A
@@ -194,12 +210,14 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
 
   const refundable = payment.amount - alreadyRefunded;
   if (refundable <= 0) {
-    throw new RefundValidationError(
+    const err = new RefundValidationError(
       `Payment ${input.paymentId} has no refundable balance (amount=${payment.amount}, ` +
         `refunded=${refundedSoFar}, chargeback-reversed=${chargedBack}); the customer was ` +
         `already made whole — a chargeback returns money via the bank, not an app refund`,
       "ALREADY_FULLY_REFUNDED",
     );
+    reportModelledRefundOutcome(err);
+    throw err;
   }
 
   // #1008 — block an app-initiated refund while a dispute is LIVE (non-terminal)
@@ -215,24 +233,30 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
     select: { status: true },
   });
   if (liveDispute) {
-    throw new RefundValidationError(
+    const err = new RefundValidationError(
       `Payment ${input.paymentId} has an open dispute (${liveDispute.status}); resolve it before refunding`,
       "REFUND_BLOCKED_BY_DISPUTE",
     );
+    reportModelledRefundOutcome(err);
+    throw err;
   }
 
   const requested = input.amountPaise ?? refundable;
   if (requested <= 0) {
-    throw new RefundValidationError(
+    const err = new RefundValidationError(
       `Refund amount must be positive; got ${requested}`,
       "INVALID_AMOUNT",
     );
+    reportModelledRefundOutcome(err);
+    throw err;
   }
   if (requested > refundable) {
-    throw new RefundValidationError(
+    const err = new RefundValidationError(
       `Refund amount ${requested} exceeds refundable ${refundable} on payment ${input.paymentId}`,
       "AMOUNT_EXCEEDS_REFUNDABLE",
     );
+    reportModelledRefundOutcome(err);
+    throw err;
   }
 
   // PHASE 1 — reserve. Create the Refund row in PENDING with a `pending_`
@@ -282,10 +306,12 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
           refundedNow -
           sumPaise(chargedBackNow._sum.amountPaise);
         if (requested > remainingNow) {
-          throw new RefundValidationError(
+          const err = new RefundValidationError(
             `Race-loss: refund amount ${requested} exceeds refundable ${remainingNow} on payment ${input.paymentId}`,
             "AMOUNT_EXCEEDS_REFUNDABLE",
           );
+          reportModelledRefundOutcome(err);
+          throw err;
         }
 
         // #1008 — re-check for a live dispute inside the Serializable tx. Reading
@@ -300,10 +326,12 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
           select: { id: true },
         });
         if (liveDisputeNow) {
-          throw new RefundValidationError(
+          const err = new RefundValidationError(
             `Payment ${input.paymentId} has an open dispute; resolve it before refunding`,
             "REFUND_BLOCKED_BY_DISPUTE",
           );
+          reportModelledRefundOutcome(err);
+          throw err;
         }
 
         return tx.refund.create({
@@ -350,7 +378,11 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
     Sentry.captureException(
       err instanceof Error ? err : new Error(String(err)),
       {
-        tags: { subsystem: "payments", feature: "refund" },
+        tags: {
+          subsystem: "payments",
+          feature: "refund",
+          expected: "false",
+        },
         extra: { paymentId: input.paymentId, refundRowId: reserved.id },
       },
     );
@@ -507,8 +539,10 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
       });
     } catch (err) {
       // ALREADY_FULLY_REFUNDED / PAYMENT_NOT_SUCCEEDED are benign idempotent
-      // re-drives; anything else is a real gap between the parent refund and the
-      // member's credit-back — page ops rather than fail the settled parent.
+      // re-drives — the nested refundPayment call already reported them
+      // (expected:true) at their origin above; anything else here is a real
+      // gap between the parent refund and the member's credit-back — page
+      // ops rather than fail the settled parent.
       if (
         !(err instanceof RefundValidationError) ||
         (err.code !== "ALREADY_FULLY_REFUNDED" &&
@@ -517,7 +551,11 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         Sentry.captureException(
           err instanceof Error ? err : new Error(String(err)),
           {
-            tags: { subsystem: "payments", feature: "overage-credit-back" },
+            tags: {
+              subsystem: "payments",
+              feature: "overage-credit-back",
+              expected: "false",
+            },
             extra: { parentPaymentId: input.paymentId, sidePaymentId },
           },
         );
@@ -584,6 +622,14 @@ export async function applyRefundCascade(
     data: { cascadedAt: new Date() },
   });
   if (claim.count === 0) {
+    // Idempotency short-circuit — the system working as designed (a
+    // redelivered webhook or a racing cron lost the claim). Reported for
+    // volume/pattern visibility only.
+    Sentry.captureMessage("Refund cascade idempotency short-circuit", {
+      level: "info",
+      tags: { subsystem: "payments", feature: "refund", expected: "true" },
+      extra: { refundId: input.refundId, paymentId: input.paymentId },
+    });
     return {
       legsReversed: 0,
       consultantEarningsReversed: 0,
@@ -1264,7 +1310,7 @@ export async function applyRefundCascade(
     Sentry.captureException(
       err instanceof Error ? err : new Error(String(err)),
       {
-        tags: { subsystem: "payments" },
+        tags: { subsystem: "payments", expected: "false" },
         contexts: {
           refund: { paymentId: payment.id, refundId: input.refundId },
         },

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -37,7 +37,7 @@
  * the paise.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import {
   EarningStatus,
@@ -110,9 +110,10 @@ export class RefundValidationError extends Error {
  * every call site still throws the same error object right after this.
  */
 function reportModelledRefundOutcome(err: RefundValidationError): void {
-  Sentry.captureException(err, {
-    tags: { subsystem: "payments", feature: "refund", expected: "true" },
-    level: "info",
+  reportError(err, {
+    subsystem: "payments",
+    tags: { feature: "refund" },
+    expected: true,
   });
 }
 
@@ -375,17 +376,11 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
       idempotencyKey: reserved.id,
     });
   } catch (err) {
-    Sentry.captureException(
-      err instanceof Error ? err : new Error(String(err)),
-      {
-        tags: {
-          subsystem: "payments",
-          feature: "refund",
-          expected: "false",
-        },
-        extra: { paymentId: input.paymentId, refundRowId: reserved.id },
-      },
-    );
+    reportError(err, {
+      subsystem: "payments",
+      tags: { feature: "refund" },
+      extra: { paymentId: input.paymentId, refundRowId: reserved.id },
+    });
     // Keep the PENDING placeholder: the reconcile cron matches it against
     // the gateway (covers "call actually landed but we never heard back")
     // or FAILs it after 24h, which triggers the payer notification (#779).
@@ -548,17 +543,11 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         (err.code !== "ALREADY_FULLY_REFUNDED" &&
           err.code !== "PAYMENT_NOT_SUCCEEDED")
       ) {
-        Sentry.captureException(
-          err instanceof Error ? err : new Error(String(err)),
-          {
-            tags: {
-              subsystem: "payments",
-              feature: "overage-credit-back",
-              expected: "false",
-            },
-            extra: { parentPaymentId: input.paymentId, sidePaymentId },
-          },
-        );
+        reportError(err, {
+          subsystem: "payments",
+          tags: { feature: "overage-credit-back" },
+          extra: { parentPaymentId: input.paymentId, sidePaymentId },
+        });
         void recordSystemError({
           organizationId: null,
           category: "PAYMENT",
@@ -625,9 +614,10 @@ export async function applyRefundCascade(
     // Idempotency short-circuit — the system working as designed (a
     // redelivered webhook or a racing cron lost the claim). Reported for
     // volume/pattern visibility only.
-    Sentry.captureMessage("Refund cascade idempotency short-circuit", {
-      level: "info",
-      tags: { subsystem: "payments", feature: "refund", expected: "true" },
+    reportMessage("Refund cascade idempotency short-circuit", {
+      subsystem: "payments",
+      tags: { feature: "refund" },
+      expected: true,
       extra: { refundId: input.refundId, paymentId: input.paymentId },
     });
     return {
@@ -1307,15 +1297,12 @@ export async function applyRefundCascade(
     console.error(
       `[ledger] refund reversal posting FAILED for payment ${payment.id} — rolling back the cascade: ${err instanceof Error ? err.message : String(err)}`,
     );
-    Sentry.captureException(
-      err instanceof Error ? err : new Error(String(err)),
-      {
-        tags: { subsystem: "payments", expected: "false" },
-        contexts: {
-          refund: { paymentId: payment.id, refundId: input.refundId },
-        },
+    reportError(err, {
+      subsystem: "payments",
+      contexts: {
+        refund: { paymentId: payment.id, refundId: input.refundId },
       },
-    );
+    });
     void recordSystemError({
       organizationId: payment.organizationId ?? null,
       category: "LEDGER",

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -37,7 +37,7 @@
  * the paise.
  */
 
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import {
   EarningStatus,
@@ -110,7 +110,7 @@ export class RefundValidationError extends Error {
  * every call site still throws the same error object right after this.
  */
 function reportModelledRefundOutcome(err: RefundValidationError): void {
-  reportError(err, {
+  reportSentryError(err, {
     subsystem: "payments",
     tags: { feature: "refund" },
     expected: true,
@@ -376,7 +376,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
       idempotencyKey: reserved.id,
     });
   } catch (err) {
-    reportError(err, {
+    reportSentryError(err, {
       subsystem: "payments",
       tags: { feature: "refund" },
       extra: { paymentId: input.paymentId, refundRowId: reserved.id },
@@ -543,7 +543,7 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         (err.code !== "ALREADY_FULLY_REFUNDED" &&
           err.code !== "PAYMENT_NOT_SUCCEEDED")
       ) {
-        reportError(err, {
+        reportSentryError(err, {
           subsystem: "payments",
           tags: { feature: "overage-credit-back" },
           extra: { parentPaymentId: input.paymentId, sidePaymentId },
@@ -614,7 +614,7 @@ export async function applyRefundCascade(
     // Idempotency short-circuit — the system working as designed (a
     // redelivered webhook or a racing cron lost the claim). Reported for
     // volume/pattern visibility only.
-    reportMessage("Refund cascade idempotency short-circuit", {
+    reportSentryMessage("Refund cascade idempotency short-circuit", {
       subsystem: "payments",
       tags: { feature: "refund" },
       expected: true,
@@ -1297,7 +1297,7 @@ export async function applyRefundCascade(
     console.error(
       `[ledger] refund reversal posting FAILED for payment ${payment.id} — rolling back the cascade: ${err instanceof Error ? err.message : String(err)}`,
     );
-    reportError(err, {
+    reportSentryError(err, {
       subsystem: "payments",
       contexts: {
         refund: { paymentId: payment.id, refundId: input.refundId },

--- a/lib/payments/operations/refund.ts
+++ b/lib/payments/operations/refund.ts
@@ -417,11 +417,19 @@ export async function refundPayment(input: RefundInput): Promise<RefundResult> {
         failedAt: new Date(),
       },
     });
-    throw new RefundGatewayError(
+    const declineErr = new RefundGatewayError(
       `Gateway declined refund for payment ${input.paymentId}`,
       "GATEWAY_REFUND_DECLINED",
       reserved.id,
     );
+    // Declined outcomes reach here as data (gateway.status), never a thrown
+    // rejection, so unlike the catch above this had no Sentry trace at all.
+    reportSentryError(declineErr, {
+      subsystem: "payments",
+      tags: { feature: "refund" },
+      extra: { paymentId: input.paymentId, refundRowId: reserved.id },
+    });
+    throw declineErr;
   }
 
   await prisma.refund.update({

--- a/lib/payments/operations/reversal-engine.ts
+++ b/lib/payments/operations/reversal-engine.ts
@@ -1,4 +1,4 @@
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import type { Tx } from "@/lib/prisma";
 /**
  * Unified reversal engine (#776 §C / ARCH #4).
@@ -273,7 +273,7 @@ async function reversePayoutClawback(
     select: { id: true, clawbackInitiatedAt: true },
   });
   if (!payout) {
-    reportMessage("reversePayoutClawback: target OrganizationPayout not found", {
+    reportSentryMessage("reversePayoutClawback: target OrganizationPayout not found", {
       subsystem: "payments",
       level: "warning",
       extra: { orgPayoutId, refundId: input.refundId },
@@ -325,7 +325,7 @@ async function reversePayoutClawback(
       ],
     });
   } catch (err) {
-    reportError(err, { subsystem: "payments", level: "fatal" });
+    reportSentryError(err, { subsystem: "payments", level: "fatal" });
     console.error(
       `[ledger] payout clawback posting FAILED for payout ${orgPayoutId} (reconcile will flag): ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/lib/payments/operations/reversal-engine.ts
+++ b/lib/payments/operations/reversal-engine.ts
@@ -272,7 +272,17 @@ async function reversePayoutClawback(
     where: { id: orgPayoutId },
     select: { id: true, clawbackInitiatedAt: true },
   });
-  if (!payout) return false;
+  if (!payout) {
+    Sentry.captureMessage(
+      "reversePayoutClawback: target OrganizationPayout not found",
+      {
+        level: "warning",
+        tags: { subsystem: "payments", expected: "false" },
+        extra: { orgPayoutId, refundId: input.refundId },
+      },
+    );
+    return false;
+  }
 
   await tx.organizationPayout.update({
     where: { id: orgPayoutId },
@@ -320,7 +330,7 @@ async function reversePayoutClawback(
   } catch (err) {
     Sentry.captureException(
       err instanceof Error ? err : new Error(String(err)),
-      { tags: { subsystem: "payments" }, level: "fatal" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "fatal" },
     );
     console.error(
       `[ledger] payout clawback posting FAILED for payout ${orgPayoutId} (reconcile will flag): ${err instanceof Error ? err.message : String(err)}`,

--- a/lib/payments/operations/reversal-engine.ts
+++ b/lib/payments/operations/reversal-engine.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import type { Tx } from "@/lib/prisma";
 /**
  * Unified reversal engine (#776 §C / ARCH #4).
@@ -273,14 +273,11 @@ async function reversePayoutClawback(
     select: { id: true, clawbackInitiatedAt: true },
   });
   if (!payout) {
-    Sentry.captureMessage(
-      "reversePayoutClawback: target OrganizationPayout not found",
-      {
-        level: "warning",
-        tags: { subsystem: "payments", expected: "false" },
-        extra: { orgPayoutId, refundId: input.refundId },
-      },
-    );
+    reportMessage("reversePayoutClawback: target OrganizationPayout not found", {
+      subsystem: "payments",
+      level: "warning",
+      extra: { orgPayoutId, refundId: input.refundId },
+    });
     return false;
   }
 
@@ -328,10 +325,7 @@ async function reversePayoutClawback(
       ],
     });
   } catch (err) {
-    Sentry.captureException(
-      err instanceof Error ? err : new Error(String(err)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "fatal" },
-    );
+    reportError(err, { subsystem: "payments", level: "fatal" });
     console.error(
       `[ledger] payout clawback posting FAILED for payout ${orgPayoutId} (reconcile will flag): ${err instanceof Error ? err.message : String(err)}`,
     );

--- a/lib/payments/payouts/earning-status.ts
+++ b/lib/payments/payouts/earning-status.ts
@@ -16,7 +16,7 @@
  * OrganizationEarnings.status MUST call this guard first.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { EarningStatus } from "@prisma/client";
 
 export class IllegalEarningStatusTransitionError extends Error {
@@ -41,13 +41,13 @@ export function assertEarningStatusTransitionLegal(
     const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
     // Modelled invariant guard (a lost race or a caller bug) — reported for
     // visibility, control flow unchanged.
-    reportError(err, { subsystem: "payments", expected: true, level: "warning" });
+    reportSentryError(err, { subsystem: "payments", expected: true, level: "warning" });
     throw err;
   }
   // REFUNDED is terminal — once refunded, no further status mutations.
   if (from === EarningStatus.REFUNDED) {
     const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
-    reportError(err, { subsystem: "payments", expected: true, level: "warning" });
+    reportSentryError(err, { subsystem: "payments", expected: true, level: "warning" });
     throw err;
   }
 }

--- a/lib/payments/payouts/earning-status.ts
+++ b/lib/payments/payouts/earning-status.ts
@@ -39,15 +39,18 @@ export function assertEarningStatusTransitionLegal(
 ): void {
   if (from === EarningStatus.PAID && to !== EarningStatus.REFUNDED) {
     const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
-    // Modelled invariant guard (a lost race or a caller bug) — reported for
-    // visibility, control flow unchanged.
-    reportSentryError(err, { subsystem: "payments", expected: true, level: "warning" });
+    // Unlike a CAS lost-race (an expected outcome of concurrent writers),
+    // this guard isn't a compare-and-swap — it's asserting a business
+    // invariant on money that has already moved (a real bank transfer + TDS
+    // deduction). Firing means a caller bug or state corruption, not a
+    // routine race, so it stays a fault.
+    reportSentryError(err, { subsystem: "payments", expected: false });
     throw err;
   }
   // REFUNDED is terminal — once refunded, no further status mutations.
   if (from === EarningStatus.REFUNDED) {
     const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
-    reportSentryError(err, { subsystem: "payments", expected: true, level: "warning" });
+    reportSentryError(err, { subsystem: "payments", expected: false });
     throw err;
   }
 }

--- a/lib/payments/payouts/earning-status.ts
+++ b/lib/payments/payouts/earning-status.ts
@@ -16,7 +16,7 @@
  * OrganizationEarnings.status MUST call this guard first.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { EarningStatus } from "@prisma/client";
 
 export class IllegalEarningStatusTransitionError extends Error {
@@ -41,19 +41,13 @@ export function assertEarningStatusTransitionLegal(
     const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
     // Modelled invariant guard (a lost race or a caller bug) — reported for
     // visibility, control flow unchanged.
-    Sentry.captureException(err, {
-      tags: { subsystem: "payments", expected: "true" },
-      level: "warning",
-    });
+    reportError(err, { subsystem: "payments", expected: true, level: "warning" });
     throw err;
   }
   // REFUNDED is terminal — once refunded, no further status mutations.
   if (from === EarningStatus.REFUNDED) {
     const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
-    Sentry.captureException(err, {
-      tags: { subsystem: "payments", expected: "true" },
-      level: "warning",
-    });
+    reportError(err, { subsystem: "payments", expected: true, level: "warning" });
     throw err;
   }
 }

--- a/lib/payments/payouts/earning-status.ts
+++ b/lib/payments/payouts/earning-status.ts
@@ -16,6 +16,7 @@
  * OrganizationEarnings.status MUST call this guard first.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import { EarningStatus } from "@prisma/client";
 
 export class IllegalEarningStatusTransitionError extends Error {
@@ -37,10 +38,22 @@ export function assertEarningStatusTransitionLegal(
   to: EarningStatus,
 ): void {
   if (from === EarningStatus.PAID && to !== EarningStatus.REFUNDED) {
-    throw new IllegalEarningStatusTransitionError(from, to, earningsId);
+    const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
+    // Modelled invariant guard (a lost race or a caller bug) — reported for
+    // visibility, control flow unchanged.
+    Sentry.captureException(err, {
+      tags: { subsystem: "payments", expected: "true" },
+      level: "warning",
+    });
+    throw err;
   }
   // REFUNDED is terminal — once refunded, no further status mutations.
   if (from === EarningStatus.REFUNDED) {
-    throw new IllegalEarningStatusTransitionError(from, to, earningsId);
+    const err = new IllegalEarningStatusTransitionError(from, to, earningsId);
+    Sentry.captureException(err, {
+      tags: { subsystem: "payments", expected: "true" },
+      level: "warning",
+    });
+    throw err;
   }
 }

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -260,7 +260,7 @@ async function resolveOrgSplit(
       new Error(
         `[Earnings] Negative orgShare (${orgShare}) for org ${orgId}: platformBps=${resolved.platformBps}, consultantBps=${resolved.consultantBps}. Clamping.`,
       ),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     console.error(
       `[Earnings] Negative orgShare (${orgShare}) for org ${orgId}: ` +
@@ -816,7 +816,7 @@ export async function createEarningsFromPayment({
                 Sentry.captureException(
                   err instanceof Error ? err : new Error(String(err)),
                   {
-                    tags: { subsystem: "payments" },
+                    tags: { subsystem: "payments", expected: "false" },
                   },
                 );
                 console.error(
@@ -833,6 +833,16 @@ export async function createEarningsFromPayment({
                   err,
                   context: { paymentId: payment.id },
                 }).catch(() => {});
+              } else {
+                // Lost SSI race — withSerializableRetry re-runs the whole txn.
+                // Modelled outcome, reported at low volume/info only.
+                Sentry.captureException(
+                  err instanceof Error ? err : new Error(String(err)),
+                  {
+                    tags: { subsystem: "payments", expected: "true" },
+                    level: "info",
+                  },
+                );
               }
               throw err;
             }
@@ -852,6 +862,11 @@ export async function createEarningsFromPayment({
       console.warn(
         `[Earnings] Duplicate earnings creation for payment ${payment.id} (P2002). Treating as idempotent success.`,
       );
+      Sentry.captureException(error, {
+        tags: { subsystem: "payments", expected: "true" },
+        level: "info",
+        extra: { paymentId: payment.id, consultantProfileId },
+      });
       const existing = await prisma.consultantEarnings.findFirst({
         where: { paymentId: payment.id, consultantProfileId },
       });

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -15,7 +15,7 @@
  * consultant's personal payout for that booking is zero.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import {
@@ -256,7 +256,7 @@ async function resolveOrgSplit(
   }
 
   if (orgShare < 0) {
-    reportError(
+    reportSentryError(
       new Error(
         `[Earnings] Negative orgShare (${orgShare}) for org ${orgId}: platformBps=${resolved.platformBps}, consultantBps=${resolved.consultantBps}. Clamping.`,
       ),
@@ -813,7 +813,7 @@ export async function createEarningsFromPayment({
                 err instanceof Prisma.PrismaClientKnownRequestError &&
                 err.code === "P2034";
               if (!isRetryableSerialization) {
-                reportError(err, { subsystem: "payments" });
+                reportSentryError(err, { subsystem: "payments" });
                 console.error(
                   `[ledger] booking posting FAILED for payment ${payment.id} — rolling back the booking: ${err instanceof Error ? err.message : String(err)}`,
                 );
@@ -831,7 +831,7 @@ export async function createEarningsFromPayment({
               } else {
                 // Lost SSI race — withSerializableRetry re-runs the whole txn.
                 // Modelled outcome, reported at low volume/info only.
-                reportError(err, { subsystem: "payments", expected: true });
+                reportSentryError(err, { subsystem: "payments", expected: true });
               }
               throw err;
             }
@@ -851,7 +851,7 @@ export async function createEarningsFromPayment({
       console.warn(
         `[Earnings] Duplicate earnings creation for payment ${payment.id} (P2002). Treating as idempotent success.`,
       );
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "payments",
         expected: true,
         extra: { paymentId: payment.id, consultantProfileId },

--- a/lib/payments/payouts/earnings-service.ts
+++ b/lib/payments/payouts/earnings-service.ts
@@ -15,7 +15,7 @@
  * consultant's personal payout for that booking is zero.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import { withSerializableRetry } from "@/lib/db/serializable-retry";
 import {
@@ -256,11 +256,11 @@ async function resolveOrgSplit(
   }
 
   if (orgShare < 0) {
-    Sentry.captureException(
+    reportError(
       new Error(
         `[Earnings] Negative orgShare (${orgShare}) for org ${orgId}: platformBps=${resolved.platformBps}, consultantBps=${resolved.consultantBps}. Clamping.`,
       ),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
+      { subsystem: "payments", level: "warning" },
     );
     console.error(
       `[Earnings] Negative orgShare (${orgShare}) for org ${orgId}: ` +
@@ -813,12 +813,7 @@ export async function createEarningsFromPayment({
                 err instanceof Prisma.PrismaClientKnownRequestError &&
                 err.code === "P2034";
               if (!isRetryableSerialization) {
-                Sentry.captureException(
-                  err instanceof Error ? err : new Error(String(err)),
-                  {
-                    tags: { subsystem: "payments", expected: "false" },
-                  },
-                );
+                reportError(err, { subsystem: "payments" });
                 console.error(
                   `[ledger] booking posting FAILED for payment ${payment.id} — rolling back the booking: ${err instanceof Error ? err.message : String(err)}`,
                 );
@@ -836,13 +831,7 @@ export async function createEarningsFromPayment({
               } else {
                 // Lost SSI race — withSerializableRetry re-runs the whole txn.
                 // Modelled outcome, reported at low volume/info only.
-                Sentry.captureException(
-                  err instanceof Error ? err : new Error(String(err)),
-                  {
-                    tags: { subsystem: "payments", expected: "true" },
-                    level: "info",
-                  },
-                );
+                reportError(err, { subsystem: "payments", expected: true });
               }
               throw err;
             }
@@ -862,9 +851,9 @@ export async function createEarningsFromPayment({
       console.warn(
         `[Earnings] Duplicate earnings creation for payment ${payment.id} (P2002). Treating as idempotent success.`,
       );
-      Sentry.captureException(error, {
-        tags: { subsystem: "payments", expected: "true" },
-        level: "info",
+      reportError(error, {
+        subsystem: "payments",
+        expected: true,
         extra: { paymentId: payment.id, consultantProfileId },
       });
       const existing = await prisma.consultantEarnings.findFirst({

--- a/lib/payments/payouts/org-payout-service.ts
+++ b/lib/payments/payouts/org-payout-service.ts
@@ -484,6 +484,12 @@ export async function createOrgPayoutBatch(
         },
       });
       if (existing) {
+        // Lost race — a sibling worker already created this payout under the
+        // same idempotency key. Modelled outcome, not a fault.
+        Sentry.captureException(err, {
+          tags: { subsystem: "payments", expected: "true" },
+          level: "info",
+        });
         return {
           payoutId: existing.id,
           amountPaise: existing.amountPaise,
@@ -494,7 +500,7 @@ export async function createOrgPayoutBatch(
         };
       }
     }
-    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments" } });
+    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments", expected: "false" } });
     throw err;
   } finally {
     await releaseLock(lockKey, token);
@@ -632,6 +638,14 @@ export async function processOrgPayout(
       } catch (err) {
         const cls = classifyGatewaySubmissionError(err);
         if (cls === "PERMANENT_4XX") {
+          // Gateway declined the submission — an answer, not a fault.
+          Sentry.captureException(
+            err instanceof Error ? err : new Error(String(err)),
+            {
+              tags: { subsystem: "payments", expected: "true" },
+              level: "info",
+            },
+          );
           await markPayoutFailedFromSubmission(
             payoutId,
             err instanceof Error ? err.message : String(err),
@@ -647,7 +661,7 @@ export async function processOrgPayout(
         }
         // Transient — leave row in PROCESSING and re-throw so the cron
         // retries with the same idempotency key.
-        Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments" } });
+        Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments", expected: "false" } });
         throw err;
       }
     });
@@ -846,7 +860,7 @@ export async function processPendingOrgPayouts(): Promise<OrgProcessingResult> {
         result.advanced++;
       }
     } catch (err) {
-      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments" } });
+      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments", expected: "false" } });
       const message = err instanceof Error ? err.message : String(err);
       result.errors.push(`OrgPayout ${p.id}: ${message}`);
     }
@@ -1232,7 +1246,7 @@ export async function markOrgPayoutReversed(
         kind: "REVERSED",
         dashboardUrl: `${getAppUrl()}/dashboard/organization/${completedResult.notify.organizationId}/payouts`,
       }).catch((e) => {
-        Sentry.captureException(e instanceof Error ? e : new Error(String(e)), { tags: { subsystem: "payments" } });
+        Sentry.captureException(e instanceof Error ? e : new Error(String(e)), { tags: { subsystem: "payments", expected: "false" } });
         console.error("[org-payout] REVERSED notify failed:", e);
       });
     }

--- a/lib/payments/payouts/org-payout-service.ts
+++ b/lib/payments/payouts/org-payout-service.ts
@@ -49,7 +49,7 @@
  *     re-derive these for any rows still on stub defaults.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import type { PaymentGateway, PayoutStatus } from "@prisma/client";
@@ -486,10 +486,7 @@ export async function createOrgPayoutBatch(
       if (existing) {
         // Lost race — a sibling worker already created this payout under the
         // same idempotency key. Modelled outcome, not a fault.
-        Sentry.captureException(err, {
-          tags: { subsystem: "payments", expected: "true" },
-          level: "info",
-        });
+        reportError(err, { subsystem: "payments", expected: true });
         return {
           payoutId: existing.id,
           amountPaise: existing.amountPaise,
@@ -500,7 +497,7 @@ export async function createOrgPayoutBatch(
         };
       }
     }
-    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments", expected: "false" } });
+    reportError(err, { subsystem: "payments" });
     throw err;
   } finally {
     await releaseLock(lockKey, token);
@@ -639,13 +636,7 @@ export async function processOrgPayout(
         const cls = classifyGatewaySubmissionError(err);
         if (cls === "PERMANENT_4XX") {
           // Gateway declined the submission — an answer, not a fault.
-          Sentry.captureException(
-            err instanceof Error ? err : new Error(String(err)),
-            {
-              tags: { subsystem: "payments", expected: "true" },
-              level: "info",
-            },
-          );
+          reportError(err, { subsystem: "payments", expected: true });
           await markPayoutFailedFromSubmission(
             payoutId,
             err instanceof Error ? err.message : String(err),
@@ -661,7 +652,7 @@ export async function processOrgPayout(
         }
         // Transient — leave row in PROCESSING and re-throw so the cron
         // retries with the same idempotency key.
-        Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments", expected: "false" } });
+        reportError(err, { subsystem: "payments" });
         throw err;
       }
     });
@@ -860,7 +851,7 @@ export async function processPendingOrgPayouts(): Promise<OrgProcessingResult> {
         result.advanced++;
       }
     } catch (err) {
-      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), { tags: { subsystem: "payments", expected: "false" } });
+      reportError(err, { subsystem: "payments" });
       const message = err instanceof Error ? err.message : String(err);
       result.errors.push(`OrgPayout ${p.id}: ${message}`);
     }
@@ -1246,7 +1237,7 @@ export async function markOrgPayoutReversed(
         kind: "REVERSED",
         dashboardUrl: `${getAppUrl()}/dashboard/organization/${completedResult.notify.organizationId}/payouts`,
       }).catch((e) => {
-        Sentry.captureException(e instanceof Error ? e : new Error(String(e)), { tags: { subsystem: "payments", expected: "false" } });
+        reportError(e, { subsystem: "payments" });
         console.error("[org-payout] REVERSED notify failed:", e);
       });
     }

--- a/lib/payments/payouts/org-payout-service.ts
+++ b/lib/payments/payouts/org-payout-service.ts
@@ -49,7 +49,7 @@
  *     re-derive these for any rows still on stub defaults.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import type { PaymentGateway, PayoutStatus } from "@prisma/client";
@@ -486,7 +486,7 @@ export async function createOrgPayoutBatch(
       if (existing) {
         // Lost race — a sibling worker already created this payout under the
         // same idempotency key. Modelled outcome, not a fault.
-        reportError(err, { subsystem: "payments", expected: true });
+        reportSentryError(err, { subsystem: "payments", expected: true });
         return {
           payoutId: existing.id,
           amountPaise: existing.amountPaise,
@@ -497,7 +497,7 @@ export async function createOrgPayoutBatch(
         };
       }
     }
-    reportError(err, { subsystem: "payments" });
+    reportSentryError(err, { subsystem: "payments" });
     throw err;
   } finally {
     await releaseLock(lockKey, token);
@@ -636,7 +636,7 @@ export async function processOrgPayout(
         const cls = classifyGatewaySubmissionError(err);
         if (cls === "PERMANENT_4XX") {
           // Gateway declined the submission — an answer, not a fault.
-          reportError(err, { subsystem: "payments", expected: true });
+          reportSentryError(err, { subsystem: "payments", expected: true });
           await markPayoutFailedFromSubmission(
             payoutId,
             err instanceof Error ? err.message : String(err),
@@ -652,7 +652,7 @@ export async function processOrgPayout(
         }
         // Transient — leave row in PROCESSING and re-throw so the cron
         // retries with the same idempotency key.
-        reportError(err, { subsystem: "payments" });
+        reportSentryError(err, { subsystem: "payments" });
         throw err;
       }
     });
@@ -851,7 +851,7 @@ export async function processPendingOrgPayouts(): Promise<OrgProcessingResult> {
         result.advanced++;
       }
     } catch (err) {
-      reportError(err, { subsystem: "payments" });
+      reportSentryError(err, { subsystem: "payments" });
       const message = err instanceof Error ? err.message : String(err);
       result.errors.push(`OrgPayout ${p.id}: ${message}`);
     }
@@ -1237,7 +1237,7 @@ export async function markOrgPayoutReversed(
         kind: "REVERSED",
         dashboardUrl: `${getAppUrl()}/dashboard/organization/${completedResult.notify.organizationId}/payouts`,
       }).catch((e) => {
-        reportError(e, { subsystem: "payments" });
+        reportSentryError(e, { subsystem: "payments" });
         console.error("[org-payout] REVERSED notify failed:", e);
       });
     }

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -3,7 +3,7 @@
  * Provider-agnostic payout orchestration with admin approval workflow
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import {
   PayoutStatus,
@@ -605,9 +605,9 @@ async function processSinglePayout(payout: {
       );
       // Lost CAS race — a concurrent runner already claimed this payout. The
       // system working as designed.
-      Sentry.captureMessage("Payout CAS claim lost to a concurrent runner", {
-        level: "info",
-        tags: { subsystem: "payments", expected: "true" },
+      reportMessage("Payout CAS claim lost to a concurrent runner", {
+        subsystem: "payments",
+        expected: true,
         extra: { payoutId: payout.id },
       });
       return { payoutId: payout.id, success: false, skipped: true };
@@ -778,25 +778,19 @@ async function processSinglePayout(payout: {
           `[payout-service] CRITICAL: gateway accepted ${providerPayoutId} but DB persist failed twice for payout ${payout.id}; manual reconcile required`,
           persistErr,
         );
-        Sentry.captureException(
-          persistErr instanceof Error
-            ? persistErr
-            : new Error(String(persistErr)),
-          {
-            tags: { subsystem: "payments", expected: "false" },
-            level: "fatal",
-            contexts: { payout: { payoutId: payout.id, providerPayoutId } },
-          },
-        );
+        reportError(persistErr, {
+          subsystem: "payments",
+          level: "fatal",
+          contexts: { payout: { payoutId: payout.id, providerPayoutId } },
+        });
       }
       console.error(
         `⚠️ Payout ${payout.id}: gateway accepted ${providerPayoutId} but DB write failed — quarantined PROCESSING (NOT failed) to avoid double-pay`,
       );
-      Sentry.captureException(
+      reportError(
         new Error(`gateway-accepted-db-write-failed: payout ${payout.id}`),
         {
-          tags: { subsystem: "payments", expected: "false" },
-          level: "error",
+          subsystem: "payments",
           contexts: { payout: { payoutId: payout.id, providerPayoutId } },
         },
       );
@@ -1015,9 +1009,9 @@ export async function handlePayoutWebhook(
       );
       // Idempotency short-circuit — a redelivered/duplicate gateway webhook.
       // The system working as designed.
-      Sentry.captureMessage("Payout webhook idempotency short-circuit", {
-        level: "info",
-        tags: { subsystem: "payments", expected: "true" },
+      reportMessage("Payout webhook idempotency short-circuit", {
+        subsystem: "payments",
+        expected: true,
         extra: { payoutId: payout.id, status },
       });
       return;
@@ -1152,13 +1146,7 @@ export async function handlePayoutWebhook(
         dashboardUrl: `${getAppUrl()}/dashboard`,
       }).catch((error) => {
         console.error("[payouts] Failed to send payout notification:", error);
-        Sentry.captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: { subsystem: "payments", expected: "false" },
-            level: "warning",
-          },
-        );
+        reportError(error, { subsystem: "payments", level: "warning" });
       });
     }
   }
@@ -1194,13 +1182,9 @@ export async function markConsultantPayoutReversed(
       console.warn(
         `[payouts] markConsultantPayoutReversed: payout not found for provider ID ${providerPayoutId}`,
       );
-      Sentry.captureMessage(
+      reportMessage(
         "markConsultantPayoutReversed: payout not found for provider ID",
-        {
-          level: "warning",
-          tags: { subsystem: "payments", expected: "false" },
-          extra: { providerPayoutId },
-        },
+        { subsystem: "payments", level: "warning", extra: { providerPayoutId } },
       );
       return { wasNoOp: true, notify: null };
     }
@@ -1216,14 +1200,11 @@ export async function markConsultantPayoutReversed(
     if (claim.count === 0) {
       // Modelled no-op — caller falls through to the pre-settlement FAILED
       // path when the payout wasn't COMPLETED.
-      Sentry.captureMessage(
-        "markConsultantPayoutReversed: no-op (not COMPLETED)",
-        {
-          level: "info",
-          tags: { subsystem: "payments", expected: "true" },
-          extra: { payoutId: payout.id },
-        },
-      );
+      reportMessage("markConsultantPayoutReversed: no-op (not COMPLETED)", {
+        subsystem: "payments",
+        expected: true,
+        extra: { payoutId: payout.id },
+      });
       return { wasNoOp: true, notify: null };
     }
 

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -3,7 +3,7 @@
  * Provider-agnostic payout orchestration with admin approval workflow
  */
 
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import prisma from "@/lib/prisma";
 import {
   PayoutStatus,
@@ -605,7 +605,7 @@ async function processSinglePayout(payout: {
       );
       // Lost CAS race — a concurrent runner already claimed this payout. The
       // system working as designed.
-      reportMessage("Payout CAS claim lost to a concurrent runner", {
+      reportSentryMessage("Payout CAS claim lost to a concurrent runner", {
         subsystem: "payments",
         expected: true,
         extra: { payoutId: payout.id },
@@ -778,7 +778,7 @@ async function processSinglePayout(payout: {
           `[payout-service] CRITICAL: gateway accepted ${providerPayoutId} but DB persist failed twice for payout ${payout.id}; manual reconcile required`,
           persistErr,
         );
-        reportError(persistErr, {
+        reportSentryError(persistErr, {
           subsystem: "payments",
           level: "fatal",
           contexts: { payout: { payoutId: payout.id, providerPayoutId } },
@@ -787,7 +787,7 @@ async function processSinglePayout(payout: {
       console.error(
         `⚠️ Payout ${payout.id}: gateway accepted ${providerPayoutId} but DB write failed — quarantined PROCESSING (NOT failed) to avoid double-pay`,
       );
-      reportError(
+      reportSentryError(
         new Error(`gateway-accepted-db-write-failed: payout ${payout.id}`),
         {
           subsystem: "payments",
@@ -1009,7 +1009,7 @@ export async function handlePayoutWebhook(
       );
       // Idempotency short-circuit — a redelivered/duplicate gateway webhook.
       // The system working as designed.
-      reportMessage("Payout webhook idempotency short-circuit", {
+      reportSentryMessage("Payout webhook idempotency short-circuit", {
         subsystem: "payments",
         expected: true,
         extra: { payoutId: payout.id, status },
@@ -1146,7 +1146,7 @@ export async function handlePayoutWebhook(
         dashboardUrl: `${getAppUrl()}/dashboard`,
       }).catch((error) => {
         console.error("[payouts] Failed to send payout notification:", error);
-        reportError(error, { subsystem: "payments", level: "warning" });
+        reportSentryError(error, { subsystem: "payments", level: "warning" });
       });
     }
   }
@@ -1182,7 +1182,7 @@ export async function markConsultantPayoutReversed(
       console.warn(
         `[payouts] markConsultantPayoutReversed: payout not found for provider ID ${providerPayoutId}`,
       );
-      reportMessage(
+      reportSentryMessage(
         "markConsultantPayoutReversed: payout not found for provider ID",
         { subsystem: "payments", level: "warning", extra: { providerPayoutId } },
       );
@@ -1200,7 +1200,7 @@ export async function markConsultantPayoutReversed(
     if (claim.count === 0) {
       // Modelled no-op — caller falls through to the pre-settlement FAILED
       // path when the payout wasn't COMPLETED.
-      reportMessage("markConsultantPayoutReversed: no-op (not COMPLETED)", {
+      reportSentryMessage("markConsultantPayoutReversed: no-op (not COMPLETED)", {
         subsystem: "payments",
         expected: true,
         extra: { payoutId: payout.id },

--- a/lib/payments/payouts/payout-service.ts
+++ b/lib/payments/payouts/payout-service.ts
@@ -603,6 +603,13 @@ async function processSinglePayout(payout: {
       console.warn(
         `[Payouts] Payout ${payout.id} already claimed by a concurrent run — skipping`,
       );
+      // Lost CAS race — a concurrent runner already claimed this payout. The
+      // system working as designed.
+      Sentry.captureMessage("Payout CAS claim lost to a concurrent runner", {
+        level: "info",
+        tags: { subsystem: "payments", expected: "true" },
+        extra: { payoutId: payout.id },
+      });
       return { payoutId: payout.id, success: false, skipped: true };
     }
 
@@ -776,7 +783,7 @@ async function processSinglePayout(payout: {
             ? persistErr
             : new Error(String(persistErr)),
           {
-            tags: { subsystem: "payments" },
+            tags: { subsystem: "payments", expected: "false" },
             level: "fatal",
             contexts: { payout: { payoutId: payout.id, providerPayoutId } },
           },
@@ -788,7 +795,7 @@ async function processSinglePayout(payout: {
       Sentry.captureException(
         new Error(`gateway-accepted-db-write-failed: payout ${payout.id}`),
         {
-          tags: { subsystem: "payments" },
+          tags: { subsystem: "payments", expected: "false" },
           level: "error",
           contexts: { payout: { payoutId: payout.id, providerPayoutId } },
         },
@@ -1006,6 +1013,13 @@ export async function handlePayoutWebhook(
       console.log(
         `Payout ${payout.id} already in terminal state, skipping duplicate ${status} webhook`,
       );
+      // Idempotency short-circuit — a redelivered/duplicate gateway webhook.
+      // The system working as designed.
+      Sentry.captureMessage("Payout webhook idempotency short-circuit", {
+        level: "info",
+        tags: { subsystem: "payments", expected: "true" },
+        extra: { payoutId: payout.id, status },
+      });
       return;
     }
 
@@ -1141,7 +1155,7 @@ export async function handlePayoutWebhook(
         Sentry.captureException(
           error instanceof Error ? error : new Error(String(error)),
           {
-            tags: { subsystem: "payments" },
+            tags: { subsystem: "payments", expected: "false" },
             level: "warning",
           },
         );
@@ -1180,6 +1194,14 @@ export async function markConsultantPayoutReversed(
       console.warn(
         `[payouts] markConsultantPayoutReversed: payout not found for provider ID ${providerPayoutId}`,
       );
+      Sentry.captureMessage(
+        "markConsultantPayoutReversed: payout not found for provider ID",
+        {
+          level: "warning",
+          tags: { subsystem: "payments", expected: "false" },
+          extra: { providerPayoutId },
+        },
+      );
       return { wasNoOp: true, notify: null };
     }
 
@@ -1191,7 +1213,19 @@ export async function markConsultantPayoutReversed(
         failureReason: reason.slice(0, 500),
       },
     });
-    if (claim.count === 0) return { wasNoOp: true, notify: null };
+    if (claim.count === 0) {
+      // Modelled no-op — caller falls through to the pre-settlement FAILED
+      // path when the payout wasn't COMPLETED.
+      Sentry.captureMessage(
+        "markConsultantPayoutReversed: no-op (not COMPLETED)",
+        {
+          level: "info",
+          tags: { subsystem: "payments", expected: "true" },
+          extra: { payoutId: payout.id },
+        },
+      );
+      return { wasNoOp: true, notify: null };
+    }
 
     // Re-open the earnings this payout had marked PAID so a future batch re-pays
     // them — the inverse of the completion path's PAID flip. Unlike the FAILED

--- a/lib/payments/payouts/razorpay-payouts.ts
+++ b/lib/payments/payouts/razorpay-payouts.ts
@@ -6,7 +6,7 @@
  */
 
 import * as Sentry from "@sentry/nextjs";
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import crypto from "crypto";
 
 // ============================================
@@ -322,7 +322,7 @@ export class RazorpayPayoutsService {
       // Genuinely unexpected (network/shape/auth) — the fail-open null return
       // is a deliberate caller-side decision (assertPayoutBalance), not a
       // claim that this failure is routine.
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "payments",
         tags: { provider: "razorpay" },
       });
@@ -434,7 +434,7 @@ export class RazorpayPayoutsService {
       // captured at warning/expected so it never reads as a platform fault.
       // Candidate for a Sentry inbound rate-limit on this event if volume
       // ever needs bounding.
-      reportMessage("RazorpayX webhook signature length mismatch", {
+      reportSentryMessage("RazorpayX webhook signature length mismatch", {
         subsystem: "payments",
         tags: { provider: "razorpay" },
         expected: true,
@@ -449,7 +449,7 @@ export class RazorpayPayoutsService {
     );
     if (!valid) {
       // Same rate-limit candidacy note as above.
-      reportMessage("RazorpayX webhook signature mismatch", {
+      reportSentryMessage("RazorpayX webhook signature mismatch", {
         subsystem: "payments",
         tags: { provider: "razorpay" },
         expected: true,
@@ -558,7 +558,7 @@ export function isRazorpayPayoutsConfigured(): boolean {
   } catch (error) {
     // Constructor throws only on missing credentials — a modelled
     // "not configured yet" outcome (e.g. local/dev env), not a fault.
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "razorpay" },
       expected: true,

--- a/lib/payments/payouts/razorpay-payouts.ts
+++ b/lib/payments/payouts/razorpay-payouts.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import crypto from "crypto";
 
 // ============================================
@@ -321,16 +322,10 @@ export class RazorpayPayoutsService {
       // Genuinely unexpected (network/shape/auth) — the fail-open null return
       // is a deliberate caller-side decision (assertPayoutBalance), not a
       // claim that this failure is routine.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "payments",
-            provider: "razorpay",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, {
+        subsystem: "payments",
+        tags: { provider: "razorpay" },
+      });
       return null;
     }
   }
@@ -439,9 +434,11 @@ export class RazorpayPayoutsService {
       // captured at warning/expected so it never reads as a platform fault.
       // Candidate for a Sentry inbound rate-limit on this event if volume
       // ever needs bounding.
-      Sentry.captureMessage("RazorpayX webhook signature length mismatch", {
+      reportMessage("RazorpayX webhook signature length mismatch", {
+        subsystem: "payments",
+        tags: { provider: "razorpay" },
+        expected: true,
         level: "warning",
-        tags: { subsystem: "payments", provider: "razorpay", expected: "true" },
       });
       return false;
     }
@@ -452,9 +449,11 @@ export class RazorpayPayoutsService {
     );
     if (!valid) {
       // Same rate-limit candidacy note as above.
-      Sentry.captureMessage("RazorpayX webhook signature mismatch", {
+      reportMessage("RazorpayX webhook signature mismatch", {
+        subsystem: "payments",
+        tags: { provider: "razorpay" },
+        expected: true,
         level: "warning",
-        tags: { subsystem: "payments", provider: "razorpay", expected: "true" },
       });
     }
     return valid;
@@ -559,17 +558,11 @@ export function isRazorpayPayoutsConfigured(): boolean {
   } catch (error) {
     // Constructor throws only on missing credentials — a modelled
     // "not configured yet" outcome (e.g. local/dev env), not a fault.
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: {
-          subsystem: "payments",
-          provider: "razorpay",
-          expected: "true",
-        },
-        level: "info",
-      },
-    );
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "razorpay" },
+      expected: true,
+    });
     return false;
   }
 }

--- a/lib/payments/payouts/razorpay-payouts.ts
+++ b/lib/payments/payouts/razorpay-payouts.ts
@@ -317,7 +317,20 @@ export class RazorpayPayoutsService {
       if (typeof res.balance === "number") return res.balance;
       const first = res.balances?.[0]?.balance;
       return typeof first === "number" ? first : null;
-    } catch {
+    } catch (error) {
+      // Genuinely unexpected (network/shape/auth) — the fail-open null return
+      // is a deliberate caller-side decision (assertPayoutBalance), not a
+      // claim that this failure is routine.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "payments",
+            provider: "razorpay",
+            expected: "false",
+          },
+        },
+      );
       return null;
     }
   }
@@ -422,13 +435,29 @@ export class RazorpayPayoutsService {
     // header could turn signature rejection into an unhandled exception.
     // Compare lengths first, exactly as app/api/webhooks/utils.ts does.
     if (signature.length !== expectedSignature.length) {
+      // Internet-facing and hostile traffic can drive this arbitrarily high —
+      // captured at warning/expected so it never reads as a platform fault.
+      // Candidate for a Sentry inbound rate-limit on this event if volume
+      // ever needs bounding.
+      Sentry.captureMessage("RazorpayX webhook signature length mismatch", {
+        level: "warning",
+        tags: { subsystem: "payments", provider: "razorpay", expected: "true" },
+      });
       return false;
     }
 
-    return crypto.timingSafeEqual(
+    const valid = crypto.timingSafeEqual(
       Buffer.from(signature),
       Buffer.from(expectedSignature),
     );
+    if (!valid) {
+      // Same rate-limit candidacy note as above.
+      Sentry.captureMessage("RazorpayX webhook signature mismatch", {
+        level: "warning",
+        tags: { subsystem: "payments", provider: "razorpay", expected: "true" },
+      });
+    }
+    return valid;
   }
 
   /**
@@ -527,7 +556,20 @@ export function isRazorpayPayoutsConfigured(): boolean {
   try {
     const service = getRazorpayPayoutsService();
     return service.isConfigured();
-  } catch {
+  } catch (error) {
+    // Constructor throws only on missing credentials — a modelled
+    // "not configured yet" outcome (e.g. local/dev env), not a fault.
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        tags: {
+          subsystem: "payments",
+          provider: "razorpay",
+          expected: "true",
+        },
+        level: "info",
+      },
+    );
     return false;
   }
 }

--- a/lib/payments/payouts/stripe-connect.ts
+++ b/lib/payments/payouts/stripe-connect.ts
@@ -5,7 +5,7 @@
  * API Documentation: https://docs.stripe.com/connect
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import Stripe from "stripe";
 
 // ============================================
@@ -538,7 +538,7 @@ export function isStripeConnectConfigured(): boolean {
   } catch (error) {
     // Constructor throws only on a missing secret key — a modelled
     // "not configured yet" outcome (e.g. local/dev env), not a fault.
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "payments",
       tags: { provider: "stripe" },
       expected: true,

--- a/lib/payments/payouts/stripe-connect.ts
+++ b/lib/payments/payouts/stripe-connect.ts
@@ -5,6 +5,7 @@
  * API Documentation: https://docs.stripe.com/connect
  */
 
+import * as Sentry from "@sentry/nextjs";
 import Stripe from "stripe";
 
 // ============================================
@@ -534,7 +535,20 @@ export function isStripeConnectConfigured(): boolean {
   try {
     const service = getStripeConnectService();
     return service.isConfigured();
-  } catch {
+  } catch (error) {
+    // Constructor throws only on a missing secret key — a modelled
+    // "not configured yet" outcome (e.g. local/dev env), not a fault.
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        tags: {
+          subsystem: "payments",
+          provider: "stripe",
+          expected: "true",
+        },
+        level: "info",
+      },
+    );
     return false;
   }
 }

--- a/lib/payments/payouts/stripe-connect.ts
+++ b/lib/payments/payouts/stripe-connect.ts
@@ -5,7 +5,7 @@
  * API Documentation: https://docs.stripe.com/connect
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import Stripe from "stripe";
 
 // ============================================
@@ -538,17 +538,11 @@ export function isStripeConnectConfigured(): boolean {
   } catch (error) {
     // Constructor throws only on a missing secret key — a modelled
     // "not configured yet" outcome (e.g. local/dev env), not a fault.
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: {
-          subsystem: "payments",
-          provider: "stripe",
-          expected: "true",
-        },
-        level: "info",
-      },
-    );
+    reportError(error, {
+      subsystem: "payments",
+      tags: { provider: "stripe" },
+      expected: true,
+    });
     return false;
   }
 }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -192,13 +192,24 @@ export async function handlePaymentSuccess(
         });
 
         if (!payment) {
-          throw new Error(
+          const err = new Error(
             `Payment record not found for intent: ${paymentIntentId}`,
           );
+          Sentry.captureException(err, {
+            tags: { subsystem: "payments", expected: "false" },
+          });
+          throw err;
         }
 
         if (payment.paymentStatus === PaymentStatus.SUCCEEDED) {
           console.log(`Payment ${paymentIntentId} has already been processed.`);
+          // Idempotency short-circuit — a redelivered webhook. The system
+          // working as designed.
+          Sentry.captureMessage("Payment webhook idempotency short-circuit", {
+            level: "info",
+            tags: { subsystem: "payments", expected: "true" },
+            extra: { paymentIntentId },
+          });
           return null; // Signal: already processed, skip Phase 2
         }
 
@@ -217,7 +228,7 @@ export async function handlePaymentSuccess(
               `Capture amount mismatch for ${paymentIntentId}: gateway=${gatewayAmountPaise} expected=${payment.amount}`,
             ),
             {
-              tags: { subsystem: "payments" },
+              tags: { subsystem: "payments", expected: "false" },
               level: "fatal",
               contexts: {
                 payment: {
@@ -280,7 +291,7 @@ export async function handlePaymentSuccess(
               ? validationError
               : new Error(String(validationError)),
             {
-              tags: { subsystem: "payments" },
+              tags: { subsystem: "payments", expected: "false" },
               level: "fatal",
               contexts: {
                 payment: {
@@ -482,7 +493,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
           ? refundError
           : new Error(String(refundError)),
         {
-          tags: { subsystem: "payments" },
+          tags: { subsystem: "payments", expected: "false" },
           level: "error",
           contexts: {
             payment: {
@@ -517,7 +528,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         refundError instanceof Error
           ? refundError
           : new Error(String(refundError)),
-        { tags: { subsystem: "payments" }, level: "error" },
+        { tags: { subsystem: "payments", expected: "false" }, level: "error" },
       );
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
@@ -556,7 +567,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
           ? refundError
           : new Error(String(refundError)),
         {
-          tags: { subsystem: "payments" },
+          tags: { subsystem: "payments", expected: "false" },
           level: "error",
           contexts: {
             booking: {
@@ -596,7 +607,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   } catch (emailError) {
     Sentry.captureException(
       emailError instanceof Error ? emailError : new Error(String(emailError)),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     console.error(
       "Failed to send payment success email (Phase 2):",
@@ -733,7 +744,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       referralError instanceof Error
         ? referralError
         : new Error(String(referralError)),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     console.error(
       `⚠️ Failed to process referral qualifying action for user ${userId}:`,
@@ -752,7 +763,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       consultantReferralError instanceof Error
         ? consultantReferralError
         : new Error(String(consultantReferralError)),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     console.error(
       `⚠️ Failed to process consultant referral qualifying action:`,
@@ -865,7 +876,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   } catch (novuError) {
     Sentry.captureException(
       novuError instanceof Error ? novuError : new Error(String(novuError)),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     console.error(
       `⚠️ Failed to send Novu notifications for payment ${paymentId}:`,
@@ -1000,6 +1011,11 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.warn(
         `Payment record not found for failed intent: ${paymentIntentId}`,
       );
+      Sentry.captureMessage("Payment failure webhook: payment not found", {
+        level: "warning",
+        tags: { subsystem: "payments", expected: "false" },
+        extra: { paymentIntentId },
+      });
       return;
     }
 
@@ -1007,6 +1023,14 @@ export async function handlePaymentFailure(paymentIntentId: string) {
     if (payment.paymentStatus === PaymentStatus.FAILED) {
       console.log(
         `Payment ${paymentIntentId} has already been marked as failed.`,
+      );
+      Sentry.captureMessage(
+        "Payment failure webhook idempotency short-circuit",
+        {
+          level: "info",
+          tags: { subsystem: "payments", expected: "true" },
+          extra: { paymentIntentId },
+        },
       );
       return;
     }
@@ -1017,6 +1041,14 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.warn(
         `Payment ${paymentIntentId} already SUCCEEDED. Ignoring late failure webhook.`,
       );
+      Sentry.captureMessage(
+        "Payment failure webhook arrived after SUCCEEDED — ignored",
+        {
+          level: "warning",
+          tags: { subsystem: "payments", expected: "true" },
+          extra: { paymentIntentId },
+        },
+      );
       return;
     }
 
@@ -1025,6 +1057,14 @@ export async function handlePaymentFailure(paymentIntentId: string) {
     if (payment.paymentStatus === PaymentStatus.EXPIRED) {
       console.log(
         `Payment ${paymentIntentId} already EXPIRED. Ignoring late failure webhook.`,
+      );
+      Sentry.captureMessage(
+        "Payment failure webhook arrived after EXPIRED — ignored",
+        {
+          level: "info",
+          tags: { subsystem: "payments", expected: "true" },
+          extra: { paymentIntentId },
+        },
       );
       return;
     }
@@ -1064,7 +1104,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
     } catch (novuError) {
       Sentry.captureException(
         novuError instanceof Error ? novuError : new Error(String(novuError)),
-        { tags: { subsystem: "payments" }, level: "warning" },
+        { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
       );
       console.error(
         `⚠️ Failed to send Novu payment failed notification for payment ${payment.id}:`,
@@ -1517,11 +1557,14 @@ export async function confirmExistingAppointment(
         select: { id: true, appointmentId: true },
       });
       if (conflict) {
+        // Modelled outcome — the #827 first-confirmed-wins guard working as
+        // designed (lost race). Phase 2 auto-refunds the loser; still
+        // reported at "warning" (not "info") since it needs that follow-up.
         Sentry.captureException(
           new Error("CONFIRMATION_BLOCKED_DOUBLE_BOOKING"),
           {
-            tags: { subsystem: "payments" },
-            level: "error",
+            tags: { subsystem: "payments", expected: "true" },
+            level: "warning",
             contexts: {
               booking: {
                 appointmentId,
@@ -1776,7 +1819,7 @@ async function sendPaymentSuccessNotification(
         new Error(
           `Cannot send payment success email: appointment ${appointmentId} not found`,
         ),
-        { tags: { subsystem: "payments" }, level: "warning" },
+        { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
       );
       console.error(
         `Cannot send payment success email: appointment ${appointmentId} not found`,
@@ -1829,7 +1872,7 @@ async function sendPaymentSuccessNotification(
   } catch (error) {
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     // Don't throw - email failures shouldn't block payment processing
     console.error("Failed to send payment success email:", error);
@@ -1875,7 +1918,7 @@ async function sendPaymentFailureNotification(
         new Error(
           `Cannot send payment failure email: appointment not found for payment ${payment.id}`,
         ),
-        { tags: { subsystem: "payments" }, level: "warning" },
+        { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
       );
       console.error(
         `Cannot send payment failure email: appointment not found for payment ${payment.id}`,
@@ -1923,7 +1966,7 @@ async function sendPaymentFailureNotification(
   } catch (error) {
     Sentry.captureException(
       error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments" }, level: "warning" },
+      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
     );
     // Don't throw - email failures shouldn't block payment processing
     console.error("Failed to send payment failure email:", error);

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -4,7 +4,7 @@
  * Can be used by both webhook API routes and direct checkout flows
  */
 
-import { reportError, reportMessage } from "@/lib/observability/report";
+import { reportSentryError, reportSentryMessage } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import {
   AppointmentsType,
@@ -195,7 +195,7 @@ export async function handlePaymentSuccess(
           const err = new Error(
             `Payment record not found for intent: ${paymentIntentId}`,
           );
-          reportError(err, { subsystem: "payments" });
+          reportSentryError(err, { subsystem: "payments" });
           throw err;
         }
 
@@ -203,7 +203,7 @@ export async function handlePaymentSuccess(
           console.log(`Payment ${paymentIntentId} has already been processed.`);
           // Idempotency short-circuit — a redelivered webhook. The system
           // working as designed.
-          reportMessage("Payment webhook idempotency short-circuit", {
+          reportSentryMessage("Payment webhook idempotency short-circuit", {
             subsystem: "payments",
             expected: true,
             extra: { paymentIntentId },
@@ -221,7 +221,7 @@ export async function handlePaymentSuccess(
           gatewayAmountPaise !== undefined &&
           gatewayAmountPaise !== payment.amount
         ) {
-          reportError(
+          reportSentryError(
             new Error(
               `Capture amount mismatch for ${paymentIntentId}: gateway=${gatewayAmountPaise} expected=${payment.amount}`,
             ),
@@ -284,7 +284,7 @@ export async function handlePaymentSuccess(
                 ? validationError.message
                 : String(validationError);
 
-          reportError(validationError, {
+          reportSentryError(validationError, {
             subsystem: "payments",
             level: "fatal",
             contexts: {
@@ -481,7 +481,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         },
       });
     } catch (refundError) {
-      reportError(refundError, {
+      reportSentryError(refundError, {
         subsystem: "payments",
         contexts: {
           payment: {
@@ -511,7 +511,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         initiatedByUserId: null,
       });
     } catch (refundError) {
-      reportError(refundError, { subsystem: "payments" });
+      reportSentryError(refundError, { subsystem: "payments" });
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
         refundError,
@@ -544,7 +544,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         ),
       );
     } catch (refundError) {
-      reportError(refundError, {
+      reportSentryError(refundError, {
         subsystem: "payments",
         contexts: {
           booking: {
@@ -581,7 +581,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       );
     }
   } catch (emailError) {
-    reportError(emailError, { subsystem: "payments", level: "warning" });
+    reportSentryError(emailError, { subsystem: "payments", level: "warning" });
     console.error(
       "Failed to send payment success email (Phase 2):",
       emailError,
@@ -713,7 +713,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   try {
     await processQualifyingAction(userId, "first_paid_booking");
   } catch (referralError) {
-    reportError(referralError, { subsystem: "payments", level: "warning" });
+    reportSentryError(referralError, { subsystem: "payments", level: "warning" });
     console.error(
       `⚠️ Failed to process referral qualifying action for user ${userId}:`,
       referralError,
@@ -727,7 +727,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   try {
     await processConsultantBookingReferral({ id: paymentId }, userId);
   } catch (consultantReferralError) {
-    reportError(consultantReferralError, {
+    reportSentryError(consultantReferralError, {
       subsystem: "payments",
       level: "warning",
     });
@@ -840,7 +840,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       dashboardUrl,
     });
   } catch (novuError) {
-    reportError(novuError, { subsystem: "payments", level: "warning" });
+    reportSentryError(novuError, { subsystem: "payments", level: "warning" });
     console.error(
       `⚠️ Failed to send Novu notifications for payment ${paymentId}:`,
       novuError,
@@ -974,7 +974,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.warn(
         `Payment record not found for failed intent: ${paymentIntentId}`,
       );
-      reportMessage("Payment failure webhook: payment not found", {
+      reportSentryMessage("Payment failure webhook: payment not found", {
         subsystem: "payments",
         level: "warning",
         extra: { paymentIntentId },
@@ -987,7 +987,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.log(
         `Payment ${paymentIntentId} has already been marked as failed.`,
       );
-      reportMessage("Payment failure webhook idempotency short-circuit", {
+      reportSentryMessage("Payment failure webhook idempotency short-circuit", {
         subsystem: "payments",
         expected: true,
         extra: { paymentIntentId },
@@ -1001,7 +1001,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.warn(
         `Payment ${paymentIntentId} already SUCCEEDED. Ignoring late failure webhook.`,
       );
-      reportMessage("Payment failure webhook arrived after SUCCEEDED — ignored", {
+      reportSentryMessage("Payment failure webhook arrived after SUCCEEDED — ignored", {
         subsystem: "payments",
         expected: true,
         level: "warning",
@@ -1016,7 +1016,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.log(
         `Payment ${paymentIntentId} already EXPIRED. Ignoring late failure webhook.`,
       );
-      reportMessage("Payment failure webhook arrived after EXPIRED — ignored", {
+      reportSentryMessage("Payment failure webhook arrived after EXPIRED — ignored", {
         subsystem: "payments",
         expected: true,
         extra: { paymentIntentId },
@@ -1057,7 +1057,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
         retryUrl: `${getAppUrl()}/dashboard`,
       });
     } catch (novuError) {
-      reportError(novuError, { subsystem: "payments", level: "warning" });
+      reportSentryError(novuError, { subsystem: "payments", level: "warning" });
       console.error(
         `⚠️ Failed to send Novu payment failed notification for payment ${payment.id}:`,
         novuError,
@@ -1512,7 +1512,7 @@ export async function confirmExistingAppointment(
         // Modelled outcome — the #827 first-confirmed-wins guard working as
         // designed (lost race). Phase 2 auto-refunds the loser; still
         // reported at "warning" (not "info") since it needs that follow-up.
-        reportError(new Error("CONFIRMATION_BLOCKED_DOUBLE_BOOKING"), {
+        reportSentryError(new Error("CONFIRMATION_BLOCKED_DOUBLE_BOOKING"), {
           subsystem: "payments",
           expected: true,
           level: "warning",
@@ -1765,7 +1765,7 @@ async function sendPaymentSuccessNotification(
     });
 
     if (!appointment) {
-      reportError(
+      reportSentryError(
         new Error(
           `Cannot send payment success email: appointment ${appointmentId} not found`,
         ),
@@ -1820,7 +1820,7 @@ async function sendPaymentSuccessNotification(
       `📧 Payment success email sent to ${payment.user.email} for ${appointmentType}`,
     );
   } catch (error) {
-    reportError(error, { subsystem: "payments", level: "warning" });
+    reportSentryError(error, { subsystem: "payments", level: "warning" });
     // Don't throw - email failures shouldn't block payment processing
     console.error("Failed to send payment success email:", error);
   }
@@ -1861,7 +1861,7 @@ async function sendPaymentFailureNotification(
     });
 
     if (!appointment) {
-      reportError(
+      reportSentryError(
         new Error(
           `Cannot send payment failure email: appointment not found for payment ${payment.id}`,
         ),
@@ -1911,7 +1911,7 @@ async function sendPaymentFailureNotification(
       `📧 Payment failure email sent to ${payment.user.email} for ${appointmentType}`,
     );
   } catch (error) {
-    reportError(error, { subsystem: "payments", level: "warning" });
+    reportSentryError(error, { subsystem: "payments", level: "warning" });
     // Don't throw - email failures shouldn't block payment processing
     console.error("Failed to send payment failure email:", error);
   }

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -4,7 +4,7 @@
  * Can be used by both webhook API routes and direct checkout flows
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError, reportMessage } from "@/lib/observability/report";
 import prisma, { type Tx } from "@/lib/prisma";
 import {
   AppointmentsType,
@@ -195,9 +195,7 @@ export async function handlePaymentSuccess(
           const err = new Error(
             `Payment record not found for intent: ${paymentIntentId}`,
           );
-          Sentry.captureException(err, {
-            tags: { subsystem: "payments", expected: "false" },
-          });
+          reportError(err, { subsystem: "payments" });
           throw err;
         }
 
@@ -205,9 +203,9 @@ export async function handlePaymentSuccess(
           console.log(`Payment ${paymentIntentId} has already been processed.`);
           // Idempotency short-circuit — a redelivered webhook. The system
           // working as designed.
-          Sentry.captureMessage("Payment webhook idempotency short-circuit", {
-            level: "info",
-            tags: { subsystem: "payments", expected: "true" },
+          reportMessage("Payment webhook idempotency short-circuit", {
+            subsystem: "payments",
+            expected: true,
             extra: { paymentIntentId },
           });
           return null; // Signal: already processed, skip Phase 2
@@ -223,12 +221,12 @@ export async function handlePaymentSuccess(
           gatewayAmountPaise !== undefined &&
           gatewayAmountPaise !== payment.amount
         ) {
-          Sentry.captureException(
+          reportError(
             new Error(
               `Capture amount mismatch for ${paymentIntentId}: gateway=${gatewayAmountPaise} expected=${payment.amount}`,
             ),
             {
-              tags: { subsystem: "payments", expected: "false" },
+              subsystem: "payments",
               level: "fatal",
               contexts: {
                 payment: {
@@ -286,22 +284,17 @@ export async function handlePaymentSuccess(
                 ? validationError.message
                 : String(validationError);
 
-          Sentry.captureException(
-            validationError instanceof Error
-              ? validationError
-              : new Error(String(validationError)),
-            {
-              tags: { subsystem: "payments", expected: "false" },
-              level: "fatal",
-              contexts: {
-                payment: {
-                  paymentIntentId,
-                  paymentId: payment.id,
-                  userId: payment.userId,
-                },
+          reportError(validationError, {
+            subsystem: "payments",
+            level: "fatal",
+            contexts: {
+              payment: {
+                paymentIntentId,
+                paymentId: payment.id,
+                userId: payment.userId,
               },
             },
-          );
+          });
           console.error(
             `❌ Metadata validation failed for payment ${paymentIntentId}:`,
             errorMessage,
@@ -488,22 +481,16 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         },
       });
     } catch (refundError) {
-      Sentry.captureException(
-        refundError instanceof Error
-          ? refundError
-          : new Error(String(refundError)),
-        {
-          tags: { subsystem: "payments", expected: "false" },
-          level: "error",
-          contexts: {
-            payment: {
-              paymentId: txResult.paymentId,
-              gatewayAmountPaise: txResult.gatewayAmountPaise,
-              expectedAmount: txResult.expectedAmount,
-            },
+      reportError(refundError, {
+        subsystem: "payments",
+        contexts: {
+          payment: {
+            paymentId: txResult.paymentId,
+            gatewayAmountPaise: txResult.gatewayAmountPaise,
+            expectedAmount: txResult.expectedAmount,
           },
         },
-      );
+      });
       console.error(
         "Failed to auto-refund amount-mismatch capture; REQUIRES_MANUAL_RECOVERY (Phase 2):",
         refundError,
@@ -524,12 +511,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         initiatedByUserId: null,
       });
     } catch (refundError) {
-      Sentry.captureException(
-        refundError instanceof Error
-          ? refundError
-          : new Error(String(refundError)),
-        { tags: { subsystem: "payments", expected: "false" }, level: "error" },
-      );
+      reportError(refundError, { subsystem: "payments" });
       console.error(
         "Failed to auto-refund capture-after-cancellation (Phase 2):",
         refundError,
@@ -562,21 +544,15 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
         ),
       );
     } catch (refundError) {
-      Sentry.captureException(
-        refundError instanceof Error
-          ? refundError
-          : new Error(String(refundError)),
-        {
-          tags: { subsystem: "payments", expected: "false" },
-          level: "error",
-          contexts: {
-            booking: {
-              paymentId: txResult.paymentId,
-              appointmentId: txResult.appointmentId,
-            },
+      reportError(refundError, {
+        subsystem: "payments",
+        contexts: {
+          booking: {
+            paymentId: txResult.paymentId,
+            appointmentId: txResult.appointmentId,
           },
         },
-      );
+      });
       console.error(
         "Failed to auto-refund double-booking loser; slots left for #830 sweep (Phase 2):",
         refundError,
@@ -605,10 +581,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       );
     }
   } catch (emailError) {
-    Sentry.captureException(
-      emailError instanceof Error ? emailError : new Error(String(emailError)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-    );
+    reportError(emailError, { subsystem: "payments", level: "warning" });
     console.error(
       "Failed to send payment success email (Phase 2):",
       emailError,
@@ -740,12 +713,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   try {
     await processQualifyingAction(userId, "first_paid_booking");
   } catch (referralError) {
-    Sentry.captureException(
-      referralError instanceof Error
-        ? referralError
-        : new Error(String(referralError)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-    );
+    reportError(referralError, { subsystem: "payments", level: "warning" });
     console.error(
       `⚠️ Failed to process referral qualifying action for user ${userId}:`,
       referralError,
@@ -759,12 +727,10 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
   try {
     await processConsultantBookingReferral({ id: paymentId }, userId);
   } catch (consultantReferralError) {
-    Sentry.captureException(
-      consultantReferralError instanceof Error
-        ? consultantReferralError
-        : new Error(String(consultantReferralError)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-    );
+    reportError(consultantReferralError, {
+      subsystem: "payments",
+      level: "warning",
+    });
     console.error(
       `⚠️ Failed to process consultant referral qualifying action:`,
       consultantReferralError,
@@ -874,10 +840,7 @@ ACTION REQUIRED: Customer was charged but appointment was NOT created!
       dashboardUrl,
     });
   } catch (novuError) {
-    Sentry.captureException(
-      novuError instanceof Error ? novuError : new Error(String(novuError)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-    );
+    reportError(novuError, { subsystem: "payments", level: "warning" });
     console.error(
       `⚠️ Failed to send Novu notifications for payment ${paymentId}:`,
       novuError,
@@ -1011,9 +974,9 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.warn(
         `Payment record not found for failed intent: ${paymentIntentId}`,
       );
-      Sentry.captureMessage("Payment failure webhook: payment not found", {
+      reportMessage("Payment failure webhook: payment not found", {
+        subsystem: "payments",
         level: "warning",
-        tags: { subsystem: "payments", expected: "false" },
         extra: { paymentIntentId },
       });
       return;
@@ -1024,14 +987,11 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.log(
         `Payment ${paymentIntentId} has already been marked as failed.`,
       );
-      Sentry.captureMessage(
-        "Payment failure webhook idempotency short-circuit",
-        {
-          level: "info",
-          tags: { subsystem: "payments", expected: "true" },
-          extra: { paymentIntentId },
-        },
-      );
+      reportMessage("Payment failure webhook idempotency short-circuit", {
+        subsystem: "payments",
+        expected: true,
+        extra: { paymentIntentId },
+      });
       return;
     }
 
@@ -1041,14 +1001,12 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.warn(
         `Payment ${paymentIntentId} already SUCCEEDED. Ignoring late failure webhook.`,
       );
-      Sentry.captureMessage(
-        "Payment failure webhook arrived after SUCCEEDED — ignored",
-        {
-          level: "warning",
-          tags: { subsystem: "payments", expected: "true" },
-          extra: { paymentIntentId },
-        },
-      );
+      reportMessage("Payment failure webhook arrived after SUCCEEDED — ignored", {
+        subsystem: "payments",
+        expected: true,
+        level: "warning",
+        extra: { paymentIntentId },
+      });
       return;
     }
 
@@ -1058,14 +1016,11 @@ export async function handlePaymentFailure(paymentIntentId: string) {
       console.log(
         `Payment ${paymentIntentId} already EXPIRED. Ignoring late failure webhook.`,
       );
-      Sentry.captureMessage(
-        "Payment failure webhook arrived after EXPIRED — ignored",
-        {
-          level: "info",
-          tags: { subsystem: "payments", expected: "true" },
-          extra: { paymentIntentId },
-        },
-      );
+      reportMessage("Payment failure webhook arrived after EXPIRED — ignored", {
+        subsystem: "payments",
+        expected: true,
+        extra: { paymentIntentId },
+      });
       return;
     }
 
@@ -1102,10 +1057,7 @@ export async function handlePaymentFailure(paymentIntentId: string) {
         retryUrl: `${getAppUrl()}/dashboard`,
       });
     } catch (novuError) {
-      Sentry.captureException(
-        novuError instanceof Error ? novuError : new Error(String(novuError)),
-        { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-      );
+      reportError(novuError, { subsystem: "payments", level: "warning" });
       console.error(
         `⚠️ Failed to send Novu payment failed notification for payment ${payment.id}:`,
         novuError,
@@ -1560,20 +1512,18 @@ export async function confirmExistingAppointment(
         // Modelled outcome — the #827 first-confirmed-wins guard working as
         // designed (lost race). Phase 2 auto-refunds the loser; still
         // reported at "warning" (not "info") since it needs that follow-up.
-        Sentry.captureException(
-          new Error("CONFIRMATION_BLOCKED_DOUBLE_BOOKING"),
-          {
-            tags: { subsystem: "payments", expected: "true" },
-            level: "warning",
-            contexts: {
-              booking: {
-                appointmentId,
-                conflictingAppointmentId: conflict.appointmentId,
-                slotId: slot.id,
-              },
+        reportError(new Error("CONFIRMATION_BLOCKED_DOUBLE_BOOKING"), {
+          subsystem: "payments",
+          expected: true,
+          level: "warning",
+          contexts: {
+            booking: {
+              appointmentId,
+              conflictingAppointmentId: conflict.appointmentId,
+              slotId: slot.id,
             },
           },
-        );
+        });
         console.error(
           JSON.stringify({
             event: "confirmation_blocked_double_booking",
@@ -1815,11 +1765,11 @@ async function sendPaymentSuccessNotification(
     });
 
     if (!appointment) {
-      Sentry.captureException(
+      reportError(
         new Error(
           `Cannot send payment success email: appointment ${appointmentId} not found`,
         ),
-        { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
+        { subsystem: "payments", level: "warning" },
       );
       console.error(
         `Cannot send payment success email: appointment ${appointmentId} not found`,
@@ -1870,10 +1820,7 @@ async function sendPaymentSuccessNotification(
       `📧 Payment success email sent to ${payment.user.email} for ${appointmentType}`,
     );
   } catch (error) {
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-    );
+    reportError(error, { subsystem: "payments", level: "warning" });
     // Don't throw - email failures shouldn't block payment processing
     console.error("Failed to send payment success email:", error);
   }
@@ -1914,11 +1861,11 @@ async function sendPaymentFailureNotification(
     });
 
     if (!appointment) {
-      Sentry.captureException(
+      reportError(
         new Error(
           `Cannot send payment failure email: appointment not found for payment ${payment.id}`,
         ),
-        { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
+        { subsystem: "payments", level: "warning" },
       );
       console.error(
         `Cannot send payment failure email: appointment not found for payment ${payment.id}`,
@@ -1964,10 +1911,7 @@ async function sendPaymentFailureNotification(
       `📧 Payment failure email sent to ${payment.user.email} for ${appointmentType}`,
     );
   } catch (error) {
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      { tags: { subsystem: "payments", expected: "false" }, level: "warning" },
-    );
+    reportError(error, { subsystem: "payments", level: "warning" });
     // Don't throw - email failures shouldn't block payment processing
     console.error("Failed to send payment failure email:", error);
   }

--- a/lib/scheduling/allocationService.ts
+++ b/lib/scheduling/allocationService.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { TimeSlot } from "./calendarUtils";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
@@ -137,16 +137,10 @@ export class AllocationService {
       };
     } catch (error) {
       console.error(`Allocation request failed (${url}):`, error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            feature: "slot-allocation",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        tags: { feature: "slot-allocation" },
+      });
       return {
         success: false,
         error:
@@ -189,16 +183,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating consultation slots:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -241,16 +226,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating subscription slots:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -336,16 +312,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating class slots:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -388,16 +355,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating webinar slots:", error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "false",
-          },
-        },
-      );
+      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -463,18 +421,12 @@ export class AllocationService {
           : undefined;
       const expected =
         typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            op: "slot-allocation",
-            ...(expected ? { expected: "true" } : {}),
-          },
-          extra: { consultantId, httpStatus },
-          ...(expected ? { level: "info" as const } : {}),
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        op: "slot-allocation",
+        expected,
+        extra: { consultantId, httpStatus },
+      });
       throw error;
     }
   }
@@ -569,18 +521,12 @@ export class AllocationService {
           : undefined;
       const expected =
         typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            op: "slot-allocation",
-            ...(expected ? { expected: "true" } : {}),
-          },
-          extra: { consultantId, httpStatus },
-          ...(expected ? { level: "info" as const } : {}),
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        op: "slot-allocation",
+        expected,
+        extra: { consultantId, httpStatus },
+      });
       throw error;
     }
   }
@@ -647,18 +593,12 @@ export class AllocationService {
           : undefined;
       const expected =
         typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "client",
-            op: "slot-allocation",
-            ...(expected ? { expected: "true" } : {}),
-          },
-          extra: { eventType, eventId, httpStatus },
-          ...(expected ? { level: "info" as const } : {}),
-        },
-      );
+      reportError(error, {
+        subsystem: "client",
+        op: "slot-allocation",
+        expected,
+        extra: { eventType, eventId, httpStatus },
+      });
       throw error;
     }
   }

--- a/lib/scheduling/allocationService.ts
+++ b/lib/scheduling/allocationService.ts
@@ -1,4 +1,4 @@
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { TimeSlot } from "./calendarUtils";
 import type { SlotConflictResult } from "@/utils/slotAllocation/types";
 
@@ -137,7 +137,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error(`Allocation request failed (${url}):`, error);
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         tags: { feature: "slot-allocation" },
       });
@@ -183,7 +183,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating consultation slots:", error);
-      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
+      reportSentryError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -226,7 +226,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating subscription slots:", error);
-      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
+      reportSentryError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -312,7 +312,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating class slots:", error);
-      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
+      reportSentryError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -355,7 +355,7 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating webinar slots:", error);
-      reportError(error, { subsystem: "scheduling", op: "slot-allocation" });
+      reportSentryError(error, { subsystem: "scheduling", op: "slot-allocation" });
       return {
         success: false,
         error:
@@ -421,7 +421,7 @@ export class AllocationService {
           : undefined;
       const expected =
         typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         op: "slot-allocation",
         expected,
@@ -521,7 +521,7 @@ export class AllocationService {
           : undefined;
       const expected =
         typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         op: "slot-allocation",
         expected,
@@ -593,7 +593,7 @@ export class AllocationService {
           : undefined;
       const expected =
         typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "client",
         op: "slot-allocation",
         expected,

--- a/lib/scheduling/allocationService.ts
+++ b/lib/scheduling/allocationService.ts
@@ -139,7 +139,13 @@ export class AllocationService {
       console.error(`Allocation request failed (${url}):`, error);
       Sentry.captureException(
         error instanceof Error ? error : new Error(String(error)),
-        { tags: { subsystem: "client", feature: "slot-allocation" } },
+        {
+          tags: {
+            subsystem: "client",
+            feature: "slot-allocation",
+            expected: "false",
+          },
+        },
       );
       return {
         success: false,
@@ -183,6 +189,16 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating consultation slots:", error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "false",
+          },
+        },
+      );
       return {
         success: false,
         error:
@@ -225,6 +241,16 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating subscription slots:", error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "false",
+          },
+        },
+      );
       return {
         success: false,
         error:
@@ -284,13 +310,16 @@ export class AllocationService {
     slots: string[],
   ): Promise<ValidationResponse> {
     try {
-      const response = await fetch(`/api/bookings/classes/${classId}/validate`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `/api/bookings/classes/${classId}/validate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ slots }),
         },
-        body: JSON.stringify({ slots }),
-      });
+      );
 
       const data = await response.json();
 
@@ -307,6 +336,16 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating class slots:", error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "false",
+          },
+        },
+      );
       return {
         success: false,
         error:
@@ -349,6 +388,16 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error validating webinar slots:", error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "false",
+          },
+        },
+      );
       return {
         success: false,
         error:
@@ -396,13 +445,36 @@ export class AllocationService {
       const response = await fetch(`/api/user/consultants/${consultantId}`);
 
       if (!response.ok) {
-        throw new Error("Failed to fetch consultant data");
+        // Carry the status onto the thrown Error (message/instanceof
+        // unchanged) so the catch below can tell a 4xx business answer
+        // (consultant not found/forbidden) from a real 5xx/network fault.
+        throw Object.assign(new Error("Failed to fetch consultant data"), {
+          httpStatus: response.status,
+        });
       }
 
       const { data } = await response.json();
       return data;
     } catch (error) {
       console.error("Error fetching consultant data:", error);
+      const httpStatus =
+        error && typeof error === "object" && "httpStatus" in error
+          ? (error as { httpStatus?: number }).httpStatus
+          : undefined;
+      const expected =
+        typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            op: "slot-allocation",
+            ...(expected ? { expected: "true" } : {}),
+          },
+          extra: { consultantId, httpStatus },
+          ...(expected ? { level: "info" as const } : {}),
+        },
+      );
       throw error;
     }
   }
@@ -469,15 +541,21 @@ export class AllocationService {
       );
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(
-          errorData.error || "Failed to fetch availability slots",
+        // See fetchConsultantData: httpStatus lets the catch distinguish a
+        // 4xx business answer from a real fault without changing the thrown
+        // Error's message/shape.
+        throw Object.assign(
+          new Error(errorData.error || "Failed to fetch availability slots"),
+          { httpStatus: response.status },
         );
       }
       const result = await response.json();
       const { data: slotsByDate } = result;
 
       // Flatten the grouped-by-date slots into a single array
-      const allSlots: RawAvailabilityApiSlot[] = (Object.values(slotsByDate) as RawAvailabilityApiSlot[][]).flat();
+      const allSlots: RawAvailabilityApiSlot[] = (
+        Object.values(slotsByDate) as RawAvailabilityApiSlot[][]
+      ).flat();
 
       return {
         weekly: allSlots.filter((s) => s.type === "WEEKLY"),
@@ -485,6 +563,24 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error fetching availability slots:", error);
+      const httpStatus =
+        error && typeof error === "object" && "httpStatus" in error
+          ? (error as { httpStatus?: number }).httpStatus
+          : undefined;
+      const expected =
+        typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            op: "slot-allocation",
+            ...(expected ? { expected: "true" } : {}),
+          },
+          extra: { consultantId, httpStatus },
+          ...(expected ? { level: "info" as const } : {}),
+        },
+      );
       throw error;
     }
   }
@@ -528,7 +624,12 @@ export class AllocationService {
       const response = await fetch(`/api/slots/appointments?${params}`);
 
       if (!response.ok) {
-        throw new Error("Failed to fetch event slots");
+        // See fetchConsultantData: httpStatus lets the catch distinguish a
+        // 4xx business answer from a real fault without changing the thrown
+        // Error's message/shape.
+        throw Object.assign(new Error("Failed to fetch event slots"), {
+          httpStatus: response.status,
+        });
       }
 
       const { data, weeklyConfirmedCallCounts } = await response.json();
@@ -540,6 +641,24 @@ export class AllocationService {
       };
     } catch (error) {
       console.error("Error fetching event slots:", error);
+      const httpStatus =
+        error && typeof error === "object" && "httpStatus" in error
+          ? (error as { httpStatus?: number }).httpStatus
+          : undefined;
+      const expected =
+        typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "client",
+            op: "slot-allocation",
+            ...(expected ? { expected: "true" } : {}),
+          },
+          extra: { eventType, eventId, httpStatus },
+          ...(expected ? { level: "info" as const } : {}),
+        },
+      );
       throw error;
     }
   }

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -5,6 +5,7 @@
  * Handles auto, manual, and requested slot allocation.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import prisma, {
   type Tx,
   type PrismaLike,
@@ -142,6 +143,30 @@ export class SlotAllocationService {
       }
     } catch (error) {
       const { errorCode, httpStatus } = this.classifyError(error);
+      // Full-coverage policy: every error reaching here is reported, modelled
+      // outcome or not, so volume/pattern of ordinary answers (slot taken,
+      // limit reached, lost CAS race) is visible in Sentry too — but at
+      // info + expected:true so a dashboard scan can't mistake "no slots
+      // available" for a database failure. Real faults keep the default
+      // error level with no expected tag.
+      const modeled = this.isModeledOutcome(error);
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            ...(modeled ? { expected: "true" } : {}),
+          },
+          extra: {
+            mode: request.mode,
+            eventType: request.eventType,
+            eventId: request.eventId,
+            errorCode,
+          },
+          ...(modeled ? { level: "info" as const } : {}),
+        },
+      );
       return {
         success: false,
         error: error instanceof Error ? error.message : "Allocation failed",
@@ -149,6 +174,29 @@ export class SlotAllocationService {
         httpStatus,
       };
     }
+  }
+
+  /**
+   * Whether `error` is one of the modelled business outcomes this engine
+   * throws for ordinary reasons (validation, not-found, lock/CAS contention,
+   * an org cap reached) rather than an actual fault. Both branches are
+   * reported to Sentry (full-coverage policy); this only decides the
+   * level/tag so a modelled answer never reads as a fault on the dashboard.
+   * Deliberately narrower than classifyError()'s message-sniffing fallback,
+   * which exists only to pick an HTTP status for legacy untyped throws and
+   * would otherwise also mark real bugs "expected" if the message happens to
+   * contain "not found".
+   */
+  private static isModeledOutcome(error: unknown): boolean {
+    return (
+      error instanceof AllocationValidationError ||
+      error instanceof AllocationNotFoundError ||
+      error instanceof AllocationConflictError ||
+      error instanceof IllegalTransitionError ||
+      error instanceof ProgramAssignmentLimitError ||
+      isUniqueViolation(error) ||
+      isExclusionViolation(error)
+    );
   }
 
   /**
@@ -1346,10 +1394,36 @@ export class SlotAllocationService {
               });
             } catch (err) {
               if (isUniqueViolation(err)) {
+                // A same-key retry losing this race is the ordinary replay
+                // case (#837) — reported at info so its frequency is visible
+                // without reading as a fault.
+                Sentry.captureException(
+                  err instanceof Error ? err : new Error(String(err)),
+                  {
+                    tags: {
+                      subsystem: "scheduling",
+                      op: "slot-allocation",
+                      expected: "true",
+                    },
+                    extra: { phase: "requested-stamp", idempotencyKey },
+                    level: "info",
+                  },
+                );
                 throw new AllocationConflictError(
                   "This allocation was already submitted; the original result applies.",
                 );
               }
+              Sentry.captureException(
+                err instanceof Error ? err : new Error(String(err)),
+                {
+                  tags: {
+                    subsystem: "scheduling",
+                    op: "slot-allocation",
+                    expected: "false",
+                  },
+                  extra: { phase: "requested-stamp", idempotencyKey },
+                },
+              );
               throw err;
             }
           }
@@ -2169,10 +2243,35 @@ export class SlotAllocationService {
       );
     } catch (error) {
       if (isExclusionViolation(error) || isUniqueViolation(error)) {
+        // A concurrent booking winning the #440 overlap guard is the ordinary
+        // "someone else got there first" race, not a fault.
+        Sentry.captureException(
+          error instanceof Error ? error : new Error(String(error)),
+          {
+            tags: {
+              subsystem: "scheduling",
+              op: "slot-allocation",
+              expected: "true",
+            },
+            extra: { phase: "create-appointments", eventType, eventId },
+            level: "info",
+          },
+        );
         throw new AllocationConflictError(
           "This time slot was just booked by someone else. Please pick another time.",
         );
       }
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "false",
+          },
+          extra: { phase: "create-appointments", eventType, eventId },
+        },
+      );
       throw error;
     }
 
@@ -2340,9 +2439,31 @@ export class SlotAllocationService {
         // Cap exceeded with BLOCK behavior — surface upward so the
         // transaction rolls back the newly-created appointments. The
         // SlotAllocationService.allocate() error mapper translates this
-        // to the appropriate HTTP status for the route handler.
+        // to the appropriate HTTP status for the route handler. An
+        // organization's overage cap being hit is an ANSWER, not a fault —
+        // reported at info so its rate is visible without paging anyone.
+        Sentry.captureException(err, {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "true",
+          },
+          extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
+          level: "info",
+        });
         throw err;
       }
+      Sentry.captureException(
+        err instanceof Error ? err : new Error(String(err)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-allocation",
+            expected: "false",
+          },
+          extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
+        },
+      );
       throw err;
     }
   }

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -1396,25 +1396,17 @@ export class SlotAllocationService {
                 data: { allocationIdempotencyKey: idempotencyKey },
               });
             } catch (err) {
+              // Not captured here — useRequestedSlots only ever runs inside
+              // allocate()'s try, whose catch reports every error reaching it
+              // (including this one, same instance) with the correct modeled
+              // classification. A second capture here would be a pure dupe.
               if (isUniqueViolation(err)) {
                 // A same-key retry losing this race is the ordinary replay
-                // case (#837) — reported at info so its frequency is visible
-                // without reading as a fault.
-                reportSentryError(err, {
-                  subsystem: "scheduling",
-                  op: "slot-allocation",
-                  expected: true,
-                  extra: { phase: "requested-stamp", idempotencyKey },
-                });
+                // case (#837).
                 throw new AllocationConflictError(
                   "This allocation was already submitted; the original result applies.",
                 );
               }
-              reportSentryError(err, {
-                subsystem: "scheduling",
-                op: "slot-allocation",
-                extra: { phase: "requested-stamp", idempotencyKey },
-              });
               throw err;
             }
           }
@@ -2233,24 +2225,17 @@ export class SlotAllocationService {
         }),
       );
     } catch (error) {
+      // Not captured here — createAppointments only runs inside
+      // autoAllocate/manualAllocate, both under allocate()'s try, whose catch
+      // reports every error reaching it (this one included). A second
+      // capture here would be a pure dupe of the same instance.
       if (isExclusionViolation(error) || isUniqueViolation(error)) {
         // A concurrent booking winning the #440 overlap guard is the ordinary
         // "someone else got there first" race, not a fault.
-        reportSentryError(error, {
-          subsystem: "scheduling",
-          op: "slot-allocation",
-          expected: true,
-          extra: { phase: "create-appointments", eventType, eventId },
-        });
         throw new AllocationConflictError(
           "This time slot was just booked by someone else. Please pick another time.",
         );
       }
-      reportSentryError(error, {
-        subsystem: "scheduling",
-        op: "slot-allocation",
-        extra: { phase: "create-appointments", eventType, eventId },
-      });
       throw error;
     }
 
@@ -2400,42 +2385,23 @@ export class SlotAllocationService {
       }
     }
 
-    try {
-      await recordBookingUtilization(tx, {
-        programAssignmentId: assignment.id,
-        paymentId: orgPayment.id,
-        engagementsConsumed: idsToDebit.length,
-        priceAtBookingPaise,
-        // PR-1e (G3): pass the appointment ids so re-allocation
-        // (delete+recreate of the same slot) can't double-debit. The
-        // helper computes the set diff against
-        // BookingUtilization.appointmentIds and increments only by the
-        // genuinely-new ids.
-        appointmentIds: idsToDebit,
-      });
-    } catch (err) {
-      if (err instanceof ProgramAssignmentLimitError) {
-        // Cap exceeded with BLOCK behavior — surface upward so the
-        // transaction rolls back the newly-created appointments. The
-        // SlotAllocationService.allocate() error mapper translates this
-        // to the appropriate HTTP status for the route handler. An
-        // organization's overage cap being hit is an ANSWER, not a fault —
-        // reported at info so its rate is visible without paging anyone.
-        reportSentryError(err, {
-          subsystem: "scheduling",
-          op: "slot-allocation",
-          expected: true,
-          extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
-        });
-        throw err;
-      }
-      reportSentryError(err, {
-        subsystem: "scheduling",
-        op: "slot-allocation",
-        extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
-      });
-      throw err;
-    }
+    // Not captured here — this only runs from createAppointments, itself only
+    // reachable via allocate()'s try, whose catch reports every error
+    // reaching it (a ProgramAssignmentLimitError cap-exceeded included,
+    // correctly classified as one of its modelled outcomes). A capture here
+    // too would be a dupe, so this no longer needs its own try/catch.
+    await recordBookingUtilization(tx, {
+      programAssignmentId: assignment.id,
+      paymentId: orgPayment.id,
+      engagementsConsumed: idsToDebit.length,
+      priceAtBookingPaise,
+      // PR-1e (G3): pass the appointment ids so re-allocation
+      // (delete+recreate of the same slot) can't double-debit. The
+      // helper computes the set diff against
+      // BookingUtilization.appointmentIds and increments only by the
+      // genuinely-new ids.
+      appointmentIds: idsToDebit,
+    });
   }
 
   /**

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -5,7 +5,7 @@
  * Handles auto, manual, and requested slot allocation.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma, {
   type Tx,
   type PrismaLike,
@@ -150,7 +150,7 @@ export class SlotAllocationService {
       // available" for a database failure. Real faults keep the default
       // error level with no expected tag.
       const modeled = this.isModeledOutcome(error);
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "scheduling",
         op: "slot-allocation",
         expected: modeled,
@@ -215,6 +215,15 @@ export class SlotAllocationService {
     // was allocating; the whole allocation tx rolled back.
     if (error instanceof IllegalTransitionError) {
       return { errorCode: "ILLEGAL_TRANSITION", httpStatus: error.httpStatus };
+    }
+
+    // The org's per-cycle overage ceiling refusing an assignment is a decision,
+    // not a fault. It was already reported to Sentry as an expected outcome
+    // while falling through to UNKNOWN_ERROR/500 here — so the dashboard called
+    // it routine and the caller got a server error. 402 matches what
+    // recordOverageAtCheckout returns for the very same ceiling.
+    if (error instanceof ProgramAssignmentLimitError) {
+      return { errorCode: "PROGRAM_CAP_EXHAUSTED", httpStatus: 402 };
     }
 
     // Structured DB-conflict detection (no message sniffing): unique (P2002 /
@@ -1391,7 +1400,7 @@ export class SlotAllocationService {
                 // A same-key retry losing this race is the ordinary replay
                 // case (#837) — reported at info so its frequency is visible
                 // without reading as a fault.
-                reportError(err, {
+                reportSentryError(err, {
                   subsystem: "scheduling",
                   op: "slot-allocation",
                   expected: true,
@@ -1401,7 +1410,7 @@ export class SlotAllocationService {
                   "This allocation was already submitted; the original result applies.",
                 );
               }
-              reportError(err, {
+              reportSentryError(err, {
                 subsystem: "scheduling",
                 op: "slot-allocation",
                 extra: { phase: "requested-stamp", idempotencyKey },
@@ -2227,7 +2236,7 @@ export class SlotAllocationService {
       if (isExclusionViolation(error) || isUniqueViolation(error)) {
         // A concurrent booking winning the #440 overlap guard is the ordinary
         // "someone else got there first" race, not a fault.
-        reportError(error, {
+        reportSentryError(error, {
           subsystem: "scheduling",
           op: "slot-allocation",
           expected: true,
@@ -2237,7 +2246,7 @@ export class SlotAllocationService {
           "This time slot was just booked by someone else. Please pick another time.",
         );
       }
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "scheduling",
         op: "slot-allocation",
         extra: { phase: "create-appointments", eventType, eventId },
@@ -2412,7 +2421,7 @@ export class SlotAllocationService {
         // to the appropriate HTTP status for the route handler. An
         // organization's overage cap being hit is an ANSWER, not a fault —
         // reported at info so its rate is visible without paging anyone.
-        reportError(err, {
+        reportSentryError(err, {
           subsystem: "scheduling",
           op: "slot-allocation",
           expected: true,
@@ -2420,7 +2429,7 @@ export class SlotAllocationService {
         });
         throw err;
       }
-      reportError(err, {
+      reportSentryError(err, {
         subsystem: "scheduling",
         op: "slot-allocation",
         extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },

--- a/utils/slotAllocation/SlotAllocationService.ts
+++ b/utils/slotAllocation/SlotAllocationService.ts
@@ -5,7 +5,7 @@
  * Handles auto, manual, and requested slot allocation.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma, {
   type Tx,
   type PrismaLike,
@@ -150,23 +150,17 @@ export class SlotAllocationService {
       // available" for a database failure. Real faults keep the default
       // error level with no expected tag.
       const modeled = this.isModeledOutcome(error);
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            ...(modeled ? { expected: "true" } : {}),
-          },
-          extra: {
-            mode: request.mode,
-            eventType: request.eventType,
-            eventId: request.eventId,
-            errorCode,
-          },
-          ...(modeled ? { level: "info" as const } : {}),
+      reportError(error, {
+        subsystem: "scheduling",
+        op: "slot-allocation",
+        expected: modeled,
+        extra: {
+          mode: request.mode,
+          eventType: request.eventType,
+          eventId: request.eventId,
+          errorCode,
         },
-      );
+      });
       return {
         success: false,
         error: error instanceof Error ? error.message : "Allocation failed",
@@ -1397,33 +1391,21 @@ export class SlotAllocationService {
                 // A same-key retry losing this race is the ordinary replay
                 // case (#837) — reported at info so its frequency is visible
                 // without reading as a fault.
-                Sentry.captureException(
-                  err instanceof Error ? err : new Error(String(err)),
-                  {
-                    tags: {
-                      subsystem: "scheduling",
-                      op: "slot-allocation",
-                      expected: "true",
-                    },
-                    extra: { phase: "requested-stamp", idempotencyKey },
-                    level: "info",
-                  },
-                );
+                reportError(err, {
+                  subsystem: "scheduling",
+                  op: "slot-allocation",
+                  expected: true,
+                  extra: { phase: "requested-stamp", idempotencyKey },
+                });
                 throw new AllocationConflictError(
                   "This allocation was already submitted; the original result applies.",
                 );
               }
-              Sentry.captureException(
-                err instanceof Error ? err : new Error(String(err)),
-                {
-                  tags: {
-                    subsystem: "scheduling",
-                    op: "slot-allocation",
-                    expected: "false",
-                  },
-                  extra: { phase: "requested-stamp", idempotencyKey },
-                },
-              );
+              reportError(err, {
+                subsystem: "scheduling",
+                op: "slot-allocation",
+                extra: { phase: "requested-stamp", idempotencyKey },
+              });
               throw err;
             }
           }
@@ -2245,33 +2227,21 @@ export class SlotAllocationService {
       if (isExclusionViolation(error) || isUniqueViolation(error)) {
         // A concurrent booking winning the #440 overlap guard is the ordinary
         // "someone else got there first" race, not a fault.
-        Sentry.captureException(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            tags: {
-              subsystem: "scheduling",
-              op: "slot-allocation",
-              expected: "true",
-            },
-            extra: { phase: "create-appointments", eventType, eventId },
-            level: "info",
-          },
-        );
+        reportError(error, {
+          subsystem: "scheduling",
+          op: "slot-allocation",
+          expected: true,
+          extra: { phase: "create-appointments", eventType, eventId },
+        });
         throw new AllocationConflictError(
           "This time slot was just booked by someone else. Please pick another time.",
         );
       }
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "false",
-          },
-          extra: { phase: "create-appointments", eventType, eventId },
-        },
-      );
+      reportError(error, {
+        subsystem: "scheduling",
+        op: "slot-allocation",
+        extra: { phase: "create-appointments", eventType, eventId },
+      });
       throw error;
     }
 
@@ -2442,28 +2412,19 @@ export class SlotAllocationService {
         // to the appropriate HTTP status for the route handler. An
         // organization's overage cap being hit is an ANSWER, not a fault —
         // reported at info so its rate is visible without paging anyone.
-        Sentry.captureException(err, {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "true",
-          },
+        reportError(err, {
+          subsystem: "scheduling",
+          op: "slot-allocation",
+          expected: true,
           extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
-          level: "info",
         });
         throw err;
       }
-      Sentry.captureException(
-        err instanceof Error ? err : new Error(String(err)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-allocation",
-            expected: "false",
-          },
-          extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
-        },
-      );
+      reportError(err, {
+        subsystem: "scheduling",
+        op: "slot-allocation",
+        extra: { phase: "subscription-cap", subscriptionId, consulteeUserId },
+      });
       throw err;
     }
   }

--- a/utils/slotAllocation/SlotValidationService.ts
+++ b/utils/slotAllocation/SlotValidationService.ts
@@ -5,6 +5,7 @@
  * Single source of truth for validation rules - eliminates duplication across routes.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import prisma, { type PrismaLike } from "@/lib/prisma";
 import { AppointmentStatus, ScheduleType } from "@prisma/client";
 import {
@@ -665,6 +666,20 @@ export class SlotValidationService {
         "Consultation duration",
       );
     } catch (error) {
+      // A misconfigured duration failing validation is a modelled answer
+      // (bad plan config), not a fault — reported at info for visibility.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-validation",
+            expected: "true",
+          },
+          extra: { phase: "consultation-duration" },
+          level: "info",
+        },
+      );
       return {
         isValid: false,
         errors: [
@@ -834,6 +849,20 @@ export class SlotValidationService {
     try {
       SlotCalculationService.validateDuration(duration, "Webinar duration");
     } catch (error) {
+      // Same reasoning as validateConsultation's duration guard: a modelled
+      // config-validation answer, reported at info.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-validation",
+            expected: "true",
+          },
+          extra: { phase: "webinar-duration" },
+          level: "info",
+        },
+      );
       return {
         isValid: false,
         errors: [
@@ -920,6 +949,19 @@ export class SlotValidationService {
         "Session duration",
       );
     } catch (error) {
+      // Same reasoning as the consultation/webinar duration guards.
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          tags: {
+            subsystem: "scheduling",
+            op: "slot-validation",
+            expected: "true",
+          },
+          extra: { phase: "class-session-duration" },
+          level: "info",
+        },
+      );
       return {
         isValid: false,
         errors: [

--- a/utils/slotAllocation/SlotValidationService.ts
+++ b/utils/slotAllocation/SlotValidationService.ts
@@ -5,7 +5,7 @@
  * Single source of truth for validation rules - eliminates duplication across routes.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import prisma, { type PrismaLike } from "@/lib/prisma";
 import { AppointmentStatus, ScheduleType } from "@prisma/client";
 import {
@@ -668,18 +668,12 @@ export class SlotValidationService {
     } catch (error) {
       // A misconfigured duration failing validation is a modelled answer
       // (bad plan config), not a fault — reported at info for visibility.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-validation",
-            expected: "true",
-          },
-          extra: { phase: "consultation-duration" },
-          level: "info",
-        },
-      );
+      reportError(error, {
+        subsystem: "scheduling",
+        op: "slot-validation",
+        expected: true,
+        extra: { phase: "consultation-duration" },
+      });
       return {
         isValid: false,
         errors: [
@@ -851,18 +845,12 @@ export class SlotValidationService {
     } catch (error) {
       // Same reasoning as validateConsultation's duration guard: a modelled
       // config-validation answer, reported at info.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-validation",
-            expected: "true",
-          },
-          extra: { phase: "webinar-duration" },
-          level: "info",
-        },
-      );
+      reportError(error, {
+        subsystem: "scheduling",
+        op: "slot-validation",
+        expected: true,
+        extra: { phase: "webinar-duration" },
+      });
       return {
         isValid: false,
         errors: [
@@ -950,18 +938,12 @@ export class SlotValidationService {
       );
     } catch (error) {
       // Same reasoning as the consultation/webinar duration guards.
-      Sentry.captureException(
-        error instanceof Error ? error : new Error(String(error)),
-        {
-          tags: {
-            subsystem: "scheduling",
-            op: "slot-validation",
-            expected: "true",
-          },
-          extra: { phase: "class-session-duration" },
-          level: "info",
-        },
-      );
+      reportError(error, {
+        subsystem: "scheduling",
+        op: "slot-validation",
+        expected: true,
+        extra: { phase: "class-session-duration" },
+      });
       return {
         isValid: false,
         errors: [

--- a/utils/slotAllocation/SlotValidationService.ts
+++ b/utils/slotAllocation/SlotValidationService.ts
@@ -5,7 +5,7 @@
  * Single source of truth for validation rules - eliminates duplication across routes.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import prisma, { type PrismaLike } from "@/lib/prisma";
 import { AppointmentStatus, ScheduleType } from "@prisma/client";
 import {
@@ -668,7 +668,7 @@ export class SlotValidationService {
     } catch (error) {
       // A misconfigured duration failing validation is a modelled answer
       // (bad plan config), not a fault — reported at info for visibility.
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "scheduling",
         op: "slot-validation",
         expected: true,
@@ -845,7 +845,7 @@ export class SlotValidationService {
     } catch (error) {
       // Same reasoning as validateConsultation's duration guard: a modelled
       // config-validation answer, reported at info.
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "scheduling",
         op: "slot-validation",
         expected: true,
@@ -938,7 +938,7 @@ export class SlotValidationService {
       );
     } catch (error) {
       // Same reasoning as the consultation/webinar duration guards.
-      reportError(error, {
+      reportSentryError(error, {
         subsystem: "scheduling",
         op: "slot-validation",
         expected: true,

--- a/utils/slotAllocation/slotTimeUtils.ts
+++ b/utils/slotAllocation/slotTimeUtils.ts
@@ -11,7 +11,7 @@
  * the new Int-based representation.
  */
 
-import * as Sentry from "@sentry/nextjs";
+import { reportError } from "@/lib/observability/report";
 import { DayOfWeek, Prisma } from "@prisma/client";
 import {
   isNextDayOfWeek,
@@ -337,18 +337,12 @@ export function getTimezoneOffsetMinutes(
     // caller in the codebase invokes this once per request (timezone
     // resolution), never per slot candidate in a scan loop, so this can't
     // fan out into per-candidate volume.
-    Sentry.captureException(
-      error instanceof Error ? error : new Error(String(error)),
-      {
-        tags: {
-          subsystem: "scheduling",
-          op: "slot-validation",
-          expected: "true",
-        },
-        extra: { timezone },
-        level: "info",
-      },
-    );
+    reportError(error, {
+      subsystem: "scheduling",
+      op: "slot-validation",
+      expected: true,
+      extra: { timezone },
+    });
     return 0;
   }
 }

--- a/utils/slotAllocation/slotTimeUtils.ts
+++ b/utils/slotAllocation/slotTimeUtils.ts
@@ -11,6 +11,7 @@
  * the new Int-based representation.
  */
 
+import * as Sentry from "@sentry/nextjs";
 import { DayOfWeek, Prisma } from "@prisma/client";
 import {
   isNextDayOfWeek,
@@ -330,7 +331,24 @@ export function getTimezoneOffsetMinutes(
       return 0;
     }
     return offset;
-  } catch {
+  } catch (error) {
+    // An unresolvable IANA zone falling back to 0 is a modelled answer
+    // (documented contract above), not a fault. Safe to report here: every
+    // caller in the codebase invokes this once per request (timezone
+    // resolution), never per slot candidate in a scan loop, so this can't
+    // fan out into per-candidate volume.
+    Sentry.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        tags: {
+          subsystem: "scheduling",
+          op: "slot-validation",
+          expected: "true",
+        },
+        extra: { timezone },
+        level: "info",
+      },
+    );
     return 0;
   }
 }

--- a/utils/slotAllocation/slotTimeUtils.ts
+++ b/utils/slotAllocation/slotTimeUtils.ts
@@ -11,7 +11,7 @@
  * the new Int-based representation.
  */
 
-import { reportError } from "@/lib/observability/report";
+import { reportSentryError } from "@/lib/observability/report";
 import { DayOfWeek, Prisma } from "@prisma/client";
 import {
   isNextDayOfWeek,
@@ -337,7 +337,7 @@ export function getTimezoneOffsetMinutes(
     // caller in the codebase invokes this once per request (timezone
     // resolution), never per slot candidate in a scan loop, so this can't
     // fan out into per-candidate volume.
-    reportError(error, {
+    reportSentryError(error, {
       subsystem: "scheduling",
       op: "slot-validation",
       expected: true,

--- a/utils/slotAllocation/types.ts
+++ b/utils/slotAllocation/types.ts
@@ -94,6 +94,7 @@ export type AllocationErrorCode =
   | "INVALID_MODE" // unknown allocation mode — 400
   | "LOCK_CONTENTION" // Redis lock busy — 409
   | "ILLEGAL_TRANSITION" // event left the approvable state mid-allocation (#836) — 409
+  | "PROGRAM_CAP_EXHAUSTED" // org's per-cycle overage ceiling vetoed it — 402
   | "UNKNOWN_ERROR"; // infra / unexpected — 500
 
 /**


### PR DESCRIPTION
Split out of the reschedule/pages work so observability ships first and alone. The surface rework (dedicated pages, palette, withdraw, flicker, org-403) follows as its own PR.

The ordering is deliberate: #1060's defects were found by clicking, not by CI. Landing error reporting **before** the next PR is written means that PR's own failures are visible from the moment its preview builds.

## Why

Three areas reported almost nothing.

**The booking engine reported nothing at all.** `utils/slotAllocation` had zero `captureException` across seven files. Every failure — an invariant violation in `createAppointments`, a Prisma error, an unhandled throw from any of the three allocation modes — converged on one catch that returned `{success:false, errorCode:"UNKNOWN_ERROR"}` and left no trace. A production allocation failure was invisible.

**A failed read renders as an empty state.** `lib/data` feeds the RSC pages; when one of those throws, the user sees "you have no bookings" rather than an error. `useCalendarData`'s event-slot fetch was the clearest case — it set everything to empty with no toast and no error state.

**The money paths were half-covered.** 23 files in `lib/payments` had catch blocks; 11 had reporting. A swallowed error there can leave a captured payment with no booking, a half-applied refund, or a ledger posting that never landed.

## The policy: capture everything, tag by expectedness

Modelled outcomes are captured too — a slot being unavailable, an idempotency short-circuit, a declined card, a lost CAS race. They are ANSWERS rather than faults, so they are recorded for volume and pattern, not as incidents.

What keeps that from drowning the real signal is the tag:

| | `level` | `tags.expected` |
|---|---|---|
| Modelled outcome | `info` (or `warning` where it needs follow-up) | `"true"` |
| Genuine fault | default `error` | `"false"` |

`expected` is present in **both** directions rather than omitted on faults, so a dashboard can split on one key either way. `subsystem` and `op` reuse whatever already existed at each site.

## Deliberate carve-outs

Three things are **not** captured, each for a reason that survives the policy:

- **Hot loops.** Volume there scales with iterations, not events — a capture per slot *candidate* would emit thousands for one allocation. The single candidate, `getTimezoneOffsetMinutes`, was instrumented only after verifying it runs once per request and never inside that loop.
- **`AbortError`** from unmounted components and superseded queries. It fires on ordinary navigation. (Checked: none of the newly-instrumented hooks can actually produce one.)
- **`lib/data/fail-open.ts`.** It already emits a Sentry *breadcrumb* rather than an exception, explicitly to avoid flooding on a known and tracked transient-timeout class. A coverage policy is not authority to overrule a considered decision, so it is untouched and raised separately.

## Two limits, stated rather than hidden

**`checkout.ts` can emit two events for one failure.** Its outer catch now reports paths the inner one never saw, so they overlap. Redundancy was preferred to leaving lock acquisition and amount validation blind — but the duplicates are real and you will see them.

**Roughly 200 `throw` sites are not individually classified.** They live in `lib/payments` files that never had a catch block, and they propagate to the `checkout` / `refund` boundaries which now capture. So there is a net, just not a per-site one. That is a genuine limit of applying this policy at this scale.

## Notable specifics

- The three availability fetch helpers mixed business 4xx with network faults in one catch and had no way to tell them apart. The thrown `Error` now carries `httpStatus`, checked against its only consumer, which reads `.message` alone.
- `postLedgerTxn` captures its own final failure. Several callers wrap it and several do not, so for `payout-service` and `org-payout-service` this is the only backstop.
- `useCalendarData`'s believed-unreachable outer catches are tagged `expected:"false"` on purpose: if one ever fires, the invariant it rests on has broken, which is a fault rather than a routine outcome.

## Required before this ships — dashboard config, not code

With routine outcomes now flowing in:

1. **Sentry inbound filters**, so expected-tagged volume does not consume the quota.
2. **A rate limit on the webhook signature-verification endpoint.** It is internet-facing and signature failures are now captured, so hostile traffic alone could burn the quota.

## Still missing, and it is the biggest gap of all

**`Sentry.init` never runs for cron jobs.** It is invoked only through `instrumentation.ts`, but GitHub Actions runs `npx tsx jobs/…` *outside* the Next runtime — and **58 files under `jobs/` call `captureException`**. The entire scheduled-job fleet reports nothing, and none of the work in this PR helps a cron until that is fixed.

That needs a shared job bootstrap imported by every entry point, plus confirmation that `SENTRY_DSN` actually reaches each workflow's env. Tracked, and a candidate to fold into this PR before merge.

Also outstanding: `lib/supabase.ts`'s `fetchImagesFromSupabaseStorage` swallows every error and returns `[]`, so a broken image backend renders as "no images" with no trace.

## Verification

Cold `tsc` clean, **2,079 tests across 185 files**, and lint down to four warnings that already exist on `dev` (two `eqeqeq`, two `no-explicit-any`, all on untouched lines).

No runtime behaviour changed anywhere: every edit is a capture inserted before an existing `return` or `throw`. Control flow, return values, thrown error types and messages, status codes, and transaction/retry/idempotency semantics are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Expanded error reporting across scheduling, chat, consultant data, currency, events, and payment workflows.
  * Classified expected business outcomes separately from unexpected system failures, improving monitoring signal quality.
  * Added contextual details for payment, payout, webhook, allocation, and timezone-related errors.
  * Preserved existing fallback behavior, retries, validation responses, and user-facing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->