### PR TITLE
fix(appointments): gate Manage Timings on commitment, and give group events a real Unschedule

### DIFF
--- a/__tests__/booking-algorithm/manage-timings-affordance.test.ts
+++ b/__tests__/booking-algorithm/manage-timings-affordance.test.ts
@@ -152,6 +152,28 @@ describe("allowsManageTimings", () => {
       unschedule: false,
     });
   });
+
+  it("refuses Timings when a LATER session is still committed", () => {
+    // The reverse of the case above, and the one that actually bit: a partial
+    // reschedule releases one session of a multi-session booking, so the
+    // earliest slot is the released one while the consultee still holds a
+    // confirmed time afterwards. Reading only slots[0] saw "tentative" and
+    // handed back the unilateral surface.
+    const releasedFirst: TestSlot[] = [
+      { isTentative: true, completionStatus: "RESCHEDULED" },
+      { isTentative: false, completionStatus: "SCHEDULED" },
+    ];
+    expect(menu("SUBSCRIPTION", releasedFirst).timings).toBe(false);
+    expect(menu("CONSULTATION", releasedFirst).timings).toBe(false);
+  });
+
+  it("still offers Timings when every upcoming session is unallocated", () => {
+    const allTentative: TestSlot[] = [
+      { isTentative: true, completionStatus: null },
+      { isTentative: true, completionStatus: null },
+    ];
+    expect(menu("SUBSCRIPTION", allTentative).timings).toBe(true);
+  });
 });
 
 describe("allowsUnschedule", () => {

--- a/__tests__/booking-algorithm/manage-timings-affordance.test.ts
+++ b/__tests__/booking-algorithm/manage-timings-affordance.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The Manage Timings menu item's gate, and its complement.
+ *
+ * Manage Timings writes new times straight onto the calendar with no notice
+ * requirement and no acceptance from anyone, so it may only be offered where
+ * nobody else has committed to a time. Where somebody has, the negotiated
+ * Reschedule takes its place — the two are alternatives, and offering both
+ * would hand a consultant a way around the proposal (#1082).
+ */
+
+import {
+  allowsManageTimings,
+  slotsAllowReschedule,
+  upcomingSlots,
+} from "@/lib/appointments/slots";
+import type { AppointmentKind } from "@/lib/appointments/view-model";
+
+type TestSlot = {
+  isTentative?: boolean | null;
+  completionStatus?: string | null;
+};
+
+const confirmed: TestSlot[] = [
+  { isTentative: false, completionStatus: "SCHEDULED" },
+];
+const tentative: TestSlot[] = [{ isTentative: true, completionStatus: null }];
+const nothingAllocated: TestSlot[] = [];
+
+/** Mirrors ConsultantAppointmentsAdapter's two guards, minus the status checks. */
+function offered(kind: AppointmentKind, slots: TestSlot[]) {
+  const timings = allowsManageTimings(kind, slots);
+  return { timings, reschedule: !timings && slotsAllowReschedule(slots) };
+}
+
+describe("allowsManageTimings", () => {
+  it("keeps Timings on a webinar whose instance is already confirmed", () => {
+    // Attendees bought into a published schedule; there is no counterparty to
+    // send a proposal to, and thirty of them cannot each accept one.
+    expect(offered("WEBINAR", confirmed)).toEqual({
+      timings: true,
+      reschedule: false,
+    });
+  });
+
+  it("keeps Timings on a class instance", () => {
+    expect(offered("CLASS", confirmed)).toEqual({
+      timings: true,
+      reschedule: false,
+    });
+  });
+
+  it("keeps Timings on an offering that was never scheduled", () => {
+    // The `unscheduled-class-…` / `unscheduled-webinar-…` rows: no Appointment
+    // row at all, so no slots.
+    expect(offered("CLASS", nothingAllocated)).toEqual({
+      timings: true,
+      reschedule: false,
+    });
+    expect(offered("WEBINAR", nothingAllocated)).toEqual({
+      timings: true,
+      reschedule: false,
+    });
+  });
+
+  it("keeps Timings on a consultation whose slots are still tentative", () => {
+    // Nothing has been placed — the request is awaiting allocation, so the
+    // consultee holds no time yet.
+    expect(offered("CONSULTATION", tentative)).toEqual({
+      timings: true,
+      reschedule: false,
+    });
+  });
+
+  it("keeps Timings on an approved 1:1 with nothing allocated", () => {
+    // "Not scheduled · 0/0". Reschedule refuses it for want of a time to move,
+    // so Timings has to hold this case or the row would offer neither.
+    expect(offered("CONSULTATION", nothingAllocated)).toEqual({
+      timings: true,
+      reschedule: false,
+    });
+  });
+
+  it("replaces Timings with Reschedule on a confirmed consultation", () => {
+    expect(offered("CONSULTATION", confirmed)).toEqual({
+      timings: false,
+      reschedule: true,
+    });
+  });
+
+  it("replaces Timings with Reschedule on a confirmed subscription session", () => {
+    expect(
+      offered("SUBSCRIPTION", [
+        { isTentative: false, completionStatus: "SCHEDULED" },
+        { isTentative: false, completionStatus: "SCHEDULED" },
+      ]),
+    ).toEqual({ timings: false, reschedule: true });
+  });
+
+  it("refuses Timings on a confirmed trial", () => {
+    // A trial is 1:1 and the consultant allocates the time, but the slot is
+    // created non-tentative and the consultee is notified of it — so it is a
+    // commitment by the same test as a consultation. The consultant's menu
+    // offers a trial neither action today, because the reschedule API has no
+    // TRIAL branch; that gap predates this and is out of scope.
+    expect(allowsManageTimings("TRIAL", confirmed)).toBe(false);
+    expect(offered("TRIAL", confirmed)).toEqual({
+      timings: false,
+      reschedule: true,
+    });
+  });
+
+  it("offers exactly one action in every settled case", () => {
+    const cases: Array<[AppointmentKind, TestSlot[]]> = [
+      ["WEBINAR", confirmed],
+      ["CLASS", confirmed],
+      ["CLASS", nothingAllocated],
+      ["WEBINAR", nothingAllocated],
+      ["CONSULTATION", tentative],
+      ["CONSULTATION", nothingAllocated],
+      ["CONSULTATION", confirmed],
+      ["SUBSCRIPTION", confirmed],
+      ["TRIAL", confirmed],
+    ];
+    for (const [kind, slots] of cases) {
+      const { timings, reschedule } = offered(kind, slots);
+      expect(timings).not.toBe(reschedule);
+    }
+  });
+
+  it("offers neither only while a proposal is already live", () => {
+    // The one deliberate gap: a released slot awaiting a new time IS the open
+    // reschedule, so Reschedule would earn a 409 and Timings would write
+    // straight over the proposal the consultee is still answering.
+    const inFlight: TestSlot[] = [
+      { isTentative: false, completionStatus: "SCHEDULED" },
+      { isTentative: true, completionStatus: "RESCHEDULED" },
+    ];
+    expect(offered("CONSULTATION", inFlight)).toEqual({
+      timings: false,
+      reschedule: false,
+    });
+  });
+});
+
+describe("upcomingSlots", () => {
+  const now = new Date("2026-08-01T12:00:00Z");
+  const hoursFromNow = (h: number) =>
+    new Date(now.getTime() + h * 3_600_000).toISOString();
+
+  it("drops finished sessions and orders the rest", () => {
+    const slots = [
+      { startsAt: hoursFromNow(48), endsAt: hoursFromNow(49) },
+      { startsAt: hoursFromNow(-48), endsAt: hoursFromNow(-47) },
+      { startsAt: hoursFromNow(24), endsAt: hoursFromNow(25) },
+    ];
+    expect(upcomingSlots(slots, now).map((s) => s.startsAt)).toEqual([
+      hoursFromNow(24),
+      hoursFromNow(48),
+    ]);
+  });
+
+  it("keeps Timings on a program whose remaining sessions are unallocated", () => {
+    // A subscription part-way through: past sessions are confirmed, but the
+    // consultee holds no future time. Deciding on the raw list would read the
+    // finished session as a commitment and hide the action.
+    const slots = [
+      {
+        startsAt: hoursFromNow(-48),
+        endsAt: hoursFromNow(-47),
+        isTentative: false,
+        completionStatus: "COMPLETED",
+      },
+      {
+        startsAt: hoursFromNow(24),
+        endsAt: hoursFromNow(25),
+        isTentative: true,
+        completionStatus: null,
+      },
+    ];
+    expect(allowsManageTimings("SUBSCRIPTION", upcomingSlots(slots, now))).toBe(
+      true,
+    );
+  });
+});

--- a/__tests__/booking-algorithm/manage-timings-affordance.test.ts
+++ b/__tests__/booking-algorithm/manage-timings-affordance.test.ts
@@ -1,15 +1,21 @@
 /**
- * The Manage Timings menu item's gate, and its complement.
+ * The three time-change affordances on the consultant's appointment menu.
  *
  * Manage Timings writes new times straight onto the calendar with no notice
  * requirement and no acceptance from anyone, so it may only be offered where
  * nobody else has committed to a time. Where somebody has, the negotiated
  * Reschedule takes its place — the two are alternatives, and offering both
  * would hand a consultant a way around the proposal (#1082).
+ *
+ * Unschedule sits outside that pair rather than inside it. It withdraws a
+ * placed group event's date and puts it back in the allocate queue with the
+ * sale, the enrolment and the money all untouched, so a confirmed webinar
+ * offers Timings AND Unschedule, and a 1:1 never offers Unschedule at all.
  */
 
 import {
   allowsManageTimings,
+  allowsUnschedule,
   slotsAllowReschedule,
   upcomingSlots,
 } from "@/lib/appointments/slots";
@@ -30,6 +36,11 @@ const nothingAllocated: TestSlot[] = [];
 function offered(kind: AppointmentKind, slots: TestSlot[]) {
   const timings = allowsManageTimings(kind, slots);
   return { timings, reschedule: !timings && slotsAllowReschedule(slots) };
+}
+
+/** All three menu gates together, which is how a consultant actually meets them. */
+function menu(kind: AppointmentKind, slots: TestSlot[]) {
+  return { ...offered(kind, slots), unschedule: allowsUnschedule(kind, slots) };
 }
 
 describe("allowsManageTimings", () => {
@@ -135,9 +146,89 @@ describe("allowsManageTimings", () => {
       { isTentative: false, completionStatus: "SCHEDULED" },
       { isTentative: true, completionStatus: "RESCHEDULED" },
     ];
-    expect(offered("CONSULTATION", inFlight)).toEqual({
+    expect(menu("CONSULTATION", inFlight)).toEqual({
       timings: false,
       reschedule: false,
+      unschedule: false,
+    });
+  });
+});
+
+describe("allowsUnschedule", () => {
+  it("offers a confirmed webinar Timings AND Unschedule, never Reschedule", () => {
+    // The pair's "exactly one" property is about Timings vs Reschedule only.
+    // Unschedule is orthogonal: it withdraws the date, Timings sets a new one.
+    expect(menu("WEBINAR", confirmed)).toEqual({
+      timings: true,
+      reschedule: false,
+      unschedule: true,
+    });
+  });
+
+  it("offers a confirmed class Timings AND Unschedule, never Reschedule", () => {
+    expect(menu("CLASS", confirmed)).toEqual({
+      timings: true,
+      reschedule: false,
+      unschedule: true,
+    });
+  });
+
+  it("withholds Unschedule from an offering that was never scheduled", () => {
+    // No Appointment row, so no slots and no date to withdraw. Timings is the
+    // surface for putting one on the calendar in the first place.
+    expect(menu("WEBINAR", nothingAllocated)).toEqual({
+      timings: true,
+      reschedule: false,
+      unschedule: false,
+    });
+    expect(menu("CLASS", nothingAllocated)).toEqual({
+      timings: true,
+      reschedule: false,
+      unschedule: false,
+    });
+  });
+
+  it("withholds Unschedule from an event already unscheduled", () => {
+    // The release leaves every slot tentative, so the action is idempotent by
+    // construction rather than by a second guard.
+    expect(allowsUnschedule("WEBINAR", tentative)).toBe(false);
+    expect(allowsUnschedule("CLASS", tentative)).toBe(false);
+  });
+
+  it("offers Unschedule while any session of a part-released class is still placed", () => {
+    // A class is several session appointments; the route releases all of them,
+    // so one still-placed session is enough to have something to withdraw.
+    const partlyReleased: TestSlot[] = [
+      { isTentative: true, completionStatus: "RESCHEDULED" },
+      { isTentative: false, completionStatus: "SCHEDULED" },
+    ];
+    expect(allowsUnschedule("CLASS", partlyReleased)).toBe(true);
+  });
+
+  it("never offers Unschedule for a 1:1, whatever its slots look like", () => {
+    // Releasing a time a counterparty holds is the negotiation Reschedule runs.
+    const oneToOne: AppointmentKind[] = [
+      "CONSULTATION",
+      "SUBSCRIPTION",
+      "TRIAL",
+    ];
+    for (const kind of oneToOne) {
+      for (const slots of [confirmed, tentative, nothingAllocated]) {
+        expect(allowsUnschedule(kind, slots)).toBe(false);
+      }
+    }
+  });
+
+  it("gives a confirmed 1:1 Reschedule and neither other action", () => {
+    expect(menu("CONSULTATION", confirmed)).toEqual({
+      timings: false,
+      reschedule: true,
+      unschedule: false,
+    });
+    expect(menu("SUBSCRIPTION", confirmed)).toEqual({
+      timings: false,
+      reschedule: true,
+      unschedule: false,
     });
   });
 });

--- a/__tests__/booking-algorithm/reschedule-proposals.test.ts
+++ b/__tests__/booking-algorithm/reschedule-proposals.test.ts
@@ -12,6 +12,7 @@ import {
   computeProposalExpiry,
   mayAutoConfirm,
   proposalCountMatches,
+  rescheduleNotificationVariant,
   supportsProposals,
 } from "../../lib/booking/reschedule-proposals";
 import {
@@ -153,5 +154,69 @@ describe("allocationRequestSchema carries override", () => {
         expect(result.success).toBe(false);
       },
     );
+  });
+});
+
+describe("rescheduleNotificationVariant", () => {
+  const released = new Date("2026-08-10T09:00:00Z");
+  const proposed = new Date("2026-08-12T14:00:00Z");
+
+  it("carries both times when the proposal auto-confirmed", () => {
+    expect(
+      rescheduleNotificationVariant({
+        releasedAt: released,
+        proposedAt: proposed,
+        autoConfirmed: true,
+      }),
+    ).toEqual({
+      outcome: "MOVED",
+      oldDateTime: released.toISOString(),
+      newDateTime: proposed.toISOString(),
+    });
+  });
+
+  it("distinguishes a proposal still awaiting an answer from a confirmed move", () => {
+    expect(
+      rescheduleNotificationVariant({
+        releasedAt: released,
+        proposedAt: proposed,
+        autoConfirmed: false,
+      }),
+    ).toEqual({
+      outcome: "PROPOSED",
+      oldDateTime: released.toISOString(),
+      newDateTime: proposed.toISOString(),
+    });
+  });
+
+  it("emits no destination for a plain release", () => {
+    // The bug this replaces: a template rendering "from {{oldDateTime}} to
+    // {{newDateTime}}" against a payload carrying neither, which reached the
+    // consultant's inbox as "rescheduled ... from  to".
+    const variant = rescheduleNotificationVariant({
+      releasedAt: released,
+      proposedAt: null,
+      autoConfirmed: false,
+    });
+
+    expect(variant).toEqual({
+      outcome: "RELEASED",
+      oldDateTime: released.toISOString(),
+    });
+    // Absent, not undefined — an explicit key would still serialize into the
+    // payload Novu interpolates.
+    expect("newDateTime" in variant).toBe(false);
+  });
+
+  it("omits the released time too when there is none to report", () => {
+    const variant = rescheduleNotificationVariant({
+      releasedAt: null,
+      proposedAt: proposed,
+      autoConfirmed: true,
+    });
+
+    // A destination alone cannot render "moved from X to Y", so it degrades to
+    // the released sentence rather than half-filling the other one.
+    expect(variant).toEqual({ outcome: "RELEASED" });
   });
 });

--- a/app/api/appointments/[appointmentId]/reschedule/route.ts
+++ b/app/api/appointments/[appointmentId]/reschedule/route.ts
@@ -8,6 +8,7 @@ import { RescheduleProposalSchema } from "@/schemas/appointments";
 import {
   computeProposalExpiry,
   proposalCountMatches,
+  rescheduleNotificationVariant,
   supportsProposals,
 } from "@/lib/booking/reschedule-proposals";
 import {
@@ -537,10 +538,20 @@ export async function POST(
 
         const rescheduleType = getRescheduleType();
 
+        // Captured here because an auto-confirm deletes these rows and writes
+        // new ones — by the time the notification is built, the time being
+        // given up no longer exists anywhere.
+        const releasedAt = slotsToReschedule.reduce<Date | null>(
+          (earliest, slot) =>
+            !earliest || slot.startsAt < earliest ? slot.startsAt : earliest,
+          null,
+        );
+
         // Return detailed response
         return {
           success: true,
           rescheduleType,
+          releasedAt,
           // #448 — sessionsAffected is the user-facing count (distinct sessions);
           // slotsAffected stays for back-compat / debugging.
           sessionsAffected,
@@ -751,9 +762,26 @@ export async function POST(
               ? "webinar"
               : "class";
 
+        // Earliest of the times asked for, and only when a proposal actually
+        // opened: a group event never carries one, so it is always a release.
+        const proposedAt = result.rescheduleRequestId
+          ? (proposedSlots?.reduce<Date | null>(
+              (earliest, slot) =>
+                !earliest || slot.startsAt < earliest
+                  ? slot.startsAt
+                  : earliest,
+              null,
+            ) ?? null)
+          : null;
+
         if (uniqueUserIds.length > 0) {
           void notifyAppointmentRescheduled(uniqueUserIds, {
             ...notificationScope(appointment.organizationId),
+            ...rescheduleNotificationVariant({
+              releasedAt: result.releasedAt,
+              proposedAt,
+              autoConfirmed,
+            }),
             appointmentType,
             consultantName: plan?.consultantProfile?.user?.name ?? "Consultant",
             consulteeName: requestedBy?.user?.name ?? "Participant",

--- a/app/api/staff/support-tickets/[ticketId]/responses/route.ts
+++ b/app/api/staff/support-tickets/[ticketId]/responses/route.ts
@@ -86,6 +86,10 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         ticketId: ticket.id,
         ticketTitle: ticket.title || "Support Ticket",
         message: validatedData.message,
+        // Declared on the payload and never passed, so a template naming the
+        // responder rendered an empty attribution — same shape as the blank
+        // reschedule times.
+        respondedBy: response.user?.name ?? "Support",
         dashboardUrl: "/dashboard",
       });
     }

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/ConsultantAppointmentsAdapter.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/ConsultantAppointmentsAdapter.tsx
@@ -8,9 +8,11 @@ import type {
   PrimaryAction,
 } from "@/lib/appointments/adapter";
 import {
+  allowsManageTimings,
   CONSULTANT_JOIN_WINDOW_MS,
   getJoinableSlot,
   slotsAllowReschedule,
+  upcomingSlots,
 } from "@/lib/appointments/slots";
 import {
   isApprovedStatus,
@@ -38,7 +40,7 @@ const TYPE_LABEL: Record<AppointmentVM["kind"], string> = {
   TRIAL: "Trial",
 };
 
-/** Webinar/class cancel+reschedule is plan-owner only (API rejects collaborators). */
+/** Webinar/class lifecycle actions are plan-owner only (API rejects collaborators). */
 function canManageBookingLifecycle(vm: AppointmentVM): boolean {
   if (vm.kind === "WEBINAR" || vm.kind === "CLASS") {
     return !vm.collaboratorRole || vm.collaboratorRole === "HOST";
@@ -54,14 +56,9 @@ function actionableRawSlots(vm: AppointmentVM) {
       : vm.raw.appointment
         ? [vm.raw.appointment]
         : [];
-  const now = Date.now();
-  return sources
-    .flatMap((a) => a.slotsOfAppointment ?? [])
-    .filter((slot) => new Date(slot.endsAt).getTime() >= now)
-    .sort(
-      (a, b) =>
-        new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
-    );
+  // Shared with the timings page's own gate, so the menu cannot offer a route
+  // that then 404s on a different reading of the same slots (#1082).
+  return upcomingSlots(sources.flatMap((a) => a.slotsOfAppointment ?? []));
 }
 
 export function useConsultantAppointmentsAdapter(
@@ -209,7 +206,18 @@ export function useConsultantAppointmentsAdapter(
     const lifecycleOk = canManageBookingLifecycle(vm);
     const isTrial = vm.kind === "TRIAL";
 
-    if (appointment && vm.bucket !== "cancelled" && vm.bucket !== "past") {
+    // Manage Timings moves sessions with no notice and no acceptance, so it is
+    // only offered where nobody else has committed to the time. A 1:1 whose
+    // consultee already holds a confirmed slot gets Reschedule below instead —
+    // the two are alternatives, never both (#1082).
+    const timingsOk = allowsManageTimings(vm.kind, rawSlots);
+
+    if (
+      appointment &&
+      vm.bucket !== "cancelled" &&
+      vm.bucket !== "past" &&
+      timingsOk
+    ) {
       items.push({
         key: "timings",
         label: "Timings",
@@ -231,6 +239,9 @@ export function useConsultantAppointmentsAdapter(
       lifecycleOk &&
       !inactive &&
       isApprovedStatus(vm.status) &&
+      // Reschedule is the negotiated path, so it belongs exactly where Manage
+      // Timings does not: a booking a counterparty holds a confirmed time on.
+      !timingsOk &&
       slotsAllowReschedule(rawSlots)
     ) {
       items.push({

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/ConsultantAppointmentsAdapter.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/ConsultantAppointmentsAdapter.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@/lib/appointments/adapter";
 import {
   allowsManageTimings,
+  allowsUnschedule,
   CONSULTANT_JOIN_WINDOW_MS,
   getJoinableSlot,
   slotsAllowReschedule,
@@ -28,9 +29,10 @@ import {
 } from "./utils/participantHelpers";
 import { useConsultantEventActions } from "./components/useConsultantEventActions";
 import { CancelConfirmationDialog } from "@/components/appointments/consultee/CancelConfirmationDialog";
+import { UnscheduleConfirmationDialog } from "@/components/appointments/UnscheduleConfirmationDialog";
 import { ConsultantResponseUpload } from "../documents/ConsultantResponseUpload";
 
-type DialogKind = "cancel" | "documents";
+type DialogKind = "cancel" | "unschedule" | "documents";
 
 const TYPE_LABEL: Record<AppointmentVM["kind"], string> = {
   CONSULTATION: "Consultation",
@@ -257,6 +259,25 @@ export function useConsultantAppointmentsAdapter(
       });
     }
 
+    // Unschedule is not a third branch of the pair above: a confirmed webinar
+    // offers Timings AND this. It withdraws the date only — the booking stays
+    // sold, attendees stay enrolled, no money moves — which is the whole of
+    // what separates it from Cancel below (#1082).
+    if (
+      vm.appointmentId &&
+      lifecycleOk &&
+      !inactive &&
+      // The route's own from-state for a group release is SCHEDULED/IN_PROGRESS.
+      isConfirmedStatus(vm.status) &&
+      allowsUnschedule(vm.kind, rawSlots)
+    ) {
+      items.push({
+        key: "unschedule",
+        label: "Unschedule",
+        onClick: () => openDialog(vm, "unschedule"),
+      });
+    }
+
     if (vm.appointmentId && !isTrial && lifecycleOk && !inactive) {
       items.push({
         key: "cancel",
@@ -309,6 +330,18 @@ export function useConsultantAppointmentsAdapter(
             onCancel={closeDialog}
             title={activeVm.title}
             consultant={activeVm.counterpart.name}
+            appointmentType={typeLabel}
+            isLoading={actions.isLoading}
+          />
+
+          <UnscheduleConfirmationDialog
+            isOpen={dialog === "unschedule"}
+            onConfirm={async () => {
+              await actions.handleUnschedule();
+              closeDialog();
+            }}
+            onCancel={closeDialog}
+            title={activeVm.title}
             appointmentType={typeLabel}
             isLoading={actions.isLoading}
           />

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/[appointmentId]/timings/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/[appointmentId]/timings/page.tsx
@@ -4,7 +4,12 @@ import { notFound } from "next/navigation";
 
 import { PanelHeader } from "@/components/dashboard/PageScaffold";
 import { Badge } from "@/components/ui/badge";
-import { readManageTimingsTarget } from "@/lib/data/manage-timings-target";
+import { allowsManageTimings, upcomingSlots } from "@/lib/appointments/slots";
+import { readAppointmentDetail } from "@/lib/data/appointment-detail";
+import {
+  readManageTimingsTarget,
+  type ManageTimingsTarget,
+} from "@/lib/data/manage-timings-target";
 import { requirePersonalProfileAccess } from "@/lib/auth/personal-dashboard-access";
 import { buildManageTimingsSubject } from "@/lib/scheduling/manage-timings-subject";
 
@@ -28,6 +33,38 @@ type PageProps = {
 
 // React.cache so generateMetadata() and the page body share one query per request.
 const loadTarget = cache(readManageTimingsTarget);
+const loadDetail = cache(readAppointmentDetail);
+
+/**
+ * The counterparty gate, server side (#1082).
+ *
+ * This surface writes new times with no notice and no acceptance, which is
+ * honest only while nobody else has committed to one. The menu already hides
+ * it for a 1:1 whose consultee holds a confirmed slot, but the URL is linkable
+ * and survives a refresh, so the menu is not the control.
+ *
+ * Only the two 1:1 kinds need the extra read, and only they pay for it: a
+ * group event is allowed regardless. Slots are fetched here rather than
+ * widened into `ManageTimingsTarget` to stay clear of #1075; `cache` keeps it
+ * to one query across metadata and body.
+ */
+async function manageTimingsAllowed(
+  target: ManageTimingsTarget,
+  appointmentId: string,
+): Promise<boolean> {
+  const kind = target.appointment.appointmentType;
+  if (kind !== "CONSULTATION" && kind !== "SUBSCRIPTION") return true;
+
+  const detail = await loadDetail(appointmentId);
+  if (!detail) return false;
+  // Program-wide, same as the menu's group card: a subscription session is one
+  // Appointment among several and any of them may carry the committed time.
+  const slots = [
+    ...detail.appointment.slotsOfAppointment,
+    ...detail.siblings.flatMap((sibling) => sibling.slotsOfAppointment),
+  ];
+  return allowsManageTimings(kind, upcomingSlots(slots));
+}
 
 /**
  * Names the offering, not the task. A consultant with several unscheduled
@@ -40,10 +77,15 @@ export async function generateMetadata({
   const target = await loadTarget(appointmentId).catch(() => null);
   // Metadata runs BEFORE the body's guards and is not covered by them, so the
   // same ownership check runs here — otherwise the tab title named the
-  // offering for any id a signed-in consultant cared to try.
+  // offering for any id a signed-in consultant cared to try. The counterparty
+  // gate joins it so a route that 404s never gets a titled tab either.
   if (!target || !target.planOwnerIds.includes(consultantId)) {
     return { title: "Manage timings — Familiarise" };
   }
+  const allowed = await manageTimingsAllowed(target, appointmentId).catch(
+    () => false,
+  );
+  if (!allowed) return { title: "Manage timings — Familiarise" };
 
   const resolved = buildManageTimingsSubject(consultantId, target.appointment);
   return { title: `Manage timings: ${resolved.title} — Familiarise` };
@@ -64,6 +106,10 @@ export default async function ManageTimingsPage({
   // Binds the offering to the URL's consultant; the guard above binds that
   // consultant to the session.
   if (!target.planOwnerIds.includes(consultantId)) notFound();
+
+  // Ownership is not the question a booked consultee cares about — see
+  // manageTimingsAllowed. Reschedule is the route for that case.
+  if (!(await manageTimingsAllowed(target, appointmentId))) notFound();
 
   const resolved = buildManageTimingsSubject(
     consultantId,
@@ -98,8 +144,8 @@ export default async function ManageTimingsPage({
           Tip: Each class is{" "}
           {Math.ceil(resolved.classInfo.durationInHours / 0.5)} consecutive
           30-min slots. Complete an in-progress class before starting another.
-          Max {resolved.classInfo.sessionsPerWeek} classes per day; weekly
-          limit applies.
+          Max {resolved.classInfo.sessionsPerWeek} classes per day; weekly limit
+          applies.
         </div>
       )}
 

--- a/app/dashboard/consultant/[consultantId]/(features)/appointments/components/useConsultantEventActions.ts
+++ b/app/dashboard/consultant/[consultantId]/(features)/appointments/components/useConsultantEventActions.ts
@@ -83,9 +83,7 @@ export function useConsultantEventActions({
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: Object.keys(payload).length
-          ? JSON.stringify(payload)
-          : undefined,
+        body: Object.keys(payload).length ? JSON.stringify(payload) : undefined,
       });
 
       const data = await response.json();
@@ -125,6 +123,61 @@ export function useConsultantEventActions({
           error instanceof Error
             ? error.message
             : "Failed to request reschedule",
+        variant: "destructive",
+      });
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  /**
+   * Withdraw a published group event's date without ending the booking.
+   *
+   * Same route as `handleReschedule`, deliberately: for a WEBINAR/CLASS that
+   * call never opened a proposal — there is no single counterparty to propose
+   * to — it only released the slots back to the allocate queue. That behaviour
+   * was correct and is what this names (#1082). Nothing here touches money,
+   * enrolment, earnings or the ledger; that is Cancel.
+   */
+  const handleUnschedule = async (): Promise<boolean> => {
+    if (!appointmentId) {
+      toast({
+        title: "Error",
+        description: "Appointment ID is missing",
+        variant: "destructive",
+      });
+      return false;
+    }
+
+    setIsLoading(true);
+    try {
+      // No `type` param: the route derives it from the DB and only compares
+      // when one is supplied, so omitting it cannot mismatch.
+      const response = await fetch(
+        `/api/appointments/${appointmentId}/reschedule`,
+        { method: "POST", headers: { "Content-Type": "application/json" } },
+      );
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to unschedule");
+      }
+
+      toast({
+        title: `${type} unscheduled`,
+        description: `"${title}" is off the calendar and back in your queue. Attendees stay enrolled and have been told the date is withdrawn.`,
+      });
+      invalidateBookingData();
+      return true;
+    } catch (error) {
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+        { tags: { subsystem: "client" } },
+      );
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error ? error.message : "Failed to unschedule",
         variant: "destructive",
       });
       return false;
@@ -194,6 +247,7 @@ export function useConsultantEventActions({
   return {
     isLoading,
     handleReschedule,
+    handleUnschedule,
     handleCancelConfirm,
   };
 }

--- a/components/appointments/UnscheduleConfirmationDialog.tsx
+++ b/components/appointments/UnscheduleConfirmationDialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { CalendarX, Loader2 } from "lucide-react";
+
+interface UnscheduleConfirmationDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title: string;
+  /** "Webinar" / "Class" — the only kinds this action exists for. */
+  appointmentType: string;
+  isLoading?: boolean;
+}
+
+/**
+ * Unschedule is one menu row away from Cancel booking and undoes far less, so
+ * the whole job of this dialog is to make the two impossible to confuse: the
+ * event stays sold, nobody is refunded, and the only thing withdrawn is the
+ * date (#1082). Deliberately not styled destructive — it is reversible by
+ * setting new times, and a red button here would read as "refund everyone".
+ */
+export function UnscheduleConfirmationDialog({
+  isOpen,
+  onConfirm,
+  onCancel,
+  title,
+  appointmentType,
+  isLoading = false,
+}: Readonly<UnscheduleConfirmationDialogProps>) {
+  const kind = appointmentType.toLowerCase();
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <CalendarX className="h-5 w-5 text-amber-500" />
+            Unschedule this {kind}?
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                This takes <strong>&quot;{title}&quot;</strong> off the calendar
+                and back into your queue, so you can set a new date for it.
+              </p>
+              <p className="text-muted-foreground">
+                The {kind} is still sold and everyone enrolled stays enrolled.
+                Nobody is refunded and your earnings do not change.
+              </p>
+              <p className="text-muted-foreground">
+                Attendees will be told the date has been withdrawn, so only do
+                this if you intend to set a new one.
+              </p>
+              <p className="text-muted-foreground text-sm">
+                To end the {kind} instead and refund attendees, use{" "}
+                <strong>Cancel booking</strong>.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel} disabled={isLoading}>
+            Keep the date
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Unscheduling...
+              </>
+            ) : (
+              "Unschedule"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/notifications/NotificationInbox.tsx
+++ b/components/notifications/NotificationInbox.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useMemo } from "react";
-import { Inbox } from "@novu/nextjs";
-import { Bell } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Bell, Inbox, InboxContent } from "@novu/nextjs";
+import { Bell as BellIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useSession } from "@/lib/auth-client";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 const NOVU_APP_ID = process.env.NEXT_PUBLIC_NOVU_APP_ID;
 
@@ -16,6 +21,7 @@ type OrgMembershipLite = {
 export function NotificationInbox() {
   const router = useRouter();
   const { data: session } = useSession();
+  const [open, setOpen] = useState(false);
 
   const memberships = useMemo(() => {
     const raw = (session?.user as Record<string, unknown> | undefined)
@@ -68,36 +74,24 @@ export function NotificationInbox() {
     return null;
   }
 
+  /**
+   * Novu's bundled popover is deliberately not used. Given children, `Inbox`
+   * drops to a provider and the panel becomes ours to place, which is what the
+   * calendar needed: its own popover took a fixed 400px at a bespoke z-index of
+   * 9999, could not be closed programmatically, and so stayed parked over the
+   * Friday and Saturday columns of the slot grid after a notification click
+   * navigated there.
+   *
+   * The repo's Radix popover fixes the placement (collision-aware, capped at
+   * the viewport, on the shared z-layer) and, because the open state is ours,
+   * the panel dismisses itself before routing rather than following the user
+   * onto the page they asked for.
+   */
   return (
     <Inbox
       applicationIdentifier={NOVU_APP_ID}
       subscriberId={session.user.id}
       tabs={tabs}
-      placement="bottom-end"
-      placementOffset={12}
-      renderBell={(unreadCount) => {
-        const count = unreadCount?.total ?? 0;
-        return (
-          <div
-            role="status"
-            className="relative inline-flex h-9 w-9 items-center justify-center"
-            aria-label={`Notifications${count > 0 ? ` (${count} unread)` : ""}`}
-          >
-            <Bell className="h-5 w-5" />
-            {count > 0 && (
-              <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
-                {count > 99 ? "99+" : count}
-              </span>
-            )}
-          </div>
-        );
-      }}
-      onNotificationClick={(notification) => {
-        const url = notification?.redirect?.url;
-        if (url) {
-          router.push(url);
-        }
-      }}
       appearance={{
         variables: {
           colorBackground: "#ffffff",
@@ -114,28 +108,64 @@ export function NotificationInbox() {
           borderRadius: "0.5rem",
         },
         elements: {
-          popoverContent: {
-            zIndex: 9999,
-            width: "min(400px, calc(100vw - 2rem))",
-            maxHeight: "calc(100vh - 6rem)",
-            borderRadius: "0.75rem",
-            boxShadow:
-              "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
-            border: "1px solid #e4e4e7",
-            overflowY: "auto",
-          },
-          popoverTrigger: {
-            zIndex: 9998,
-          },
-          bellContainer: {
-            display: "contents",
-          },
           notification: {
             padding: "12px 16px",
             gap: "12px",
           },
         },
       }}
-    />
+    >
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Notifications"
+            aria-haspopup="dialog"
+            className="relative inline-flex h-9 w-9 items-center justify-center rounded-md text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+          >
+            <Bell
+              renderBell={(unreadCount) => {
+                const count = unreadCount?.total ?? 0;
+                return (
+                  <span className="relative flex items-center justify-center">
+                    <BellIcon className="h-5 w-5" />
+                    {count > 0 && (
+                      <span
+                        role="status"
+                        aria-label={`${count} unread notifications`}
+                        className="absolute -top-2 -right-2 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white"
+                      >
+                        {count > 99 ? "99+" : count}
+                      </span>
+                    )}
+                  </span>
+                );
+              }}
+            />
+          </button>
+        </PopoverTrigger>
+        {/* Narrower than the old 400px and collision-padded so the panel stays
+            inside the viewport instead of running to the window edge over the
+            page it is anchored above. */}
+        <PopoverContent
+          align="end"
+          sideOffset={8}
+          collisionPadding={12}
+          className="max-h-[min(32rem,calc(100vh-6rem))] w-[min(22rem,calc(100vw-2rem))] overflow-y-auto p-0"
+        >
+          <InboxContent
+            onNotificationClick={(notification) => {
+              const url = notification?.redirect?.url;
+              // Closed first: the panel must not still be sitting over the
+              // grid it just sent the user to.
+              setOpen(false);
+              if (url) {
+                router.push(url);
+              }
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </Inbox>
   );
 }

--- a/lib/appointments/slots.ts
+++ b/lib/appointments/slots.ts
@@ -90,6 +90,27 @@ export function allowsManageTimings(
 }
 
 /**
+ * Whether Unschedule may be offered — pulling a placed group event off the
+ * calendar and back into the allocate queue, without cancelling it (#1082).
+ *
+ * Orthogonal to the Timings/Reschedule pair rather than a third branch of it.
+ * A confirmed webinar offers Timings AND this; a 1:1 never offers it, because
+ * releasing a time a counterparty holds is the negotiation Reschedule already
+ * runs. It is emphatically NOT Cancel: the booking stays sold, attendees stay
+ * enrolled, and no money, earnings or ledger row moves.
+ */
+export function allowsUnschedule(
+  kind: AppointmentKind,
+  slots: Array<{ isTentative?: boolean | null }>,
+): boolean {
+  if (kind !== "WEBINAR" && kind !== "CLASS") return false;
+  // Nothing placed yet — an offering that was never scheduled, or one already
+  // unscheduled (the release leaves every slot tentative). No date to withdraw,
+  // and Timings is the surface for setting one.
+  return slots.some((slot) => !slot.isTentative);
+}
+
+/**
  * The slots a time-change decision acts on: still ahead of now, chronological.
  * A finished session is not what "has someone committed to a time" is asking
  * about, and the first entry has to be the earliest for the tentative test.

--- a/lib/appointments/slots.ts
+++ b/lib/appointments/slots.ts
@@ -84,9 +84,12 @@ export function allowsManageTimings(
   // Nothing placed: an offering that was never scheduled, or a booking whose
   // sessions are not allocated yet. Still the consultant's own calendar.
   if (slots.length === 0) return true;
-  // Tentative means the request is still awaiting allocation, not booked —
-  // same reading as slotsAllowReschedule, which refuses on the same test.
-  return Boolean(slots[0]?.isTentative);
+  // EVERY upcoming slot, not just the earliest. A partial reschedule releases
+  // one session of a multi-session booking and leaves the rest confirmed, so
+  // the first slot chronologically can be the released one while a consultee
+  // still holds a committed time later in the same booking. Reading only
+  // `slots[0]` handed back the unilateral surface in exactly that case.
+  return slots.every((slot) => Boolean(slot.isTentative));
 }
 
 /**

--- a/lib/appointments/slots.ts
+++ b/lib/appointments/slots.ts
@@ -7,6 +7,7 @@
 import {
   toDate,
   toDateOrNull,
+  type AppointmentKind,
   type SessionVM,
   type SlotLike,
 } from "./view-model";
@@ -56,6 +57,52 @@ export function slotsAllowReschedule(
   // be live per appointment (the nullable-unique openForAppointmentId), so
   // offering the action again only earns a 409.
   return !slots.some((slot) => slot.completionStatus === "RESCHEDULED");
+}
+
+/**
+ * Whether Manage Timings may be offered at all — the menu item AND the page,
+ * since that URL is linkable (#1082).
+ *
+ * Manage Timings writes new times straight onto the calendar: no notice
+ * requirement, no acceptance from anyone. That is honest only while nobody
+ * else has committed to a time, so the deciding question is whether a
+ * counterparty already holds one — not who owns the calendar.
+ *
+ * The exact complement of `slotsAllowReschedule` for the surfaces that offer
+ * both, so a consultant is never handed the unilateral surface and the
+ * negotiated one for the same booking.
+ */
+export function allowsManageTimings(
+  kind: AppointmentKind,
+  slots: Array<{ isTentative?: boolean | null }>,
+): boolean {
+  // A webinar or class is a published schedule attendees buy into rather than
+  // a time anyone negotiated, so the organiser keeps this surface even once
+  // the instance is confirmed — there is no single counterparty to propose to,
+  // and asking every attendee to accept is not a coherent flow.
+  if (kind === "WEBINAR" || kind === "CLASS") return true;
+  // Nothing placed: an offering that was never scheduled, or a booking whose
+  // sessions are not allocated yet. Still the consultant's own calendar.
+  if (slots.length === 0) return true;
+  // Tentative means the request is still awaiting allocation, not booked —
+  // same reading as slotsAllowReschedule, which refuses on the same test.
+  return Boolean(slots[0]?.isTentative);
+}
+
+/**
+ * The slots a time-change decision acts on: still ahead of now, chronological.
+ * A finished session is not what "has someone committed to a time" is asking
+ * about, and the first entry has to be the earliest for the tentative test.
+ */
+export function upcomingSlots<
+  T extends { startsAt: Date | string; endsAt: Date | string },
+>(slots: T[], now: Date = new Date()): T[] {
+  const cutoff = now.getTime();
+  return slots
+    .filter((slot) => toDate(slot.endsAt).getTime() >= cutoff)
+    .sort(
+      (a, b) => toDate(a.startsAt).getTime() - toDate(b.startsAt).getTime(),
+    );
 }
 
 function slotTimes(slot: SlotLike): { start: number; end: number } {

--- a/lib/booking/reschedule-proposals.ts
+++ b/lib/booking/reschedule-proposals.ts
@@ -18,6 +18,7 @@
  */
 
 import type { AppointmentsType, RescheduleInitiatorRole } from "@prisma/client";
+import type { RescheduleOutcomeFields } from "@/lib/novu/workflows";
 
 /** Ceiling on how long an unanswered proposal may sit. */
 export const PROPOSAL_MAX_LIFETIME_HOURS = 72;
@@ -105,6 +106,43 @@ export function proposalCountMatches(
   proposedSlotCount: number,
 ): boolean {
   return releasedSlotCount === proposedSlotCount;
+}
+
+/**
+ * Which sentence the reschedule notification should render.
+ *
+ * The three outcomes the route already distinguishes in its response message
+ * are the same three a recipient needs told apart: you were moved, you were
+ * asked, or the time was given up and nobody has picked a new one. Collapsing
+ * them into one "moved from X to Y" template is what left the released case
+ * interpolating two empty strings.
+ *
+ * `releasedAt` is the earliest slot handed back, `proposedAt` the earliest time
+ * asked for — earliest rather than all of them because a multi-session
+ * reschedule still needs one sentence.
+ */
+export function rescheduleNotificationVariant(args: {
+  releasedAt: Date | null;
+  proposedAt: Date | null;
+  autoConfirmed: boolean;
+}): RescheduleOutcomeFields {
+  const { releasedAt, proposedAt, autoConfirmed } = args;
+
+  // A destination needs both ends: the arms carrying `newDateTime` also carry
+  // `oldDateTime`, so a missing released time falls back to RELEASED rather
+  // than half-filling the sentence.
+  if (releasedAt && proposedAt) {
+    return {
+      outcome: autoConfirmed ? "MOVED" : "PROPOSED",
+      oldDateTime: releasedAt.toISOString(),
+      newDateTime: proposedAt.toISOString(),
+    };
+  }
+
+  return {
+    outcome: "RELEASED",
+    ...(releasedAt ? { oldDateTime: releasedAt.toISOString() } : {}),
+  };
 }
 
 /*

--- a/lib/novu/workflows.ts
+++ b/lib/novu/workflows.ts
@@ -184,10 +184,40 @@ export type AppointmentCancelledPayload = AppointmentPayload & {
   cancelledBy: "consultant" | "consultee" | "system";
 };
 
-export type AppointmentRescheduledPayload = AppointmentPayload & {
-  oldDateTime?: string;
-  newDateTime?: string;
-};
+/**
+ * Which of the three reschedule outcomes happened, and therefore which sentence
+ * the `appointment-rescheduled` template must render.
+ *
+ * A reschedule does not always have a destination. "Any time works" is the
+ * common case — the slots go back to the consultant's queue and no new time
+ * exists yet — so a template that always says "moved from X to Y" has nothing
+ * to put in either blank. The discriminator makes that a template branch rather
+ * than two empty interpolations, the same way `OrgInvoiceOverduePayload`
+ * (`reminderStage`) and `OrgPayoutFailedPayload` (`kind`) drive their copy.
+ *
+ * The arms are unions rather than optional fields on purpose: MOVED and
+ * PROPOSED cannot be constructed without both times, so the blank-blank payload
+ * that produced "from&nbsp;&nbsp;to" is now a compile error.
+ */
+export type RescheduleOutcomeFields =
+  | {
+      /** MOVED: auto-confirmed, the booking now holds `newDateTime`.
+       *  PROPOSED: `newDateTime` was asked for and awaits the other party. */
+      outcome: "MOVED" | "PROPOSED";
+      oldDateTime: string;
+      newDateTime: string;
+    }
+  | {
+      /** Slots released with no replacement time — awaiting a new one. */
+      outcome: "RELEASED";
+      oldDateTime?: string;
+      newDateTime?: never;
+    };
+
+// `dateTime` from AppointmentPayload is deliberately unused here: a reschedule
+// is about the pair of times, not a single one.
+export type AppointmentRescheduledPayload = AppointmentPayload &
+  RescheduleOutcomeFields;
 
 export type PaymentSuccessPayload = NotificationScope & {
   amount: number;


### PR DESCRIPTION
A consultee books a consultation, pays for it, and puts the time in their diary. The consultant then opens **Manage Timings** on that booking, picks a different slot, and saves. There is no notice period, no request, and nothing for the consultee to accept — the session simply moves, and they find out when their calendar changes. The same is true of a subscription session part-way through a programme.

The cause is one line in the wrong place, not a wrong policy. The `MANAGE_TIMINGS` picker sets `minLeadHours: 0` and its own comment explains why: the surface has no counterparty to give notice to. That is entirely true of what it was built for, which is a consultant deciding when their own webinar or class instance runs. The consultant appointments menu simply never made the distinction, and offered the action for every appointment in a non-cancelled, non-past bucket.

This PR fixes that, and in doing so gives the consultant's menu three named actions where it previously had two, one of which was wearing the wrong label.

## The model — three actions, three predicates

The deciding question for the first two is whether anyone has already committed to a time, not who owns the calendar.

**Manage Timings** stays wherever nobody has committed. A webinar or class instance keeps it unconditionally, including once its slots are confirmed: the organiser publishes a schedule and attendees buy into it, so there is no counterparty to negotiate with and asking thirty attendees to each accept a new time is not a coherent flow. An offering that has never been scheduled keeps it, since it has no `Appointment` row at all and travels as an `unscheduled-class-<id>` / `unscheduled-webinar-<id>` synthetic id. A booking whose slots are still tentative keeps it too, because a tentative slot means the request is awaiting allocation and nothing has been placed yet.

**Reschedule** replaces it wherever a counterparty holds a confirmed time. That means a consultation or a subscription session with allocated, non-tentative slots. Moving one of those is a two-party negotiation, so it goes through the proposal the consultee has to answer. It is 1:1 only.

**Unschedule** is new, and it is orthogonal to that pair rather than a third branch of it. It pulls a *placed* group event off the calendar and back into the allocate queue without cancelling it, so a confirmed webinar offers Manage Timings **and** Unschedule, while a 1:1 offers neither of those and gets Reschedule instead. The "never both, never neither" property from the original change still holds, unchanged, within the Timings/Reschedule pair.

Trials follow the same rule and land on the same side as a consultation. A trial is strictly one consultant and one consultee, and although the consultant is the one who allocates the time, the slot is created with `isTentative: false` and the consultee is notified of it immediately — so it is a commitment by exactly the test above. This changes nothing in practice: the menu already withheld Timings from trials because a trial VM carries no `raw.appointment`, and `readManageTimingsTarget` already returned `null` for a `TRIAL` appointment type. The predicate now says so explicitly rather than leaving it to those two accidents.

## Unschedule is not Cancel, and a reviewer should not read it as one

This is the distinction the whole second half of the PR exists to draw. The two actions sit one menu row apart and undo wildly different amounts.

| | Unschedule | Cancel booking |
|---|---|---|
| the booking | still exists, still sold | over |
| money | untouched, no refund | refunded per policy tier |
| attendees | still enrolled | refunded and released |
| earnings / ledger | untouched | reversed |
| slots | tentative, back in the allocate queue | `CANCELLED`, terminal |
| reversible | yes, by setting new times | no |

Unschedule means "this is still happening, I just do not know when yet." For a webinar with thirty paid attendees, that is the difference between moving the date and refunding ₹150,000. Nothing on this path touches money, earnings, the ledger or utilization, and the confirm dialog says so in as many words before naming Cancel booking as the action for the other outcome. It is deliberately not styled destructive, because a red button would read as "refund everyone".

## Why the capability already existed

The first commit's removal of Reschedule from webinars and classes was correct, but it removed a real capability along with a wrong label. For a group event that route never opened a proposal — its own docstring says "For WEBINAR/CLASS: Marks all slots as tentative", and the auto-confirm block notes that "Only the two 1:1 kinds carry proposals". Marking every slot tentative and re-stamping the event `SCHEDULED` *is* an unschedule. It was an Unschedule wearing the Reschedule label.

So `handleUnschedule` posts to the same `POST /api/appointments/[appointmentId]/reschedule` with no body, exactly as the group-event Reschedule menu item used to. There is no parallel implementation, no new route and no new transaction. What is new is the name, the predicate that decides when to offer it, and copy that tells the truth about what it does. The `type` query param is deliberately omitted: the route derives the type from the DB and only compares when one is supplied, so omitting it cannot mismatch.

## Attendee notification — already correct, and confirmed

A sibling audit found that group-event **cancellation** notifies nobody (being fixed separately in #1081), so the same gap was expected here. It is not present. The reschedule route's post-transaction fan-out re-reads the appointment with `slotsOfAppointment: { select: { user: … } }` and pushes every connected user into the recipient list before calling `notifyAppointmentRescheduled` — the "FIX #624" block. Attendees are excluded only if they are the initiator.

That is sufficient for classes as well as webinars, even though the notification is scoped to a single appointment while the release covers every session of the class. Group checkout never mints a per-buyer slot: `handleClassCheckout` connects the buyer to every slot of every session appointment, and `handleWebinarCheckout` to every slot of the shared appointment. One appointment's slots therefore already carry the whole roster. No second recipient assembly was written.

## Why no new mechanism was needed for the 1:1 side

A reviewer will reasonably ask whether this should have shipped a reschedule-request feature. It should not, because the two-party protocol already exists and is already asymmetric in the right direction. A consultee proposing a time inside the consultant's published availability auto-confirms, since publishing availability is standing consent to be booked within it. A consultant proposing never auto-confirms, since a consultee merely being free at a time is not consent to be moved to it. The initiator may withdraw, the recipient may decline, and both decline and expiry drop the booking into the consultant's allocate queue, so nothing dead-ends. A consultant with a genuine emergency opens a proposal and the consultee accepts; if they never answer, expiry hands it back to the allocate queue; and cancellation with a refund remains available throughout. There is therefore no case that requires moving a committed session without agreement.

## What changed

`lib/appointments/slots.ts` gains `allowsManageTimings(kind, slots)` and `allowsUnschedule(kind, slots)`, alongside the `slotsAllowReschedule` the first is the complement of. `allowsUnschedule` returns true only for a `WEBINAR` or `CLASS` with at least one placed (non-tentative) upcoming slot, which makes the action idempotent by construction rather than by a second guard — the release leaves every slot tentative, so an already-unscheduled event stops offering it and offers Manage Timings instead. The module also gains `upcomingSlots`, the "still ahead of now, chronological" filter that the consultant adapter had inline, so the menu and the page decide on the same list: a finished session is not what "has someone committed to a time" is asking about, and without the filter a subscription with past sessions and unallocated future ones would read as committed.

`ConsultantAppointmentsAdapter.tsx` gates the Timings item on the new predicate and adds its negation to the Reschedule item's condition, so those two are now mutually exclusive by construction rather than by coincidence. The one deliberate exception is a booking with a reschedule already in flight, where the released slot awaiting a new time *is* the open proposal — Reschedule would earn a 409 and Timings would write straight over the proposal the consultee is still answering, so neither is offered. There is a test naming that case. The adapter also gains the Unschedule item, gated on plan ownership (the same `canManageBookingLifecycle` check Cancel and Reschedule use, so a collaborator who is not the HOST does not get it), a non-terminal status, `isConfirmedStatus` — which matches the route's own from-state of `SCHEDULED`/`IN_PROGRESS` for a group release — and the new predicate.

`components/appointments/UnscheduleConfirmationDialog.tsx` is new: the confirm step described above.

`useConsultantEventActions.ts` gains `handleUnschedule`, the thin call onto the existing route, with a success toast that repeats the two things a consultant needs to be sure of — the event is back in their queue, and attendees stay enrolled and have been told.

`timings/page.tsx` enforces the Manage Timings rule with `notFound()` after the ownership check. The menu is not a control on its own: the URL is linkable and survives a refresh. `generateMetadata` already gated the offering title on `planOwnerIds`; that stays, and the counterparty gate joins it so a route that 404s never gets a titled tab either. Only the two 1:1 kinds need the extra slot read and only they pay for it, and it goes through `React.cache` so metadata and body share one query. The slots are fetched in the page rather than widened into `ManageTimingsTarget` deliberately, to stay clear of #1075, which is editing that file concurrently.

## Not in scope

**Whether an attendee may refund out of a booking that has been unscheduled is an open question.** If a consultant withdraws the date of a webinar someone paid for, it is arguable that the attendee should be able to take their money back rather than wait for a date that may not suit them. That is a consumer-protection decision rather than an engineering one, it has not been made, and nothing here builds toward either answer: there is no refund affordance on the unschedule path and no policy hook waiting for one. It needs a decision before this ships to consultants at scale.

The route's existing 24-hour floor applies to Unschedule unchanged, since it is the same route: an event starting within 24 hours cannot be unscheduled and the API returns a 400. The menu does not pre-empt that, exactly as it does not for Reschedule today, so the consultant meets it as an error rather than as a hidden action. Duplicating `MINIMUM_HOURS_BEFORE_RESCHEDULE` into the client to hide the item would put the policy in two places, which is worse.

The proposal protocol, the auto-confirm asymmetry and the single round are all untouched, as is the `MANAGE_TIMINGS` policy itself — `minLeadHours: 0` and "no counterparty" remain correct for the surface's real use. There is no schema change and no migration. The consultant's menu still offers a trial neither Timings nor Reschedule, because the reschedule API has no `TRIAL` branch and returns 403 for one; that gap predates this change. Group-event *cancellation* still notifies nobody; that is #1081, not this.

## Also in this PR — two bugs on the notification surface

Neither belongs to the Manage Timings story. Both were found while looking at it, this branch already owns the reschedule route that causes the first, and there are more open branches than is useful right now, so they ride here as two separate commits rather than as a third pull request.

### A reschedule with no new time rendered "from&nbsp;&nbsp;to"

A reschedule notification reached the consultant's inbox with both of its times missing, reading "rescheduled … from  to". `AppointmentRescheduledPayload` declared `oldDateTime?` and `newDateTime?`, the reschedule route passed neither, and the template interpolated both anyway.

Passing two values would not have been the fix, because the sentence itself is wrong for the common case. A plain release has no destination — that is the entire point of "Any time works", where the released slots go back to the consultant's queue and no new time exists yet. Only an auto-confirmed proposal has actually moved anything. Between those two sits a third case the route already distinguishes in its own response message, which is a proposal that has been made and is still waiting for the other party to answer.

The payload now carries an `outcome` of `MOVED`, `PROPOSED` or `RELEASED`, and its arms are a union rather than a bag of optional fields: `MOVED` and `PROPOSED` cannot be constructed without both times, so the blank-blank payload that produced the screenshot is a compile error rather than a rendering accident. One workflow id with a variant flag in the payload is the idiom the enterprise workflows already use, where `reminderStage` drives the dunning copy and `kind` separates a rejected payout from a reversed one, so no second workflow id was minted.

`rescheduleNotificationVariant` in `lib/booking/reschedule-proposals.ts` derives the variant, which keeps the route a caller and makes the rule unit-testable without a database. The released time is captured inside the transaction rather than read back afterwards, because an auto-confirm deletes those slot rows and writes new ones — by the time the notification is assembled, the time being given up exists nowhere else.

### What still has to change in Novu

The `appointment-rescheduled` template lives in the Novu dashboard and not in this repository, so **this PR cannot fix the rendered sentence on its own**. What it does is make the payload carry enough for the template to tell the three cases apart. The dashboard template has to branch on the discriminator:

```liquid
{% if payload.outcome == "MOVED" %}
  Your {{payload.appointmentType}} moved from {{payload.oldDateTime}} to {{payload.newDateTime}}.
{% elsif payload.outcome == "PROPOSED" %}
  {{payload.consulteeName}} asked to move your {{payload.appointmentType}} from {{payload.oldDateTime}} to {{payload.newDateTime}}.
{% else %}
  Your {{payload.appointmentType}} was released and is awaiting a new time.
{% endif %}
```

The `RELEASED` branch must not reference `newDateTime` at all: the payload does not carry the key, and it is absent rather than `undefined` so that nothing serializes into the interpolation. `oldDateTime` is present on `RELEASED` too in every ordinary case and may be used as colour, but the branch must still read correctly without it, since a booking with no placed slots supplies none.

Until that template change lands, the auto-confirmed case renders real times where it rendered two blanks, and the released case still renders the wrong sentence. Merging this alone does not close the bug.

### The same shape elsewhere in `lib/novu`

A payload field that is declared optional and then passed by no caller is a pattern rather than a one-off, so every optional field on every payload in `lib/novu/workflows.ts` and `lib/novu/org-workflows.ts` was checked against its call sites. Four fields are never passed by anyone.

`AppointmentRescheduledPayload.oldDateTime` and `newDateTime` are the bug above. `SupportTicketPayload.respondedBy` is the same shape one subsystem over — a template naming the staff member who replied had nothing to name — and it is fixed here, since the responder is already loaded on the row the route just created. `AppointmentPayload.dateTime` is missing from `notifyAppointmentBooked` in the payment webhook handler and from both `notifyAppointmentCompleted` calls in the auto-complete sweep; neither is fixed here. The booked one needs a slot read added to a select that #734 deliberately trimmed, in a payments file another branch is currently editing, and the completed ones need the sweep's slot bookkeeping changed to keep the row rather than only its end time. The reminder path, which is the one where a missing date would be most obviously wrong, does pass it.

Every other optional field is passed by at least one caller.

### The Inbox panel sat on top of the calendar

The notification panel covered the Friday and Saturday columns of the slot grid entirely at a normal laptop width. Two things put it there. It was Novu's own bundled popover, fixed at 400px on a bespoke z-index of 9999 with no collision handling, and its open state belonged to Novu, so clicking a notification routed the user to the page that notification was about and then stayed open on top of it. The panel a consultant found over their calendar was usually the one that had just sent them there.

Given children, Novu's `Inbox` drops to being a provider and exposes `Bell` and `InboxContent` as composition parts, which makes the panel ours to place. It is now the repo's Radix popover from `components/ui/popover`, so it gets collision-aware placement, a size capped against the viewport on both axes, Escape and outside-click dismissal, and the shared `z-[1200]` layer instead of a number picked to beat everything else on the page. Because the open state is ours, the panel closes before routing. It is also narrower, at 22rem against the old 25rem, which leaves more of the grid legible while it is open.

This is presentational and nothing about the notification data flow moved. The subscriber, the ADR 23 scope tabs, the appearance variables and the click-to-route behaviour are all unchanged. The two appearance keys that styled Novu's popover are dropped because that popover no longer renders, and `bellContainer` goes with them, because a custom `renderBell` has always bypassed the container it styled.

## Verification

`tsc --noEmit` is clean from a cold build (cache cleared, 8 GB heap). `eslint` is clean on all nine changed files. Prettier is clean on every changed file but three; the three the notification commits touch — the reschedule route, the staff support-response route and the Inbox component — were already Prettier-dirty on `dev` before this branch existed, and running `--write` over them would reformat unrelated lines, so the added code is hand-formatted to match what Prettier would emit and the pre-existing drift is left where it was. Jest goes from 192 suites / 2166 tests on the untouched branch, to 193 / 2178 after the first commit, to 193 / 2185 after the second, and to **194 suites / 2199 tests** here — all passing, no regressions. The extra suite is not one of ours: it arrived with the `dev` merge that brought #1079 onto this branch. The nineteen new tests cover each case in the rule, the mutual exclusivity of Timings and Reschedule across all of them, the in-flight exception, the upcoming-slots filter, and for Unschedule: that a confirmed webinar and a confirmed class each offer Timings and Unschedule but not Reschedule, that a never-scheduled offering and an already-unscheduled event offer Timings but not Unschedule, that a part-released class still offers it while any session is placed, that a confirmed 1:1 offers Reschedule and neither other action, and that Unschedule never appears for any 1:1 kind whatever its slots look like.

Four further tests cover the reschedule payload: an auto-confirmed proposal carries both times as `MOVED`, an unanswered one carries the same pair as `PROPOSED`, a plain release carries `RELEASED` with the released time and no `newDateTime` key at all, and a reschedule with no released time to report degrades to `RELEASED` rather than half-filling the other sentence.

One caveat on the Inbox change. The instruction for this work was no dev server, so the panel has been verified by type-checking, linting and reading Novu's composition API — `Inbox` with children mounts the provider only, `Bell` with a custom `renderBell` renders no button of its own so nothing nests inside the trigger, and `InboxContent` carries the tabs through context — but not by opening it in a browser. It wants one look before merge.

Closes #1082



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Unschedule for eligible webinar and class bookings, with confirmation messaging that distinguishes it from cancellation.
  * Improved appointment actions by showing Manage Timings or Reschedule based on booking status and upcoming time slots.
  * Added safeguards preventing Manage Timings access when committed upcoming sessions exist.
  * Enhanced rescheduling notifications with clearer moved, proposed, and released outcomes and relevant times.
  * Staff response notifications now include the responder’s name.
  * Improved notification inbox behavior, placement, and unread-count presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->