### PR TITLE
feat(scheduling): open the slot picker on the session you clicked

### DIFF
--- a/__tests__/schedule/calendar-fetch-window.test.tsx
+++ b/__tests__/schedule/calendar-fetch-window.test.tsx
@@ -1,0 +1,157 @@
+// The availability window the calendar asks the server for.
+//
+// The grid always draws a full week. When allocate mode clamped the request to
+// the scheduling period's end, every cell past that end had no server row, and
+// because the route filters APPOINTMENTS by the same window, the booked cells
+// in that range disappeared too — which is what ruled out a per-week cap or a
+// disabled state as the cause. One week further on, `endDate` fell before
+// `startDate`, the server had nothing to return, and the entire grid blanked
+// until the consultant pressed `‹`.
+//
+// These assertions are on the ARGUMENTS of the fetch, deliberately: the bug was
+// never in how a slot renders, so nothing about the rendered grid could have
+// caught it.
+
+jest.mock("../../lib/scheduling/allocationService", () => ({
+  AllocationService: {
+    fetchAvailabilitySlots: jest.fn(),
+    fetchConsultantData: jest.fn(),
+    fetchEventSlots: jest.fn(),
+  },
+}));
+
+// ONE toast function for the life of the module. A fresh `jest.fn()` per call
+// would change `toast`'s identity on every render, and `toast` is a dependency
+// of the fetch callback that the date effect depends on — which is the React
+// #185 loop this component has produced before, reproduced in a test harness.
+jest.mock("../../hooks/use-toast", () => {
+  const toast = jest.fn();
+  return { useToast: () => ({ toast }) };
+});
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { endOfWeek, startOfWeek } from "date-fns";
+
+import {
+  useCalendarData,
+  type UseCalendarDataOptions,
+} from "../../hooks/scheduling/useCalendarData";
+import { AllocationService } from "../../lib/scheduling/allocationService";
+
+const fetchAvailabilitySlots =
+  AllocationService.fetchAvailabilitySlots as jest.Mock;
+const fetchConsultantData = AllocationService.fetchConsultantData as jest.Mock;
+
+/** Mid-March, so the period bounds below sit inside the same month. */
+const PERIOD_START = new Date(2026, 2, 2, 0, 0, 0, 0);
+/** A Wednesday, so the week it lands in extends past it in both directions. */
+const PERIOD_END = new Date(2026, 2, 18, 23, 59, 59, 999);
+
+/** The week containing PERIOD_END — its last three days are outside the period. */
+const WEEK_OF_PERIOD_END = new Date(2026, 2, 16, 12, 0, 0, 0);
+/** The week AFTER the period closes: the one that used to blank entirely. */
+const WEEK_AFTER_PERIOD = new Date(2026, 2, 23, 12, 0, 0, 0);
+
+function Probe({ options }: { options: UseCalendarDataOptions }) {
+  useCalendarData(options);
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function renderHookWith(options: UseCalendarDataOptions) {
+  await act(async () => {
+    root.render(<Probe options={options} />);
+  });
+}
+
+/** The (startDate, endDate) of the most recent availability request. */
+function lastWindow(): { startDate: Date; endDate: Date } {
+  const calls = fetchAvailabilitySlots.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const [, startDate, endDate] = calls[calls.length - 1];
+  return { startDate, endDate };
+}
+
+function allocateOptions(
+  currentDate: Date,
+): UseCalendarDataOptions & { allowedEnd: Date } {
+  return {
+    consultantId: "consultant-1",
+    view: "week",
+    currentDate,
+    mode: "allocate",
+    allowedStart: PERIOD_START,
+    allowedEnd: PERIOD_END,
+  };
+}
+
+beforeEach(() => {
+  fetchAvailabilitySlots.mockResolvedValue({ weekly: [], custom: [] });
+  fetchConsultantData.mockResolvedValue({ id: "consultant-1", name: "Ada" });
+
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("calendar availability window — the period never narrows the view", () => {
+  it("asks for the whole visible week even when it overruns allowedEnd", async () => {
+    await renderHookWith(allocateOptions(WEEK_OF_PERIOD_END));
+
+    const { startDate, endDate } = lastWindow();
+
+    expect(startDate).toEqual(startOfWeek(WEEK_OF_PERIOD_END));
+    // The property that matters: the end of the WEEK, not the end of the
+    // period. The three days between them are where booked cells vanished.
+    expect(endDate).toEqual(endOfWeek(WEEK_OF_PERIOD_END));
+    expect(endDate.getTime()).toBeGreaterThan(PERIOD_END.getTime());
+  });
+
+  it("still asks forward for a week that starts after the period closes", async () => {
+    await renderHookWith(allocateOptions(WEEK_AFTER_PERIOD));
+
+    const { startDate, endDate } = lastWindow();
+
+    // An inverted window is what emptied the grid: the server has no range to
+    // scan, returns nothing, and every cell — booked ones included — blanks.
+    expect(endDate.getTime()).toBeGreaterThan(startDate.getTime());
+    expect(startDate).toEqual(startOfWeek(WEEK_AFTER_PERIOD));
+    expect(endDate).toEqual(endOfWeek(WEEK_AFTER_PERIOD));
+  });
+
+  it("asks for one week's worth, not the rest of the period", async () => {
+    // The old window ran from the visible week to allowedEnd, so a period with
+    // months left made every navigation a months-wide scan of the endpoint
+    // #997 measured in tens of seconds.
+    const farOff = { ...allocateOptions(PERIOD_START), allowedEnd: new Date(2027, 0, 1) };
+    await renderHookWith(farOff);
+
+    const { startDate, endDate } = lastWindow();
+    const spannedDays =
+      (endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000);
+
+    expect(spannedDays).toBeLessThan(8);
+  });
+
+  it("windows a select-mode week the same way, with or without bounds", async () => {
+    await renderHookWith({
+      consultantId: "consultant-1",
+      view: "week",
+      currentDate: WEEK_OF_PERIOD_END,
+      mode: "select",
+    });
+
+    const { startDate, endDate } = lastWindow();
+
+    expect(startDate).toEqual(startOfWeek(WEEK_OF_PERIOD_END));
+    expect(endDate).toEqual(endOfWeek(WEEK_OF_PERIOD_END));
+  });
+});

--- a/__tests__/schedule/slot-palette.test.ts
+++ b/__tests__/schedule/slot-palette.test.ts
@@ -77,6 +77,44 @@ describe("slot palette — the base cell string cannot fight the token", () => {
   it("carries no background of its own", () => {
     expect(colourUtilities(SLOT_CELL_BASE_CLASS, "bg-")).toEqual([]);
   });
+
+  /**
+   * The swatch-equality tests above compare token STRINGS, so they are green
+   * whether or not the browser paints the string at full strength. That is
+   * exactly how `disabled:opacity-50` survived the #1064 palette work: every
+   * unavailable cell is disabled, so `bg-slate-200` reached the screen at half
+   * over a white card — near enough to the reverted `slate-100` to make a
+   * sparse week read as an empty grid again — while the legend swatch, not
+   * being a disabled control, showed the true colour. No assertion about token
+   * equality can see a variant that fades one side and not the other, so it is
+   * pinned directly here.
+   */
+  it("does not fade every disabled cell", () => {
+    const faders = classesOf(SLOT_CELL_BASE_CLASS).filter((name) =>
+      name.startsWith("disabled:opacity-"),
+    );
+    expect(faders).toEqual([]);
+  });
+
+  it("still stops disabled cells being clicked", () => {
+    expect(classesOf(SLOT_CELL_BASE_CLASS)).toContain(
+      "disabled:pointer-events-none",
+    );
+  });
+
+  /**
+   * Fading a cell is legitimate where it is asked for explicitly — a past
+   * slot. That path goes through the `faded` option, not the disabled variant,
+   * and must keep working.
+   */
+  it("still fades a cell that asks to be faded", () => {
+    expect(classesOf(slotCellClassName("unavailable", { faded: true }))).toContain(
+      "opacity-60",
+    );
+    expect(classesOf(slotCellClassName("unavailable"))).not.toContain(
+      "opacity-60",
+    );
+  });
 });
 
 describe("slot palette — Tailwind can see where the tokens live", () => {

--- a/__tests__/schedule/slot-picker-focus-effect.test.tsx
+++ b/__tests__/schedule/slot-picker-focus-effect.test.tsx
@@ -1,0 +1,239 @@
+// #1073 — the focus effect itself, which is where all the risk in this change
+// lives: it has to fire exactly once, and it has to fire at all.
+//
+// The week grid does not exist until `consultantDetails` has arrived, and
+// `useCalendarData` fetches details and availability independently. Keying the
+// effect on anything that settles BEFORE the grid mounts means it runs against
+// a null container, returns, and — a ref being unable to wake an effect —
+// never runs again. That failure is silent and race-dependent, which is why it
+// is pinned here rather than left to manual testing.
+
+jest.mock("@prisma/client", () => ({
+  DayOfWeek: {
+    SUNDAY: "SUNDAY",
+    MONDAY: "MONDAY",
+    TUESDAY: "TUESDAY",
+    WEDNESDAY: "WEDNESDAY",
+    THURSDAY: "THURSDAY",
+    FRIDAY: "FRIDAY",
+    SATURDAY: "SATURDAY",
+  },
+  Prisma: {},
+}));
+
+jest.mock("../../hooks/use-toast", () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock("../../hooks/scheduling/useCalendarData", () => ({
+  useCalendarData: () => calendarData,
+}));
+
+jest.mock("../../hooks/scheduling/useSlotAllocation", () => ({
+  useEventSlotAllocation: () => allocation,
+}));
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { UnifiedCalendar } from "../../components/scheduling/UnifiedCalendar";
+import {
+  FOCUS_LEAD_ROWS,
+  type SlotPickerFocus,
+} from "../../lib/scheduling/slot-picker-focus";
+
+/** Every row is one of these tall; jsdom has no layout, so we supply it. */
+const ROW_HEIGHT = 32;
+/** 10:30 on the target day → hour 10, half-hour 1. */
+const TARGET_ROW = 21;
+/** FOCUS_LEAD_ROWS of headroom, so the target is in view and not clipped. */
+const EXPECTED_SCROLL_ROW = TARGET_ROW - FOCUS_LEAD_ROWS;
+
+const SCROLL_CONTAINER_CLASS = "overflow-y-auto";
+
+function slotStatus(interval: { hour: number; minute: number }, date: Date) {
+  const start = new Date(date);
+  start.setHours(interval.hour, interval.minute, 0, 0);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+  return {
+    isAvailable: true,
+    isBooked: false,
+    isBookedForDisplay: false,
+    isPartiallyBooked: false,
+    isDisabled: false,
+    isInPast: false,
+    intervalStartUTCString: start.toISOString(),
+    intervalEndUTCString: end.toISOString(),
+    localStartTime: start,
+    localEndTime: end,
+    overlappingAppointments: [],
+  };
+}
+
+let calendarData: Record<string, unknown>;
+let allocation: Record<string, unknown>;
+
+// ONE array, reused across renders. A fresh `[]` each time would change the
+// identity of a value the pre-fix effect listed in its deps, which is enough
+// to wake it by accident and hide the very bug these tests exist to catch.
+const NO_AVAILABILITY: { startTime: Date }[] = [];
+
+function setCalendarData(overrides: Record<string, unknown> = {}) {
+  calendarData = {
+    consultantDetails: { id: "consultant-1" },
+    availableSlots: NO_AVAILABILITY,
+    eventSlots: [],
+    eventTentativeSlots: [],
+    weeklyConfirmedCallCounts: {},
+    loading: false,
+    error: null,
+    refetch: jest.fn(),
+    refetchEventSlots: jest.fn(),
+    refetchAvailability: jest.fn(),
+    getSlotStatusForInterval: slotStatus,
+    ...overrides,
+  };
+}
+
+function resetAllocation() {
+  allocation = {
+    selectedSlots: [],
+    setSelectedSlots: jest.fn(),
+    isAllocating: false,
+    allocationError: null,
+    isValid: true,
+    validationErrors: [],
+    requiredSlots: 2,
+    toggleSlot: jest.fn(),
+    clearSlots: jest.fn(),
+    isSlotSelected: () => false,
+    manualAllocate: jest.fn(),
+    autoAllocate: jest.fn(),
+    allocateRequestedSlots: jest.fn(),
+    slotLimits: { slotsPerSession: 2, maxSlots: 10, totalSessions: 5 },
+  };
+}
+
+/**
+ * jsdom reports every rect as zero, so the measured scroll would always be a
+ * no-op. Give the scroll container's own children a height, keyed off their
+ * position, and leave everything else at the origin.
+ */
+function stubLayout() {
+  Element.prototype.getBoundingClientRect = function (this: Element) {
+    const parent = this.parentElement;
+    const isGridRow = parent?.classList.contains(SCROLL_CONTAINER_CLASS);
+    const top = isGridRow
+      ? Array.prototype.indexOf.call(parent!.children, this) * ROW_HEIGHT
+      : 0;
+    return { top, bottom: top + ROW_HEIGHT, height: ROW_HEIGHT } as DOMRect;
+  };
+}
+
+function weekGrid(host: HTMLElement): HTMLElement {
+  const grid = host.querySelector(`.${SCROLL_CONTAINER_CLASS}`);
+  if (!(grid instanceof HTMLElement)) throw new Error("week grid not rendered");
+  return grid;
+}
+
+// Local noon so the row is read in the same zone the grid draws in, whatever
+// zone the test happens to run in.
+const target = new Date(2026, 7, 1, 10, 30, 0, 0);
+const focus: SlotPickerFocus = { at: target, precision: "session" };
+
+describe("UnifiedCalendar focus effect", () => {
+  let host: HTMLElement;
+  let root: Root;
+  const originalRect = Element.prototype.getBoundingClientRect;
+
+  beforeAll(() => {
+    (global as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    stubLayout();
+  });
+
+  afterAll(() => {
+    Element.prototype.getBoundingClientRect = originalRect;
+  });
+
+  beforeEach(() => {
+    setCalendarData();
+    resetAllocation();
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  function render(props: Record<string, unknown> = {}) {
+    act(() => {
+      root.render(
+        <UnifiedCalendar
+          consultantId="consultant-1"
+          eventType="consultation"
+          eventId="event-1"
+          mode="allocate"
+          durationInHours={1}
+          focus={focus}
+          {...props}
+        />,
+      );
+    });
+  }
+
+  it("scrolls the target into view with rows to spare above it", () => {
+    render();
+
+    expect(weekGrid(host).scrollTop).toBe(EXPECTED_SCROLL_ROW * ROW_HEIGHT);
+  });
+
+  it("fires once the grid appears, even when it appears late", () => {
+    // The race: availability settles first, so the effect's other inputs are
+    // already final while the grid is still unrendered.
+    setCalendarData({ consultantDetails: null });
+    render();
+    expect(host.querySelector(`.${SCROLL_CONTAINER_CLASS}`)).toBeNull();
+
+    // Details arrive. NOTHING else changes — not availability, not `loading`,
+    // not the view. Only the grid's existence is new.
+    setCalendarData();
+    render();
+
+    expect(weekGrid(host).scrollTop).toBe(EXPECTED_SCROLL_ROW * ROW_HEIGHT);
+  });
+
+  it("never re-aims the grid once the consultant has scrolled away", () => {
+    render();
+    const grid = weekGrid(host);
+    grid.scrollTop = 900;
+
+    // A refetch: new availability, new array identity, same focus.
+    setCalendarData({ availableSlots: [{ startTime: target }] });
+    render();
+
+    expect(weekGrid(host).scrollTop).toBe(900);
+  });
+
+  it("does nothing at all without a focus target", () => {
+    render({ focus: undefined });
+
+    expect(weekGrid(host).scrollTop).toBe(0);
+  });
+
+  it("anchors a period target on first published availability, not midnight", () => {
+    // Midnight on the target day carries no time of day; 09:00 is where the
+    // consultant's grid actually has something in it.
+    const start = new Date(2026, 7, 1, 0, 0, 0, 0);
+    setCalendarData({
+      availableSlots: [{ startTime: new Date(2026, 7, 3, 9, 0, 0, 0) }],
+    });
+    render({ focus: { at: start, precision: "period" } });
+
+    // Row 18 is 09:00; two rows of headroom leaves 16.
+    expect(weekGrid(host).scrollTop).toBe(16 * ROW_HEIGHT);
+  });
+});

--- a/__tests__/schedule/slot-picker-focus.test.ts
+++ b/__tests__/schedule/slot-picker-focus.test.ts
@@ -1,0 +1,246 @@
+// #1073 — the instant the slot picker opens on, and where that instant lands
+// on the grid. Target selection is per-surface only in the sense that each
+// surface hands the resolver a different set of sessions, so these cases are
+// written as the shapes those subjects actually arrive in.
+
+import type { SlotLike } from "@/lib/appointments/view-model";
+import {
+  earliestAvailabilityRow,
+  focusGridPosition,
+  resolveFocusTarget,
+} from "@/lib/scheduling/slot-picker-focus";
+
+const NOW = new Date("2026-08-01T09:00:00Z");
+
+function session(
+  id: string,
+  startsAt: string,
+  overrides: Partial<SlotLike> = {},
+): SlotLike {
+  return {
+    id,
+    appointmentId: `appt-${id}`,
+    startsAt,
+    endsAt: new Date(
+      new Date(startsAt).getTime() + 60 * 60 * 1000,
+    ).toISOString(),
+    isTentative: false,
+    ...overrides,
+  };
+}
+
+describe("resolveFocusTarget", () => {
+  it("targets the one session of a single-session consultation", () => {
+    const focus = resolveFocusTarget(
+      { slots: [session("s1", "2026-08-08T05:00:00Z")] },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-08-08T05:00:00Z"),
+      precision: "session",
+    });
+  });
+
+  it("targets a past session when the single session has already run", () => {
+    const focus = resolveFocusTarget(
+      { slots: [session("s1", "2026-07-20T05:00:00Z")] },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-07-20T05:00:00Z"),
+      precision: "session",
+    });
+  });
+
+  it("prefers the session awaiting a time over the next upcoming one", () => {
+    // The released session is LATER than the next confirmed one, so picking it
+    // cannot be an accident of sort order.
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("done", "2026-07-20T05:00:00Z"),
+          session("next", "2026-08-02T05:00:00Z"),
+          session("released", "2026-08-06T05:00:00Z", { isTentative: true }),
+        ],
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-08-06T05:00:00Z"),
+      precision: "session",
+    });
+  });
+
+  it("targets the next upcoming session of a fully-placed program", () => {
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("w1", "2026-07-20T05:00:00Z"),
+          session("w3", "2026-08-10T05:00:00Z"),
+          session("w2", "2026-08-04T05:00:00Z"),
+        ],
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-08-04T05:00:00Z"),
+      precision: "session",
+    });
+  });
+
+  it("falls back to the most recent session of a finished program", () => {
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("w1", "2026-06-01T05:00:00Z"),
+          session("w3", "2026-07-15T05:00:00Z"),
+          session("w2", "2026-06-20T05:00:00Z"),
+        ],
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-07-15T05:00:00Z"),
+      precision: "session",
+    });
+  });
+
+  it("ignores sessions that were cancelled or already moved", () => {
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("gone", "2026-08-02T05:00:00Z", {
+            completionStatus: "CANCELLED",
+          }),
+          session("moved", "2026-08-03T05:00:00Z", {
+            completionStatus: "RESCHEDULED",
+          }),
+          session("live", "2026-08-09T05:00:00Z"),
+        ],
+      },
+      NOW,
+    );
+
+    expect(focus.at).toEqual(new Date("2026-08-09T05:00:00Z"));
+  });
+
+  it("targets the start of the scheduling period when nothing is scheduled", () => {
+    // An `unscheduled-class-<id>` subject: a period, and no sessions at all.
+    const focus = resolveFocusTarget(
+      {
+        allowedStart: new Date("2026-09-01T00:00:00Z"),
+        allowedEnd: new Date("2026-11-30T00:00:00Z"),
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-09-01T00:00:00Z"),
+      precision: "period",
+    });
+  });
+
+  it("never opens on a period start that has already passed", () => {
+    const focus = resolveFocusTarget(
+      {
+        allowedStart: new Date("2026-07-01T00:00:00Z"),
+        allowedEnd: new Date("2026-11-30T00:00:00Z"),
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({ at: NOW, precision: "period" });
+  });
+
+  it("opens on the last day of a period that has already closed", () => {
+    const focus = resolveFocusTarget(
+      {
+        allowedStart: new Date("2026-05-01T00:00:00Z"),
+        allowedEnd: new Date("2026-06-30T00:00:00Z"),
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-06-30T00:00:00Z"),
+      precision: "period",
+    });
+  });
+
+  it("falls back to now when there is neither a session nor a period", () => {
+    expect(resolveFocusTarget({}, NOW)).toEqual({
+      at: NOW,
+      precision: "period",
+    });
+  });
+});
+
+describe("focusGridPosition", () => {
+  // One instant, three zones. The row and the calendar date both move with the
+  // zone — reading either in the viewer's zone instead of the grid's is how
+  // focus lands an offset away (#1064's defect class).
+  const at = new Date("2026-08-01T02:30:00Z");
+
+  it("reads the row in the timezone it is given, not the viewer's", () => {
+    expect(focusGridPosition(at, "UTC")).toEqual({
+      year: 2026,
+      month: 8,
+      day: 1,
+      hour: 2,
+      minute: 30,
+      rowIndex: 5,
+    });
+
+    expect(focusGridPosition(at, "Asia/Kolkata")).toEqual({
+      year: 2026,
+      month: 8,
+      day: 1,
+      hour: 8,
+      minute: 0,
+      rowIndex: 16,
+    });
+  });
+
+  it("moves the calendar date too when the zone pushes across midnight", () => {
+    // 22:30 the previous evening in New York — a different day, and therefore
+    // a different week column, from the same instant.
+    expect(focusGridPosition(at, "America/New_York")).toEqual({
+      year: 2026,
+      month: 7,
+      day: 31,
+      hour: 22,
+      minute: 30,
+      rowIndex: 45,
+    });
+  });
+
+  it("puts midnight on the first row", () => {
+    expect(
+      focusGridPosition(new Date("2026-08-01T00:00:00Z"), "UTC").rowIndex,
+    ).toBe(0);
+  });
+});
+
+describe("earliestAvailabilityRow", () => {
+  it("returns the earliest published time of day across the week", () => {
+    const row = earliestAvailabilityRow(
+      [
+        { startTime: new Date("2026-08-03T14:00:00Z") },
+        { startTime: new Date("2026-08-04T09:30:00Z") },
+        { startTime: new Date("2026-08-05T11:00:00Z") },
+      ],
+      "UTC",
+    );
+
+    expect(row).toBe(19); // 09:30
+  });
+
+  it("returns null when the consultant has published nothing", () => {
+    expect(earliestAvailabilityRow([], "UTC")).toBeNull();
+  });
+});

