### PR TITLE
fix(scheduling): stamp schedulingTimezone from the owning consultant

### DIFF
--- a/__tests__/schedule/scheduling-timezone.test.ts
+++ b/__tests__/schedule/scheduling-timezone.test.ts
@@ -1,0 +1,125 @@
+// #1076 — schedulingTimezone was never written, so every per-day/per-week cap
+// on the platform bucketed against Indian calendar days. These pin the
+// resolver that the four creation paths now call, and prove that the zone it
+// returns actually moves the bucket boundaries the caps are counted against.
+
+// calendarUtils imports Prisma enums as values; stub the client so jsdom never
+// loads the engine.
+jest.mock("@prisma/client", () => ({
+  DayOfWeek: {},
+  ScheduleType: {},
+  AppointmentsType: {},
+  Prisma: {},
+}));
+
+import {
+  isValidIanaTimezone,
+  resolveSchedulingTimezone,
+} from "@/lib/scheduling/schedulingTimezone";
+import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+import { validateDailyHours } from "@/lib/scheduling/slotSelectionValidation";
+import type { TimeSlot } from "@/lib/scheduling/calendarUtils";
+
+const hourSlot = (startIso: string): TimeSlot => {
+  const startTime = new Date(startIso);
+  return {
+    startTime,
+    endTime: new Date(startTime.getTime() + 60 * 60 * 1000),
+    isAvailable: true,
+    isBooked: false,
+  };
+};
+
+describe("resolveSchedulingTimezone", () => {
+  it("uses the consultant's recorded zone", () => {
+    expect(resolveSchedulingTimezone("Europe/London")).toBe("Europe/London");
+    expect(resolveSchedulingTimezone("America/New_York")).toBe(
+      "America/New_York",
+    );
+    expect(resolveSchedulingTimezone("UTC")).toBe("UTC");
+  });
+
+  it("falls back to the platform default when no zone is recorded", () => {
+    expect(resolveSchedulingTimezone(null)).toBe("Asia/Kolkata");
+    expect(resolveSchedulingTimezone(undefined)).toBe("Asia/Kolkata");
+    expect(resolveSchedulingTimezone("")).toBe("Asia/Kolkata");
+    expect(resolveSchedulingTimezone("   ")).toBe("Asia/Kolkata");
+  });
+
+  it("matches the constant the bucketing code defaults to", () => {
+    expect(resolveSchedulingTimezone(null)).toBe(
+      SlotCalculationService.DEFAULT_SCHEDULING_TIMEZONE,
+    );
+  });
+
+  it("falls back rather than persisting a junk zone", () => {
+    // A junk value here would silently corrupt every cap for the booking.
+    expect(resolveSchedulingTimezone("Mars/Olympus_Mons")).toBe("Asia/Kolkata");
+    expect(resolveSchedulingTimezone("GMT+5:30")).toBe("Asia/Kolkata");
+    expect(resolveSchedulingTimezone("Europe/Londonn")).toBe("Asia/Kolkata");
+    expect(resolveSchedulingTimezone("'; DROP TABLE")).toBe("Asia/Kolkata");
+  });
+
+  it("trims a padded zone rather than rejecting it", () => {
+    expect(resolveSchedulingTimezone("  Europe/London  ")).toBe(
+      "Europe/London",
+    );
+  });
+
+  it("recognises real zones and rejects invented ones", () => {
+    expect(isValidIanaTimezone("Asia/Kolkata")).toBe(true);
+    expect(isValidIanaTimezone("Pacific/Auckland")).toBe(true);
+    expect(isValidIanaTimezone("Not/AZone")).toBe(false);
+  });
+});
+
+describe("the resolved zone moves the cap buckets", () => {
+  // 20:00Z on 20 Jul 2026 is still Monday evening in London but already
+  // Tuesday in Kolkata — the 5.5h offset puts the two on different days.
+  const straddling = new Date("2026-07-20T20:00:00Z");
+
+  it("a London consultant's sessions bucket on London days", () => {
+    const london = resolveSchedulingTimezone("Europe/London");
+    expect(SlotCalculationService.dayKey(straddling, london)).toBe(
+      "2026-07-20",
+    );
+  });
+
+  it("a consultant with no zone keeps the Indian day boundaries", () => {
+    const fallback = resolveSchedulingTimezone(null);
+    expect(SlotCalculationService.dayKey(straddling, fallback)).toBe(
+      "2026-07-21",
+    );
+  });
+
+  it("week buckets move too", () => {
+    // Saturday night in London, already Sunday in Kolkata, so the two land in
+    // different Sunday-anchored weeks.
+    const weekend = new Date("2026-07-18T20:00:00Z");
+    expect(
+      SlotCalculationService.weekKey(
+        weekend,
+        resolveSchedulingTimezone("Europe/London"),
+      ),
+    ).toBe("2026-07-12");
+    expect(
+      SlotCalculationService.weekKey(weekend, resolveSchedulingTimezone(null)),
+    ).toBe("2026-07-19");
+  });
+
+  it("a cap that passes on Indian days fails on London days", () => {
+    // Two one-hour sessions that are the same London evening but straddle
+    // Indian midnight, against a one-hour-per-day cap.
+    const slots = [
+      hourSlot("2026-07-20T17:00:00Z"),
+      hourSlot("2026-07-20T20:00:00Z"),
+    ];
+
+    expect(validateDailyHours(slots, 1, resolveSchedulingTimezone(null))).toBe(
+      true,
+    );
+    expect(
+      validateDailyHours(slots, 1, resolveSchedulingTimezone("Europe/London")),
+    ).toBe(false);
+  });
+});

