### PR TITLE
fix(observability): Sentry noise — CefSharp filter + checkout double-book

### DIFF
--- a/lib/errors/classification/payment-error-classification.ts
+++ b/lib/errors/classification/payment-error-classification.ts
@@ -59,6 +59,11 @@ export const BUSINESS_ERROR_PATTERNS: ReadonlyArray<{
   { pattern: "has not been scheduled", errorType: ErrorTypes.AVAILABILITY },
   { pattern: "currently booking", errorType: ErrorTypes.AVAILABILITY },
   { pattern: "currently checking out", errorType: ErrorTypes.AVAILABILITY },
+  // Consultee double-book (FAMILIARISE_WEB-P) — message has no "slot" substring.
+  {
+    pattern: "already have a session booked",
+    errorType: ErrorTypes.AVAILABILITY,
+  },
   { pattern: "slot", errorType: ErrorTypes.AVAILABILITY },
   { pattern: "availability", errorType: ErrorTypes.AVAILABILITY },
   { pattern: "capacity", errorType: ErrorTypes.AVAILABILITY },

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -3026,6 +3026,7 @@ export async function handleCheckout(
         "ended",
         "not been scheduled",
         "already have a pending or active subscription",
+        "already have a session booked", // consultee double-book (FAMILIARISE_WEB-P)
         "overlapping dates",
         "insufficient credits",
         "session cap", // ProgramAssignmentLimitError-derived message, above
@@ -3073,6 +3074,7 @@ export async function handleCheckout(
           "ended",
           "not been scheduled",
           "already have a pending or active subscription",
+          "already have a session booked", // consultee double-book (FAMILIARISE_WEB-P)
           "overlapping dates",
           "insufficient credits",
         ];
@@ -3094,8 +3096,9 @@ export async function handleCheckout(
     // calculateAmountAndValidate/acquireCheckoutLock/revalidateInsideLock
     // (steps 1-3, above the STEP-5 try/catch that already reports) which
     // otherwise reach here uncaptured. Lock contention is a modelled,
-    // expected race between two concurrent checkouts; anything else here is
-    // unclassified and reported as a fault by default.
+    // expected race between two concurrent checkouts; consultee double-book
+    // from revalidateInsideLock is the same class of rejection (FAMILIARISE_WEB-P).
+    // Anything else here is unclassified and reported as a fault by default.
     const isLockContention =
       error instanceof Error &&
       (error.message.includes("currently checking out") ||
@@ -3109,7 +3112,13 @@ export async function handleCheckout(
     const isModeledLockRace =
       isLockContention ||
       (error instanceof Error && error.message.includes("already in progress"));
-    reportSentryError(error, { subsystem: "payments", expected: isModeledLockRace });
+    const isConsulteeDoubleBook =
+      error instanceof Error &&
+      error.message.includes("already have a session booked");
+    reportSentryError(error, {
+      subsystem: "payments",
+      expected: isModeledLockRace || isConsulteeDoubleBook,
+    });
     // Enhanced error handling with lock-specific errors
     if (isLockContention) {
       throw new Error(

--- a/lib/payments/operations/checkout.ts
+++ b/lib/payments/operations/checkout.ts
@@ -3114,7 +3114,7 @@ export async function handleCheckout(
       (error instanceof Error && error.message.includes("already in progress"));
     const isConsulteeDoubleBook =
       error instanceof Error &&
-      error.message.includes("already have a session booked");
+      error.message.toLowerCase().includes("already have a session booked");
     reportSentryError(error, {
       subsystem: "payments",
       expected: isModeledLockRace || isConsulteeDoubleBook,

--- a/sentry.shared.config.ts
+++ b/sentry.shared.config.ts
@@ -42,10 +42,17 @@ export function initSentry(overrides?: Partial<SentryInitOptions>): void {
     //   away mid-stream (react-server-dom-webpack). (FAMILIARISE_WEB-E)
     // - "func ... not found" / inpage.js — injected browser wallet extensions
     //   throwing inside their own provider bridge on our pages. (FAMILIARISE_WEB-F)
+    // - "Object Not Found Matching Id" — CefSharp / Outlook Safe Links bots
+    //   rejecting non-Error promises while scanning our pages. (FAMILIARISE_WEB-Y)
     // Do NOT add the Prisma pooler-timeout strings here: route-level fail-open
     // already degrades them to breadcrumbs, and they must stay visible so a NEW
     // unprotected route surfacing them is still detectable. (#932)
-    ignoreErrors: ["Connection closed.", /func .* not found/, /inpage\.js/],
+    ignoreErrors: [
+      "Connection closed.",
+      /func .* not found/,
+      /inpage\.js/,
+      /Object Not Found Matching Id/i,
+    ],
 
     // Events whose top stack frame originates in an injected extension script
     // are never our code — drop them regardless of message.


### PR DESCRIPTION
## Summary
- Filter CefSharp / Outlook Safe Links `Object Not Found Matching Id` UnhandledRejection noise in shared Sentry `ignoreErrors` (**FAMILIARISE_WEB-Y**).
- Classify consultee double-book (`already have a session booked`) as an expected AVAILABILITY outcome in checkout reporting + payment error classification (**FAMILIARISE_WEB-P**).
- Triaged other unresolved issues: **W/V/T/R/Q** are stale pre-`sessionsPerWeek` rename drift (already fixed on prod); **N/H/M** are Resend / waitlist env ops; **G** is a separate N+1 follow-up.

## Test plan
- [ ] Confirm `sentry.shared.config.ts` ignoreErrors includes `/Object Not Found Matching Id/i` and still keeps E/F filters
- [ ] Checkout a consultation/subscription slot that overlaps an existing consultee booking → user-facing AVAILABILITY error, Sentry event tagged `expected:true` (info), not a new error issue
- [ ] After deploy, confirm FAMILIARISE_WEB-Y stops recurring; resolve W/V/T/R/Q in Sentry if not already resolved


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkout handling for cases where a consultee already has a booked session, preventing these expected availability conflicts from being reported as system faults.
  - Preserved clearer error messaging for double-booking scenarios.
  - Reduced noise from known CefSharp/Outlook Safe Links “Object Not Found Matching Id” errors in monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->