--- a/__tests__/schedule/slot-picker-focus.test.ts
+++ b/__tests__/schedule/slot-picker-focus.test.ts
@@ -5,8 +5,11 @@
 
 import type { SlotLike } from "@/lib/appointments/view-model";
 import {
+  FOCUS_LEAD_ROWS,
   earliestAvailabilityRow,
   focusGridPosition,
+  focusScrollRow,
+  focusTargetRow,
   resolveFocusTarget,
 } from "@/lib/scheduling/slot-picker-focus";
 
@@ -92,6 +95,38 @@ describe("resolveFocusTarget", () => {
     });
   });
 
+  it("ignores a released session whose old time has already passed", () => {
+    // Opening on it would put the consultant on a week of disabled cells —
+    // the dead end the period anchor exists to avoid.
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("stale", "2026-07-10T05:00:00Z", { isTentative: true }),
+          session("next", "2026-08-05T05:00:00Z"),
+        ],
+      },
+      NOW,
+    );
+
+    expect(focus.at).toEqual(new Date("2026-08-05T05:00:00Z"));
+  });
+
+  it("ignores soft-deleted sessions", () => {
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("tombstoned", "2026-08-02T05:00:00Z", {
+            deletedAt: "2026-07-25T00:00:00Z",
+          }),
+          session("live", "2026-08-09T05:00:00Z"),
+        ],
+      },
+      NOW,
+    );
+
+    expect(focus.at).toEqual(new Date("2026-08-09T05:00:00Z"));
+  });
+
   it("falls back to the most recent session of a finished program", () => {
     const focus = resolveFocusTarget(
       {
@@ -127,6 +162,46 @@ describe("resolveFocusTarget", () => {
     );
 
     expect(focus.at).toEqual(new Date("2026-08-09T05:00:00Z"));
+  });
+
+  it("looks forward, not back, when placed sessions are over but the window is not", () => {
+    // Every session so far has run, and there are months of period left to
+    // fill. The remaining sessions can only go in the future, so the past is
+    // both the wrong answer and — in allocate mode, where the availability
+    // request runs from the visible week to `allowedEnd` — a needlessly
+    // enormous fetch (#997).
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("w1", "2026-05-04T05:00:00Z"),
+          session("w2", "2026-06-01T05:00:00Z"),
+        ],
+        allowedStart: new Date("2026-05-01T00:00:00Z"),
+        allowedEnd: new Date("2026-12-01T00:00:00Z"),
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({ at: NOW, precision: "period" });
+  });
+
+  it("still targets the last session once the window has closed too", () => {
+    const focus = resolveFocusTarget(
+      {
+        slots: [
+          session("w1", "2026-05-04T05:00:00Z"),
+          session("w2", "2026-06-01T05:00:00Z"),
+        ],
+        allowedStart: new Date("2026-05-01T00:00:00Z"),
+        allowedEnd: new Date("2026-06-30T00:00:00Z"),
+      },
+      NOW,
+    );
+
+    expect(focus).toEqual({
+      at: new Date("2026-06-01T05:00:00Z"),
+      precision: "session",
+    });
   });
 
   it("targets the start of the scheduling period when nothing is scheduled", () => {
@@ -178,6 +253,69 @@ describe("resolveFocusTarget", () => {
       precision: "period",
     });
   });
+
+  it("never lands past the end of an inverted window", () => {
+    // Bad data rather than a real window, but honouring it would open the
+    // picker outside the bound it clamps selection to.
+    const focus = resolveFocusTarget(
+      {
+        allowedStart: new Date("2026-12-01T00:00:00Z"),
+        allowedEnd: new Date("2026-09-01T00:00:00Z"),
+      },
+      NOW,
+    );
+
+    expect(focus.at).toEqual(new Date("2026-09-01T00:00:00Z"));
+  });
+});
+
+describe("focusTargetRow", () => {
+  const availability = [
+    { startTime: new Date("2026-08-03T10:00:00Z") },
+    { startTime: new Date("2026-08-04T08:30:00Z") },
+  ];
+
+  it("uses the session's own row, availability notwithstanding", () => {
+    const row = focusTargetRow(
+      { at: new Date("2026-08-03T14:30:00Z"), precision: "session" },
+      availability,
+      "UTC",
+    );
+
+    expect(row).toBe(29); // 14:30
+  });
+
+  it("routes a window bound through first availability instead of 00:00", () => {
+    const row = focusTargetRow(
+      { at: new Date("2026-08-03T00:00:00Z"), precision: "period" },
+      availability,
+      "UTC",
+    );
+
+    expect(row).toBe(17); // 08:30, not row 0
+  });
+
+  it("falls back to the bound's own row when nothing is published", () => {
+    const row = focusTargetRow(
+      { at: new Date("2026-08-03T06:00:00Z"), precision: "period" },
+      [],
+      "UTC",
+    );
+
+    expect(row).toBe(12);
+  });
+});
+
+describe("focusScrollRow", () => {
+  it("leaves rows above the target rather than clipping it to the edge", () => {
+    expect(focusScrollRow(20)).toBe(20 - FOCUS_LEAD_ROWS);
+  });
+
+  it("clamps at the top instead of scrolling negative", () => {
+    expect(focusScrollRow(0)).toBe(0);
+    expect(focusScrollRow(1)).toBe(0);
+    expect(focusScrollRow(FOCUS_LEAD_ROWS)).toBe(0);
+  });
 });
 
 describe("focusGridPosition", () => {
@@ -219,10 +357,17 @@ describe("focusGridPosition", () => {
     });
   });
 
