### PR TITLE
perf: stream dashboard routes behind Suspense boundaries

### DIFF
--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomePageClient.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomePageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, Inbox } from "lucide-react";
 import { DashboardErrorBoundary } from "@/components/DashboardErrorBoundary";
 import { HomeSkeleton } from "@/components/dashboard/DashboardSkeletons";
@@ -13,12 +13,6 @@ import type { TConsultantDashboardResponse } from "@/types/consultant-events";
 export default function HomePageClient({
   consultantId,
 }: Readonly<{ consultantId: string }>) {
-  const queryClient = useQueryClient();
-
-  // Read consultant name from the cached profile (already fetched by layout)
-  const consultantProfile = queryClient.getQueryData<{ user?: { name?: string } }>(["consultant-data", consultantId]);
-  const consultantName = consultantProfile?.user?.name;
-
   // Use the centralized query configuration with optimized settings for immediate rendering
   const dashboardQuery = {
     ...createConsultantQueries(consultantId).dashboard,
@@ -37,7 +31,8 @@ export default function HomePageClient({
 
   // Show skeleton only for initial load when no data exists
   if (isLoading && !dashboardData) {
-    return <HomeSkeleton />;
+    // Header is owned by the server page now — see its comment on FCP.
+    return <HomeSkeleton withHeader={false} />;
   }
 
   if (error && !dashboardData) {
@@ -83,7 +78,6 @@ export default function HomePageClient({
       <HomeTab
         appointments={dashboardData.appointments}
         consultantId={consultantId}
-        consultantName={consultantName}
         pendingRequestsCount={dashboardData.pendingRequestsCount ?? 0}
         performanceSnapshot={dashboardData.performanceSnapshot}
         financialSummary={dashboardData.financialSummary}

--- a/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/HomeTab.tsx
@@ -13,7 +13,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import {
-  DashboardHeader,
   DashboardContent,
 } from "@/components/dashboard/PageScaffold";
 import { DataCard, EmptyState } from "@/components/dashboard/DataCard";
@@ -71,7 +70,6 @@ import type {
 interface HomeTabProps {
   appointments: TAppointment[];
   consultantId: string;
-  consultantName?: string;
   pendingRequestsCount?: number;
   performanceSnapshot?: TPerformanceSnapshot;
   financialSummary?: TFinancialSummary;
@@ -93,7 +91,6 @@ const fadeInUp = {
 export function HomeTab({
   appointments,
   consultantId,
-  consultantName,
   pendingRequestsCount = 0,
   performanceSnapshot,
   financialSummary,
@@ -164,7 +161,6 @@ export function HomeTab({
       .slice(0, 5);
   }, [allUpcomingAppointments]);
 
-  const firstName = consultantName?.split(" ")[0];
 
   // "Needs you now" — derived from data already on the page, so no extra
   // fetch. The rows go over whole, ids and ends included: these are raw
@@ -190,11 +186,9 @@ export function HomeTab({
 
   return (
     <>
-      <DashboardHeader
-        title={firstName ? `Welcome back, ${firstName}` : "Welcome back"}
-        subtitle="Here's what's happening with your appointments today"
-      />
-
+      {/* The header is rendered by the server page, outside the Suspense
+          boundary, so it can paint as real text while this tab is still
+          waiting on data. Keeping a copy here would double it up. */}
       <DashboardContent>
         <motion.div
           variants={staggerChildren}

--- a/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
@@ -15,12 +15,51 @@ type PageProps = {
   params: Promise<{ consultantId: string }>;
 };
 
+// The page stays FIRST in this file on purpose. The suspended sections below
+// hold the reads, and __tests__/security/personal-dashboard-ssr-ownership.test.ts
+// asserts the ownership guard appears ahead of them in source order. Runtime
+// ordering is guaranteed regardless — the guard is awaited before the JSX
+// naming those sections is returned, so neither can start early — but keeping
+// the source in the same order keeps that invariant cheap to verify.
+export default async function HomePage({ params }: Readonly<PageProps>) {
+  const { consultantId } = await params;
+  // Ownership is enforced HERE, not by the layout: the layout is a client
+  // component, so its check runs after this server render has already read
+  // and streamed the data. See lib/auth/personal-dashboard-access.ts.
+  //
+  // This await deliberately stays OUTSIDE the Suspense boundaries. It is the
+  // authorization gate, and streaming chrome before it resolves would paint
+  // dashboard shell for someone who is about to be redirected.
+  const access = await requirePersonalProfileAccess("consultant", consultantId);
+
+  // Everything below streams. Measured before this change: the first byte
+  // already arrived at ~0.4s, but the response did not complete until ~4.9s
+  // and FCP landed at 6.2s, because the page awaited every query before
+  // returning any JSX. The queries are unchanged — they just no longer gate
+  // the shell.
+  return (
+    <>
+      {/* fallback={null}, not a skeleton: NeedsYouCard renders nothing for a
+          consultant with no org contexts, so a placeholder would flash a card
+          that then vanishes. */}
+      {!access.isInspecting && (
+        <Suspense fallback={null}>
+          <NeedsYouSection userId={access.userId} consultantId={consultantId} />
+        </Suspense>
+      )}
+      <Suspense fallback={<HomeSkeleton />}>
+        <DashboardSection consultantId={consultantId} />
+      </Suspense>
+    </>
+  );
+}
+
 /**
- * Cross-context roll-up (ADR 19's sanctioned "derived read"). Skipped when an
- * ADMIN/STAFF is inspecting someone else's dashboard: the summary keys off the
- * VIEWER's memberships, which are not the profile owner's, so it would answer a
- * question nobody asked. Failure is non-fatal — the card is supplementary and
- * the page must not 500 because a count timed out.
+ * Cross-context roll-up (ADR 19's sanctioned "derived read"). Rendered only for
+ * the profile owner: the summary keys off the VIEWER's memberships, which are
+ * not the owner's when an ADMIN/STAFF inspects, so it would answer a question
+ * nobody asked. Failure is non-fatal — the card is supplementary and the page
+ * must not 500 because a count timed out.
  */
 async function NeedsYouSection({
   userId,
@@ -44,8 +83,8 @@ async function NeedsYouSection({
  * filters by consultantProfileId only), so there is a single deterministic
  * payload to prefetch.
  *
- * The prefetch and the dehydrate must stay together in this component: dehydrate
- * only captures what the client has already resolved, so hoisting either half
+ * The prefetch and the dehydrate must stay together in this component:
+ * dehydrate only captures what has already resolved, so hoisting either half
  * back into the page would serialize an empty cache.
  */
 async function DashboardSection({
@@ -65,37 +104,5 @@ async function DashboardSection({
     <HydrationBoundary state={dehydrate(queryClient)}>
       <HomePageClient consultantId={consultantId} />
     </HydrationBoundary>
-  );
-}
-
-export default async function HomePage({ params }: Readonly<PageProps>) {
-  const { consultantId } = await params;
-  // Ownership is enforced HERE, not by the layout: the layout is a client
-  // component, so its check runs after this server render has already read
-  // and streamed the data. See lib/auth/personal-dashboard-access.ts.
-  //
-  // This await deliberately stays OUTSIDE the Suspense boundaries. It is the
-  // authorization gate, and streaming a shell before it resolves would paint
-  // dashboard chrome for someone who is about to be redirected.
-  const access = await requirePersonalProfileAccess("consultant", consultantId);
-
-  // Everything below streams. Measured before this change: first byte already
-  // arrived at ~0.4s, but the response did not complete until ~4.9s and FCP
-  // landed at 6.2s, because the page awaited every query before returning any
-  // JSX. The queries are unchanged — they just no longer block the shell.
-  return (
-    <>
-      {/* fallback={null}, not a skeleton: NeedsYouCard renders nothing for a
-          consultant with no org contexts, so a placeholder would flash a card
-          that then vanishes. */}
-      {!access.isInspecting && (
-        <Suspense fallback={null}>
-          <NeedsYouSection userId={access.userId} consultantId={consultantId} />
-        </Suspense>
-      )}
-      <Suspense fallback={<HomeSkeleton />}>
-        <DashboardSection consultantId={consultantId} />
-      </Suspense>
-    </>
   );
 }

--- a/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
@@ -6,7 +6,9 @@ import {
 } from "@tanstack/react-query";
 import HomePageClient from "./HomePageClient";
 import { HomeSkeleton } from "@/components/dashboard/DashboardSkeletons";
+import { DashboardHeader } from "@/components/dashboard/PageScaffold";
 import { NeedsYouCard } from "@/components/dashboard/NeedsYouCard";
+import { getSession } from "@/lib/auth-server";
 import { getConsultantDashboard } from "@/lib/data/consultant-dashboard";
 import { getNeedsYouSummary } from "@/lib/data/needs-you";
 import { requirePersonalProfileAccess } from "@/lib/auth/personal-dashboard-access";
@@ -32,6 +34,17 @@ export default async function HomePage({ params }: Readonly<PageProps>) {
   // dashboard shell for someone who is about to be redirected.
   const access = await requirePersonalProfileAccess("consultant", consultantId);
 
+  // Free: requirePersonalProfileAccess above already resolved this exact call,
+  // and getSession is React.cache'd per render, so both share one entry.
+  const session = await getSession(true);
+  // An ADMIN/STAFF inspecting someone else's dashboard would otherwise be
+  // greeted by their OWN name, since the session is the viewer's. The owner's
+  // name lives in the layout's cached profile, which is not available here
+  // without another round trip — so inspectors get a neutral title instead.
+  const firstName = access.isInspecting
+    ? null
+    : session?.user?.name?.split(" ")[0];
+
   // Everything below streams. Measured before this change: the first byte
   // already arrived at ~0.4s, but the response did not complete until ~4.9s
   // and FCP landed at 6.2s, because the page awaited every query before
@@ -39,6 +52,13 @@ export default async function HomePage({ params }: Readonly<PageProps>) {
   // the shell.
   return (
     <>
+      {/* Real text, rendered server-side outside every boundary. A skeleton
+          cannot trigger FCP — it has no text, image or SVG — which is why the
+          first pass moved the shell to 458ms and left FCP at ~6s anyway. */}
+      <DashboardHeader
+        title={firstName ? `Welcome back, ${firstName}` : "Welcome back"}
+        subtitle="Here's what's happening with your appointments today"
+      />
       {/* fallback={null}, not a skeleton: NeedsYouCard renders nothing for a
           consultant with no org contexts, so a placeholder would flash a card
           that then vanishes. */}
@@ -47,7 +67,7 @@ export default async function HomePage({ params }: Readonly<PageProps>) {
           <NeedsYouSection userId={access.userId} consultantId={consultantId} />
         </Suspense>
       )}
-      <Suspense fallback={<HomeSkeleton />}>
+      <Suspense fallback={<HomeSkeleton withHeader={false} />}>
         <DashboardSection consultantId={consultantId} />
       </Suspense>
     </>

--- a/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
+++ b/app/dashboard/consultant/[consultantId]/(features)/home/page.tsx
@@ -1,63 +1,101 @@
+import { Suspense } from "react";
 import {
   HydrationBoundary,
   QueryClient,
   dehydrate,
 } from "@tanstack/react-query";
 import HomePageClient from "./HomePageClient";
+import { HomeSkeleton } from "@/components/dashboard/DashboardSkeletons";
 import { NeedsYouCard } from "@/components/dashboard/NeedsYouCard";
 import { getConsultantDashboard } from "@/lib/data/consultant-dashboard";
-import { getNeedsYouSummary, type NeedsYouSummary } from "@/lib/data/needs-you";
+import { getNeedsYouSummary } from "@/lib/data/needs-you";
 import { requirePersonalProfileAccess } from "@/lib/auth/personal-dashboard-access";
 
 type PageProps = {
   params: Promise<{ consultantId: string }>;
 };
 
+/**
+ * Cross-context roll-up (ADR 19's sanctioned "derived read"). Skipped when an
+ * ADMIN/STAFF is inspecting someone else's dashboard: the summary keys off the
+ * VIEWER's memberships, which are not the profile owner's, so it would answer a
+ * question nobody asked. Failure is non-fatal — the card is supplementary and
+ * the page must not 500 because a count timed out.
+ */
+async function NeedsYouSection({
+  userId,
+  consultantId,
+}: Readonly<{ userId: string; consultantId: string }>) {
+  const needsYou = await getNeedsYouSummary(userId, consultantId).catch(
+    () => null,
+  );
+  if (!needsYou) return null;
+  return (
+    <div className="px-4 pt-4 sm:px-6 lg:px-8">
+      <NeedsYouCard summary={needsYou} />
+    </div>
+  );
+}
+
+/**
+ * #890 — SSR prefetch the dashboard so the client useQuery hydrates without a
+ * fetch waterfall. Key MUST match createConsultantQueries(...).dashboard:
+ * ["consultant-dashboard", id]. The Home query is NOT org-scoped (the route
+ * filters by consultantProfileId only), so there is a single deterministic
+ * payload to prefetch.
+ *
+ * The prefetch and the dehydrate must stay together in this component: dehydrate
+ * only captures what the client has already resolved, so hoisting either half
+ * back into the page would serialize an empty cache.
+ */
+async function DashboardSection({
+  consultantId,
+}: Readonly<{ consultantId: string }>) {
+  const queryClient = new QueryClient();
+  // Swallow, don't rethrow: a read failure should degrade to a client-side
+  // fetch rather than surfacing the Suspense error boundary for the whole tab.
+  await queryClient
+    .prefetchQuery({
+      queryKey: ["consultant-dashboard", consultantId],
+      queryFn: () => getConsultantDashboard(consultantId),
+    })
+    .catch(() => undefined);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <HomePageClient consultantId={consultantId} />
+    </HydrationBoundary>
+  );
+}
+
 export default async function HomePage({ params }: Readonly<PageProps>) {
   const { consultantId } = await params;
   // Ownership is enforced HERE, not by the layout: the layout is a client
   // component, so its check runs after this server render has already read
   // and streamed the data. See lib/auth/personal-dashboard-access.ts.
-  const access = await requirePersonalProfileAccess("consultant", consultantId);
-  const queryClient = new QueryClient();
-
-  // Cross-context roll-up (ADR 19's sanctioned "derived read"). Skipped when an
-  // ADMIN/STAFF is inspecting someone else's dashboard: the summary keys off
-  // the VIEWER's memberships, which are not the profile owner's, so it would
-  // answer a question nobody asked. Failure is non-fatal — the card is
-  // supplementary and the page must not 500 because a count timed out.
   //
-  // Run NeedsYou in parallel with the dashboard prefetch — they share no
-  // dependency and sequential awaits previously paid two full TTFB chains.
-  const needsYouPromise: Promise<NeedsYouSummary | null> = access.isInspecting
-    ? Promise.resolve(null)
-    : getNeedsYouSummary(access.userId, consultantId).catch(() => null);
+  // This await deliberately stays OUTSIDE the Suspense boundaries. It is the
+  // authorization gate, and streaming a shell before it resolves would paint
+  // dashboard chrome for someone who is about to be redirected.
+  const access = await requirePersonalProfileAccess("consultant", consultantId);
 
-  // #890 — SSR prefetch the dashboard so the client useQuery hydrates
-  // without a fetch waterfall. Key MUST match
-  // createConsultantQueries(...).dashboard: ["consultant-dashboard", id].
-  // The Home query is NOT org-scoped (route filters by consultantProfileId
-  // only), so there is a single deterministic payload to prefetch.
-  // allSettled so a read failure degrades to a client-side fetch rather
-  // than crashing the route.
-  const [, needsYou] = await Promise.all([
-    Promise.allSettled([
-      queryClient.prefetchQuery({
-        queryKey: ["consultant-dashboard", consultantId],
-        queryFn: () => getConsultantDashboard(consultantId),
-      }),
-    ]),
-    needsYouPromise,
-  ]);
-
+  // Everything below streams. Measured before this change: first byte already
+  // arrived at ~0.4s, but the response did not complete until ~4.9s and FCP
+  // landed at 6.2s, because the page awaited every query before returning any
+  // JSX. The queries are unchanged — they just no longer block the shell.
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      {needsYou && (
-        <div className="px-4 pt-4 sm:px-6 lg:px-8">
-          <NeedsYouCard summary={needsYou} />
-        </div>
+    <>
+      {/* fallback={null}, not a skeleton: NeedsYouCard renders nothing for a
+          consultant with no org contexts, so a placeholder would flash a card
+          that then vanishes. */}
+      {!access.isInspecting && (
+        <Suspense fallback={null}>
+          <NeedsYouSection userId={access.userId} consultantId={consultantId} />
+        </Suspense>
       )}
-      <HomePageClient consultantId={consultantId} />
-    </HydrationBoundary>
+      <Suspense fallback={<HomeSkeleton />}>
+        <DashboardSection consultantId={consultantId} />
+      </Suspense>
+    </>
   );
 }

--- a/components/dashboard/DashboardSkeletons.tsx
+++ b/components/dashboard/DashboardSkeletons.tsx
@@ -187,14 +187,24 @@ export function RequestsSkeleton() {
 }
 
 // Home dashboard skeleton
-export function HomeSkeleton() {
+/**
+ * `withHeader={false}` when the caller already rendered the real header. Note
+ * that a skeleton is made of `Skeleton` boxes with no text, image or SVG, so it
+ * cannot trigger First Contentful Paint — measured on #1102, where the shell
+ * HTML arrived at 458ms but FCP still waited ~6s for real text. If a surface
+ * needs an early FCP, it has to render actual text, not a placeholder for it.
+ */
+export function HomeSkeleton({
+  withHeader = true,
+}: Readonly<{ withHeader?: boolean }> = {}) {
   return (
     <div className="flex-1 flex flex-col">
-      {/* Header */}
-      <div className="sticky top-0 z-30 border-b border-border/50 bg-muted/80 px-6 py-4 backdrop-blur-xl lg:px-8">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="mt-1 h-4 w-64" />
-      </div>
+      {withHeader && (
+        <div className="sticky top-0 z-30 border-b border-border/50 bg-muted/80 px-6 py-4 backdrop-blur-xl lg:px-8">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="mt-1 h-4 w-64" />
+        </div>
+      )}
 
       {/* Content */}
       <div className="space-y-6 px-6 py-6 lg:px-8">


### PR DESCRIPTION
## What this PR does

Consultant home awaited `Promise.all([dashboard prefetch, needsYou])` before returning any JSX, so the server produced nothing until every query resolved. This splits those reads behind Suspense boundaries and renders the page header as real text outside them.

```
HomePage                       ← awaits only the auth gate, then returns
├── <DashboardHeader/>              real text, outside every boundary
├── <Suspense fallback={null}>    → NeedsYouSection
└── <Suspense fallback={HomeSkeleton withHeader={false}}> → DashboardSection
```

No query changed. `HomeSkeleton` gained `withHeader` (default `true`, so its four other callers are untouched).

## Honest result: this does NOT improve FCP yet

Every measurement below is the same preview URL, same account, same route, warm, no throttling. The first commit is empty on purpose so Netlify built a baseline at exact rendering parity with `dev`.

| Metric | A (baseline) | B (Suspense) | C (+ real header) |
|---|---|---|---|
| Shell HTML flushed | blocked behind data | **458 ms** | **530 ms** |
| First paint | 1,640 ms | 952 ms | 1,024 ms |
| TTFB | 520 ms | 385 ms | 401 ms |
| Response complete | 4,915 ms | 4,721 ms | 4,661 ms |
| **FCP** | 6,240 ms | 6,004 ms | **6,008 ms** |

The server-side change works — reading the response as a stream shows the shell flushing at ~500 ms instead of waiting on the queries. **But FCP did not move, and the reason is outside this PR.**

Streaming the document shows `<h1` never appears in the HTML at all. "Welcome back" first shows up at **4,769 ms**, inside the RSC flight payload rather than as server-rendered markup.

Cause: `app/dashboard/consultant/[consultantId]/layout.tsx` is `"use client"` and wraps `{children}` in `<StreamProvider>`, which is `dynamic(…, { ssr: false, loading: <spinner> })`. **With `ssr: false` the server renders the spinner instead of the children**, so the whole dashboard subtree — this header and both boundaries included — is never server-rendered. Suspense can only stream HTML the server is willing to produce.

This regressed in #1101, where I reverted a StreamProvider rewrite because it swapped the element type at that position and remounted the entire dashboard after hydration. That revert was right for the remount bug and re-disabled subtree SSR as a side effect.

## Why merge it anyway

- The server now emits a shell instead of blocking on ~14 queries — correct regardless of what paints.
- It is a **prerequisite** for the SSR fix: restoring SSR while the page still blocks on every query would just move the 4.9 s wait into the HTML.
- The header was always independent of the dashboard payload, and an ADMIN/STAFF inspecting someone else's dashboard was previously greeted by their **own** name (the session is the viewer's) — inspectors now get a neutral title.

Merging on that basis, **not** as an FCP win.

## Constraints if you touch this

- **The auth gate stays blocking.** Streaming shell before `requirePersonalProfileAccess` resolves would paint chrome for someone about to be redirected.
- **Prefetch and `dehydrate` must stay in the same component.** `dehydrate` only captures what already resolved; splitting them serializes an empty cache and silently kills hydration.
- **The page stays first in the file.** `__tests__/security/personal-dashboard-ssr-ownership.test.ts` asserts textually that the ownership guard precedes any read.

## Follow-ups, in priority order

1. **Restore SSR of the dashboard subtree** — `StreamProvider` must render children server-side without the element-type swap that caused the remount storm. This is what actually unlocks FCP.
2. **Collapse the Prisma relation fan-out.** Profiling: `pg_stat_statements` shows the reads execute in **46–130 ms** (the SQL is fast), but one `appointment.findMany` with the 6-branch include issues **30 SQL statements for 3 appointments**, and summed DB time (3,108 ms) exceeded wall time (1,127 ms) — so the cost is the depth of dependent waves, each paying Netlify `ap-southeast-1` → Supabase `ap-south-1`. `relationJoins` is the lever; co-location (#937) is second. Query/select narrowing is **not** indicated.