--- a/app/api/bookings/classes/crud-with-plan/route.ts
+++ b/app/api/bookings/classes/crud-with-plan/route.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/events/capacity";
 
 import { getSession } from "@/lib/auth-server";
+import { resolveSchedulingTimezone } from "@/lib/scheduling/schedulingTimezone";
 // Schema for class content input (without Prisma-managed fields like createdAt, updatedAt, classPlanId)
 const ClassContentInputSchema = ClassContentSchema.omit({
   createdAt: true,
@@ -152,6 +153,8 @@ export async function POST(request: NextRequest) {
         id: consultantProfileId,
         userId: session.user.id,
       },
+      // #1076 — the host's zone is what the per-day/week caps bucket on.
+      include: { user: { select: { timezone: true } } },
     });
 
     if (!consultantProfile) {
@@ -238,6 +241,9 @@ export async function POST(request: NextRequest) {
             status,
             schedulingPeriodStartsAt: start, // Will be undefined if not provided
             schedulingPeriodEndsAt: end, // Will be undefined if start is not provided
+            schedulingTimezone: resolveSchedulingTimezone(
+              consultantProfile.user.timezone,
+            ),
             classPlan: { connect: { id: classPlan.id } },
             // Create appointments for the full duration
             appointments: {

--- a/app/api/organizations/[orgId]/catalog/route.ts
+++ b/app/api/organizations/[orgId]/catalog/route.ts
@@ -21,6 +21,7 @@ import prisma from "@/lib/prisma";
 import { requireOrgAccess } from "@/lib/auth-helpers";
 import { AUDIT_ACTIONS } from "@/lib/enterprise/audit-actions";
 import { planLevelSchema, planPositioningShape } from "@/schemas/plans";
+import { resolveSchedulingTimezone } from "@/lib/scheduling/schedulingTimezone";
 
 const PlanKindSchema = z.enum(["WEBINAR", "CLASS"]);
 
@@ -137,7 +138,11 @@ export async function POST(
       role: "EXPERT",
       consultantProfileId: body.consultantProfileId,
     },
-    select: { id: true },
+    // #1076 — the named deliverer's zone is what a class's caps bucket on.
+    select: {
+      id: true,
+      consultantProfile: { select: { user: { select: { timezone: true } } } },
+    },
   });
   if (!expert) {
     return NextResponse.json(
@@ -217,7 +222,13 @@ export async function POST(
         });
       } else {
         await tx.class.create({
-          data: { status: "DRAFT", classPlan: { connect: { id: plan.id } } },
+          data: {
+            status: "DRAFT",
+            classPlan: { connect: { id: plan.id } },
+            schedulingTimezone: resolveSchedulingTimezone(
+              expert.consultantProfile?.user.timezone,
+            ),
+          },
         });
       }
 

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -35,6 +35,7 @@ import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancy
 import { isUserEnrolled } from "@/lib/payments/utils/participants";
 import { getClassCapacity, getWebinarCapacity } from "@/lib/events/capacity";
 import { getExchangeRates } from "@/lib/currency";
+import { resolveSchedulingTimezone } from "@/lib/scheduling/schedulingTimezone";
 import {
   applyCreditsToPayment,
   getUserCredits,
@@ -1542,6 +1543,10 @@ export async function handleSubscriptionCheckout(
       bookingSource: "DIRECT_CHECKOUT",
       schedulingPeriodStartsAt: startDate,
       schedulingPeriodEndsAt: endDate,
+      // #1076 — caps bucket on the consultant's days, not the column default.
+      schedulingTimezone: resolveSchedulingTimezone(
+        plan.consultantProfile?.user?.timezone,
+      ),
     },
   });
 