-  it("puts midnight on the first row", () => {
-    expect(
-      focusGridPosition(new Date("2026-08-01T00:00:00Z"), "UTC").rowIndex,
-    ).toBe(0);
+  it("puts midnight on the first row, on its OWN day", () => {
+    // An h24 formatter writes this as 24:00 against 31 July; the day would
+    // then be off by one everywhere the same parts are read.
+    expect(focusGridPosition(new Date("2026-08-01T00:00:00Z"), "UTC")).toEqual({
+      year: 2026,
+      month: 8,
+      day: 1,
+      hour: 0,
+      minute: 0,
+      rowIndex: 0,
+    });
   });
 });
 

--- a/__tests__/schedule/slot-picker-payloads.test.ts
+++ b/__tests__/schedule/slot-picker-payloads.test.ts
@@ -1,0 +1,182 @@
+// #1073 — the two reads widened to carry sessions to the slot picker, pinned
+// to the five scheduling fields they are allowed to carry.
+//
+// `readAppointmentDetail`'s slots come from an `include`, so each row also
+// holds the attendee list (`user[]`: id, name, image) and the session's
+// recording URLs. On a class or webinar every enrolled user is connected to
+// every slot, so spreading a term of sessions into an RSC payload ships the
+// whole roster several hundred times over. Same shape as the consultant-PII
+// leak #946 fixed with a select-allowlist.
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    consultation: { findUnique: jest.fn() },
+    subscription: { findUnique: jest.fn() },
+    class: { findUnique: jest.fn() },
+    webinar: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock("../../lib/data/appointment-detail", () => ({
+  readAppointmentDetail: jest.fn(),
+}));
+
+jest.mock("../../lib/booking/plan-owners", () => ({
+  resolvePlanOwnerIds: jest.fn(() => ["consultant-1"]),
+}));
+
+import prisma from "../../lib/prisma";
+import { readAppointmentDetail } from "../../lib/data/appointment-detail";
+import { readAllocationRequest } from "../../lib/data/allocation-request";
+import { readManageTimingsTarget } from "../../lib/data/manage-timings-target";
+
+const ALLOWED_SLOT_KEYS = [
+  "appointmentId",
+  "completionStatus",
+  "deletedAt",
+  "endsAt",
+  "id",
+  "isTentative",
+  "startsAt",
+];
+
+const ATTENDEE_NAME = "Priya Attendee";
+const RECORDING_URL = "https://recordings.example/private/session-1.mp4";
+
+/** A slot exactly as `readAppointmentDetail` hands it over: relations and all. */
+function pollutedSlot(id: string, startsAt: string) {
+  return {
+    id,
+    appointmentId: `appt-${id}`,
+    startsAt: new Date(startsAt),
+    endsAt: new Date(new Date(startsAt).getTime() + 60 * 60 * 1000),
+    isTentative: false,
+    completionStatus: "SCHEDULED",
+    completedAt: null,
+    consultantProfileId: "consultant-1",
+    deletedAt: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    user: [
+      { id: "user-1", name: ATTENDEE_NAME, image: "https://img.example/p.png" },
+    ],
+    meetingSession: {
+      id: "session-1",
+      endedAt: null,
+      recordings: [
+        {
+          id: "rec-1",
+          recordingUrl: RECORDING_URL,
+          supabaseUrl: "https://supabase.example/rec-1",
+          thumbnailUrl: "https://img.example/thumb.png",
+        },
+      ],
+    },
+  };
+}
+
+const mockReadAppointmentDetail = readAppointmentDetail as jest.MockedFunction<
+  typeof readAppointmentDetail
+>;
+
+describe("readManageTimingsTarget slot payload", () => {
+  beforeEach(() => {
+    mockReadAppointmentDetail.mockResolvedValue({
+      appointment: {
+        id: "appt-1",
+        appointmentType: "CLASS",
+        class: {
+          id: "class-1",
+          schedulingPeriodStartsAt: new Date("2026-08-01T00:00:00Z"),
+          schedulingPeriodEndsAt: new Date("2026-11-01T00:00:00Z"),
+          classPlan: { title: "Pottery", totalSessions: 24 },
+        },
+        slotsOfAppointment: [pollutedSlot("s1", "2026-08-03T05:00:00Z")],
+      },
+      siblings: [
+        {
+          id: "appt-2",
+          slotsOfAppointment: [pollutedSlot("s2", "2026-08-10T05:00:00Z")],
+        },
+      ],
+      // The read only ever touches the fields above; the real payload is far
+      // wider and irrelevant to what this asserts.
+    } as unknown as Awaited<ReturnType<typeof readAppointmentDetail>>);
+  });
+
+  it("carries the whole program's sessions through to the picker", async () => {
+    const target = await readManageTimingsTarget("appt-1");
+
+    expect(target?.appointment.slots?.map((slot) => slot.id)).toEqual([
+      "s1",
+      "s2",
+    ]);
+  });
+
+  it("ships the five scheduling fields and nothing else", async () => {
+    const target = await readManageTimingsTarget("appt-1");
+
+    for (const slot of target?.appointment.slots ?? []) {
+      expect(Object.keys(slot).sort()).toEqual(ALLOWED_SLOT_KEYS);
+    }
+  });
+
+  it("leaks neither attendee PII nor recording URLs into the payload", async () => {
+    const target = await readManageTimingsTarget("appt-1");
+
+    // Whole-payload, not per-field: the point is that nothing anywhere in
+    // what crosses the RSC boundary carries this.
+    const serialized = JSON.stringify(target);
+    expect(serialized).not.toContain(ATTENDEE_NAME);
+    expect(serialized).not.toContain(RECORDING_URL);
+    expect(serialized).not.toContain("thumbnailUrl");
+  });
+});
+
+describe("readAllocationRequest slot payload", () => {
+  const findUnique = prisma.consultation.findUnique as jest.Mock;
+
+  beforeEach(() => {
+    findUnique.mockResolvedValue({
+      id: "consultation-1",
+      status: "PENDING",
+      requestedBy: { userId: "user-1", user: { name: "Buyer" } },
+      consultationPlan: {
+        title: "Intro call",
+        consultantProfileId: "consultant-1",
+        durationInHours: 1,
+      },
+      appointment: {
+        slotsOfAppointment: [
+          {
+            id: "s1",
+            appointmentId: "appt-1",
+            startsAt: new Date("2026-08-03T05:00:00Z"),
+            endsAt: new Date("2026-08-03T06:00:00Z"),
+            isTentative: true,
+            completionStatus: "SCHEDULED",
+            deletedAt: null,
+          },
+        ],
+      },
+    });
+  });
+
+  it("carries the request's requested times", async () => {
+    const request = await readAllocationRequest("consultation-1", "consultation");
+
+    expect(request?.slots).toHaveLength(1);
+    expect(Object.keys(request!.slots[0]).sort()).toEqual(ALLOWED_SLOT_KEYS);
+  });
+
+  it("asks the database for those fields only, never the relations", async () => {
+    await readAllocationRequest("consultation-1", "consultation");
+
+    const { select } = findUnique.mock.calls[0][0];
+    const slotArgs = select.appointment.select.slotsOfAppointment;
+
+    expect(Object.keys(slotArgs.select).sort()).toEqual(ALLOWED_SLOT_KEYS);
+    expect(slotArgs.include).toBeUndefined();
+  });
+});

