### PR TITLE
perf: cut dashboard nav TTFB via session cache and slim reads

### DIFF
--- a/__tests__/dashboards/consultant-home-read-shape.test.ts
+++ b/__tests__/dashboards/consultant-home-read-shape.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * #1101 — pins the three consultant-Home read regressions that shipped inside a
+ * perf change and produced quietly-wrong numbers rather than errors.
+ *
+ * These are asserted here rather than on the deploy preview because the dev
+ * database cannot reproduce any of them: its busiest consultant has 10
+ * appointments (the display cap is 20) and there are 4 pending requests
+ * platform-wide (the old badge cap was 40). Clicking through the preview
+ * renders green on both the buggy and the fixed code.
+ */
+
+import prisma from "@/lib/prisma";
+import { getConsultantDashboard } from "@/lib/data/consultant-dashboard";
+
+jest.mock("../../lib/prisma", () => ({
+  __esModule: true,
+  default: {
+    slotOfAppointment: { findMany: jest.fn(), groupBy: jest.fn() },
+    appointment: { findMany: jest.fn() },
+    consultation: { findMany: jest.fn(), count: jest.fn() },
+    subscription: { findMany: jest.fn(), count: jest.fn() },
+    activityLog: { findMany: jest.fn() },
+    consultantEarnings: { aggregate: jest.fn() },
+    consultantReview: { aggregate: jest.fn() },
+    trialSession: { groupBy: jest.fn() },
+  },
+}));
+
+const slotFindMany = prisma.slotOfAppointment.findMany as jest.Mock;
+const apptFindMany = prisma.appointment.findMany as jest.Mock;
+const consultationCount = prisma.consultation.count as jest.Mock;
+const subscriptionCount = prisma.subscription.count as jest.Mock;
+
+describe("consultant Home read shape (#1101)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    slotFindMany.mockResolvedValue([]);
+    apptFindMany.mockResolvedValue([]);
+    consultationCount.mockResolvedValue(0);
+    subscriptionCount.mockResolvedValue(0);
+    (prisma.slotOfAppointment.groupBy as jest.Mock).mockResolvedValue([]);
+    (prisma.consultation.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.subscription.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.activityLog.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.trialSession.groupBy as jest.Mock).mockResolvedValue([]);
+    (prisma.consultantEarnings.aggregate as jest.Mock).mockResolvedValue({
+      _sum: { consultantSharePaise: null, refundedShareAmount: null },
+    });
+    (prisma.consultantReview.aggregate as jest.Mock).mockResolvedValue({
+      _avg: { rating: null },
+      _count: { rating: 0 },
+    });
+  });
+
+  it("ranks Home appointments by slot time anchored at today, not by createdAt", async () => {
+    await getConsultantDashboard("cp-1").catch(() => undefined);
+
+    expect(slotFindMany).toHaveBeenCalledTimes(1);
+    const args = slotFindMany.mock.calls[0][0];
+
+    // Ordering must key off the slot clock. `createdAt` truncated on the wrong
+    // key: a consultant who booked next month a fortnight ago and then took a
+    // burst of bookings for last week got 20 all-past rows.
+    expect(args.orderBy).toEqual({ startsAt: "asc" });
+
+    // ...and the window must be anchored at the PRESENT. Ordering ascending
+    // from a lower bound in the past returns the OLDEST slots, which
+    // reproduces the same empty Today/Upcoming widgets in a new disguise.
+    expect(args.where.endsAt?.gte).toBeInstanceOf(Date);
+    expect(args.where.startsAt).toBeUndefined();
+    const anchor: Date = args.where.endsAt.gte;
+    const now = new Date();
+    expect(anchor.getTime()).toBeLessThanOrEqual(now.getTime());
+    // Start-of-today, so a session already running today survives.
+    expect(anchor.getHours()).toBe(0);
+    expect(anchor.getMinutes()).toBe(0);
+    expect(now.getTime() - anchor.getTime()).toBeLessThan(24 * 60 * 60 * 1000);
+
+    // Tombstoned slots must not steer the ranking.
+    expect(args.where.deletedAt).toBeNull();
+  });
+
+  it("counts pending requests with count(), uncapped, so the badge cannot disagree with NeedsYou", async () => {
+    // More pending than any list cap: the old badge read `approvals.length`
+    // off a capped list and contradicted NeedsYou on the same screen.
+    consultationCount.mockResolvedValue(37);
+    subscriptionCount.mockResolvedValue(18);
+
+    const result = await getConsultantDashboard("cp-1");
+
+    expect(result.pendingRequestsCount).toBe(55);
+
+    // NeedsYou counts every pending request regardless of age, so these must
+    // not inherit the list's 90-day bound or the two numbers drift apart.
+    for (const call of [
+      consultationCount.mock.calls[0][0],
+      subscriptionCount.mock.calls[0][0],
+    ]) {
+      expect(call.where.status).toBe("PENDING");
+      expect(call.where.requestedAt).toBeUndefined();
+    }
+  });
+
+  it("derives active clients from a dedicated query, not the truncated display list", async () => {
+    // Display list is capped; the active book is not. Deriving counts from the
+    // capped array under-reported Financial Summary for any real consultant.
+    const activeBook = Array.from({ length: 64 }, (_, i) => ({
+      consultation: { requestedBy: { id: `consultee-${i}` } },
+      subscription: null,
+      class: null,
+    }));
+
+    apptFindMany.mockImplementation((args: { select?: unknown }) =>
+      // The active-book read is the `select` one; the display read uses `include`.
+      Promise.resolve(args.select ? activeBook : []),
+    );
+
+    const result = await getConsultantDashboard("cp-1");
+
+    expect(result.financialSummary.activeClients).toBe(64);
+
+    const activeBookCall = apptFindMany.mock.calls.find((c) => c[0].select);
+    expect(activeBookCall).toBeDefined();
+    // No cap on the counting read.
+    expect(activeBookCall![0].take).toBeUndefined();
+    // Soft-deleted slots must not keep an appointment counted as active.
+    for (const clause of activeBookCall![0].where.AND) {
+      expect(clause.slotsOfAppointment.some.deletedAt).toBeNull();
+    }
+  });
+});

--- a/actions/forms/onboarding.action.ts
+++ b/actions/forms/onboarding.action.ts
@@ -68,13 +68,11 @@ export async function updateOnboardingInformationAction(
   }
 
   // Use the central processing function
-  const result = await processOnboardingData(userId, body);
-  // Refresh Better Auth cookie cache so requireOnboarded() (cookie-cached
-  // layout gate) sees onboardingCompleted / profile ids immediately.
-  if (result.success) {
-    await getSession(true);
-  }
-  return result;
+  // No cookie-cache refresh here: requireOnboarded() reads force-fresh, so it
+  // already sees onboardingCompleted / profile ids. A refresh would also be the
+  // wrong tool — getSession reads the CALLER's headers, and this action lets an
+  // ADMIN/STAFF update someone else, whose session it could not refresh anyway.
+  return processOnboardingData(userId, body);
 }
 // #endregion
 
@@ -139,8 +137,6 @@ export async function setOnboardingRoleAction(
     },
   });
 
-  // Refresh cookie cache so subsequent layout/API reads see the new role.
-  await getSession(true);
   return { success: true };
 }
 
@@ -167,8 +163,5 @@ export async function completeOrgWorkspaceOnboardingAction(
     data: { onboardingCompleted: true },
   });
 
-  // Refresh cookie cache so /dashboard requireOnboarded() does not bounce
-  // back to onboarding on a stale onboardingCompleted=false cookie.
-  await getSession(true);
   return { success: true };
 }

--- a/actions/forms/onboarding.action.ts
+++ b/actions/forms/onboarding.action.ts
@@ -68,7 +68,13 @@ export async function updateOnboardingInformationAction(
   }
 
   // Use the central processing function
-  return await processOnboardingData(userId, body);
+  const result = await processOnboardingData(userId, body);
+  // Refresh Better Auth cookie cache so requireOnboarded() (cookie-cached
+  // layout gate) sees onboardingCompleted / profile ids immediately.
+  if (result.success) {
+    await getSession(true);
+  }
+  return result;
 }
 // #endregion
 
@@ -133,6 +139,8 @@ export async function setOnboardingRoleAction(
     },
   });
 
+  // Refresh cookie cache so subsequent layout/API reads see the new role.
+  await getSession(true);
   return { success: true };
 }
 
@@ -159,5 +167,8 @@ export async function completeOrgWorkspaceOnboardingAction(
     data: { onboardingCompleted: true },
   });
 
+  // Refresh cookie cache so /dashboard requireOnboarded() does not bounce
+  // back to onboarding on a stale onboardingCompleted=false cookie.
+  await getSession(true);
   return { success: true };
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/earnings/EarningsTabs.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/earnings/EarningsTabs.tsx
@@ -1,8 +1,20 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { UrlTabs } from "@/components/dashboard/UrlTabs";
-import AnalyticsPageClient from "../analytics/AnalyticsPageClient";
 import { EarningsSummaryPanel } from "./EarningsSummaryPanel";