--- a/lib/payments/webhooks/handlers.ts
+++ b/lib/payments/webhooks/handlers.ts
@@ -17,6 +17,7 @@ import { calculateSubscriptionEndDate } from "@/utils/dateUtils";
 import { buildOccupiedAppointmentFilter } from "@/utils/slotAllocation/occupancyPolicy";
 import { REQUEST_ALLOWED_FROM } from "@/lib/booking/transitions";
 import { withSerializableRetry } from "@/lib/db/serializable-retry";
+import { resolveSchedulingTimezone } from "@/lib/scheduling/schedulingTimezone";
 import { recordSystemError } from "@/lib/enterprise/system-events";
 import { refundPayment } from "@/lib/payments/operations/refund";
 import {
@@ -1199,6 +1200,10 @@ async function createConsultation(tx: Tx, data: ConsultationData) {
 async function createSubscription(tx: Tx, data: SubscriptionData) {
   const plan = await tx.subscriptionPlan.findUnique({
     where: { id: data.planId },
+    // #1076 — the owning consultant's zone is what the caps bucket on.
+    include: {
+      consultantProfile: { select: { user: { select: { timezone: true } } } },
+    },
   });
   if (!plan) throw new Error("Subscription plan not found");
 
@@ -1228,6 +1233,9 @@ async function createSubscription(tx: Tx, data: SubscriptionData) {
       bookingSource: "DIRECT_CHECKOUT",
       schedulingPeriodStartsAt: startDate,
       schedulingPeriodEndsAt: endDate,
+      schedulingTimezone: resolveSchedulingTimezone(
+        plan.consultantProfile?.user?.timezone,
+      ),
     },
   });
 

--- a/lib/scheduling/schedulingTimezone.ts
+++ b/lib/scheduling/schedulingTimezone.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolves the scheduling timezone stamped onto a Subscription or Class at
+ * creation time.
+ *
+ * #1076 — the column has always existed with a `Asia/Kolkata` default and no
+ * writer, so every per-day/per-week cap on the platform bucketed against
+ * Indian calendar days no matter where the consultant was. A cap is a
+ * statement about the *consultant's* workload, so it has to bucket on the
+ * consultant's day boundaries.
+ *
+ * The source is `User.timezone` on the owning consultant rather than
+ * `SlotOfAvailabilityWeekly.timezone`: the latter is nullable, deliberately
+ * left unwritten until the post-MVP DST work (#872), and is per-availability-
+ * row, so several rows could disagree with no rule for picking between them.
+ * `User.timezone` is one value per consultant and is actually written today,
+ * by onboarding and by the profile editor.
+ */
+import { SlotCalculationService } from "@/utils/slotAllocation/SlotCalculationService";
+
+/** A junk zone here silently corrupts every cap for the booking, so gate it. */
+export function isValidIanaTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The consultant's zone when it is recorded and real, otherwise the platform
+ * default — an unset or invalid zone leaves that consultant's behaviour
+ * exactly as it is today.
+ */
+export function resolveSchedulingTimezone(
+  consultantTimezone: string | null | undefined,
+): string {
+  const timezone = consultantTimezone?.trim();
+  if (!timezone || !isValidIanaTimezone(timezone)) {
+    return SlotCalculationService.DEFAULT_SCHEDULING_TIMEZONE;
+  }
+  return timezone;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2990,9 +2990,10 @@ model Subscription {
   id                       String   @id @default(cuid())
   schedulingPeriodStartsAt DateTime @db.Timestamptz
   schedulingPeriodEndsAt   DateTime @db.Timestamptz
-  // #676 AE-3 / #872 — ornamental at launch: allocation reads the consultant's
-  // user.timezone, never this. Kept as frozen schema; made load-bearing in #872
-  // to pin a subscription's scheduling zone independent of the consultant's.
+  // #1076 — stamped from the owning consultant's user.timezone at creation, so
+  // the per-day/week caps bucket on the consultant's days. Pinned at creation
+  // rather than followed live: moving it would shift an existing booking's day
+  // boundaries. The default only applies where the consultant has no zone.
   schedulingTimezone       String   @default("Asia/Kolkata")
 
   status                 AppointmentStatus @default(PENDING) @map("requestStatus")
@@ -3350,8 +3351,8 @@ model Class {
   id                       String      @id @default(cuid())
   schedulingPeriodStartsAt DateTime?   @db.Timestamptz
   schedulingPeriodEndsAt   DateTime?   @db.Timestamptz
-  // #676 AE-3 / #872 — ornamental at launch (allocation reads the consultant's
-  // user.timezone). Kept as frozen schema; made load-bearing in #872.
+  // #1076 — stamped from the host consultant's user.timezone at creation. See
+  // Subscription.schedulingTimezone for why it is pinned, not followed.
   schedulingTimezone       String      @default("Asia/Kolkata")
   status                   ClassStatus @default(SCHEDULED)
 


### PR DESCRIPTION
Every per-day and per-week session cap on the platform is currently counted against Indian calendar days, no matter where the consultant actually is. A consultant in London whose plan allows one session per day has that rule enforced against a day that begins at 18:30 their time, so two sessions that sit in different columns on their calendar can land in the same bucket and be refused, while two sessions in one visible column can straddle two buckets and be allowed. The defect is invisible to anyone in India, which is why it has gone unreported: for a consultant in Asia/Kolkata the viewer-local grid and the bucketing zone agree exactly, and the two only diverge the moment the consultant is somewhere else.

The cause is a single line of absence. `Subscription.schedulingTimezone` and `Class.schedulingTimezone` are both declared `@default("Asia/Kolkata")`, and nothing on the platform has ever written either of them. `SlotCalculationService.dayKey` and `weekKey` take that column as the zone that defines a day and a week for the caps, so in practice they have always read the constant.

## What changed

A new `resolveSchedulingTimezone` helper in `lib/scheduling/schedulingTimezone.ts` takes the owning consultant's `User.timezone`, validates it, and returns it — or returns `SlotCalculationService.DEFAULT_SCHEDULING_TIMEZONE` when the consultant has no zone recorded or the recorded value is not a real zone. Validation is a `Intl.DateTimeFormat(undefined, { timeZone: tz })` inside a try/catch, because a junk string written into this column would silently corrupt every cap calculation for that booking with no error anywhere.

Every path that creates a `Subscription` or a `Class` now calls it:

- `lib/payments/operations/checkout.ts:1546` — direct subscription checkout. The plan query already included `consultantProfile.user`, so no extra read was needed.
- `lib/payments/webhooks/handlers.ts:1236` — the legacy webhook flow that creates a subscription when checkout did not. Its plan lookup now selects the consultant's timezone alongside.
- `app/api/bookings/classes/crud-with-plan/route.ts:244` — a consultant authoring a class and its plan together. The existing ownership lookup now also returns the timezone.
- `app/api/organizations/[orgId]/catalog/route.ts:228` — an organization authoring a class in its catalog. The zone comes from the named delivering expert, not from whoever in the organization pressed the button, because the cap describes the deliverer's workload.

Consultations and webinars are untouched by design: they carry no `schedulingTimezone` column because per-day and per-week caps only apply to recurring events.

## Why `User.timezone` and not `SlotOfAvailabilityWeekly.timezone`

`SlotOfAvailabilityWeekly` carries an IANA `timezone` alongside its frozen `utcOffsetMinutes`, so it was worth considering as the source. It is the worse of the two. The schema comment above it states plainly that the column is frozen into the launch schema but left nullable and unwritten until the post-MVP DST work in #872, so reading it today would return null for every consultant on the platform and the fix would be a no-op. Beyond that, it is per-availability-row: a consultant has many weekly availability rows, they could in principle disagree, and there is no rule for choosing between them. `User.timezone` is one value per consultant, it is written today by onboarding and by the profile editor, and the booking validators already read it for offset resolution. It is also the right thing conceptually — a cap is a statement about a person's workload, and the person is the consultant, not any particular availability block.

## Existing rows are deliberately untouched

There is no backfill migration here. This repository does not do them, a pre-MVP reset is coming, and more importantly a backfill would be actively wrong: rewriting the zone on a subscription or class that is already booked would move that booking's day and week boundaries underneath it, and slot allocations that were valid when they were made could become invalid, or vice versa. New bookings get the correct zone; existing rows keep whatever they have, which is the `Asia/Kolkata` default. The schema comments on both columns now say the value is pinned at creation rather than followed live, and explain why.

No schema change was required — both columns already exist. The only edit to `schema.prisma` is to the comments above them, which previously described the field as ornamental and asserted that allocation reads the consultant's timezone rather than the column. That was the inverted description of the bug.

## Grid, labels and calendar are unchanged

The grid is already correct for the person who matters. A consultant looking at their own allocate or timings grid sees their own wall clock, which is the right thing to show them, and once the bucketing zone is theirs too the grid and the caps agree. Nothing about the calendar, its columns, or any label was touched.

## Verification

`npx tsc --noEmit` passes with zero errors after a cold rebuild. `npx eslint` on all six changed files reports zero errors and one warning, an `eqeqeq` at `checkout.ts:2583` that is pre-existing on `dev` and untouched by this change. The full suite is 193 suites and 2176 tests, all passing, which is the branch baseline of 192 and 2166 plus the ten new tests added here.

The new `__tests__/schedule/scheduling-timezone.test.ts` covers the resolver and, more importantly, proves the bucketing actually moved: a consultant in `Europe/London` buckets a 20:00Z session on 20 July onto 20 July while a consultant with no zone buckets the same instant onto 21 July, the same divergence is shown for week keys across a Saturday-to-Sunday boundary, and a real cap is run both ways — two one-hour sessions that share a London evening but straddle Indian midnight pass a one-hour-per-day cap under the old default and fail it under the consultant's own zone.

Part of #1076


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduling now uses the consultant’s valid timezone when creating classes and subscriptions.
  * Timezones are trimmed, validated, and safely defaulted when missing or invalid.
  * Daily and weekly scheduling calculations now respect timezone boundaries consistently.

* **Bug Fixes**
  * Improved scheduling-cap accuracy across calendar boundaries, including different regional timezones.

* **Documentation**
  * Clarified how scheduling timezones are captured and retained for future calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->