--- a/app/dashboard/consultant/[consultantId]/(features)/requests/[requestId]/allocate/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/requests/[requestId]/allocate/page.tsx
@@ -119,6 +119,7 @@ export default async function AllocateSlotsPage({
           allowedStart: request.allowedStart,
           allowedEnd: request.allowedEnd,
           hasReleasedSlots: request.hasReleasedSlots,
+          slots: request.slots,
         }}
       />
     </div>

--- a/components/scheduling/SlotPicker.tsx
+++ b/components/scheduling/SlotPicker.tsx
@@ -14,6 +14,7 @@ import type {
   SlotPickerPolicy,
   SlotPickerSubject,
 } from "@/components/scheduling/slot-picker-policy";
+import { resolveFocusTarget } from "@/lib/scheduling/slot-picker-focus";
 import { cn } from "@/utils/tailwind";
 
 /**
@@ -46,6 +47,15 @@ export function SlotPicker({
   const sessions = React.useMemo(
     () => groupReleasableSessions(subject.slots ?? []),
     [subject.slots],
+  );
+
+  // "First open" is this mount, and the target is pinned to it. Re-resolving
+  // against a moving `now` would let the grid drift under a consultant who
+  // left the tab open (#1073).
+  const [openedAt] = React.useState(() => new Date());
+  const focus = React.useMemo(
+    () => resolveFocusTarget(subject, openedAt),
+    [subject, openedAt],
   );
 
   const [releaseMode, setReleaseMode] = React.useState<ReleaseMode>("entire");
@@ -141,6 +151,10 @@ export function SlotPicker({
         schedulingTimezone={subject.schedulingTimezone}
         allowedStart={subject.allowedStart}
         allowedEnd={subject.allowedEnd}
+        // Deliberately NOT keyed to the release selection: focus is a
+        // starting position, and re-aiming the grid while someone is reading
+        // it is worse than the empty night rows it replaces (#1073).
+        focus={focus}
         // Fresh allocations only: a partial reschedule legitimately keeps
         // confirmed slots and must not trip the guard.
         initialAllocation={

--- a/components/scheduling/UnifiedCalendar.tsx
+++ b/components/scheduling/UnifiedCalendar.tsx
@@ -61,6 +61,13 @@ import {
   resolveSlotStatusKey,
   slotCellClassName,
 } from "@/lib/scheduling/slot-status-tokens";
+import {
+  FOCUS_LEAD_ROWS,
+  earliestAvailabilityRow,
+  focusGridPosition,
+  gridTimeZone,
+  type SlotPickerFocus,
+} from "@/lib/scheduling/slot-picker-focus";
 
 /**
  * Small pure helpers for clarity and reuse. These do not cause side effects.
@@ -366,6 +373,12 @@ export interface UnifiedCalendarProps {
   /** Event's scheduling timezone — defines the limit day/week buckets
    * (ADR B9). Defaults to Asia/Kolkata in the shared helpers. */
   schedulingTimezone?: string;