+
+const AnalyticsPageClient = dynamic(
+  () => import("../analytics/AnalyticsPageClient"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+        Loading analytics…
+      </div>
+    ),
+  },
+);
 
 /**
  * Earnings, with Analytics as its second panel.
@@ -13,6 +25,9 @@ import { EarningsSummaryPanel } from "./EarningsSummaryPanel";
  * is the pattern the rule exists to stop. Both panels keep their own filter and
  * pagination state, deliberately: they answer different questions and resetting
  * one when the other moves would be surprising.
+ *
+ * Analytics (recharts) is code-split so the Summary tab does not pay for the
+ * charting library on first paint.
  */
 export function EarningsTabs({
   consultantId,

--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomePageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomePageClient.tsx
@@ -84,7 +84,7 @@ export default function HomePageClient({
         appointments={dashboardData.appointments}
         consultantId={consultantId}
         consultantName={consultantName}
-        pendingRequestsCount={dashboardData.approvals?.length ?? 0}
+        pendingRequestsCount={dashboardData.pendingRequestsCount ?? 0}
         performanceSnapshot={dashboardData.performanceSnapshot}
         financialSummary={dashboardData.financialSummary}
       />

--- a/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
@@ -26,12 +26,12 @@ export default async function HomePage({ params }: Readonly<PageProps>) {
   // the VIEWER's memberships, which are not the profile owner's, so it would
   // answer a question nobody asked. Failure is non-fatal — the card is
   // supplementary and the page must not 500 because a count timed out.
-  let needsYou: NeedsYouSummary | null = null;
-  if (!access.isInspecting) {
-    needsYou = await getNeedsYouSummary(access.userId, consultantId).catch(
-      () => null,
-    );
-  }
+  //
+  // Run NeedsYou in parallel with the dashboard prefetch — they share no
+  // dependency and sequential awaits previously paid two full TTFB chains.
+  const needsYouPromise: Promise<NeedsYouSummary | null> = access.isInspecting
+    ? Promise.resolve(null)
+    : getNeedsYouSummary(access.userId, consultantId).catch(() => null);
 
   // #890 — SSR prefetch the dashboard so the client useQuery hydrates
   // without a fetch waterfall. Key MUST match
@@ -40,11 +40,14 @@ export default async function HomePage({ params }: Readonly<PageProps>) {
   // only), so there is a single deterministic payload to prefetch.
   // allSettled so a read failure degrades to a client-side fetch rather
   // than crashing the route.
-  await Promise.allSettled([
-    queryClient.prefetchQuery({
-      queryKey: ["consultant-dashboard", consultantId],
-      queryFn: () => getConsultantDashboard(consultantId),
-    }),
+  const [, needsYou] = await Promise.all([
+    Promise.allSettled([
+      queryClient.prefetchQuery({
+        queryKey: ["consultant-dashboard", consultantId],
+        queryFn: () => getConsultantDashboard(consultantId),
+      }),
+    ]),
+    needsYouPromise,
   ]);
 
   return (

--- a/app/dashboard/consultee/[consulteeId]/(features)/home/HomePageClient.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/home/HomePageClient.tsx
@@ -33,8 +33,9 @@ export default function HomePageClient({
 
   const eventsQuery = {
     ...createConsulteeQueries(consulteeId, orgScopeParam).events,
-    // Show stale data immediately while fetching in background
-    staleTime: 0,
+    // Keep SSR-dehydrated events warm long enough to avoid an immediate
+    // refetch waterfall on first paint (aligned with dashboard staleTimes).
+    staleTime: 60_000,
     refetchOnWindowFocus: false,
   };
   const { data: eventsData, isLoading, error, refetch } = useQuery(eventsQuery);

--- a/app/dashboard/consultee/[consulteeId]/(features)/home/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/home/page.tsx
@@ -6,11 +6,34 @@ import {
 import HomePageClient from "./HomePageClient";
 import { readConsulteeEvents } from "@/lib/data/consultee-events-read";
 import { requirePersonalProfileAccess } from "@/lib/auth/personal-dashboard-access";
+import { getSession } from "@/lib/auth-server";
+import type { Scope } from "@/lib/api/scope/parse";
 
 type PageProps = {
   params: Promise<{ consulteeId: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+/**
+ * Mirror useOrgScope({ defaultForOrgMember: "all" }) when the URL has no
+ * ?orgScope= — otherwise SSR dehydrates "personal" and org members immediately
+ * refetch "all".
+ */
+function defaultHomeScope(session: Awaited<ReturnType<typeof getSession>>): Scope {
+  const role = session?.user?.role;
+  const firstOrgId =
+    session?.user?.organizationMemberships?.[0]?.organizationId ?? null;
+  if (role === "ADMIN" || role === "STAFF" || firstOrgId) {
+    return { kind: "all" };
+  }
+  return { kind: "personal" };
+}
+
+function scopeQueryKey(scope: Scope): string {
+  if (scope.kind === "personal") return "personal";
+  if (scope.kind === "all") return "all";
+  return scope.orgId;
+}
 
 export default async function HomePage({ params }: Readonly<PageProps>) {
   const { consulteeId } = await params;
@@ -18,19 +41,21 @@ export default async function HomePage({ params }: Readonly<PageProps>) {
   // component, so its check runs after this server render has already read
   // and streamed the data. See lib/auth/personal-dashboard-access.ts.
   await requirePersonalProfileAccess("consultee", consulteeId);
+  // Shares React.cache with the access guard / dashboard layout.
+  const session = await getSession();
+  const scope = defaultHomeScope(session);
+  const scopeKey = scopeQueryKey(scope);
   const queryClient = new QueryClient();
 
-  // #890 — SSR prefetch the default (personal) scope so the client
-  // useQuery hydrates without a fetch waterfall. Key base MUST match
+  // #890 — SSR prefetch the same default scope the client useQuery asks for
+  // so hydration hits. Key base MUST match
   // createConsulteeQueries(...).events: ["consultee-events", id, scope].
-  // The route's default (no ?orgScope=) is `personal`, so the scope
-  // segment is the literal "personal" and the read runs with that scope.
   // allSettled so a read failure degrades to a client-side fetch rather
   // than crashing the route.
   await Promise.allSettled([
     queryClient.prefetchQuery({
-      queryKey: ["consultee-events", consulteeId, "personal"],
-      queryFn: () => readConsulteeEvents(consulteeId, { kind: "personal" }),
+      queryKey: ["consultee-events", consulteeId, scopeKey],
+      queryFn: () => readConsulteeEvents(consulteeId, scope),
     }),
   ]);
 

--- a/app/form/onboarding/page.tsx
+++ b/app/form/onboarding/page.tsx
@@ -16,21 +16,62 @@ import { useToast } from "@/hooks/use-toast";
 import { signOut, useSession } from "@/lib/auth-client";
 import { getPendingReferral, clearPendingReferral } from "@/lib/pending-referral";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import React, { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import ConsultantPreferredScheduleForm from "./components/ConsultantPreferredScheduleForm";
-import ConsultantProfessionalStep from "./components/ConsultantProfessionalStep";
-import ConsultantAgreementAndVerificationStep from "./components/ConsultantAgreementAndVerificationStep";
-import ConsultantReviewForm from "./components/ConsultantReviewForm";
-import ConsulteeAgreementForm from "./components/ConsulteeAgreementForm";
-import ConsulteeProfileForm from "./components/ConsulteeProfileForm";
-import ConsulteeReviewForm from "./components/ConsulteeReviewForm";
+// Step 0 stays eager — every user sees Personal Info first.
 import PersonalInfoAndRoleForm from "./components/PersonalInfoAndRoleForm";
-import StaffAgreementForm from "./components/StaffAgreementForm";
-import StaffProfileForm from "./components/StaffProfileForm";
-import StaffReviewForm from "./components/StaffReviewForm";
-import { CreateOrganizationWizard } from "@/components/organization/create-wizard/Wizard";
+
+// Later steps + org wizard are code-split so the initial onboarding chunk
+// does not pay for schedule UI, review forms, or the create-org wizard.
+const ConsultantPreferredScheduleForm = dynamic(
+  () => import("./components/ConsultantPreferredScheduleForm"),
+  { ssr: false },
+);
+const ConsultantProfessionalStep = dynamic(
+  () => import("./components/ConsultantProfessionalStep"),
+  { ssr: false },
+);
+const ConsultantAgreementAndVerificationStep = dynamic(
+  () => import("./components/ConsultantAgreementAndVerificationStep"),
+  { ssr: false },
+);
+const ConsultantReviewForm = dynamic(
+  () => import("./components/ConsultantReviewForm"),
+  { ssr: false },
+);
+const ConsulteeAgreementForm = dynamic(
+  () => import("./components/ConsulteeAgreementForm"),
+  { ssr: false },
+);
+const ConsulteeProfileForm = dynamic(
+  () => import("./components/ConsulteeProfileForm"),
+  { ssr: false },
+);
+const ConsulteeReviewForm = dynamic(
+  () => import("./components/ConsulteeReviewForm"),
+  { ssr: false },
+);
+const StaffAgreementForm = dynamic(
+  () => import("./components/StaffAgreementForm"),
+  { ssr: false },
+);
+const StaffProfileForm = dynamic(
+  () => import("./components/StaffProfileForm"),
+  { ssr: false },
+);
+const StaffReviewForm = dynamic(
+  () => import("./components/StaffReviewForm"),
+  { ssr: false },
+);
+const CreateOrganizationWizard = dynamic(
+  () =>
+    import("@/components/organization/create-wizard/Wizard").then((m) => ({
+      default: m.CreateOrganizationWizard,
+    })),
+  { ssr: false },
+);
 
 // Step labels for progress indicator
 const STEP_LABELS = {

--- a/app/form/onboarding/page.tsx
+++ b/app/form/onboarding/page.tsx
@@ -28,7 +28,10 @@ import PersonalInfoAndRoleForm from "./components/PersonalInfoAndRoleForm";
 //
 // Every split step needs `loading` — next/dynamic renders null while the chunk
 // downloads, so without it pressing Next collapses the card to zero height and
-// reads as a frozen app on a slow connection.
+// reads as a frozen app on a slow connection. The options object is repeated
+// inline rather than hoisted to a shared const because SWC statically analyses
+// it: a variable fails the build with "next/dynamic options must be an object
+// literal".
 function StepLoading() {
   return (
     <div className="flex items-center justify-center min-h-[240px]">
@@ -38,54 +41,52 @@ function StepLoading() {
   );
 }
 
-const stepChunk = { ssr: false, loading: () => <StepLoading /> } as const;
-
 const ConsultantPreferredScheduleForm = dynamic(
   () => import("./components/ConsultantPreferredScheduleForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const ConsultantProfessionalStep = dynamic(
   () => import("./components/ConsultantProfessionalStep"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const ConsultantAgreementAndVerificationStep = dynamic(
   () => import("./components/ConsultantAgreementAndVerificationStep"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const ConsultantReviewForm = dynamic(
   () => import("./components/ConsultantReviewForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const ConsulteeAgreementForm = dynamic(
   () => import("./components/ConsulteeAgreementForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const ConsulteeProfileForm = dynamic(
   () => import("./components/ConsulteeProfileForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const ConsulteeReviewForm = dynamic(
   () => import("./components/ConsulteeReviewForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const StaffAgreementForm = dynamic(
   () => import("./components/StaffAgreementForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const StaffProfileForm = dynamic(
   () => import("./components/StaffProfileForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const StaffReviewForm = dynamic(
   () => import("./components/StaffReviewForm"),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 const CreateOrganizationWizard = dynamic(
   () =>
     import("@/components/organization/create-wizard/Wizard").then((m) => ({
       default: m.CreateOrganizationWizard,
     })),
-  stepChunk,
+  { ssr: false, loading: () => <StepLoading /> },
 );
 
 // Step labels for progress indicator

--- a/app/form/onboarding/page.tsx
+++ b/app/form/onboarding/page.tsx
@@ -393,7 +393,8 @@ const MultiStepForm: React.FC = () => {
               <StaffProfileForm
                 onNext={handleNext}
                 onBack={handleBack}
-                initialData={formData as Parameters<typeof StaffProfileForm>[0]["initialData"]}
+                // Dynamic imports widen to ComponentType; keep the runtime shape.
+                initialData={formData as Partial<OnboardingFormData>}
               />
             );
           default:
@@ -414,7 +415,7 @@ const MultiStepForm: React.FC = () => {
               <ConsulteeAgreementForm
                 onNext={handleNext}
                 onBack={handleBack}
-                formData={formData as Parameters<typeof ConsulteeAgreementForm>[0]["formData"]}
+                formData={formData as Partial<OnboardingFormData>}
               />
             );
           case "STAFF":
@@ -422,7 +423,7 @@ const MultiStepForm: React.FC = () => {
               <StaffAgreementForm
                 onNext={handleNext}
                 onBack={handleBack}
-                initialData={formData as Parameters<typeof StaffAgreementForm>[0]["initialData"]}
+                initialData={formData as Partial<OnboardingFormData>}
               />
             );
           default:
@@ -443,7 +444,7 @@ const MultiStepForm: React.FC = () => {
               <ConsulteeReviewForm
                 onSubmit={handleSubmit}
                 onBack={handleBack}
-                formData={formData as Parameters<typeof ConsulteeReviewForm>[0]["formData"]}
+                formData={formData as Partial<OnboardingFormData>}
                 onGoToStep={handleGoToStep}
               />
             );
@@ -452,7 +453,7 @@ const MultiStepForm: React.FC = () => {
               <StaffReviewForm
                 onSubmit={handleSubmit}
                 onBack={handleBack}
-                formData={formData as Parameters<typeof StaffReviewForm>[0]["formData"]}
+                formData={formData as Partial<OnboardingFormData>}
                 onGoToStep={handleGoToStep}
               />
             );

--- a/app/form/onboarding/page.tsx
+++ b/app/form/onboarding/page.tsx
@@ -393,8 +393,8 @@ const MultiStepForm: React.FC = () => {
               <StaffProfileForm
                 onNext={handleNext}
                 onBack={handleBack}
-                // Dynamic imports widen to ComponentType; keep the runtime shape.
-                initialData={formData as Partial<OnboardingFormData>}
+                // Dynamic imports lose prop types; role branch guarantees shape.
+                initialData={formData as never}
               />
             );
           default:
@@ -415,7 +415,7 @@ const MultiStepForm: React.FC = () => {
               <ConsulteeAgreementForm
                 onNext={handleNext}
                 onBack={handleBack}
-                formData={formData as Partial<OnboardingFormData>}
+                formData={formData as never}
               />
             );
           case "STAFF":
@@ -423,7 +423,7 @@ const MultiStepForm: React.FC = () => {
               <StaffAgreementForm
                 onNext={handleNext}
                 onBack={handleBack}
-                initialData={formData as Partial<OnboardingFormData>}
+                initialData={formData as never}
               />
             );
           default:
@@ -444,7 +444,7 @@ const MultiStepForm: React.FC = () => {
               <ConsulteeReviewForm
                 onSubmit={handleSubmit}
                 onBack={handleBack}
-                formData={formData as Partial<OnboardingFormData>}
+                formData={formData as never}
                 onGoToStep={handleGoToStep}
               />
             );
@@ -453,7 +453,7 @@ const MultiStepForm: React.FC = () => {
               <StaffReviewForm
                 onSubmit={handleSubmit}
                 onBack={handleBack}
-                formData={formData as Partial<OnboardingFormData>}
+                formData={formData as never}
                 onGoToStep={handleGoToStep}
               />
             );

--- a/app/form/onboarding/page.tsx
+++ b/app/form/onboarding/page.tsx
@@ -25,52 +25,67 @@ import PersonalInfoAndRoleForm from "./components/PersonalInfoAndRoleForm";
 
 // Later steps + org wizard are code-split so the initial onboarding chunk
 // does not pay for schedule UI, review forms, or the create-org wizard.
+//
+// Every split step needs `loading` — next/dynamic renders null while the chunk
+// downloads, so without it pressing Next collapses the card to zero height and
+// reads as a frozen app on a slow connection.
+function StepLoading() {
+  return (
+    <div className="flex items-center justify-center min-h-[240px]">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-muted border-t-primary" />
+      <span className="sr-only">Loading this step…</span>
+    </div>
+  );
+}
+
+const stepChunk = { ssr: false, loading: () => <StepLoading /> } as const;
+
 const ConsultantPreferredScheduleForm = dynamic(
   () => import("./components/ConsultantPreferredScheduleForm"),
-  { ssr: false },
+  stepChunk,
 );
 const ConsultantProfessionalStep = dynamic(
   () => import("./components/ConsultantProfessionalStep"),
-  { ssr: false },
+  stepChunk,
 );
 const ConsultantAgreementAndVerificationStep = dynamic(
   () => import("./components/ConsultantAgreementAndVerificationStep"),
-  { ssr: false },
+  stepChunk,
 );
 const ConsultantReviewForm = dynamic(
   () => import("./components/ConsultantReviewForm"),
-  { ssr: false },
+  stepChunk,
 );
 const ConsulteeAgreementForm = dynamic(
   () => import("./components/ConsulteeAgreementForm"),
-  { ssr: false },
+  stepChunk,
 );
 const ConsulteeProfileForm = dynamic(
   () => import("./components/ConsulteeProfileForm"),
-  { ssr: false },
+  stepChunk,
 );
 const ConsulteeReviewForm = dynamic(
   () => import("./components/ConsulteeReviewForm"),
-  { ssr: false },
+  stepChunk,
 );
 const StaffAgreementForm = dynamic(
   () => import("./components/StaffAgreementForm"),
-  { ssr: false },
+  stepChunk,
 );
 const StaffProfileForm = dynamic(
   () => import("./components/StaffProfileForm"),
-  { ssr: false },
+  stepChunk,
 );
 const StaffReviewForm = dynamic(
   () => import("./components/StaffReviewForm"),
-  { ssr: false },
+  stepChunk,
 );
 const CreateOrganizationWizard = dynamic(
   () =>
     import("@/components/organization/create-wizard/Wizard").then((m) => ({
       default: m.CreateOrganizationWizard,
     })),
-  { ssr: false },
+  stepChunk,
 );
 
 // Step labels for progress indicator
@@ -393,8 +408,7 @@ const MultiStepForm: React.FC = () => {
               <StaffProfileForm
                 onNext={handleNext}
                 onBack={handleBack}
-                // Dynamic imports lose prop types; role branch guarantees shape.
-                initialData={formData as never}
+                initialData={formData}
               />
             );
           default:
@@ -415,7 +429,7 @@ const MultiStepForm: React.FC = () => {
               <ConsulteeAgreementForm
                 onNext={handleNext}
                 onBack={handleBack}
-                formData={formData as never}
+                formData={formData}
               />
             );
           case "STAFF":
@@ -423,7 +437,7 @@ const MultiStepForm: React.FC = () => {
               <StaffAgreementForm
                 onNext={handleNext}
                 onBack={handleBack}
-                initialData={formData as never}
+                initialData={formData}
               />
             );
           default:
@@ -444,7 +458,7 @@ const MultiStepForm: React.FC = () => {
               <ConsulteeReviewForm
                 onSubmit={handleSubmit}
                 onBack={handleBack}
-                formData={formData as never}
+                formData={formData}
                 onGoToStep={handleGoToStep}
               />
             );
@@ -453,7 +467,7 @@ const MultiStepForm: React.FC = () => {
               <StaffReviewForm
                 onSubmit={handleSubmit}
                 onBack={handleBack}
-                formData={formData as never}
+                formData={formData}
                 onGoToStep={handleGoToStep}
               />
             );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
 import {
   ChevronDown,
   Menu,
@@ -347,22 +346,16 @@ function DesktopDropdownPanel({
   const panelGrid = isWide ? "grid-cols-3" : "grid-cols-2";
 
   return (
-    <motion.div
+    <div
       id={panelId}
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 8 }}
-      transition={{ duration: 0.15 }}
       // Mega panels centre on the VIEWPORT (fixed), list panels on their
       // trigger (absolute) — an 860px panel hung off a narrow left-side trigger
       // reads as badly misaligned.
       //
       // Centred with `inset-x-0 mx-auto`, never `left-1/2 -translate-x-1/2`:
-      // motion.div writes an inline `transform` for its y animation, which
-      // beats Tailwind's translate class, so the -50% shift was silently
-      // dropped and the panel sat half a viewport to the right. Margin centring
-      // can't be clobbered by a transform.
-      className={`inset-x-0 mx-auto bg-popover rounded-xl shadow-xl border border-border overflow-hidden z-[1100] ${
+      // a transform-based centre fights other transforms. Margin centring
+      // can't be clobbered.
+      className={`inset-x-0 mx-auto bg-popover rounded-xl shadow-xl border border-border overflow-hidden z-[1100] animate-in fade-in slide-in-from-top-1 duration-150 ${
         isMega
           ? `fixed max-w-[calc(100vw-2rem)] ${panelWidth}`
           : `absolute top-full mt-2 ${panelWidth}`
@@ -420,7 +413,7 @@ function DesktopDropdownPanel({
           </div>
         </div>
       )}
-    </motion.div>
+    </div>
   );
 }
 
@@ -508,15 +501,13 @@ function DesktopNavItem({
           className={`w-3.5 h-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
         />
       </button>
-      <AnimatePresence>
-        {open && (
-          <DesktopDropdownPanel
-            group={group}
-            panelId={panelId}
-            onClose={() => setOpen(false)}
-          />
-        )}
-      </AnimatePresence>
+      {open && (
+        <DesktopDropdownPanel
+          group={group}
+          panelId={panelId}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -734,26 +725,19 @@ const Navbar = () => {
         </div>
       </nav>
 
-      {/* Mobile Drawer */}
-      <AnimatePresence>
-        {isOpen && (
+      {/* Mobile Drawer — CSS transitions only; framer-motion was pulled into
+          every public page via the root navbar for enter/exit polish. */}
+      {isOpen && (
           <>
             {/* Backdrop */}
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[1001] lg:hidden"
+            <div
+              className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[1001] lg:hidden animate-in fade-in duration-150"
               onClick={closeMenu}
             />
 
             {/* Drawer */}
-            <motion.div
-              initial={{ x: "-100%" }}
-              animate={{ x: 0 }}
-              exit={{ x: "-100%" }}
-              transition={{ type: "spring", damping: 25, stiffness: 200 }}
-              className="lg:hidden fixed top-0 left-0 h-full w-[85%] max-w-sm bg-zinc-950 z-[1002] shadow-2xl safe-top safe-bottom safe-left"
+            <div
+              className="lg:hidden fixed top-0 left-0 h-full w-[85%] max-w-sm bg-zinc-950 z-[1002] shadow-2xl safe-top safe-bottom safe-left animate-in slide-in-from-left duration-300"
             >
               {/* Drawer Header */}
               <div className="flex justify-between items-center p-5 border-b border-zinc-800">
@@ -936,10 +920,9 @@ const Navbar = () => {
                   </Button>
                 )}
               </div>
-            </motion.div>
+            </div>
           </>
         )}
-      </AnimatePresence>
     </>
   );
 };

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -729,8 +729,11 @@ const Navbar = () => {
           every public page via the root navbar for enter/exit polish. */}
       {isOpen && (
           <>
-            {/* Backdrop */}
-            <div
+            {/* Backdrop — native button so keyboard/AT get a real interactive
+                control (Sonar typescript:S6848 / S1082). */}
+            <button
+              type="button"
+              aria-label="Close menu"
               className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[1001] lg:hidden animate-in fade-in duration-150"
               onClick={closeMenu}
             />

--- a/components/dashboard/UrlTabs.tsx
+++ b/components/dashboard/UrlTabs.tsx
@@ -73,8 +73,8 @@ export function UrlTabs({
       // page 3 — or on an empty page, if it has fewer.
       params.delete("page");
       const qs = params.toString();
-      const target = `${pathname}${qs ? `?${qs}` : ""}`;
-      const current = `${window.location.pathname}${window.location.search}`;
+      const target = qs ? pathname + "?" + qs : pathname;
+      const current = window.location.pathname + window.location.search;
       if (target !== current) {
         window.history.replaceState(window.history.state, "", target);
       }

--- a/components/dashboard/UrlTabs.tsx
+++ b/components/dashboard/UrlTabs.tsx
@@ -10,18 +10,19 @@
  * state has to be addressable — a plain `defaultValue` would drop the user on
  * the first panel regardless of where they came from.
  *
- * Uses `router.replace` with `scroll: false`: switching a tab is a lateral
- * move, not navigation, so it shouldn't stack history entries or jump the
- * viewport. The browser back button still leaves the page rather than walking
- * back through every tab the user glanced at.
+ * URL writes use `history.replaceState` (not `router.replace`) so switching a
+ * tab does not trigger a Next.js soft navigation / RSC refetch. Local state
+ * keeps the active panel in sync immediately; the address bar stays shareable.
+ * History is not pushed — back still leaves the page rather than walking
+ * every tab glance.
  *
  * Tabs are filtered by `show` so a caller can gate individual panels off the
  * same permission matrix that gates the sidebar — a hidden tab must not render
  * a trigger that 403s when clicked.
  */
 
-import { useCallback } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -42,7 +43,6 @@ export function UrlTabs({
   paramName?: string;
   className?: string;
 }) {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -50,20 +50,36 @@ export function UrlTabs({
   const requested = searchParams?.get(paramName);
   // Fall back to the first visible tab when the param is absent or names a tab
   // this user can't see — a stale bookmark shouldn't render an empty page.
-  const active =
+  const urlActive =
     visible.find((t) => t.value === requested)?.value ?? visible[0]?.value;
+
+  // Local override so replaceState (which does not update useSearchParams)
+  // still flips the panel immediately.
+  const [localActive, setLocalActive] = useState<string | null>(null);
+  const active = localActive ?? urlActive;
+
+  // External URL change (e.g. redirect into ?tab=) wins over a stale local pick.
+  useEffect(() => {
+    setLocalActive(null);
+  }, [requested]);
 
   const onValueChange = useCallback(
     (value: string) => {
+      setLocalActive(value);
       const params = new URLSearchParams(searchParams?.toString() ?? "");
       params.set(paramName, value);
       // Panels that paginate all read the same `?page=`. Without this, moving
       // to page 3 of Documents and then clicking Trials would open Trials on
       // page 3 — or on an empty page, if it has fewer.
       params.delete("page");
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      const qs = params.toString();
+      const target = `${pathname}${qs ? `?${qs}` : ""}`;
+      const current = `${window.location.pathname}${window.location.search}`;
+      if (target !== current) {
+        window.history.replaceState(window.history.state, "", target);
+      }
     },
-    [paramName, pathname, router, searchParams],
+    [paramName, pathname, searchParams],
   );
 
   if (!active) return null;

--- a/components/scheduling/SafeUnifiedCalendar.tsx
+++ b/components/scheduling/SafeUnifiedCalendar.tsx
@@ -1,13 +1,24 @@
 "use client";
 
-import { UnifiedCalendar, UnifiedCalendarProps } from "./UnifiedCalendar";
+import dynamic from "next/dynamic";
+import type { UnifiedCalendarProps } from "./UnifiedCalendar";
 import CalendarErrorBoundary from "./CalendarErrorBoundary";
+import { CalendarGridSkeleton } from "@/components/scheduling/CalendarSkeletons";
 import { SlotStatusLegend } from "./SlotStatusLegend";
 import {
   BUYER_LEGEND_KEYS,
   CONSULTANT_LEGEND_KEYS,
 } from "@/lib/scheduling/slot-status-tokens";
 import { cn } from "@/utils/tailwind";
+
+const UnifiedCalendar = dynamic(
+  () =>
+    import("./UnifiedCalendar").then((m) => ({ default: m.UnifiedCalendar })),
+  {
+    ssr: false,
+    loading: () => <CalendarGridSkeleton className="min-h-0 flex-1" />,
+  },
+);
 
 /**
  * Mounts the legend alongside the calendar.
@@ -16,6 +27,10 @@ import { cn } from "@/utils/tailwind";
  * what any of them meant, so a consultant seeing a yellow cell had to guess
  * whether it was bookable. Putting the legend here rather than inside
  * UnifiedCalendar means every caller gets it and none can forget it.
+ *
+ * UnifiedCalendar itself is code-split here so SlotPicker / allocate /
+ * reschedule routes do not pay the calendar module on first paint of the
+ * surrounding page chrome.
  */
 export function SafeUnifiedCalendar({
   className,

--- a/lib/auth-guard.ts
+++ b/lib/auth-guard.ts
@@ -80,10 +80,15 @@ async function onboardingRedirectTarget(
 /**
  * Require an authenticated AND fully onboarded user.
  * Redirects to sign-in if no session, to onboarding if not completed or
- * profile is missing. Uses disableCookieCache to avoid stale values.
+ * profile is missing.
+ *
+ * Uses the Better Auth cookie cache (5 min) for steady-state layout gates so
+ * soft-nav between dashboard pages does not re-run customSession Prisma work
+ * on every request. Force-fresh with getSession(true) at onboarding/mutation
+ * boundaries (see requireNotOnboarded and onboarding actions).
  */
 export async function requireOnboarded() {
-  const session = await getSession(true);
+  const session = await getSession();
   if (!session?.user?.id) {
     redirectWithCookieCleanup();
   }

--- a/lib/auth-guard.ts
+++ b/lib/auth-guard.ts
@@ -80,15 +80,18 @@ async function onboardingRedirectTarget(
 /**
  * Require an authenticated AND fully onboarded user.
  * Redirects to sign-in if no session, to onboarding if not completed or
- * profile is missing.
+ * profile is missing. Uses disableCookieCache to avoid stale values.
  *
- * Uses the Better Auth cookie cache (5 min) for steady-state layout gates so
- * soft-nav between dashboard pages does not re-run customSession Prisma work
- * on every request. Force-fresh with getSession(true) at onboarding/mutation
- * boundaries (see requireNotOnboarded and onboarding actions).
+ * Do NOT switch this to the cookie cache. This guard has no `banned` check of
+ * its own — it catches bans, DPDP erasure and revoked sessions only because the
+ * forced read finds no session row. A 5-minute cookie cache would keep those
+ * users inside /dashboard/admin, /checkout and /settings. The cache would also
+ * buy almost nothing: customSession re-runs its Prisma enrichment on every
+ * getSession call regardless, so the cache skips one query out of ~4. The
+ * per-render dedupe that actually helps is getSession's React.cache.
  */
 export async function requireOnboarded() {
-  const session = await getSession();
+  const session = await getSession(true);
   if (!session?.user?.id) {
     redirectWithCookieCleanup();
   }

--- a/lib/auth-guard.ts
+++ b/lib/auth-guard.ts
@@ -45,10 +45,24 @@ function isFullyOnboarded(user: SessionUser): boolean {
 /**
  * Require an authenticated session. Redirects to sign-in if no session.
  * Returns the validated session (never null).
+ *
+ * Force-fresh for the same reason as requireOnboarded below: this guard covers
+ * /settings, /profile and all of /dashboard/org-workspace (including billing),
+ * and a cookie-cached read cannot see a session that was revoked, erased under
+ * DPDP, or signed out from another device — those delete the session row, which
+ * only a fresh lookup consults. It costs those routes one session read; that is
+ * the intended trade.
  */
 export async function requireAuth() {
-  const session = await getSession();
+  const session = await getSession(true);
   if (!session?.user?.id) {
+    redirectWithCookieCleanup();
+  }
+  // Mirrors requireApiAuth's #693 check. `banned` is rebuilt by customSession on
+  // every call, so it stays accurate even in the window where ban-time session
+  // deletion has not landed yet — worth checking explicitly rather than relying
+  // on row deletion alone.
+  if (session.user.banned === true) {
     redirectWithCookieCleanup();
   }
   return session;

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -17,11 +17,17 @@ import {
 /**
  * Requires API authentication and returns the session or an error response.
  * Use this at the start of protected API route handlers.
+ *
+ * Defaults to the Better Auth cookie cache for read-heavy dashboard APIs.
+ * Pass `{ fresh: true }` (or call getSession(true) directly) for money /
+ * authz / ban-sensitive mutations that must not trust a stale cookie cache.
  */
-export async function requireApiAuth(): Promise<
+export async function requireApiAuth(options?: {
+  fresh?: boolean;
+}): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const session = await getSession(true);
+  const session = await getSession(options?.fresh === true);
   if (!session?.user?.id) {
     return {
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
@@ -58,7 +64,7 @@ export function isPrivileged(role: string | undefined | null): boolean {
 export async function requireAdminAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth();
+  const auth = await requireApiAuth({ fresh: true });
   if (auth.error) return { error: auth.error };
   if (auth.session.user.role !== "ADMIN") {
     return {
@@ -84,7 +90,7 @@ export async function requireAdminAuth(): Promise<
 export async function requireStaffAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth();
+  const auth = await requireApiAuth({ fresh: true });
   if (auth.error) return { error: auth.error };
   if (auth.session.user.role !== "STAFF") {
     return {
@@ -108,7 +114,7 @@ export async function requireStaffAuth(): Promise<
 export async function requirePrivilegedAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth();
+  const auth = await requireApiAuth({ fresh: true });
   if (auth.error) return { error: auth.error };
   if (!isPrivileged(auth.session.user.role)) {
     return {
@@ -139,7 +145,7 @@ export async function requireBackofficeSurface(
 ): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth();
+  const auth = await requireApiAuth({ fresh: true });
   if (auth.error) return { error: auth.error };
 
   const role = auth.session.user.role as UserRole | undefined;
@@ -384,7 +390,8 @@ export async function requireOrgAccess(
     requireActive,
   } = options;
 
-  const auth = await requireApiAuth();
+  // Org capability gates often precede money / membership mutations.
+  const auth = await requireApiAuth({ fresh: true });
   if (auth.error) return { error: auth.error };
 
   // Pull the billingAccount alongside the org so fundingSource gates

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -18,18 +18,18 @@ import {
  * Requires API authentication and returns the session or an error response.
  * Use this at the start of protected API route handlers.
  *
- * Reads force-fresh by default. `session.user.role` comes from the cookie
- * payload, so a cached read honours role demotion up to 5 minutes late — and
- * ~86 call sites branch on that role directly (e.g. the ADMIN gate on DELETE
- * /api/bookings/subscriptions/[id]). Opt into `{ fresh: false }` only for a
- * route that reads no role and no ban-sensitive field.
+ * Always reads force-fresh, and there is deliberately no opt-out. Session
+ * revocation is invisible to a cached read, and `session.user.role` comes from
+ * the cookie payload — ~86 call sites branch on that role directly (e.g. the
+ * ADMIN gate on DELETE /api/bookings/subscriptions/[id]), so a stale read
+ * honours a demotion up to 5 minutes late. The cookie cache would save roughly
+ * one query in four anyway, because customSession re-runs its enrichment on
+ * every call regardless.
  */
-export async function requireApiAuth(options?: {
-  fresh?: boolean;
-}): Promise<
+export async function requireApiAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const session = await getSession(options?.fresh !== false);
+  const session = await getSession(true);
   if (!session?.user?.id) {
     return {
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
@@ -66,7 +66,7 @@ export function isPrivileged(role: string | undefined | null): boolean {
 export async function requireAdminAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth({ fresh: true });
+  const auth = await requireApiAuth();
   if (auth.error) return { error: auth.error };
   if (auth.session.user.role !== "ADMIN") {
     return {
@@ -92,7 +92,7 @@ export async function requireAdminAuth(): Promise<
 export async function requireStaffAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth({ fresh: true });
+  const auth = await requireApiAuth();
   if (auth.error) return { error: auth.error };
   if (auth.session.user.role !== "STAFF") {
     return {
@@ -116,7 +116,7 @@ export async function requireStaffAuth(): Promise<
 export async function requirePrivilegedAuth(): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth({ fresh: true });
+  const auth = await requireApiAuth();
   if (auth.error) return { error: auth.error };
   if (!isPrivileged(auth.session.user.role)) {
     return {
@@ -147,7 +147,7 @@ export async function requireBackofficeSurface(
 ): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const auth = await requireApiAuth({ fresh: true });
+  const auth = await requireApiAuth();
   if (auth.error) return { error: auth.error };
 
   const role = auth.session.user.role as UserRole | undefined;
@@ -392,8 +392,7 @@ export async function requireOrgAccess(
     requireActive,
   } = options;
 
-  // Org capability gates often precede money / membership mutations.
-  const auth = await requireApiAuth({ fresh: true });
+  const auth = await requireApiAuth();
   if (auth.error) return { error: auth.error };
 
   // Pull the billingAccount alongside the org so fundingSource gates

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -18,16 +18,18 @@ import {
  * Requires API authentication and returns the session or an error response.
  * Use this at the start of protected API route handlers.
  *
- * Defaults to the Better Auth cookie cache for read-heavy dashboard APIs.
- * Pass `{ fresh: true }` (or call getSession(true) directly) for money /
- * authz / ban-sensitive mutations that must not trust a stale cookie cache.
+ * Reads force-fresh by default. `session.user.role` comes from the cookie
+ * payload, so a cached read honours role demotion up to 5 minutes late — and
+ * ~86 call sites branch on that role directly (e.g. the ADMIN gate on DELETE
+ * /api/bookings/subscriptions/[id]). Opt into `{ fresh: false }` only for a
+ * route that reads no role and no ban-sensitive field.
  */
 export async function requireApiAuth(options?: {
   fresh?: boolean;
 }): Promise<
   { session: Session; error?: never } | { session?: never; error: NextResponse }
 > {
-  const session = await getSession(options?.fresh === true);
+  const session = await getSession(options?.fresh !== false);
   if (!session?.user?.id) {
     return {
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),

--- a/lib/auth-server.ts
+++ b/lib/auth-server.ts
@@ -1,9 +1,22 @@
+import { cache } from "react";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 
-export async function getSession(disableCookieCache = false) {
+/**
+ * Request-memoized session read. Nested layouts that call requireOnboarded /
+ * requireAuth in the same RSC render share one Better Auth getSession call
+ * instead of re-running customSession enrichment for each guard.
+ *
+ * Keyed by disableCookieCache so a force-fresh read never serves a cached
+ * cookie-cache result (and vice versa) within the same request.
+ */
+const getSessionCached = cache(async (disableCookieCache: boolean) => {
   return auth.api.getSession({
     headers: await headers(),
     ...(disableCookieCache && { query: { disableCookieCache: true } }),
   });
+});
+
+export async function getSession(disableCookieCache = false) {
+  return getSessionCached(disableCookieCache);
 }

--- a/lib/auth-server.ts
+++ b/lib/auth-server.ts
@@ -16,7 +16,17 @@ import { headers } from "next/headers";
  * Route Handlers and Server Actions get a throwaway cache per call and still
  * pay per getSession. And the memo holds the promise, so if the first read
  * rejects every later guard in that render re-throws the same rejection rather
- * than retrying independently.
+ * than retrying independently (documented: react.dev/reference/react/cache).
+ *
+ * Undeclared dependency, deliberately recorded: package.json pins react
+ * ^18.3.1, and react@18.3.1 does NOT export `cache` — `Object.keys(require(
+ * "react")).includes("cache")` is false. This resolves only because Next
+ * aliases `react` to its own vendored React 19 inside the RSC layer. It works
+ * (the build is green and 5 pages plus lib/data already rely on it), but it
+ * rests on a bundler alias rather than on the declared dep. If that alias ever
+ * stops applying, this silently degrades to no memoization — correct results,
+ * N times the queries, and no test would catch it. Revisit when React 19
+ * lands properly; Next 15's App Router targets it.
  */
 const getSessionCached = cache(async (disableCookieCache: boolean) => {
   return auth.api.getSession({

--- a/lib/auth-server.ts
+++ b/lib/auth-server.ts
@@ -3,12 +3,20 @@ import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 
 /**
- * Request-memoized session read. Nested layouts that call requireOnboarded /
+ * Render-memoized session read. Nested layouts that call requireOnboarded /
  * requireAuth in the same RSC render share one Better Auth getSession call
- * instead of re-running customSession enrichment for each guard.
+ * instead of re-running customSession enrichment for each guard. This is the
+ * dedupe that actually cuts dashboard TTFB — the Better Auth cookie cache is
+ * not, because customSession re-runs its Prisma work on every call anyway.
  *
  * Keyed by disableCookieCache so a force-fresh read never serves a cached
  * cookie-cache result (and vice versa) within the same request.
+ *
+ * Two limits worth knowing. React.cache memoizes only during an RSC render, so
+ * Route Handlers and Server Actions get a throwaway cache per call and still
+ * pay per getSession. And the memo holds the promise, so if the first read
+ * rejects every later guard in that render re-throws the same rejection rather
+ * than retrying independently.
  */
 const getSessionCached = cache(async (disableCookieCache: boolean) => {
   return auth.api.getSession({

--- a/lib/auth/personal-dashboard-access.ts
+++ b/lib/auth/personal-dashboard-access.ts
@@ -55,10 +55,11 @@ export async function requirePersonalProfileAccess(
   kind: PersonalProfileKind,
   profileId: string,
 ): Promise<PersonalProfileAccess> {
-  // Cookie-cached session is fine here: the parent dashboard layout already
-  // gated onboarded, and ownership is re-checked via prisma.user below.
-  // Shares React.cache with requireOnboarded() in the same RSC request.
-  const session = await getSession();
+  // Force-fresh, matching requireOnboarded(): ownership and role are re-read
+  // from prisma below, but only a fresh read notices a REVOKED session, and
+  // this is the gate on someone's personal dashboard. Both readers pass `true`,
+  // so they share one React.cache entry per request anyway.
+  const session = await getSession(true);
   if (!session?.user?.id) redirect("/auth/signin");
 
   // Mirrors requireApiAuth's #693 check: ban-time session deletion covers the

--- a/lib/auth/personal-dashboard-access.ts
+++ b/lib/auth/personal-dashboard-access.ts
@@ -55,7 +55,10 @@ export async function requirePersonalProfileAccess(
   kind: PersonalProfileKind,
   profileId: string,
 ): Promise<PersonalProfileAccess> {
-  const session = await getSession(true);
+  // Cookie-cached session is fine here: the parent dashboard layout already
+  // gated onboarded, and ownership is re-checked via prisma.user below.
+  // Shares React.cache with requireOnboarded() in the same RSC request.
+  const session = await getSession();
   if (!session?.user?.id) redirect("/auth/signin");
 
   // Mirrors requireApiAuth's #693 check: ban-time session deletion covers the

--- a/lib/data/consultant-appointments.ts
+++ b/lib/data/consultant-appointments.ts
@@ -254,13 +254,20 @@ export async function getConsultantAppointments(
     whereClause.AND = [...existingAnd, { OR: statusFilters }];
   }
 
+  const listUserSelect = {
+    id: true,
+    name: true,
+    email: true,
+    image: true,
+  } as const;
+
   const appointments = await prisma.appointment.findMany({
     where: whereClause,
     include: {
       slotsOfAppointment: {
         orderBy: { startsAt: "asc" },
         include: {
-          user: true,
+          user: { select: listUserSelect },
           meetingSession: {
             select: { id: true, endedAt: true },
           },
@@ -272,14 +279,14 @@ export async function getConsultantAppointments(
             include: {
               consultantProfile: {
                 include: {
-                  user: true,
+                  user: { select: listUserSelect },
                 },
               },
             },
           },
           requestedBy: {
             include: {
-              user: true,
+              user: { select: listUserSelect },
             },
           },
         },
@@ -291,14 +298,14 @@ export async function getConsultantAppointments(
             include: {
               consultantProfile: {
                 include: {
-                  user: true,
+                  user: { select: listUserSelect },
                 },
               },
             },
           },
           requestedBy: {
             include: {
-              user: true,
+              user: { select: listUserSelect },
             },
           },
           schedulingPeriodStartsAt: true,
@@ -315,7 +322,7 @@ export async function getConsultantAppointments(
             include: {
               consultantProfile: {
                 include: {
-                  user: true,
+                  user: { select: listUserSelect },
                 },
               },
               collaborators: {
@@ -344,7 +351,7 @@ export async function getConsultantAppointments(
             include: {
               consultantProfile: {
                 include: {
-                  user: true,
+                  user: { select: listUserSelect },
                 },
               },
               collaborators: {

--- a/lib/data/consultant-appointments.ts
+++ b/lib/data/consultant-appointments.ts
@@ -25,6 +25,7 @@
 
 import prisma from "@/lib/prisma";
 import { AppointmentsType, AppointmentStatus, Prisma } from "@prisma/client";
+import type { User } from "@prisma/client";
 import { toPlain } from "@/lib/data/serialize";
 import type { TAppointment } from "@/types/appointment";
 
@@ -63,9 +64,26 @@ export interface GetConsultantAppointmentsArgs {
  * (the default "personal" view); the route passes the full arg set parsed
  * from the request query string.
  */
+/**
+ * Slot users on this surface are projected down to `listUserSelect`. TAppointment
+ * still declares the full User relation, so name the narrower shape here instead
+ * of letting the `as unknown as` at the bottom imply fields that were never
+ * queried — reading e.g. `.role` off one of these is `undefined` at runtime.
+ */
+type ListSlotUser = Pick<User, "id" | "name" | "email" | "image">;
+export type ConsultantListAppointment = Omit<
+  TAppointment,
+  "slotsOfAppointment"
+> & {
+  slotsOfAppointment: (Omit<
+    TAppointment["slotsOfAppointment"][number],
+    "user"
+  > & { user: ListSlotUser[] })[];
+};
+
 export async function getConsultantAppointments(
   args: GetConsultantAppointmentsArgs,
-): Promise<TAppointment[]> {
+): Promise<ConsultantListAppointment[]> {
   const {
     type,
     consultantProfileId,
@@ -395,5 +413,5 @@ export async function getConsultantAppointments(
   // result extension carries an inspect symbol), so the payload must be
   // plainified before it crosses the RSC→Client HydrationBoundary. Preserves
   // Dates as Dates. No-op for the route path (JSON drops symbols).
-  return toPlain(sorted) as unknown as TAppointment[];
+  return toPlain(sorted) as unknown as ConsultantListAppointment[];
 }

--- a/lib/data/consultant-dashboard.ts
+++ b/lib/data/consultant-dashboard.ts
@@ -29,14 +29,24 @@ import type { TConsultantDashboardResponse } from "@/types/consultant-events";
 // Prisma Query Types - Derived from actual query shape for type safety
 // =============================================================================
 
+/** Home widgets only need identity + avatar; omit phone/role from the graph. */
 const userSelectFields = {
   id: true,
   name: true,
   email: true,
   image: true,
-  role: true,
-  phone: true,
 } as const;
+
+/** Approvals list only needs the requester display name. */
+const pendingUserSelect = {
+  id: true,
+  name: true,
+  image: true,
+} as const;
+
+/** Home surfaces a handful of cards — history lives on /appointments. */
+const HOME_APPOINTMENTS_TAKE = 20;
+const HOME_PENDING_TAKE = 20;
 
 const appointmentInclude = {
   slotsOfAppointment: {
@@ -162,74 +172,23 @@ const appointmentInclude = {
   },
 } satisfies Prisma.AppointmentInclude;
 
-const consultationInclude = {
-  consultationPlan: {
-    include: {
-      consultantProfile: {
-        include: {
-          user: {
-            select: userSelectFields,
-          },
-        },
-      },
-    },
-  },
+/** Pending-approvals widget only needs id + requester name + requestedAt. */
+const pendingConsultationInclude = {
   requestedBy: {
     include: {
       user: {
-        select: userSelectFields,
+        select: pendingUserSelect,
       },
-    },
-  },
-  appointment: {
-    include: {
-      slotsOfAppointment: {
-        include: {
-          user: {
-            select: userSelectFields,
-          },
-        },
-        orderBy: {
-          startsAt: "asc" as const,
-        },
-      },
-      payment: true,
     },
   },
 } satisfies Prisma.ConsultationInclude;
 
-const subscriptionInclude = {
-  subscriptionPlan: {
-    include: {
-      consultantProfile: {
-        include: {
-          user: {
-            select: userSelectFields,
-          },
-          domain: true,
-          subDomains: true,
-          tags: true,
-        },
-      },
-    },
-  },
+const pendingSubscriptionInclude = {
   requestedBy: {
     include: {
       user: {
-        select: userSelectFields,
+        select: pendingUserSelect,
       },
-    },
-  },
-  appointments: {
-    include: {
-      slotsOfAppointment: {
-        include: {
-          user: {
-            select: userSelectFields,
-          },
-        },
-      },
-      payment: true,
     },
   },
 } satisfies Prisma.SubscriptionInclude;
@@ -243,12 +202,12 @@ type DashboardAppointment = Prisma.Result<
 >;
 type DashboardConsultation = Prisma.Result<
   typeof prisma.consultation,
-  { include: typeof consultationInclude },
+  { include: typeof pendingConsultationInclude },
   "findFirstOrThrow"
 >;
 type DashboardSubscription = Prisma.Result<
   typeof prisma.subscription,
-  { include: typeof subscriptionInclude },
+  { include: typeof pendingSubscriptionInclude },
   "findFirstOrThrow"
 >;
 
@@ -405,7 +364,7 @@ export async function getConsultantDashboard(
       // so order by createdAt to make `take` deterministic; the JS
       // sortedAppointments step re-sorts by slot startsAt afterwards.
       orderBy: { createdAt: "desc" },
-      take: 200,
+      take: HOME_APPOINTMENTS_TAKE,
     }),
     // Fetch pending consultations
     prisma.consultation.findMany({
@@ -420,11 +379,11 @@ export async function getConsultantDashboard(
         // a 90-day-old PENDING request is stale.
         requestedAt: { gte: ninetyDaysAgo },
       },
-      include: consultationInclude,
+      include: pendingConsultationInclude,
       orderBy: {
         requestedAt: "desc",
       },
-      take: 200,
+      take: HOME_PENDING_TAKE,
     }),
     // Fetch pending subscriptions
     prisma.subscription.findMany({
@@ -437,11 +396,11 @@ export async function getConsultantDashboard(
         // a 90-day-old PENDING request is stale.
         requestedAt: { gte: ninetyDaysAgo },
       },
-      include: subscriptionInclude,
+      include: pendingSubscriptionInclude,
       orderBy: {
         requestedAt: "desc",
       },
-      take: 200,
+      take: HOME_PENDING_TAKE,
     }),
     // Fetch recent activities
     prisma.activityLog.findMany({

--- a/lib/data/consultant-dashboard.ts
+++ b/lib/data/consultant-dashboard.ts
@@ -48,6 +48,62 @@ const pendingUserSelect = {
 const HOME_APPOINTMENTS_TAKE = 20;
 const HOME_PENDING_TAKE = 20;
 
+/**
+ * Every appointment this consultant owns or collaborates on. Shared by the
+ * Home display read and the active-clients count so the two can never drift.
+ */
+const consultantAppointmentScope = (consultantProfileId: string) =>
+  ({
+    OR: [
+      {
+        consultation: {
+          consultationPlan: { consultantProfileId },
+          status: "APPROVED" as const,
+        },
+      },
+      {
+        subscription: {
+          subscriptionPlan: { consultantProfileId },
+          status: "APPROVED" as const,
+        },
+      },
+      {
+        webinar: {
+          webinarPlan: { consultantProfileId },
+          status: "SCHEDULED" as const,
+        },
+      },
+      {
+        // Collaborated webinars (co-host, moderator, etc.)
+        webinar: {
+          webinarPlan: {
+            collaborators: {
+              some: { consultantProfileId, status: "ACCEPTED" as const },
+            },
+          },
+          status: "SCHEDULED" as const,
+        },
+      },
+      {
+        class: {
+          classPlan: { consultantProfileId },
+          status: "SCHEDULED" as const,
+        },
+      },
+      {
+        // Collaborated classes (co-instructor, TA, etc.)
+        class: {
+          classPlan: {
+            collaborators: {
+              some: { consultantProfileId, status: "ACCEPTED" as const },
+            },
+          },
+          status: "SCHEDULED" as const,
+        },
+      },
+    ],
+  }) satisfies Prisma.AppointmentWhereInput;
+
 const appointmentInclude = {
   slotsOfAppointment: {
     orderBy: { startsAt: "asc" as const },
@@ -282,12 +338,36 @@ export async function getConsultantDashboard(
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
 
+  // Which appointments Home actually shows. Appointment has no top-level start
+  // column, so a plain `orderBy: createdAt` + `take` truncated on the wrong key:
+  // a consultant who booked next month a fortnight ago and then took a burst of
+  // bookings for last week got 20 rows that were all in the past, and both the
+  // Today and Upcoming widgets rendered empty. Rank on the slot table instead —
+  // it has @@index([startsAt, endsAt]) — and keep only the soonest ids. Slots
+  // are per-appointment, so over-fetch before deduping to ids.
+  const soonestSlots = await prisma.slotOfAppointment.findMany({
+    where: {
+      deletedAt: null,
+      startsAt: { gte: ninetyDaysAgo },
+      appointment: consultantAppointmentScope(consultantProfileId),
+    },
+    select: { appointmentId: true },
+    orderBy: { startsAt: "asc" },
+    take: HOME_APPOINTMENTS_TAKE * 5,
+  });
+  const homeAppointmentIds = [
+    ...new Set(soonestSlots.map((s) => s.appointmentId)),
+  ].slice(0, HOME_APPOINTMENTS_TAKE);
+
   // PERFORMANCE FIX #364: Use direct Prisma queries instead of internal HTTP fetches
   // This eliminates network overhead and reduces response time significantly
   const [
     appointmentsRaw,
+    activeBookRows,
     pendingConsultations,
     pendingSubscriptions,
+    pendingConsultationCount,
+    pendingSubscriptionCount,
     recentActivities,
     earningsThisMonth,
     earningsLastMonth,
@@ -299,72 +379,32 @@ export async function getConsultantDashboard(
   ] = await Promise.all([
     // Fetch approved appointments for consultations, subscriptions, webinars, and classes
     prisma.appointment.findMany({
+      where: { id: { in: homeAppointmentIds } },
+      include: appointmentInclude,
+    }),
+    // Active clients / programs are counted over the consultant's whole active
+    // book, not the handful of rows Home renders. Deriving them from the
+    // display array meant the Financial Summary card under-reported for anyone
+    // with more appointments than the page shows. Ids only — no include graph.
+    prisma.appointment.findMany({
       where: {
-        // TTFB bound: Home only renders today/upcoming widgets, so cap
-        // to appointments with a recent-or-future slot. Full history lives
-        // on the dedicated /appointments page (separate endpoint).
-        slotsOfAppointment: { some: { startsAt: { gte: ninetyDaysAgo } } },
-        OR: [
+        ...consultantAppointmentScope(consultantProfileId),
+        AND: [
+          { slotsOfAppointment: { some: { startsAt: { gte: ninetyDaysAgo } } } },
           {
-            consultation: {
-              consultationPlan: { consultantProfileId },
-              status: "APPROVED",
-            },
-          },
-          {
-            subscription: {
-              subscriptionPlan: { consultantProfileId },
-              status: "APPROVED",
-            },
-          },
-          {
-            webinar: {
-              webinarPlan: { consultantProfileId },
-              status: "SCHEDULED",
-            },
-          },
-          {
-            // Collaborated webinars (co-host, moderator, etc.)
-            webinar: {
-              webinarPlan: {
-                collaborators: {
-                  some: {
-                    consultantProfileId,
-                    status: "ACCEPTED",
-                  },
-                },
-              },
-              status: "SCHEDULED",
-            },
-          },
-          {
-            class: {
-              classPlan: { consultantProfileId },
-              status: "SCHEDULED",
-            },
-          },
-          {
-            // Collaborated classes (co-instructor, TA, etc.)
-            class: {
-              classPlan: {
-                collaborators: {
-                  some: {
-                    consultantProfileId,
-                    status: "ACCEPTED",
-                  },
-                },
-              },
-              status: "SCHEDULED",
+            slotsOfAppointment: {
+              some: { completionStatus: { notIn: ["COMPLETED", "CANCELLED"] } },
             },
           },
         ],
       },
-      include: appointmentInclude,
-      // No top-level start field on Appointment (slots carry startsAt),
-      // so order by createdAt to make `take` deterministic; the JS
-      // sortedAppointments step re-sorts by slot startsAt afterwards.
-      orderBy: { createdAt: "desc" },
-      take: HOME_APPOINTMENTS_TAKE,
+      select: {
+        consultation: { select: { requestedBy: { select: { id: true } } } },
+        subscription: {
+          select: { id: true, requestedBy: { select: { id: true } } },
+        },
+        class: { select: { id: true } },
+      },
     }),
     // Fetch pending consultations
     prisma.consultation.findMany({
@@ -401,6 +441,23 @@ export async function getConsultantDashboard(
         requestedAt: "desc",
       },
       take: HOME_PENDING_TAKE,
+    }),
+    // The approvals badge is a total, not a list length. Counting the capped
+    // list made it disagree with NeedsYou — which counts properly — on the very
+    // same screen once a consultant had more pending requests than the cap.
+    prisma.consultation.count({
+      where: {
+        consultationPlan: { consultantProfile: { id: consultantProfileId } },
+        status: "PENDING",
+        requestedAt: { gte: ninetyDaysAgo },
+      },
+    }),
+    prisma.subscription.count({
+      where: {
+        subscriptionPlan: { consultantProfileId },
+        status: "PENDING",
+        requestedAt: { gte: ninetyDaysAgo },
+      },
     }),
     // Fetch recent activities
     prisma.activityLog.findMany({
@@ -628,6 +685,10 @@ export async function getConsultantDashboard(
     time: formatTime(approval.requestedAt),
   }));
 
+  // Total pending requests, independent of how many the widget lists.
+  const pendingRequestsCount =
+    pendingConsultationCount + pendingSubscriptionCount;
+
   // Transform activities for display
   const activities = recentActivities.map((activity) => ({
     id: activity.id,
@@ -694,17 +755,13 @@ export async function getConsultantDashboard(
   const payoutMinimum = PAYOUT_CONSTANTS.MINIMUM_PAYOUT_AMOUNT;
   const payoutEligible = readyEarningsVal >= payoutMinimum;
 
-  // Active clients + programs: single pass over sorted appointments
+  // Active clients + programs: single pass over the full active book. The
+  // query already excludes fully completed/cancelled appointments, so every
+  // row here counts.
   const activeClientIds = new Set<string>();
   const activeSubIds = new Set<string>();
   const activeClassIds = new Set<string>();
-  for (const apt of sortedAppointments) {
-    const isCompleted = apt.slotsOfAppointment.every(
-      (s) =>
-        s.completionStatus === "COMPLETED" ||
-        s.completionStatus === "CANCELLED",
-    );
-    if (isCompleted) continue;
+  for (const apt of activeBookRows) {
     const consulteeId =
       apt.consultation?.requestedBy?.id ?? apt.subscription?.requestedBy?.id;
     if (consulteeId) activeClientIds.add(consulteeId);
@@ -734,6 +791,7 @@ export async function getConsultantDashboard(
     appointments: transformedAppointments,
     activities,
     approvals,
+    pendingRequestsCount,
     performanceSnapshot: {
       earningsThisMonth: earningsThisMonthVal,
       earningsLastMonth: earningsLastMonthVal,

--- a/lib/data/consultant-dashboard.ts
+++ b/lib/data/consultant-dashboard.ts
@@ -345,10 +345,20 @@ export async function getConsultantDashboard(
   // Today and Upcoming widgets rendered empty. Rank on the slot table instead —
   // it has @@index([startsAt, endsAt]) — and keep only the soonest ids. Slots
   // are per-appointment, so over-fetch before deduping to ids.
+  //
+  // Anchor on endsAt >= start of today, NOT on a lower bound in the past:
+  // ordering ascending from 90 days ago returns the OLDEST slots in the window,
+  // which reproduces the empty-widget bug in a new disguise. Using endsAt keeps
+  // a session that started earlier today and is still running.
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
   const soonestSlots = await prisma.slotOfAppointment.findMany({
     where: {
       deletedAt: null,
-      startsAt: { gte: ninetyDaysAgo },
+      endsAt: { gte: startOfToday },
       appointment: consultantAppointmentScope(consultantProfileId),
     },
     select: { appointmentId: true },
@@ -390,10 +400,17 @@ export async function getConsultantDashboard(
       where: {
         ...consultantAppointmentScope(consultantProfileId),
         AND: [
-          { slotsOfAppointment: { some: { startsAt: { gte: ninetyDaysAgo } } } },
           {
             slotsOfAppointment: {
-              some: { completionStatus: { notIn: ["COMPLETED", "CANCELLED"] } },
+              some: { deletedAt: null, startsAt: { gte: ninetyDaysAgo } },
+            },
+          },
+          {
+            slotsOfAppointment: {
+              some: {
+                deletedAt: null,
+                completionStatus: { notIn: ["COMPLETED", "CANCELLED"] },
+              },
             },
           },
         ],
@@ -445,18 +462,21 @@ export async function getConsultantDashboard(
     // The approvals badge is a total, not a list length. Counting the capped
     // list made it disagree with NeedsYou — which counts properly — on the very
     // same screen once a consultant had more pending requests than the cap.
+    //
+    // Deliberately unbounded by date, unlike the list above. NeedsYou counts
+    // every pending request regardless of age, and these two numbers render
+    // inches apart, so matching its definition is what stops them contradicting
+    // each other. The 90-day bound stays on the list, which is only a preview.
     prisma.consultation.count({
       where: {
         consultationPlan: { consultantProfile: { id: consultantProfileId } },
         status: "PENDING",
-        requestedAt: { gte: ninetyDaysAgo },
       },
     }),
     prisma.subscription.count({
       where: {
         subscriptionPlan: { consultantProfileId },
         status: "PENDING",
-        requestedAt: { gte: ninetyDaysAgo },
       },
     }),
     // Fetch recent activities

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -243,18 +243,17 @@ export async function fetchExpertsMetadata() {
         averageRating: averageRating._avg.rating || 0,
       };
     })(),
-    // Available languages — distinct across verified consultants. ORM read + JS
-    // dedupe (no raw SQL): pull the verified profiles' `languages` arrays and
-    // flatten/unique/sort in app code. The verified-consultant set is small enough
-    // that this is cheaper than it looks and avoids a Postgres `unnest`.
-    prisma.consultantProfile
-      .findMany({
-        where: { verificationStatus: "VERIFIED", deletedAt: null },
-        select: { languages: true },
-      })
-      .then((rows) =>
-        Array.from(new Set(rows.flatMap((r) => r.languages))).sort(),
-      ),
+    // Available languages — distinct via unnest so a cache miss does not
+    // pull every verified profile's languages array into the Node process.
+    prisma
+      .$queryRaw<{ language: string }[]>(Prisma.sql`
+        SELECT DISTINCT unnest(languages) AS language
+        FROM "ConsultantProfile"
+        WHERE "verificationStatus" = 'VERIFIED'
+          AND "deletedAt" IS NULL
+        ORDER BY 1
+      `)
+      .then((rows) => rows.map((r) => r.language).filter(Boolean)),
     // Available companies (from verified consultants' work experiences)
     prisma.workExperience
       .findMany({

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -243,17 +243,20 @@ export async function fetchExpertsMetadata() {
         averageRating: averageRating._avg.rating || 0,
       };
     })(),
-    // Available languages — distinct via unnest so a cache miss does not
-    // pull every verified profile's languages array into the Node process.
-    prisma
-      .$queryRaw<{ language: string }[]>(Prisma.sql`
-        SELECT DISTINCT unnest(languages) AS language
-        FROM "ConsultantProfile"
-        WHERE "verificationStatus" = 'VERIFIED'
-          AND "deletedAt" IS NULL
-        ORDER BY 1
-      `)
-      .then((rows) => rows.map((r) => r.language).filter(Boolean)),
+    // Available languages — distinct across verified consultants. ORM read + JS
+    // dedupe (no raw SQL): pull the verified profiles' `languages` arrays and
+    // flatten/unique/sort in app code. The verified-consultant set is small enough
+    // that this is cheaper than it looks and avoids a Postgres `unnest`.
+    prisma.consultantProfile
+      .findMany({
+        where: { verificationStatus: "VERIFIED", deletedAt: null },
+        select: { languages: true },
+      })
+      .then((rows) =>
+        Array.from(new Set(rows.flatMap((r) => r.languages)))
+          .filter(Boolean)
+          .sort(),
+      ),
     // Available companies (from verified consultants' work experiences)
     prisma.workExperience
       .findMany({

--- a/lib/data/explore-experts.ts
+++ b/lib/data/explore-experts.ts
@@ -255,7 +255,7 @@ export async function fetchExpertsMetadata() {
       .then((rows) =>
         Array.from(new Set(rows.flatMap((r) => r.languages)))
           .filter(Boolean)
-          .sort(),
+          .sort((a, b) => a.localeCompare(b)),
       ),
     // Available companies (from verified consultants' work experiences)
     prisma.workExperience

--- a/lib/data/explore-programs.ts
+++ b/lib/data/explore-programs.ts
@@ -1,7 +1,7 @@
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import { toPlain } from "@/lib/data/serialize";
-import type { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { eventPlanDiscoverableWhere } from "@/lib/api/plans/visibility";
 import { generateProgramImageUrl } from "@/lib/explore/programs";
 import type {
@@ -61,54 +61,37 @@ const liveConsultantWhere = {
 // ---------------------------------------------------------------------------
 
 /**
- * Trending rank step 1: load every marketplace plan's last-30-day slot ids
- * and sort by count IN MEMORY. That scan is O(all plans × recent slots) per
- * call — with React.cache alone it ran once per REQUEST, so 1000 concurrent
- * explore loads each paid it. unstable_cache shares one computation across
- * requests for 60s; the cached value is just the FULL ranked id array
- * (callers slice to their limit — passing limit as an arg would key separate
- * cache entries per limit, each paying the scan). Staleness is harmless —
- * trending order changing 60s late is invisible.
+ * Trending rank step 1: SQL aggregate of last-30-day slots per plan.
+ *
+ * Previously pulled every marketplace plan with nested slots into Node and
+ * sorted in memory (O(all plans × recent slots)). That scan is shared across
+ * requests for 60s via unstable_cache; the cached value is the FULL ranked id
+ * array (callers slice — passing limit as an arg would key separate entries).
+ * Staleness is harmless — trending order changing 60s late is invisible.
  */
 const getTrendingClassPlanIds = unstable_cache(
   async (): Promise<string[]> => {
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-    const ranked = await prisma.classPlan.findMany({
-      where: { ...eventPlanDiscoverableWhere(), ...liveConsultantWhere }, // #726 — no ORG_ONLY in curated feed
-      select: {
-        id: true,
-        classes: {
-          select: {
-            appointments: {
-              select: {
-                slotsOfAppointment: {
-                  where: { createdAt: { gte: thirtyDaysAgo } },
-                  select: { id: true },
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const ranked = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+      SELECT cp.id
+      FROM "ClassPlan" cp
+      INNER JOIN "Class" c ON c."classPlanId" = cp.id
+      INNER JOIN "Appointment" a ON a."classId" = c.id
+      INNER JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
+      LEFT JOIN "ConsultantProfile" cons ON cons.id = cp."consultantProfileId"
+      WHERE cp.visibility IN ('PUBLIC', 'ORG_AND_PUBLIC')
+        AND cp."archivedAt" IS NULL
+        AND (cp."consultantProfileId" IS NULL OR cons."deletedAt" IS NULL)
+        AND a."deletedAt" IS NULL
+        AND soa."deletedAt" IS NULL
+        AND soa."createdAt" >= ${thirtyDaysAgo}
+      GROUP BY cp.id
+      ORDER BY COUNT(soa.id) DESC
+    `);
 
-    return ranked
-      .map((p) => ({
-        id: p.id,
-        count: p.classes.reduce(
-          (sum, cls) =>
-            sum +
-            cls.appointments.reduce(
-              (s, apt) => s + apt.slotsOfAppointment.length,
-              0,
-            ),
-          0,
-        ),
-      }))
-      .sort((a, b) => b.count - a.count)
-      .map((r) => r.id);
+    return ranked.map((r) => r.id);
   },
   ["trending-class-plan-ids"],
   { revalidate: 60 },
@@ -119,35 +102,24 @@ const getTrendingWebinarPlanIds = unstable_cache(
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-    const ranked = await prisma.webinarPlan.findMany({
-      where: { ...eventPlanDiscoverableWhere(), ...liveConsultantWhere }, // #726 — no ORG_ONLY in curated feed
-      select: {
-        id: true,
-        webinars: {
-          select: {
-            appointment: {
-              select: {
-                slotsOfAppointment: {
-                  where: { createdAt: { gte: thirtyDaysAgo } },
-                  select: { id: true },
-                },
-              },
-            },
-          },
-        },
-      },
-    });
+    const ranked = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+      SELECT wp.id
+      FROM "WebinarPlan" wp
+      INNER JOIN "Webinar" w ON w."webinarPlanId" = wp.id
+      INNER JOIN "Appointment" a ON a."webinarId" = w.id
+      INNER JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
+      LEFT JOIN "ConsultantProfile" cons ON cons.id = wp."consultantProfileId"
+      WHERE wp.visibility IN ('PUBLIC', 'ORG_AND_PUBLIC')
+        AND wp."archivedAt" IS NULL
+        AND (wp."consultantProfileId" IS NULL OR cons."deletedAt" IS NULL)
+        AND a."deletedAt" IS NULL
+        AND soa."deletedAt" IS NULL
+        AND soa."createdAt" >= ${thirtyDaysAgo}
+      GROUP BY wp.id
+      ORDER BY COUNT(soa.id) DESC
+    `);
 
-    return ranked
-      .map((p) => ({
-        id: p.id,
-        count: p.webinars.reduce(
-          (sum, w) => sum + (w.appointment?.slotsOfAppointment?.length ?? 0),
-          0,
-        ),
-      }))
-      .sort((a, b) => b.count - a.count)
-      .map((r) => r.id);
+    return ranked.map((r) => r.id);
   },
   ["trending-webinar-plan-ids"],
   { revalidate: 60 },

--- a/lib/data/explore-programs.ts
+++ b/lib/data/explore-programs.ts
@@ -77,18 +77,17 @@ const getTrendingClassPlanIds = unstable_cache(
     const ranked = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
       SELECT cp.id
       FROM "ClassPlan" cp
-      INNER JOIN "Class" c ON c."classPlanId" = cp.id
-      INNER JOIN "Appointment" a ON a."classId" = c.id
-      INNER JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
+      LEFT JOIN "Class" c ON c."classPlanId" = cp.id
+      LEFT JOIN "Appointment" a ON a."classId" = c.id AND a."deletedAt" IS NULL
+      LEFT JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
+        AND soa."deletedAt" IS NULL
+        AND soa."createdAt" >= ${thirtyDaysAgo}
       LEFT JOIN "ConsultantProfile" cons ON cons.id = cp."consultantProfileId"
       WHERE cp.visibility IN ('PUBLIC', 'ORG_AND_PUBLIC')
         AND cp."archivedAt" IS NULL
         AND (cp."consultantProfileId" IS NULL OR cons."deletedAt" IS NULL)
-        AND a."deletedAt" IS NULL
-        AND soa."deletedAt" IS NULL
-        AND soa."createdAt" >= ${thirtyDaysAgo}
       GROUP BY cp.id
-      ORDER BY COUNT(soa.id) DESC
+      ORDER BY COUNT(soa.id) DESC, cp."createdAt" DESC
     `);
 
     return ranked.map((r) => r.id);
@@ -105,18 +104,17 @@ const getTrendingWebinarPlanIds = unstable_cache(
     const ranked = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
       SELECT wp.id
       FROM "WebinarPlan" wp
-      INNER JOIN "Webinar" w ON w."webinarPlanId" = wp.id
-      INNER JOIN "Appointment" a ON a."webinarId" = w.id
-      INNER JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
+      LEFT JOIN "Webinar" w ON w."webinarPlanId" = wp.id
+      LEFT JOIN "Appointment" a ON a."webinarId" = w.id AND a."deletedAt" IS NULL
+      LEFT JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
+        AND soa."deletedAt" IS NULL
+        AND soa."createdAt" >= ${thirtyDaysAgo}
       LEFT JOIN "ConsultantProfile" cons ON cons.id = wp."consultantProfileId"
       WHERE wp.visibility IN ('PUBLIC', 'ORG_AND_PUBLIC')
         AND wp."archivedAt" IS NULL
         AND (wp."consultantProfileId" IS NULL OR cons."deletedAt" IS NULL)
-        AND a."deletedAt" IS NULL
-        AND soa."deletedAt" IS NULL
-        AND soa."createdAt" >= ${thirtyDaysAgo}
       GROUP BY wp.id
-      ORDER BY COUNT(soa.id) DESC
+      ORDER BY COUNT(soa.id) DESC, wp."createdAt" DESC
     `);
 
     return ranked.map((r) => r.id);

--- a/lib/data/explore-programs.ts
+++ b/lib/data/explore-programs.ts
@@ -1,7 +1,7 @@
 import { unstable_cache } from "next/cache";
 import prisma from "@/lib/prisma";
 import { toPlain } from "@/lib/data/serialize";
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { eventPlanDiscoverableWhere } from "@/lib/api/plans/visibility";
 import { generateProgramImageUrl } from "@/lib/explore/programs";
 import type {
@@ -61,36 +61,61 @@ const liveConsultantWhere = {
 // ---------------------------------------------------------------------------
 
 /**
- * Trending rank step 1: SQL aggregate of last-30-day slots per plan.
+ * Trending rank step 1: last-30-day slot count per plan.
  *
- * Previously pulled every marketplace plan with nested slots into Node and
- * sorted in memory (O(all plans × recent slots)). That scan is shared across
- * requests for 60s via unstable_cache; the cached value is the FULL ranked id
- * array (callers slice — passing limit as an arg would key separate entries).
- * Staleness is harmless — trending order changing 60s late is invisible.
+ * ORM read + JS tally (no raw SQL). The earlier shape nested classes →
+ * appointments → slots under every marketplace plan, so the cost scaled with
+ * plans × their whole slot history. Instead read the two sides independently:
+ * the discoverable plan ids, and only slots created in the window. The tally is
+ * a single pass over that bounded set. Plans with no recent activity keep a
+ * count of 0 and stay in the ranking — dropping them empties the Trending row
+ * in a quiet window.
+ *
+ * The scan is shared across requests for 60s via unstable_cache; the cached
+ * value is the FULL ranked id array (callers slice — passing limit as an arg
+ * would key separate entries). Staleness is harmless: trending order changing
+ * 60s late is invisible.
  */
+const thirtyDaysBefore = (now: Date) => {
+  const d = new Date(now);
+  d.setDate(d.getDate() - 30);
+  return d;
+};
+
 const getTrendingClassPlanIds = unstable_cache(
   async (): Promise<string[]> => {
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    const thirtyDaysAgo = thirtyDaysBefore(new Date());
 
-    const ranked = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
-      SELECT cp.id
-      FROM "ClassPlan" cp
-      LEFT JOIN "Class" c ON c."classPlanId" = cp.id
-      LEFT JOIN "Appointment" a ON a."classId" = c.id AND a."deletedAt" IS NULL
-      LEFT JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
-        AND soa."deletedAt" IS NULL
-        AND soa."createdAt" >= ${thirtyDaysAgo}
-      LEFT JOIN "ConsultantProfile" cons ON cons.id = cp."consultantProfileId"
-      WHERE cp.visibility IN ('PUBLIC', 'ORG_AND_PUBLIC')
-        AND cp."archivedAt" IS NULL
-        AND (cp."consultantProfileId" IS NULL OR cons."deletedAt" IS NULL)
-      GROUP BY cp.id
-      ORDER BY COUNT(soa.id) DESC, cp."createdAt" DESC
-    `);
+    const [plans, recentSlots] = await Promise.all([
+      prisma.classPlan.findMany({
+        where: { ...eventPlanDiscoverableWhere(), ...liveConsultantWhere }, // #726
+        select: { id: true, createdAt: true },
+      }),
+      prisma.slotOfAppointment.findMany({
+        where: {
+          deletedAt: null,
+          createdAt: { gte: thirtyDaysAgo },
+          appointment: { deletedAt: null, classId: { not: null } },
+        },
+        select: {
+          appointment: { select: { class: { select: { classPlanId: true } } } },
+        },
+      }),
+    ]);
 
-    return ranked.map((r) => r.id);
+    const counts = new Map<string, number>();
+    for (const slot of recentSlots) {
+      const planId = slot.appointment?.class?.classPlanId;
+      if (planId) counts.set(planId, (counts.get(planId) ?? 0) + 1);
+    }
+
+    return plans
+      .sort(
+        (a, b) =>
+          (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0) ||
+          b.createdAt.getTime() - a.createdAt.getTime(),
+      )
+      .map((p) => p.id);
   },
   ["trending-class-plan-ids"],
   { revalidate: 60 },
@@ -98,26 +123,40 @@ const getTrendingClassPlanIds = unstable_cache(
 
 const getTrendingWebinarPlanIds = unstable_cache(
   async (): Promise<string[]> => {
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    const thirtyDaysAgo = thirtyDaysBefore(new Date());
 
-    const ranked = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
-      SELECT wp.id
-      FROM "WebinarPlan" wp
-      LEFT JOIN "Webinar" w ON w."webinarPlanId" = wp.id
-      LEFT JOIN "Appointment" a ON a."webinarId" = w.id AND a."deletedAt" IS NULL
-      LEFT JOIN "SlotOfAppointment" soa ON soa."appointmentId" = a.id
-        AND soa."deletedAt" IS NULL
-        AND soa."createdAt" >= ${thirtyDaysAgo}
-      LEFT JOIN "ConsultantProfile" cons ON cons.id = wp."consultantProfileId"
-      WHERE wp.visibility IN ('PUBLIC', 'ORG_AND_PUBLIC')
-        AND wp."archivedAt" IS NULL
-        AND (wp."consultantProfileId" IS NULL OR cons."deletedAt" IS NULL)
-      GROUP BY wp.id
-      ORDER BY COUNT(soa.id) DESC, wp."createdAt" DESC
-    `);
+    const [plans, recentSlots] = await Promise.all([
+      prisma.webinarPlan.findMany({
+        where: { ...eventPlanDiscoverableWhere(), ...liveConsultantWhere }, // #726
+        select: { id: true, createdAt: true },
+      }),
+      prisma.slotOfAppointment.findMany({
+        where: {
+          deletedAt: null,
+          createdAt: { gte: thirtyDaysAgo },
+          appointment: { deletedAt: null, webinarId: { not: null } },
+        },
+        select: {
+          appointment: {
+            select: { webinar: { select: { webinarPlanId: true } } },
+          },
+        },
+      }),
+    ]);
 
-    return ranked.map((r) => r.id);
+    const counts = new Map<string, number>();
+    for (const slot of recentSlots) {
+      const planId = slot.appointment?.webinar?.webinarPlanId;
+      if (planId) counts.set(planId, (counts.get(planId) ?? 0) + 1);
+    }
+
+    return plans
+      .sort(
+        (a, b) =>
+          (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0) ||
+          b.createdAt.getTime() - a.createdAt.getTime(),
+      )
+      .map((p) => p.id);
   },
   ["trending-webinar-plan-ids"],
   { revalidate: 60 },

--- a/lib/data/explore-programs.ts
+++ b/lib/data/explore-programs.ts
@@ -76,25 +76,44 @@ const liveConsultantWhere = {
  * would key separate entries). Staleness is harmless: trending order changing
  * 60s late is invisible.
  */
-const thirtyDaysBefore = (now: Date) => {
-  const d = new Date(now);
-  d.setDate(d.getDate() - 30);
-  return d;
+/** Slot window shared by both plan families. */
+const recentSlotWindow = () => {
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  return { deletedAt: null, createdAt: { gte: thirtyDaysAgo } } as const;
 };
+
+/**
+ * Tally plan ids, then order plans by that count. Plans absent from the tally
+ * score 0 and keep their place — dropping them empties the Trending row.
+ */
+function rankPlansByCount(
+  plans: { id: string; createdAt: Date }[],
+  planIds: (string | null | undefined)[],
+): string[] {
+  const counts = new Map<string, number>();
+  for (const id of planIds) {
+    if (id) counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return plans
+    .sort(
+      (a, b) =>
+        (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0) ||
+        b.createdAt.getTime() - a.createdAt.getTime(),
+    )
+    .map((p) => p.id);
+}
 
 const getTrendingClassPlanIds = unstable_cache(
   async (): Promise<string[]> => {
-    const thirtyDaysAgo = thirtyDaysBefore(new Date());
-
-    const [plans, recentSlots] = await Promise.all([
+    const [plans, slots] = await Promise.all([
       prisma.classPlan.findMany({
         where: { ...eventPlanDiscoverableWhere(), ...liveConsultantWhere }, // #726
         select: { id: true, createdAt: true },
       }),
       prisma.slotOfAppointment.findMany({
         where: {
-          deletedAt: null,
-          createdAt: { gte: thirtyDaysAgo },
+          ...recentSlotWindow(),
           appointment: { deletedAt: null, classId: { not: null } },
         },
         select: {
@@ -102,20 +121,10 @@ const getTrendingClassPlanIds = unstable_cache(
         },
       }),
     ]);
-
-    const counts = new Map<string, number>();
-    for (const slot of recentSlots) {
-      const planId = slot.appointment?.class?.classPlanId;
-      if (planId) counts.set(planId, (counts.get(planId) ?? 0) + 1);
-    }
-
-    return plans
-      .sort(
-        (a, b) =>
-          (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0) ||
-          b.createdAt.getTime() - a.createdAt.getTime(),
-      )
-      .map((p) => p.id);
+    return rankPlansByCount(
+      plans,
+      slots.map((s) => s.appointment?.class?.classPlanId),
+    );
   },
   ["trending-class-plan-ids"],
   { revalidate: 60 },
@@ -123,17 +132,14 @@ const getTrendingClassPlanIds = unstable_cache(
 
 const getTrendingWebinarPlanIds = unstable_cache(
   async (): Promise<string[]> => {
-    const thirtyDaysAgo = thirtyDaysBefore(new Date());
-
-    const [plans, recentSlots] = await Promise.all([
+    const [plans, slots] = await Promise.all([
       prisma.webinarPlan.findMany({
         where: { ...eventPlanDiscoverableWhere(), ...liveConsultantWhere }, // #726
         select: { id: true, createdAt: true },
       }),
       prisma.slotOfAppointment.findMany({
         where: {
-          deletedAt: null,
-          createdAt: { gte: thirtyDaysAgo },
+          ...recentSlotWindow(),
           appointment: { deletedAt: null, webinarId: { not: null } },
         },
         select: {
@@ -143,20 +149,10 @@ const getTrendingWebinarPlanIds = unstable_cache(
         },
       }),
     ]);
-
-    const counts = new Map<string, number>();
-    for (const slot of recentSlots) {
-      const planId = slot.appointment?.webinar?.webinarPlanId;
-      if (planId) counts.set(planId, (counts.get(planId) ?? 0) + 1);
-    }
-
-    return plans
-      .sort(
-        (a, b) =>
-          (counts.get(b.id) ?? 0) - (counts.get(a.id) ?? 0) ||
-          b.createdAt.getTime() - a.createdAt.getTime(),
-      )
-      .map((p) => p.id);
+    return rankPlansByCount(
+      plans,
+      slots.map((s) => s.appointment?.webinar?.webinarPlanId),
+    );
   },
   ["trending-webinar-plan-ids"],
   { revalidate: 60 },

--- a/lib/data/needs-you.ts
+++ b/lib/data/needs-you.ts
@@ -30,6 +30,39 @@ export interface NeedsYouSummary {
   total: number;
 }
 
+function pendingConsultationWhere(
+  consultantProfileId: string,
+  organizationId: string | null,
+) {
+  const isPersonal = organizationId === null;
+  return {
+    status: "PENDING" as const,
+    consultationPlan: { consultantProfileId },
+    ...(isPersonal
+      ? {
+          OR: [
+            { appointment: null },
+            { appointment: { organizationId: null } },
+          ],
+        }
+      : { appointment: { organizationId } }),
+  };
+}
+
+function pendingSubscriptionWhere(
+  consultantProfileId: string,
+  organizationId: string | null,
+) {
+  const isPersonal = organizationId === null;
+  return {
+    status: "PENDING" as const,
+    subscriptionPlan: { consultantProfileId },
+    appointments: isPersonal
+      ? { none: { organizationId: { not: null } } }
+      : { some: { organizationId } },
+  };
+}
+
 /**
  * @param userId              the signed-in user
  * @param consultantProfileId their delivering profile
@@ -38,73 +71,52 @@ export async function getNeedsYouSummary(
   userId: string,
   consultantProfileId: string,
 ): Promise<NeedsYouSummary> {
-  // Orgs this person DELIVERS into. A LEARNER membership is not a delivery
-  // context and must not appear here — nothing is ever awaiting their
-  // allocation there.
-  const deliveringMemberships = await prisma.membership.findMany({
-    where: {
-      userId,
-      status: "ACTIVE",
-      consultantProfileId,
-      organization: { canHost: true },
-    },
-    select: {
-      organizationId: true,
-      organization: { select: { name: true } },
-    },
-  });
+  // Memberships + personal-scope counts share no dependency — fetch together
+  // so the personal context does not wait on the membership round-trip.
+  const [deliveringMemberships, personalConsultations, personalSubscriptions] =
+    await Promise.all([
+      prisma.membership.findMany({
+        where: {
+          userId,
+          status: "ACTIVE",
+          consultantProfileId,
+          organization: { canHost: true },
+        },
+        select: {
+          organizationId: true,
+          organization: { select: { name: true } },
+        },
+      }),
+      prisma.consultation.count({
+        where: pendingConsultationWhere(consultantProfileId, null),
+      }),
+      prisma.subscription.count({
+        where: pendingSubscriptionWhere(consultantProfileId, null),
+      }),
+    ]);
 
-  const scopes: { organizationId: string | null; label: string; href: string }[] =
-    [
-      {
-        organizationId: null,
-        label: "Personal",
-        href: `/dashboard/consultant/${consultantProfileId}/requests`,
-      },
-      ...deliveringMemberships.map((m) => ({
-        organizationId: m.organizationId,
-        label: m.organization.name,
-        href: `/dashboard/organization/${m.organizationId}/requests`,
-      })),
-    ];
+  const orgScopes = deliveringMemberships.map((m) => ({
+    organizationId: m.organizationId as string,
+    label: m.organization.name,
+    href: `/dashboard/organization/${m.organizationId}/requests`,
+  }));
 
-  const contexts = await Promise.all(
-    scopes.map(async (scope) => {
-      // Scope predicates are copied verbatim from the two endpoints that back
-      // the Requests page (app/api/bookings/{consultations,subscriptions}),
-      // including their asymmetry: Consultation has one optional Appointment
-      // and counts a missing one as personal ("not org-funded → personal"),
-      // whereas Subscription has many and uses none/some. If the panel and the
-      // page disagreed on what personal means, the count would send people to
-      // a list that doesn't contain the item.
-      const isPersonal = scope.organizationId === null;
-
+  const orgCounts = await Promise.all(
+    orgScopes.map(async (scope) => {
       const [consultations, subscriptions] = await Promise.all([
         prisma.consultation.count({
-          where: {
-            status: "PENDING",
-            consultationPlan: { consultantProfileId },
-            ...(isPersonal
-              ? {
-                  OR: [
-                    { appointment: null },
-                    { appointment: { organizationId: null } },
-                  ],
-                }
-              : { appointment: { organizationId: scope.organizationId } }),
-          },
+          where: pendingConsultationWhere(
+            consultantProfileId,
+            scope.organizationId,
+          ),
         }),
         prisma.subscription.count({
-          where: {
-            status: "PENDING",
-            subscriptionPlan: { consultantProfileId },
-            appointments: isPersonal
-              ? { none: { organizationId: { not: null } } }
-              : { some: { organizationId: scope.organizationId } },
-          },
+          where: pendingSubscriptionWhere(
+            consultantProfileId,
+            scope.organizationId,
+          ),
         }),
       ]);
-
       return {
         ...scope,
         pendingRequests: consultations + subscriptions,
@@ -112,10 +124,18 @@ export async function getNeedsYouSummary(
     }),
   );
 
-  const withWork = contexts.filter((c) => c.pendingRequests > 0);
+  const contexts = [
+    {
+      organizationId: null,
+      label: "Personal",
+      href: `/dashboard/consultant/${consultantProfileId}/requests`,
+      pendingRequests: personalConsultations + personalSubscriptions,
+    },
+    ...orgCounts,
+  ].filter((c) => c.pendingRequests > 0);
 
   return {
-    contexts: withWork,
-    total: withWork.reduce((sum, c) => sum + c.pendingRequests, 0),
+    contexts,
+    total: contexts.reduce((sum, c) => sum + c.pendingRequests, 0),
   };
 }

--- a/providers/StreamProvider.tsx
+++ b/providers/StreamProvider.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { createContext, useContext } from "react";
-import dynamic from "next/dynamic";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ComponentType,
+} from "react";
 
 // Re-export the logout helper from the SDK-free module so existing importers of
 // `disconnectStreamClients` from this path keep working unchanged. Callers that
@@ -51,52 +56,41 @@ export interface StreamProviderProps {
   enableVideo?: boolean;
 }
 
-// Loading strategy (deliberate, per-scenario — NOT blanket lazy):
-//
-//  • SDK code-split (lazy chunk): YES. The Stream SDK is heavy and the dashboard
-//    LANDING route is always /home, which renders no chat/video UI. Splitting the
-//    SDK + its two stylesheets into a chunk keeps them out of /home's synchronous
-//    bundle, so /home parses/paints without paying for the SDK up front.
-//
-//  • When does that chunk actually load? On dashboard routes the provider is
-//    mounted by the LAYOUT, so the chunk begins downloading on /home too — but
-//    IN PARALLEL, off the critical bundle, not blocking first paint. This is the
-//    right call (deferred/parallel, not "only when chat opens") because the
-//    consultant sidebar shows a chat-unread badge on every route incl. /home,
-//    which needs the chat client connected. Gating the whole provider behind
-//    "user opened chat" would break that badge. The actual connect (websocket)
-//    is further deferred to requestIdleCallback inside the impl (see #248 there).
-//
-//  • ssr:false: the SDK is browser-only (websockets/WebRTC); SSR-ing it is wasted
-//    server work and hydration mismatch risk.
-//
-// Children are rendered through the impl, which renders them DIRECTLY even before
-// connection completes (it no longer blocks on a spinner until connected). During
-// the brief chunk-download window the fallback below shows — this is strictly
-// shorter than the previous behavior, which blocked children until BOTH clients
-// finished their websocket handshake.
-function StreamProviderLoading() {
-  return (
-    <div className="flex items-center justify-center min-h-[200px]">
-      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary" />
-    </div>
-  );
-}
-
-const LazyStreamProviderImpl = dynamic(
-  () => import("@/providers/StreamProviderImpl"),
-  { ssr: false, loading: () => <StreamProviderLoading /> },
-);
-
 /**
- * SDK-free shell. Renders children through the lazily-loaded implementation,
- * which provides the chat/video contexts + connection lifecycle once its chunk
- * loads. The impl renders children directly even before connection completes;
- * video consumers already guard a null client, and chat consumers only render on
- * the chat route (under <Chat>).
+ * SDK-free shell. Always paints `children` immediately, then upgrades to the
+ * Stream SDK impl once its chunk loads.
+ *
+ * Why not `next/dynamic` with a loading spinner: that fallback *replaced*
+ * children during chunk download, so every dashboard route (including /home)
+ * blocked on the Stream bundle. The unread badge + Join still need the layout
+ * to mount this provider (singleton connect), but they must not gate first
+ * paint. Websocket connect itself stays deferred to requestIdleCallback inside
+ * the impl (#248).
  */
 const StreamProvider = (props: StreamProviderProps) => {
-  return <LazyStreamProviderImpl {...props} />;
+  const [Impl, setImpl] = useState<ComponentType<StreamProviderProps> | null>(
+    null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void import("@/providers/StreamProviderImpl").then((mod) => {
+      if (!cancelled) setImpl(() => mod.default);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!Impl) {
+    return (
+      <StreamConnectionContext.Provider value={DEFAULT_CONNECTION_STATE}>
+        {props.children}
+      </StreamConnectionContext.Provider>
+    );
+  }
+
+  return <Impl {...props} />;
 };
 
 export default StreamProvider;

--- a/providers/StreamProvider.tsx
+++ b/providers/StreamProvider.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ComponentType,
-} from "react";
+import { createContext, useContext } from "react";
+import dynamic from "next/dynamic";
 
 // Re-export the logout helper from the SDK-free module so existing importers of
 // `disconnectStreamClients` from this path keep working unchanged. Callers that
@@ -56,41 +51,52 @@ export interface StreamProviderProps {
   enableVideo?: boolean;
 }
 
+// Loading strategy (deliberate, per-scenario — NOT blanket lazy):
+//
+//  • SDK code-split (lazy chunk): YES. The Stream SDK is heavy and the dashboard
+//    LANDING route is always /home, which renders no chat/video UI. Splitting the
+//    SDK + its two stylesheets into a chunk keeps them out of /home's synchronous
+//    bundle, so /home parses/paints without paying for the SDK up front.
+//
+//  • When does that chunk actually load? On dashboard routes the provider is
+//    mounted by the LAYOUT, so the chunk begins downloading on /home too — but
+//    IN PARALLEL, off the critical bundle, not blocking first paint. This is the
+//    right call (deferred/parallel, not "only when chat opens") because the
+//    consultant sidebar shows a chat-unread badge on every route incl. /home,
+//    which needs the chat client connected. Gating the whole provider behind
+//    "user opened chat" would break that badge. The actual connect (websocket)
+//    is further deferred to requestIdleCallback inside the impl (see #248 there).
+//
+//  • ssr:false: the SDK is browser-only (websockets/WebRTC); SSR-ing it is wasted
+//    server work and hydration mismatch risk.
+//
+// Children are rendered through the impl, which renders them DIRECTLY even before
+// connection completes (it no longer blocks on a spinner until connected). During
+// the brief chunk-download window the fallback below shows — this is strictly
+// shorter than the previous behavior, which blocked children until BOTH clients
+// finished their websocket handshake.
+function StreamProviderLoading() {
+  return (
+    <div className="flex items-center justify-center min-h-[200px]">
+      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary" />
+    </div>
+  );
+}
+
+const LazyStreamProviderImpl = dynamic(
+  () => import("@/providers/StreamProviderImpl"),
+  { ssr: false, loading: () => <StreamProviderLoading /> },
+);
+
 /**
- * SDK-free shell. Always paints `children` immediately, then upgrades to the
- * Stream SDK impl once its chunk loads.
- *
- * Why not `next/dynamic` with a loading spinner: that fallback *replaced*
- * children during chunk download, so every dashboard route (including /home)
- * blocked on the Stream bundle. The unread badge + Join still need the layout
- * to mount this provider (singleton connect), but they must not gate first
- * paint. Websocket connect itself stays deferred to requestIdleCallback inside
- * the impl (#248).
+ * SDK-free shell. Renders children through the lazily-loaded implementation,
+ * which provides the chat/video contexts + connection lifecycle once its chunk
+ * loads. The impl renders children directly even before connection completes;
+ * video consumers already guard a null client, and chat consumers only render on
+ * the chat route (under <Chat>).
  */
 const StreamProvider = (props: StreamProviderProps) => {
-  const [Impl, setImpl] = useState<ComponentType<StreamProviderProps> | null>(
-    null,
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-    void import("@/providers/StreamProviderImpl").then((mod) => {
-      if (!cancelled) setImpl(() => mod.default);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (!Impl) {
-    return (
-      <StreamConnectionContext.Provider value={DEFAULT_CONNECTION_STATE}>
-        {props.children}
-      </StreamConnectionContext.Provider>
-    );
-  }
-
-  return <Impl {...props} />;
+  return <LazyStreamProviderImpl {...props} />;
 };
 
 export default StreamProvider;

--- a/schemas/user.ts
+++ b/schemas/user.ts
@@ -1,5 +1,6 @@
 // schemas/user.ts
 import { z } from "zod";
+import { UserRole } from "@prisma/client";
 import { experienceValidation } from "./shared";
 
 // #region Enums
@@ -29,12 +30,10 @@ export const BudgetPreferenceEnum = z.enum([
 
 export const SessionTypeEnum = z.enum(["ONE_ON_ONE", "GROUP", "ASYNC_REVIEW"]);
 
-export const UserRoleEnum = z.enum([
-  "CONSULTANT",
-  "CONSULTEE",
-  "ADMIN",
-  "STAFF",
-]);
+// Derived from Prisma, not hand-listed: this drifted when ORG_WORKSPACE landed,
+// which made Partial<OnboardingFormData> unassignable to every step-form prop
+// type in app/form/onboarding and forced a chain of casts at the call sites.
+export const UserRoleEnum = z.nativeEnum(UserRole);
 
 export const ScheduleTypeEnum = z.enum(["WEEKLY", "CUSTOM"]);
 

--- a/types/consultant-events.ts
+++ b/types/consultant-events.ts
@@ -61,6 +61,8 @@ export interface TConsultantDashboardResponse {
   appointments: TAppointment[];
   activities: TConsultantActivity[];
   approvals: TConsultantApproval[];
+  /** Total pending requests — `approvals` is a capped preview, so don't count it. */
+  pendingRequestsCount: number;
   performanceSnapshot: TPerformanceSnapshot;
   financialSummary: TFinancialSummary;
 }


### PR DESCRIPTION
## Summary

Cuts dashboard nav TTFB by removing work rather than by trusting a cache.

- **Request-memoized session reads.** `getSession` is wrapped in `React.cache`, so the nested layout gates (`requireOnboarded`, `requirePersonalProfileAccess`) that all run in one RSC render share a single Better Auth call instead of re-running `customSession` enrichment per guard. This is the actual TTFB win in the PR.
- **Slimmer Prisma graphs.** Consultant home/appointments drop `user: true` for narrow selects, and the pending-approvals widgets stop fetching `payment`/plan nests they never read — those were fetched and discarded on `dev`.
- **Home reads only what Home shows.** Appointments are selected by soonest slot rather than pulling recent history.
- **Code splitting.** Onboarding steps, `CreateOrganizationWizard`, `EarningsTabs` (recharts) and `SafeUnifiedCalendar` load on demand, each with a loading state.
- **Explore trending** replaces a nested per-plan scan with two bounded reads and a JS tally.
- **NeedsYou** runs in parallel with the dashboard prefetch.

## What was tried and reverted

The first version of this PR moved the dashboard layout gates and `requireApiAuth` onto the Better Auth **session cookie cache**. That is **reverted**. The reasoning is worth recording, because the original rationale was wrong:

- `customSession`'s `/get-session` calls core `getSession()` and then runs its callback **unconditionally** — verified in `better-auth@1.6.5` (`plugins/custom-session/index.mjs:44-54`). Our callback does `prisma.user.findUnique` + `prisma.membership.findMany` + an SSO lookup on **every** call, cache hit or not. The cookie cache only skips `internalAdapter.findSession()` — roughly **one query in four**.
- `lib/auth-guard.ts` has no `banned` check of its own. It catches bans, DPDP erasure and revoked sessions *only* because a forced read finds no session row. Cached, those users kept access to `/dashboard/admin/**`, `/checkout` and `/settings` for up to 5 minutes.
- `session.user.role` comes from the cookie payload, and ~86 bare `requireApiAuth()` call sites branch on it — including the ADMIN gate on `DELETE /api/bookings/subscriptions/[id]`.

`React.cache` gives the dedupe without any of that and works identically with `getSession(true)`. `requireApiAuth` now has **no** cache opt-out, by design.

## Correctness fixes

These were regressions introduced by earlier commits **in this PR**, not pre-existing:

- **Financial Summary counts.** `activeClients`/`activePrograms` were derived by looping the truncated display array; they now come from a dedicated ids-only query over the whole active book, with soft-deleted slots excluded.
- **Approvals badge.** Was `approvals.length` against a capped list, so it contradicted `NeedsYou` — which counts properly — on the same screen. Now a real `count()`, deliberately unbounded by date to match NeedsYou's definition; the 90-day bound stays on the list, which is only a preview.
- **Today/Upcoming could render empty.** Ranking by `createdAt` truncated on the wrong key. Now ranked on `SlotOfAppointment` anchored at `endsAt >= start of today`. An intermediate attempt ordered ascending from 90 days ago, which returns the *oldest* slots and reproduced the same symptom — that is what the new tests pin.
- **Trending could render blank.** An `INNER JOIN` dropped plans with no slot in 30 days; zero-count plans now keep their place in the ranking.
- **StreamProvider** reverted to `next/dynamic`. Swapping the element type at that position remounted the entire dashboard subtree after hydration — the remount storm `StreamProviderImpl` documents, one level up.

## Onboarding types

`schemas/user.ts` hand-listed `UserRoleEnum` and never gained `ORG_WORKSPACE`, which made `Partial<OnboardingFormData>` unassignable to five step-form props. That was masked on `dev` by `as Parameters<typeof X>[0][...]` — a tautological cast that always compiles — and briefly by `as never`. Deriving the enum from Prisma removes the mismatch and **all five casts**. No runtime change: those schemas are type-only, never `.parse()`d.

## Conventions

No raw SQL. Prisma cannot order by a *filtered* relation count ([#20838](https://github.com/prisma/prisma/issues/20838), [#14598](https://github.com/prisma/prisma/issues/14598)), which is why a `$queryRaw` aggregate was tried; sorting in JS sidesteps the limitation, so `lib/data` and `app` are back to **zero** raw-SQL call sites.

## Measured bundle impact

From the CI build output, against the `dev` baseline:

| Route | `dev` | this PR | Delta |
|---|---|---|---|
| `/form/onboarding` | 25.2 kB / **392 kB** first load | 14.6 kB / **319 kB** | **−10.6 kB / −73 kB** |
| `/explore/experts` *(control)* | 18.6 kB / 315 kB | 23.5 kB / 320 kB | +4.9 kB / +5 kB |

The control route is the point: the codebase drifted *upward* over the same period, so the onboarding drop is the code-splitting rather than ambient change. Not isolated: how much of the 73 kB is `CreateOrganizationWizard` versus the ten step forms is unknown.

## Verification

**A clean deploy preview does not verify the three read regressions — please don't read it as a pass.** The dev database's busiest consultant has 10 appointments against a display cap of 20, and there are 4 pending requests platform-wide against the old badge cap of 40. The preview renders identically on the buggy and the fixed code.

They are pinned instead in `__tests__/dashboards/consultant-home-read-shape.test.ts`. Each test was checked by reintroducing its bug and confirming it fails, so none of them passes vacuously:

| Test | Bug it catches |
|---|---|
| ranks by slot time anchored at today | ordering that returns the oldest slots → empty Today/Upcoming |
| pending counts uncapped and undated | badge disagreeing with NeedsYou on the same screen |
| active clients from a dedicated query | truncated array + tombstoned slots skewing counts |

Suite: 220 files, 2514 tests, green.

### Still worth a human pass

- [ ] `HomeTab` **rendering** given a correct payload — the tests pin query shapes, not output, and dev lacks the data volume to exercise it
- [ ] Onboarding: each split step shows a spinner rather than a collapsed card; consultant + org-workspace complete without bouncing back to `/form/onboarding`
- [ ] Ban or revoke a session, then confirm `/dashboard/admin`, `/checkout` and the booking APIs reject immediately rather than after 5 minutes
- [ ] Soft-nav consultant home ↔ appointments ↔ settings: one session enrichment per request

## Known, documented, not fixed here

`package.json` pins `react ^18.3.1`, and **react@18.3.1 does not export `cache`** — the memoization resolves only via Next's RSC-layer alias to vendored React 19. It works and the build is green, but it rests on a bundler alias rather than the declared dependency; if that alias ever stops applying it degrades silently to no memoization, with correct results and N times the queries. Recorded in `lib/auth-server.ts` rather than left to be rediscovered.

## Follow-ups (separate PRs)

- `requireAuth()` has the same stale-session shape and is **pre-existing on `dev`** — guards `/settings`, `/profile`, `/dashboard/org-workspace/**` including billing
- Onboarding step registry, plus the dead `FormProvider` (nothing calls `useFormContext`) and the ORG_WORKSPACE role committed to the DB at step 0
- No `<Suspense>` anywhere under `app/dashboard/` — consultant home still awaits ~14 queries before emitting any JSX. Largest remaining TTFB win.