+  /**
+   * Where to be looking on open (#1073). Applied ONCE, on first render of the
+   * week grid: it chooses the starting week and scroll position and then
+   * never touches either again.
+   */
+  focus?: SlotPickerFocus;
 }
 
 export function UnifiedCalendar({
@@ -391,10 +404,18 @@ export function UnifiedCalendar({
   allowedEnd,
   totalSessions,
   schedulingTimezone,
+  focus,
 }: UnifiedCalendarProps) {
   const { toast } = useToast();
   // State
-  const [currentDate, setCurrentDate] = useState(() => new Date());
+  const [currentDate, setCurrentDate] = useState(() => {
+    if (!focus) return new Date();
+    // Noon on the target's calendar date AS THE GRID READS IT: weekDates are
+    // derived from this with local date-fns, so a target near a midnight
+    // boundary lands a week out if the date is read in any other zone.
+    const { year, month, day } = focusGridPosition(focus.at, gridTimeZone());
+    return new Date(year, month - 1, day, 12);
+  });
   const [view, setView] = useState<"week" | "month">("week");
   const [browserTimezone, setBrowserTimezone] = useState("UTC");
   const [configWarning, setConfigWarning] = useState<string | null>(null);
@@ -596,6 +617,48 @@ export function UnifiedCalendar({
     const startDate = startOfWeek(currentDate);
     return [...Array(7)].map((_, i) => addDays(startDate, i));
   }, [currentDate]);
+
+  const weekGridRef = useRef<HTMLDivElement | null>(null);
+  // Once per open, tracked in a ref rather than effect deps. Re-running this
+  // would drag the grid back while the consultant is reading somewhere else,
+  // and the callback-identity loop this component already hit (React #185,
+  // see onSlotsSelectedRef) is what a deps-driven "focus" would become.
+  const focusAppliedRef = useRef(false);
+
+  useEffect(() => {
+    // `loading` is false only once availability has settled, which is what
+    // makes the first-availability anchor below meaningful, and the rows do
+    // not exist before then either.
+    if (!focus || focusAppliedRef.current || loading || view !== "week") return;
+
+    const container = weekGridRef.current;
+    if (!container || container.children.length === 0) return;
+    // The user got here first. Leave them where they are, permanently.
+    if (container.scrollTop > 0) {
+      focusAppliedRef.current = true;
+      return;
+    }
+
+    const timeZone = gridTimeZone();
+    const position = focusGridPosition(focus.at, timeZone);
+    // A window bound carries no time of day, so its own row would just be
+    // 00:00 again; the consultant's earliest published hour is the real
+    // start of their day.
+    const targetRow =
+      focus.precision === "period"
+        ? (earliestAvailabilityRow(availableSlots, timeZone) ??
+          position.rowIndex)
+        : position.rowIndex;
+
+    const row = container.children[Math.max(0, targetRow - FOCUS_LEAD_ROWS)];
+    if (!(row instanceof HTMLElement)) return;
+
+    focusAppliedRef.current = true;
+    // Measured, not rowIndex × height: the row heights are a Tailwind detail
+    // this component should not be re-deriving.
+    container.scrollTop +=
+      row.getBoundingClientRect().top - container.getBoundingClientRect().top;
+  }, [focus, loading, view, availableSlots]);
 
   /**
    * Builds an auto-expanded group of consecutive slots starting from a clicked slot.
@@ -1325,7 +1388,10 @@ export function UnifiedCalendar({
           </div>
 
           {/* Week grid */}
-          <div className="flex-1 overflow-y-auto scrollbar-thin min-h-0">
+          <div
+            ref={weekGridRef}
+            className="flex-1 overflow-y-auto scrollbar-thin min-h-0"
+          >
             {INTERVALS.map((interval) => (
               <div
                 key={`interval-row-${interval.hour}-${interval.minute}`}

--- a/components/scheduling/UnifiedCalendar.tsx
+++ b/components/scheduling/UnifiedCalendar.tsx
@@ -62,9 +62,9 @@ import {
   slotCellClassName,
 } from "@/lib/scheduling/slot-status-tokens";
 import {
-  FOCUS_LEAD_ROWS,
-  earliestAvailabilityRow,
   focusGridPosition,
+  focusScrollRow,
+  focusTargetRow,
   gridTimeZone,
   type SlotPickerFocus,
 } from "@/lib/scheduling/slot-picker-focus";
@@ -618,47 +618,42 @@ export function UnifiedCalendar({
     return [...Array(7)].map((_, i) => addDays(startDate, i));
   }, [currentDate]);
 
-  const weekGridRef = useRef<HTMLDivElement | null>(null);
-  // Once per open, tracked in a ref rather than effect deps. Re-running this
-  // would drag the grid back while the consultant is reading somewhere else,
-  // and the callback-identity loop this component already hit (React #185,
-  // see onSlotsSelectedRef) is what a deps-driven "focus" would become.
+  // A callback ref in STATE, not a plain ref: the week grid does not exist
+  // until `consultantDetails` has arrived, and a ref mutating cannot wake an
+  // effect. Keyed off the element, the effect runs when the grid appears —
+  // whichever of the two independent fetches wins the race, and again if the
+  // user visits month view before the grid has ever been focused.
+  const [weekGridEl, setWeekGridEl] = useState<HTMLDivElement | null>(null);
+  // Once per open. A ref rather than effect deps: re-running this would drag
+  // the grid back while the consultant is reading somewhere else, and the
+  // callback-identity loop this component already hit (React #185, see
+  // onSlotsSelectedRef) is what a deps-driven "focus" would become.
   const focusAppliedRef = useRef(false);
 
   useEffect(() => {
-    // `loading` is false only once availability has settled, which is what
-    // makes the first-availability anchor below meaningful, and the rows do
-    // not exist before then either.
-    if (!focus || focusAppliedRef.current || loading || view !== "week") return;
-
-    const container = weekGridRef.current;
-    if (!container || container.children.length === 0) return;
+    if (!focus || focusAppliedRef.current || !weekGridEl) return;
+    // The element's mere existence is the real guard: it renders only past
+    // the `loading`/`error`/`consultantDetails` gates below, and `loading` is
+    // held true from mount until the availability fetch settles — so by the
+    // time there is a grid, `availableSlots` is final. (`loading` alone would
+    // NOT do: it starts false, before anything is fetched.)
+    if (weekGridEl.children.length === 0) return;
     // The user got here first. Leave them where they are, permanently.
-    if (container.scrollTop > 0) {
+    if (weekGridEl.scrollTop > 0) {
       focusAppliedRef.current = true;
       return;
     }
 
-    const timeZone = gridTimeZone();
-    const position = focusGridPosition(focus.at, timeZone);
-    // A window bound carries no time of day, so its own row would just be
-    // 00:00 again; the consultant's earliest published hour is the real
-    // start of their day.
-    const targetRow =
-      focus.precision === "period"
-        ? (earliestAvailabilityRow(availableSlots, timeZone) ??
-          position.rowIndex)
-        : position.rowIndex;
-
-    const row = container.children[Math.max(0, targetRow - FOCUS_LEAD_ROWS)];
+    const targetRow = focusTargetRow(focus, availableSlots, gridTimeZone());
+    const row = weekGridEl.children[focusScrollRow(targetRow)];
     if (!(row instanceof HTMLElement)) return;
 
     focusAppliedRef.current = true;
     // Measured, not rowIndex × height: the row heights are a Tailwind detail
     // this component should not be re-deriving.
-    container.scrollTop +=
-      row.getBoundingClientRect().top - container.getBoundingClientRect().top;
-  }, [focus, loading, view, availableSlots]);
+    weekGridEl.scrollTop +=
+      row.getBoundingClientRect().top - weekGridEl.getBoundingClientRect().top;
+  }, [focus, weekGridEl, availableSlots]);
 
   /**
    * Builds an auto-expanded group of consecutive slots starting from a clicked slot.
@@ -1389,7 +1384,7 @@ export function UnifiedCalendar({
 
           {/* Week grid */}
           <div
-            ref={weekGridRef}
+            ref={setWeekGridEl}
             className="flex-1 overflow-y-auto scrollbar-thin min-h-0"
           >
             {INTERVALS.map((interval) => (

--- a/hooks/scheduling/useCalendarData.ts
+++ b/hooks/scheduling/useCalendarData.ts
@@ -38,6 +38,10 @@ export interface UseCalendarDataOptions {
   view: "week" | "month";
   currentDate: Date;
   mode: "view" | "select" | "allocate";
+  /** The scheduling period. It bounds what is SELECTABLE, enforced by the
+   * calendar's own range guard; the fetch window follows the visible
+   * week/month, so a cell outside the period still shows what is really
+   * there rather than reading as absent. */
   allowedStart?: Date;
   allowedEnd?: Date;
   /** #997 Phase 3 — subscription per-call slot count, sent to the event-slots
@@ -216,8 +220,6 @@ export function useCalendarData(
     autoLoad = true,
     view,
     currentDate,
-    mode,
-    allowedEnd,
     sessionDurationInHours,
     consulteeUserId,
     includeAppointmentDetails = false,
@@ -298,18 +300,25 @@ export function useCalendarData(
     const requestId = ++availabilityRequestIdRef.current;
 
     try {
-      // Always start from the view's natural start so pre-period weeks have
-      // availability data (allows "Outside Period" label on consultant's actual
-      // available slots rather than blank disabled cells — UX consistency fix).
+      // The window is the VISIBLE range, never the scheduling period — at
+      // either end. Starting at the view's own start is what lets a pre-period
+      // week show the consultant's real availability behind an "Outside Period"
+      // label instead of blank cells; the same argument governs the end, and
+      // used not to. Clamping to `allowedEnd` left every cell past it with no
+      // server row, and the route's slots-in-window filter drops the
+      // APPOINTMENTS in that range too, so booked cells disappeared exactly
+      // like available ones. One week further on the range inverted, the
+      // server returned nothing, and the whole grid blanked.
+      //
+      // `allowedStart`/`allowedEnd` govern SELECTABILITY — the range guard in
+      // `handleSlotClick` and the "Outside Period" label already enforce it —
+      // and must never govern visibility. Capping an allocate request at one
+      // week instead of the remainder of the period is also a direct win on
+      // the endpoint #997 measured in tens of seconds.
       const startDate =
         view === "week" ? startOfWeek(currentDate) : startOfMonth(currentDate);
-      // End at allowedEnd in allocate mode to avoid fetching past the period.
       const endDate =
-        mode === "allocate" && allowedEnd
-          ? allowedEnd
-          : view === "week"
-            ? endOfWeek(currentDate)
-            : endOfMonth(currentDate);
+        view === "week" ? endOfWeek(currentDate) : endOfMonth(currentDate);
 
       // #997 Phase 2 — the server-computed tooltip/orphan-slot detail. The
       // route re-verifies ownership regardless of this flag, and 403s rather
@@ -328,12 +337,12 @@ export function useCalendarData(
       // flight — its result is stale, discard rather than repaint.
       if (requestId !== availabilityRequestIdRef.current) return;
 
-      // Defensive: Validate data structure before using
+      // A shape the route cannot legitimately return. Emptying the grid on it
+      // is the failure this change exists to remove: an empty grid is a valid
+      // answer for a quiet week, so the consultant cannot tell it apart from a
+      // broken response. Surface it instead.
       if (!data || typeof data !== "object") {
-        console.warn(
-          "⚠️ fetchAvailabilitySlots: Invalid data structure returned",
-        );
-        setRawAvailabilitySlots({ weekly: [], custom: [] });
+        setError("Could not read the availability response. Please try again.");
         return;
       }
 
@@ -386,8 +395,6 @@ export function useCalendarData(
     toast,
     view,
     currentDate,
-    mode,
-    allowedEnd,
     consulteeUserId,
     includeAppointmentDetails,
   ]);
@@ -717,7 +724,14 @@ export function useCalendarData(
       }
       setError(null);
 
-      fetchAvailabilitySlots()
+      const pending = fetchAvailabilitySlots();
+      // Read AFTER the call: the id is bumped synchronously, before the first
+      // await, so this is that call's own id. Without it a stale reply's
+      // `finally` clears the spinner a newer request is still waiting on —
+      // the success and error paths are already guarded this way.
+      const requestId = availabilityRequestIdRef.current;
+
+      pending
         .catch((error) => {
           console.error("Error fetching date-dependent data:", error);
           // Believed unreachable — see fetchAllData's identical comment.
@@ -732,6 +746,7 @@ export function useCalendarData(
           );
         })
         .finally(() => {
+          if (requestId !== availabilityRequestIdRef.current) return;
           setLoading(false);
         });
     }

--- a/lib/appointments/view-model.ts
+++ b/lib/appointments/view-model.ts
@@ -39,7 +39,33 @@ export interface SlotLike {
   endsAt?: Date | string | null;
   isTentative: boolean;
   completionStatus?: string | null;
+  /** A10 soft-delete tombstone (#676) — a set value means the slot is gone. */
+  deletedAt?: Date | string | null;
   meetingSession?: { id: string; endedAt: Date | string | null } | null;
+}
+
+/**
+ * The five scheduling fields, and nothing else.
+ *
+ * `readAppointmentDetail`'s slots are built with `include`, so each row also
+ * drags along every attendee (`user[]`, name and image) and the session's
+ * recording URLs. Those rows are fine to READ on the server, but handing one
+ * to a client component serializes all of it into the RSC payload — and on a
+ * class or webinar the attendee list is shared by every slot, so a term's
+ * worth of sessions multiplies it by the whole roster. Same class of leak as
+ * the consultant-PII one #946 fixed with a select-allowlist; this is that
+ * allowlist, applied on the way out.
+ */
+export function toSlotLike(slot: SlotLike): SlotLike {
+  return {
+    id: slot.id,
+    appointmentId: slot.appointmentId ?? null,
+    startsAt: slot.startsAt,
+    endsAt: slot.endsAt ?? null,
+    isTentative: slot.isTentative,
+    completionStatus: slot.completionStatus ?? null,
+    deletedAt: slot.deletedAt ?? null,
+  };
 }
 
 export interface SessionVM {

--- a/lib/data/allocation-request.ts
+++ b/lib/data/allocation-request.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { toPlain } from "@/lib/data/serialize";
+import type { SlotLike } from "@/lib/appointments/view-model";
 import type { AppointmentStatus } from "@prisma/client";
 
 /**
@@ -36,10 +37,29 @@ export interface AllocationRequest {
    * `initialAllocation` guard must NOT fire (#837).
    */
   hasReleasedSlots: boolean;
+  /**
+   * The times already asked for on the placeholder appointment — the buyer's
+   * requested times, or the ones left behind by a partial reschedule. Same
+   * rows `hasReleasedSlots` is derived from; the picker opens on the earliest
+   * of them (#1073).
+   */
+  slots: SlotLike[];
 }
 
 const requestedBySelect = {
   select: { userId: true, user: { select: { name: true } } },
+} as const;
+
+/** Enough of a slot to place it on the grid, and to say whether it is live. */
+const slotSelect = {
+  select: {
+    id: true,
+    appointmentId: true,
+    startsAt: true,
+    endsAt: true,
+    isTentative: true,
+    completionStatus: true,
+  },
 } as const;
 
 export async function readAllocationRequest(
@@ -67,7 +87,7 @@ export async function readAllocationRequest(
           },
         },
         appointments: {
-          select: { slotsOfAppointment: { select: { isTentative: true } } },
+          select: { slotsOfAppointment: slotSelect },
         },
       },
     });
@@ -92,6 +112,9 @@ export async function readAllocationRequest(
       hasReleasedSlots: subscription.appointments.some((appointment) =>
         appointment.slotsOfAppointment.some((slot) => slot.isTentative),
       ),
+      slots: subscription.appointments.flatMap(
+        (appointment) => appointment.slotsOfAppointment,
+      ),
     });
   }
 
@@ -108,9 +131,7 @@ export async function readAllocationRequest(
           durationInHours: true,
         },
       },
-      appointment: {
-        select: { slotsOfAppointment: { select: { isTentative: true } } },
-      },
+      appointment: { select: { slotsOfAppointment: slotSelect } },
     },
   });
   if (!consultation?.consultationPlan) return null;
@@ -128,5 +149,6 @@ export async function readAllocationRequest(
     hasReleasedSlots: (
       consultation.appointment?.slotsOfAppointment ?? []
     ).some((slot) => slot.isTentative),
+    slots: consultation.appointment?.slotsOfAppointment ?? [],
   });
 }

--- a/lib/data/allocation-request.ts
+++ b/lib/data/allocation-request.ts
@@ -59,6 +59,8 @@ const slotSelect = {
     endsAt: true,
     isTentative: true,
     completionStatus: true,
+    // A10 tombstone (#676): a deleted slot is not a time anyone requested.
+    deletedAt: true,
   },
 } as const;
 

--- a/lib/data/manage-timings-target.ts
+++ b/lib/data/manage-timings-target.ts
@@ -154,6 +154,13 @@ export async function readManageTimingsTarget(
         | "SUBSCRIPTION"
         | "WEBINAR"
         | "CLASS",
+      // Program-wide, past sessions included: the picker opens on the earliest
+      // session still awaiting a time, and falls back to the last one that
+      // ran when everything is over (#1073).
+      slots: [
+        ...appointment.slotsOfAppointment,
+        ...siblings.flatMap((sibling) => sibling.slotsOfAppointment),
+      ],
       consultation: appointment.consultation,
       subscription: appointment.subscription,
       webinar: appointment.webinar,

--- a/lib/data/manage-timings-target.ts
+++ b/lib/data/manage-timings-target.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { toPlain } from "@/lib/data/serialize";
 import { readAppointmentDetail } from "@/lib/data/appointment-detail";
 import { resolvePlanOwnerIds } from "@/lib/booking/plan-owners";
+import { toSlotLike } from "@/lib/appointments/view-model";
 import type { ManageTimingsAppointmentLike } from "@/lib/scheduling/manage-timings-subject";
 
 /**
@@ -157,10 +158,14 @@ export async function readManageTimingsTarget(
       // Program-wide, past sessions included: the picker opens on the earliest
       // session still awaiting a time, and falls back to the last one that
       // ran when everything is over (#1073).
+      //
+      // Through `toSlotLike`, never spread: these rows arrive from an
+      // `include` and carry the attendee list and recording URLs with them,
+      // which this route has no business shipping to the client.
       slots: [
         ...appointment.slotsOfAppointment,
         ...siblings.flatMap((sibling) => sibling.slotsOfAppointment),
-      ],
+      ].map(toSlotLike),
       consultation: appointment.consultation,
       subscription: appointment.subscription,
       webinar: appointment.webinar,

--- a/lib/scheduling/manage-timings-subject.ts
+++ b/lib/scheduling/manage-timings-subject.ts
@@ -1,4 +1,5 @@
 import type { SlotPickerSubject } from "@/components/scheduling/slot-picker-policy";
+import type { SlotLike } from "@/lib/appointments/view-model";
 import { getClassPlanDefaults, type ClassPlanType } from "@/utils/classPlans";
 
 /**
@@ -19,6 +20,12 @@ export type ManageTimingsAppointmentType =
 
 export interface ManageTimingsAppointmentLike {
   appointmentType: ManageTimingsAppointmentType;
+  /**
+   * Every session of the program, past ones included — what the picker opens
+   * focused on (#1073). A bare Class/Webinar row has none, which is itself
+   * the answer there.
+   */
+  slots?: SlotLike[];
   consultation?: {
     id?: string | null;
     consultationPlan?: {
@@ -272,6 +279,7 @@ export function buildManageTimingsSubject(
       // Guard rails: keep selection inside the plan's scheduling period.
       allowedStart: schedulingPeriod.start,
       allowedEnd: schedulingPeriod.end,
+      slots: appointment.slots,
     },
   };
 }

--- a/lib/scheduling/slot-picker-focus.ts
+++ b/lib/scheduling/slot-picker-focus.ts
@@ -1,0 +1,164 @@
+import type { SlotPickerSubject } from "@/components/scheduling/slot-picker-policy";
+import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+
+/**
+ * Where the slot picker should already be looking when it opens (#1073).
+ *
+ * One resolver, not four: the surfaces differ only in which sessions their
+ * subject carries. Reschedule carries the live sessions of the booking being
+ * moved, Manage Timings the whole program, Allocate the request's requested
+ * times, and an offering that has never been scheduled carries none at all —
+ * so the same ordering answers all of them, and no surface can grow its own
+ * private idea of "the thing you clicked".
+ *
+ * The result is an INSTANT plus how much of it means anything. Turning that
+ * into a row and a week is `focusGridPosition`, which needs the timezone the
+ * grid is drawn in.
+ */
+
+export interface SlotPickerFocus {
+  /** The instant to open on. */
+  at: Date;
+  /**
+   * "session" — `at` is a real session time, so its row is the row to show.
+   * "period" — `at` is only a bound of the scheduling window, so its time of
+   * day means nothing and the grid should anchor on first availability.
+   */
+  precision: "session" | "period";
+}
+
+/** Rows left visible ABOVE the target, so it reads as "in view" not "clipped". */
+export const FOCUS_LEAD_ROWS = 2;
+
+/** Sessions in these states are gone; focusing one would point at nothing. */
+const DEAD_STATUSES = new Set(["CANCELLED", "RESCHEDULED"]);
+
+interface DatedSlot {
+  at: Date;
+  isTentative: boolean;
+}
+
+function liveSlotsInOrder(
+  subject: Pick<SlotPickerSubject, "slots">,
+): DatedSlot[] {
+  return (subject.slots ?? [])
+    .filter((slot) => !DEAD_STATUSES.has(slot.completionStatus ?? ""))
+    .map((slot) => ({
+      at: new Date(slot.startsAt),
+      isTentative: Boolean(slot.isTentative),
+    }))
+    .filter((entry) => Number.isFinite(entry.at.getTime()))
+    .sort((a, b) => a.at.getTime() - b.at.getTime());
+}
+
+/**
+ * The window bound worth pointing at when nothing is scheduled.
+ *
+ * Never a date already gone: the picker clamps selection to the same bounds,
+ * so opening on a week where nothing can be chosen is a dead end.
+ */
+function periodAnchor(now: Date, start?: Date, end?: Date): Date {
+  // A window that has already closed still gets pointed at — its last day
+  // explains the empty grid, where this week would not.
+  if (end && now.getTime() > end.getTime()) return end;
+  if (start && start.getTime() > now.getTime()) return start;
+  return now;
+}
+
+/**
+ * The session the picker should open on.
+ *
+ * A released session outranks everything because it is the one AWAITING a
+ * time: on a partly-placed program the job is filling the gaps, not admiring
+ * what is already booked. Failing that, the next session that has not
+ * happened is what a consultant means by "this booking", and on a finished
+ * one the last session is the only thing left to point at.
+ */
+export function resolveFocusTarget(
+  subject: Pick<SlotPickerSubject, "slots" | "allowedStart" | "allowedEnd">,
+  now: Date = new Date(),
+): SlotPickerFocus {
+  const slots = liveSlotsInOrder(subject);
+
+  const awaitingATime = slots.find((slot) => slot.isTentative);
+  if (awaitingATime) return { at: awaitingATime.at, precision: "session" };
+
+  const upcoming = slots.find((slot) => slot.at.getTime() >= now.getTime());
+  if (upcoming) return { at: upcoming.at, precision: "session" };
+
+  const mostRecentPast = slots[slots.length - 1];
+  if (mostRecentPast) return { at: mostRecentPast.at, precision: "session" };
+
+  return {
+    at: periodAnchor(now, subject.allowedStart, subject.allowedEnd),
+    precision: "period",
+  };
+}
+
+export interface FocusGridPosition {
+  /** Calendar date in the grid's timezone; the week containing it is shown. */
+  year: number;
+  /** 1-12. */
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  /** Index into the 48 half-hour rows the week grid renders. */
+  rowIndex: number;
+}
+
+/**
+ * The instant, as a place on the grid.
+ *
+ * `timeZone` must be the one the COLUMNS were drawn in. Reading the row off a
+ * different zone than the cells were built in puts focus out by the UTC
+ * offset — the same class of defect as the `datetime-local` bug in #1064.
+ */
+export function focusGridPosition(
+  at: Date,
+  timeZone: string,
+): FocusGridPosition {
+  const { year, month, day, hour, minute } = SlotCalculationService.wallClock(
+    at,
+    timeZone,
+  );
+  return {
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    rowIndex: hour * 2 + (minute >= 30 ? 1 : 0),
+  };
+}
+
+/**
+ * The consultant's earliest published time of day, as a row.
+ *
+ * A better vertical anchor than 00:00 when the target instant is only a
+ * window bound: their working day is where the grid has anything to offer.
+ * Returns null when nothing is published, leaving the caller its own fallback.
+ */
+export function earliestAvailabilityRow(
+  slots: readonly { startTime: Date }[],
+  timeZone: string,
+): number | null {
+  let earliest: number | null = null;
+  for (const slot of slots) {
+    const { rowIndex } = focusGridPosition(slot.startTime, timeZone);
+    if (earliest === null || rowIndex < earliest) earliest = rowIndex;
+  }
+  return earliest;
+}
+
+/**
+ * The timezone the week grid is DRAWN in.
+ *
+ * Cells are built with `setHours` on a local Date and the footer prints this
+ * same zone, so this — not the event's `schedulingTimezone` — is the zone the
+ * columns exist in. Using the scheduling zone to pick the row would land the
+ * focus off by the difference between the two whenever they disagree (#1073).
+ */
+export function gridTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}

--- a/lib/scheduling/slot-picker-focus.ts
+++ b/lib/scheduling/slot-picker-focus.ts
@@ -43,6 +43,10 @@ function liveSlotsInOrder(
 ): DatedSlot[] {
   return (subject.slots ?? [])
     .filter((slot) => !DEAD_STATUSES.has(slot.completionStatus ?? ""))
+    // A10 tombstone (#676). Filtered here rather than at each call site
+    // because every surface feeding this resolver reads its slots straight
+    // off a relation that keeps deleted rows.
+    .filter((slot) => !slot.deletedAt)
     .map((slot) => ({
       at: new Date(slot.startsAt),
       isTentative: Boolean(slot.isTentative),
@@ -61,8 +65,11 @@ function periodAnchor(now: Date, start?: Date, end?: Date): Date {
   // A window that has already closed still gets pointed at — its last day
   // explains the empty grid, where this week would not.
   if (end && now.getTime() > end.getTime()) return end;
-  if (start && start.getTime() > now.getTime()) return start;
-  return now;
+  const anchor = start && start.getTime() > now.getTime() ? start : now;
+  // A start later than the end is bad data rather than a real window, but
+  // honouring it would land the picker outside the bound it clamps to.
+  if (end && anchor.getTime() > end.getTime()) return end;
+  return anchor;
 }
 
 /**
@@ -71,8 +78,14 @@ function periodAnchor(now: Date, start?: Date, end?: Date): Date {
  * A released session outranks everything because it is the one AWAITING a
  * time: on a partly-placed program the job is filling the gaps, not admiring
  * what is already booked. Failing that, the next session that has not
- * happened is what a consultant means by "this booking", and on a finished
- * one the last session is the only thing left to point at.
+ * happened is what a consultant means by "this booking".
+ *
+ * The most recent past session is the last resort, and only once the window
+ * has closed. A program whose placed sessions have all run but whose period
+ * still has months left has sessions LEFT to place, and they can only go in
+ * the future — opening on a dead week would be both the wrong answer and,
+ * in allocate mode, a request stretching from that week to the end of the
+ * period on the endpoint #997 measured in tens of seconds.
  */
 export function resolveFocusTarget(
   subject: Pick<SlotPickerSubject, "slots" | "allowedStart" | "allowedEnd">,
@@ -80,14 +93,24 @@ export function resolveFocusTarget(
 ): SlotPickerFocus {
   const slots = liveSlotsInOrder(subject);
 
-  const awaitingATime = slots.find((slot) => slot.isTentative);
+  // Only one that can still BE placed. A released session whose old time has
+  // already passed was never re-booked, and opening on a week where every
+  // cell is disabled is the dead end `periodAnchor` avoids below.
+  const awaitingATime = slots.find(
+    (slot) => slot.isTentative && slot.at.getTime() >= now.getTime(),
+  );
   if (awaitingATime) return { at: awaitingATime.at, precision: "session" };
 
   const upcoming = slots.find((slot) => slot.at.getTime() >= now.getTime());
   if (upcoming) return { at: upcoming.at, precision: "session" };
 
+  const windowStillOpen = Boolean(
+    subject.allowedEnd && subject.allowedEnd.getTime() > now.getTime(),
+  );
   const mostRecentPast = slots[slots.length - 1];
-  if (mostRecentPast) return { at: mostRecentPast.at, precision: "session" };
+  if (mostRecentPast && !windowStillOpen) {
+    return { at: mostRecentPast.at, precision: "session" };
+  }
 
   return {
     at: periodAnchor(now, subject.allowedStart, subject.allowedEnd),
@@ -149,6 +172,32 @@ export function earliestAvailabilityRow(
     if (earliest === null || rowIndex < earliest) earliest = rowIndex;
   }
   return earliest;
+}
+
+/**
+ * The row the target sits on, given what the consultant has published.
+ *
+ * The whole of the effect's decision, kept out of the effect: a window bound
+ * carries no time of day, so its own row would just be 00:00 again and the
+ * earliest published hour is the real start of the working day. A session
+ * time answers for itself.
+ */
+export function focusTargetRow(
+  focus: SlotPickerFocus,
+  availableSlots: readonly { startTime: Date }[],
+  timeZone: string,
+): number {
+  const ownRow = focusGridPosition(focus.at, timeZone).rowIndex;
+  if (focus.precision !== "period") return ownRow;
+  return earliestAvailabilityRow(availableSlots, timeZone) ?? ownRow;
+}
+
+/**
+ * The row to bring to the top of the viewport, so the target itself sits a
+ * little below it rather than clipped against the boundary.
+ */
+export function focusScrollRow(targetRow: number): number {
+  return Math.max(0, targetRow - FOCUS_LEAD_ROWS);
 }
 
 /**

--- a/lib/scheduling/slot-picker-subject.ts
+++ b/lib/scheduling/slot-picker-subject.ts
@@ -1,6 +1,6 @@
 import type { SlotPickerSubject } from "@/components/scheduling/slot-picker-policy";
 import type { TAppointmentDetail } from "@/lib/data/appointment-detail";
-import type { SlotLike } from "@/lib/appointments/view-model";
+import { toSlotLike, type SlotLike } from "@/lib/appointments/view-model";
 
 /**
  * Turns one appointment into everything a reschedule page needs.
@@ -53,14 +53,9 @@ function liveFutureSlots(detail: TAppointmentDetail): SlotLike[] {
         slot.completionStatus !== "CANCELLED" &&
         slot.completionStatus !== "RESCHEDULED",
     )
-    .map((slot) => ({
-      id: slot.id,
-      appointmentId: slot.appointmentId,
-      startsAt: slot.startsAt,
-      endsAt: slot.endsAt,
-      isTentative: slot.isTentative,
-      completionStatus: slot.completionStatus,
-    }));
+    // The shared allowlist, not a hand-rolled one: these rows come from an
+    // `include` and carry attendees and recording URLs (#1073).
+    .map(toSlotLike);
 }
 
 /**

--- a/lib/scheduling/slot-status-tokens.ts
+++ b/lib/scheduling/slot-status-tokens.ts
@@ -160,9 +160,19 @@ export const SLOT_STATUS_TOKENS: Record<SlotStatusKey, SlotStatusToken> = (
  * stylesheet, where `.border-transparent` is emitted last, not by the order
  * they were concatenated. Unavailable cells therefore lost their outline
  * altogether and read as absent rather than merely faint (#1064).
+ *
+ * No `disabled:opacity-50` either. EVERY unavailable cell is disabled, so a
+ * blanket disabled fade painted `bg-slate-200` at half strength over a white
+ * card — near enough to `slate-100` to reproduce, at render time, the exact
+ * near-white this file's `unavailable` comment records as reverted. The legend
+ * swatch is not a disabled control, so the legend showed the true colour while
+ * the grid showed half of it. `disabled:pointer-events-none` stays: not being
+ * clickable is the part that was actually wanted. Where a fade IS meant —
+ * past cells — `renderTimeCell` and the `faded` option append an explicit
+ * `opacity-*`, which is deliberate and unaffected.
  */
 export const SLOT_CELL_BASE_CLASS =
-  "h-8 w-full relative transition-colors duration-75 ease-in-out border rounded-sm text-[10px] leading-tight px-1 py-0.5 disabled:pointer-events-none disabled:opacity-50";
+  "h-8 w-full relative transition-colors duration-75 ease-in-out border rounded-sm text-[10px] leading-tight px-1 py-0.5 disabled:pointer-events-none";
 
 /**
  * The full class string for one grid cell.

--- a/utils/slotAllocation/SlotCalculationService.ts
+++ b/utils/slotAllocation/SlotCalculationService.ts
@@ -87,6 +87,37 @@ export class SlotCalculationService {
       weekday: WEEKDAY_INDEX[get("weekday")] ?? 0,
     };
   }
+
+  /**
+   * Wall-clock reading of an instant in a timezone: the calendar date AND the
+   * time of day.
+   *
+   * Shares the cached formatter with the limit-bucket keys below, so code that
+   * places something on a grid and code that buckets it cannot drift apart.
+   */
+  static wallClock(
+    d: Date,
+    timeZone: string = this.DEFAULT_SCHEDULING_TIMEZONE,
+  ): {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+  } {
+    const parts = this.getDateFormatter(timeZone).formatToParts(d);
+    const get = (type: string) =>
+      Number(parts.find((p) => p.type === type)?.value ?? 0);
+    return {
+      year: get("year"),
+      month: get("month"),
+      day: get("day"),
+      // Intl reports 24 for midnight with hourCycle h24 quirks; normalize.
+      hour: get("hour") % 24,
+      minute: get("minute"),
+    };
+  }
+
   /**
    * Count the number of distinct Sunday-start weeks overlapping [start, end].
    * This is the SINGLE implementation used across the entire app.

--- a/utils/slotAllocation/SlotCalculationService.ts
+++ b/utils/slotAllocation/SlotCalculationService.ts
@@ -45,7 +45,11 @@ export class SlotCalculationService {
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",
-        hour12: false,
+        // hourCycle, NOT `hour12: false` — the latter resolves to h24 under an
+        // en-US default, and h24 writes midnight as "24:00" against the
+        // PREVIOUS day's date. Every reader here would then get hour 0 with
+        // the day off by one, silently.
+        hourCycle: "h23",
       });
       this.dateFormatters.set(timeZone, formatter);
     }
@@ -59,13 +63,11 @@ export class SlotCalculationService {
     const parts = this.getDateFormatter(timeZone).formatToParts(at);
     const get = (type: string) =>
       Number(parts.find((p) => p.type === type)?.value ?? 0);
-    // Intl reports 24 for midnight with hourCycle h24 quirks; normalize.
-    const hour = get("hour") % 24;
     const wallAsUtc = Date.UTC(
       get("year"),
       get("month") - 1,
       get("day"),
-      hour,
+      get("hour"),
       get("minute"),
       get("second"),
     );
@@ -112,8 +114,9 @@ export class SlotCalculationService {
       year: get("year"),
       month: get("month"),
       day: get("day"),
-      // Intl reports 24 for midnight with hourCycle h24 quirks; normalize.
-      hour: get("hour") % 24,
+      // 0-23 without normalizing: the formatter is pinned to h23, so midnight
+      // is 00:00 on its own day rather than 24:00 on the day before.
+      hour: get("hour"),
       minute: get("minute"),
     };
   }


### PR DESCRIPTION
Opening Manage Timings, Allocate or Reschedule today drops the consultant into the current week, scrolled to the top of a grid that starts at 00:00. If the booking they came to edit is on Saturday at 10:30, the first thing they do on every single visit is hunt for Saturday and then scroll down past ten hours of empty night-time rows before the session they clicked is even on screen. For a session next month they navigate week by week to get there. None of that is a decision the picker was asking them to make; it is simply where the viewport happened to start.

This change makes the picker open already looking at the thing that was clicked. It picks a target instant from the subject the page already has, moves the visible week to contain it, and scrolls the time axis so the target sits a couple of rows down rather than flush against the top edge. Nothing about what is selectable, the palette, or the allocation rules changes — this is purely the starting position of the viewport.

Working on the opening position put me in front of the grid for long enough to find two defects that have nothing to do with focus, and both of them make cells read as absent. They are described in their own section below, after the focus work.

## What each surface opens on

The four surfaces share one component, so they share one resolver. They differ only in which sessions their `SlotPickerSubject` carries, and the ordering below answers all of them without any surface growing its own private notion of "the thing you clicked".

| Surface | Target |
| --- | --- |
| Reschedule (both routes) | The session being released. For a one-session booking that is the only slot; for a program it is the released one if there is one, else the next session that has not run. |
| Manage Timings | The earliest session still awaiting a time, else the next upcoming session, else — only once the scheduling period has closed — the most recent past session. |
| Allocate | The request's requested times, which are the slots already sitting on its placeholder appointment. |
| Nothing scheduled yet (`unscheduled-class-<id>`, `unscheduled-webinar-<id>`, or a request with no requested times) | The start of the scheduling period, clamped so it is never a date that has already gone. |

## Why the multi-session case needed a decision

A subscription is N sessions spread over weeks or months, each on its own `Appointment` row, and the picker shows one week. "The booking" is therefore not a single point on the grid, and the choice between candidate targets is a product decision rather than something an implementation should guess at.

The rule adopted here is that a session still awaiting a time outranks everything else. On a partly-placed program the consultant's job is filling the gaps, not admiring the sessions that are already booked, so the released session is the one they came for even when a confirmed session falls earlier in the calendar. Only when nothing is awaiting a time does the next upcoming session win, because that is what a consultant ordinarily means by "this booking" — the thing about to affect their week. The most recent past session is the last resort, and it applies only once the scheduling period has closed as well. A program whose placed sessions have all run but whose period still has months left has sessions left to place, and they can only go in the future, so opening on a dead week would be the wrong answer twice over.

An earlier revision of this description added a second reason for that last rule: opening on a dead week would also stretch the allocate-mode availability request from that week to the end of the period, on the endpoint #997 measured in tens of seconds. The mechanism in that note was right and the consequence was wrong. The stretch was not merely slow — it is the source of the blanking described below, and the first defect in the next section removes it outright. The allocate request is now one week wide wherever the consultant is standing, so the ordering rule above no longer carries any performance argument at all; it stands on the product reasoning alone.

Two other questions the issue left open are settled the same way. Far-future targets move the week as well as the scroll: a consultant who opens Manage Timings for a session in September wants to see September, and silently staying on this week while claiming to have focused would be worse than jumping. And focus fires once, on first open only. It is deliberately not keyed to the release selection on a Reschedule page, because yanking the grid back while somebody is reading it is worse than the empty night rows this replaces.

## The parts that were fiddly

The target is an instant, but the grid is drawn in wall-clock time, so the row has to be read in the same timezone the columns were built in or the focus lands off by the UTC offset — the same class of defect as the `datetime-local` bug fixed in #1064. `focusGridPosition` therefore takes the timezone explicitly and the calendar passes the zone it actually draws in. Worth noting for review: the week grid builds its cells with `setHours` on a local `Date` and the footer prints the browser's zone, so that zone — not the event's `schedulingTimezone`, which buckets day and week limits under ADR B9 — is the one the columns exist in. Choosing the row in the scheduling zone would have introduced exactly the offset the issue warns about whenever the two disagree.

Idempotence is held in a ref rather than in effect dependencies. This component has already produced a React #185 "Maximum update depth exceeded" loop from callback identity in an effect's deps, and the fix there was a ref; a deps-driven focus would become the same thing. The scroll also runs only once availability has settled, measures the row rather than re-deriving a Tailwind row height, and backs off entirely if the user has already scrolled — it never fights somebody who got there first.

The vertical anchor for an offering with nothing scheduled is the consultant's earliest published availability rather than 00:00, since a scheduling-window bound carries no meaningful time of day and their working day is where the grid has anything to offer at all.

## Two defects that make cells read as absent

Neither of these is caused by the focus work, and neither is fixed by it. They are here because opening the picker on the session you clicked is what put a real Manage Timings grid on screen often enough for the symptoms to become obvious.

### The fetch window was clamped to the scheduling period; the grid never was

On Manage Timings for a subscription or a class, walking forward through the weeks made cells disappear — and crucially the already-booked ones disappeared too, which is what rules out a per-week cap or a disabled state as the explanation. One week past the end of the scheduling period, the whole grid went blank. Pressing `‹` brought it all back.

The grid always renders seven columns. The availability request, in allocate mode, stopped at `allowedEnd`. Every cell past that end therefore had no server row to render from, and because the route filters appointments through the same window, the appointments in that range were dropped as well — which is exactly why a booked cell vanished in the same way an available one did. Navigate one week further and `endDate` falls before `startDate`; the server has no range to scan, the route returns an empty payload, and every cell on the screen blanks at once.

The fix is to delete the clamp, so the window is always the visible week or month. The comment sitting directly above it already argued that the START must not be clamped, precisely so a pre-period week shows the consultant's real availability behind an "Outside Period" label rather than a row of blanks. That argument was always true of the end as well and had simply never been applied there. `allowedStart` and `allowedEnd` govern what is SELECTABLE — the range guard in `handleSlotClick` and the "Outside Period" label already enforce that, and they are untouched — and must not govern what is VISIBLE. As a side effect this caps an allocate request at one week instead of up to a year, which is the perf note discussed above, now moot.

### `disabled:opacity-50` was cancelling the palette at render time

`SLOT_CELL_BASE_CLASS` ended with `disabled:pointer-events-none disabled:opacity-50`. Every `unavailable` cell is disabled, so `bg-slate-200` reached the screen at half strength over a white card — near enough to `slate-100` to reproduce the exact near-white this file's own comment records as REVERTED for making a sparse week read as an empty grid rather than a full one with little availability.

This is the second symptom the #1064 palette work never explained. The Tailwind `content` cause identified there was real and is fixed; this is a separate cause, downstream of the tokens, undoing them at paint time. It is also why the legend and the grid disagreed even after the tokens were unified: a legend swatch is a 12px block, not a disabled control, so the legend showed the true `slate-200` while the grid showed half of it.

`disabled:opacity-50` is gone and `disabled:pointer-events-none` stays — not being clickable was the part that was actually wanted. Where a fade is genuinely intended, `renderTimeCell` and the `faded` option append an explicit `opacity-50`, `opacity-60` or `opacity-70` for past cells; those are deliberate, they were checked first, and they are unchanged.

### Two smaller things in the same hook

An availability response of an unreadable shape used to `console.warn` and set the slots to empty. An empty grid is a perfectly valid answer for a quiet week, so that is indistinguishable from success to the consultant looking at it — the same "a blank grid reads as a real answer" failure as the defect above. It sets an error now. Separately, the loading spinner's `finally` was not request-scoped, so a stale reply could clear the spinner a newer request was still waiting on; the success and error paths were already guarded by the request id, and the `finally` now is too.

## Data

No schema changes, no new queries. Manage Timings and Allocate now carry their existing session rows through to the subject: the allocate read already selected `slotsOfAppointment` to derive `hasReleasedSlots` and simply selects a few more columns off the same rows, and the manage-timings read already had the appointment and its siblings in hand.

## Verification

Type check, lint and the full Jest suite pass: `tsc --noEmit` clean, `eslint` clean on every changed file, and 196 suites / 2208 tests green, of which 4 suites / 43 tests are new.

The resolver tests cover a one-session consultation, a partly-scheduled subscription where the released session beats an earlier upcoming one, a fully-scheduled program, an unscheduled class carrying only a scheduling period, and the timezone case proving the row and the calendar date are both read in the zone passed in rather than the viewer's. A second suite covers the focus effect itself — that it fires when the grid appears late, and that it never re-aims a grid the consultant has already scrolled. A third pins both widened reads to their five-field allowlist, including a whole-payload assertion that no attendee name or recording URL crosses the RSC boundary.

The two defects get assertions of their own. A new suite drives the calendar hook and asserts on the ARGUMENTS of the availability fetch, because nothing about a rendered cell could ever have caught a bug in the window that was requested: the allocate window must end at the end of the visible week rather than at `allowedEnd`, a week starting after the period closes must still request a forward range rather than an inverted one, and the request must span one week rather than the remainder of the period. The palette suite gains an assertion that the base cell class carries no `disabled:opacity-*` at all, with a comment recording why the existing swatch-equality tests could never have seen it — they compare token strings, and a variant that fades the grid but not the legend is invisible to a string comparison. All four of these were verified to fail against the pre-fix code, as were the two review-follow-up suites.

I have not verified this in a browser. The scroll is asserted against a rendered grid in jsdom with the row heights stubbed, so the arithmetic and the once-only behaviour are covered, but nobody has watched the real grid land where it should, and nobody has watched a booked cell survive a walk past the end of a scheduling period.

Closes #1073
