### PR TITLE
perf: resolve org scope from server facts so prefetch keys match

### DIFF
--- a/app/dashboard/consultee/[consulteeId]/(features)/home/page.tsx
+++ b/app/dashboard/consultee/[consulteeId]/(features)/home/page.tsx
@@ -7,44 +7,36 @@ import HomePageClient from "./HomePageClient";
 import { readConsulteeEvents } from "@/lib/data/consultee-events-read";
 import { requirePersonalProfileAccess } from "@/lib/auth/personal-dashboard-access";
 import { getSession } from "@/lib/auth-server";
-import type { Scope } from "@/lib/api/scope/parse";
+import {
+  resolveDefaultScopeKey,
+  scopeFromKey,
+} from "@/lib/api/scope/server-default";
 
 type PageProps = {
   params: Promise<{ consulteeId: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-/**
- * Mirror useOrgScope({ defaultForOrgMember: "all" }) when the URL has no
- * ?orgScope= — otherwise SSR dehydrates "personal" and org members immediately
- * refetch "all".
- */
-function defaultHomeScope(session: Awaited<ReturnType<typeof getSession>>): Scope {
-  const role = session?.user?.role;
-  const firstOrgId =
-    session?.user?.organizationMemberships?.[0]?.organizationId ?? null;
-  if (role === "ADMIN" || role === "STAFF" || firstOrgId) {
-    return { kind: "all" };
-  }
-  return { kind: "personal" };
-}
-
-function scopeQueryKey(scope: Scope): string {
-  if (scope.kind === "personal") return "personal";
-  if (scope.kind === "all") return "all";
-  return scope.orgId;
-}
-
-export default async function HomePage({ params }: Readonly<PageProps>) {
+export default async function HomePage({
+  params,
+  searchParams,
+}: Readonly<PageProps>) {
   const { consulteeId } = await params;
+  const orgScope = (await searchParams)?.orgScope;
   // Ownership is enforced HERE, not by the layout: the layout is a client
   // component, so its check runs after this server render has already read
   // and streamed the data. See lib/auth/personal-dashboard-access.ts.
   await requirePersonalProfileAccess("consultee", consulteeId);
   // Shares React.cache with the access guard / dashboard layout.
   const session = await getSession();
-  const scope = defaultHomeScope(session);
-  const scopeKey = scopeQueryKey(scope);
+  // Shared with useOrgScope's default rule so the two cannot drift, and it
+  // honours ?orgScope= — which the local mirror did not, so every scope toggle
+  // prefetched the wrong scope and threw the result away.
+  const scopeKey = resolveDefaultScopeKey(session, {
+    defaultForOrgMember: "all",
+    orgScopeParam: typeof orgScope === "string" ? orgScope : null,
+  });
+  const scope = scopeFromKey(scopeKey);
   const queryClient = new QueryClient();
 
   // #890 — SSR prefetch the same default scope the client useQuery asks for

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -59,7 +59,13 @@ export default async function DashboardLayout({
     .catch(() => undefined);
 
   return (
-    <ServerUserIdProvider userId={session.user.id}>
+    <ServerUserIdProvider
+      userId={session.user.id}
+      role={session.user.role}
+      firstOrgId={
+        session.user.organizationMemberships?.[0]?.organizationId ?? null
+      }
+    >
       <HydrationBoundary state={dehydrate(queryClient)}>
         {children}
       </HydrationBoundary>

--- a/components/dashboard/ServerUserId.tsx
+++ b/components/dashboard/ServerUserId.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 
 /**
  * The session user's id, resolved on the SERVER and handed to the client
@@ -20,19 +20,56 @@ import { createContext, useContext } from "react";
  * Identity only — never authorization. The guards still resolve the session
  * themselves; this exists so the FIRST render can name the right query key.
  */
-const ServerUserIdContext = createContext<string | undefined>(undefined);
+/**
+ * Facts the SERVER already knows about the session, for client code whose first
+ * render would otherwise have to wait on `useSession()`.
+ *
+ * `userId` fixes the query keys (see above). `role` and `firstOrgId` fix the
+ * ORG SCOPE segment: `useOrgScope` derives it from `useSession()` too, so during
+ * SSR it always resolved to `personal` while the server pages computed `all` for
+ * org members / admins / staff — a guaranteed prefetch-key miss on every
+ * hydration, then a second key flip once the session landed.
+ */
+export interface ServerSessionFacts {
+  userId: string | undefined;
+  role: string | undefined;
+  firstOrgId: string | null;
+}
+
+const EMPTY: ServerSessionFacts = {
+  userId: undefined,
+  role: undefined,
+  firstOrgId: null,
+};
+
+const ServerSessionFactsContext = createContext<ServerSessionFacts>(EMPTY);
 
 export function ServerUserIdProvider({
   userId,
+  role,
+  firstOrgId = null,
   children,
-}: Readonly<{ userId: string | undefined; children: React.ReactNode }>) {
+}: Readonly<{
+  userId: string | undefined;
+  role?: string | undefined;
+  firstOrgId?: string | null;
+  children: React.ReactNode;
+}>) {
+  const value = useMemo(
+    () => ({ userId, role, firstOrgId }),
+    [userId, role, firstOrgId],
+  );
   return (
-    <ServerUserIdContext.Provider value={userId}>
+    <ServerSessionFactsContext.Provider value={value}>
       {children}
-    </ServerUserIdContext.Provider>
+    </ServerSessionFactsContext.Provider>
   );
 }
 
 export function useServerUserId(): string | undefined {
-  return useContext(ServerUserIdContext);
+  return useContext(ServerSessionFactsContext).userId;
+}
+
+export function useServerSessionFacts(): ServerSessionFacts {
+  return useContext(ServerSessionFactsContext);
 }

--- a/hooks/useOrgScope.ts
+++ b/hooks/useOrgScope.ts
@@ -23,6 +23,7 @@
 import { useCallback, useMemo } from "react";
 import { useParams, useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useSession } from "@/lib/auth-client";
+import { useServerSessionFacts } from "@/components/dashboard/ServerUserId";
 
 export type Scope =
   | { kind: "personal" }
@@ -96,9 +97,19 @@ export function useOrgScope(
     orgIdFromPath && pathname?.startsWith("/dashboard/organization/"),
   );
 
-  const role = session?.user?.role;
+  // Fall back to the server-resolved facts. useSession() is still pending
+  // during SSR, so without this both values are empty there and the scope
+  // always resolved to `personal` — while the server pages computed `all` for
+  // org members / admins / staff. The scope segment is part of the query key
+  // (["consultee-events", id, scopeKey]), so every such user got a guaranteed
+  // hydration miss and then a second key flip once the session landed. The
+  // appointments pages document this and work around it by prefetching only
+  // "personal", which is why org members get no hydration on their busiest tab.
+  const serverFacts = useServerSessionFacts();
+  const role = session?.user?.role ?? serverFacts.role;
   const firstOrgId =
-    session?.user?.organizationMemberships?.[0]?.organizationId ?? null;
+    session?.user?.organizationMemberships?.[0]?.organizationId ??
+    serverFacts.firstOrgId;
 
   const scope: Scope = useMemo(() => {
     if (pinned && orgIdFromPath) {

--- a/lib/api/scope/server-default.ts
+++ b/lib/api/scope/server-default.ts
@@ -1,0 +1,55 @@
+import type { Session } from "@/lib/auth";
+
+/**
+ * The scope segment a page should PREFETCH, resolved on the server.
+ *
+ * Must stay a mirror of `useOrgScope`'s default rule (hooks/useOrgScope.ts).
+ * The scope is part of the query key — `["consultant-appointments", id,
+ * scopeKey]` — so if the two disagree the prefetch is silently wasted and the
+ * client refetches.
+ *
+ * They disagreed by construction until now. `useOrgScope` read the role and
+ * memberships from `useSession()`, which is pending during SSR, so it always
+ * resolved `personal` there; the pages worked around that by hard-coding a
+ * `"personal"` prefetch and accepting that org members get no hydration on
+ * their busiest tab. Now that the hook falls back to server-resolved facts,
+ * the pages have to resolve the same way or the mismatch simply inverts.
+ *
+ * `?orgScope=` still wins, exactly as the hook honours the URL first.
+ */
+export type ScopeKey = "personal" | "all" | (string & {});
+
+export function resolveDefaultScopeKey(
+  session: Session | null,
+  options: {
+    defaultForOrgMember?: "first-org" | "all" | "personal";
+    orgScopeParam?: string | null;
+  } = {},
+): ScopeKey {
+  const { defaultForOrgMember = "first-org", orgScopeParam = null } = options;
+
+  const raw = orgScopeParam?.trim();
+  if (raw) return raw;
+
+  if (defaultForOrgMember === "personal") return "personal";
+
+  const role = session?.user?.role;
+  if (role === "ADMIN" || role === "STAFF") return "all";
+
+  const firstOrgId =
+    session?.user?.organizationMemberships?.[0]?.organizationId ?? null;
+  if (firstOrgId) {
+    return defaultForOrgMember === "all" ? "all" : firstOrgId;
+  }
+
+  return "personal";
+}
+
+/** The `Scope` object form, for reads that take a scope rather than a filter. */
+export function scopeFromKey(
+  scopeKey: ScopeKey,
+): { kind: "personal" } | { kind: "all" } | { kind: "org"; orgId: string } {
+  if (scopeKey === "personal") return { kind: "personal" };
+  if (scopeKey === "all") return { kind: "all" };
+  return { kind: "org", orgId: scopeKey };
+}


### PR DESCRIPTION
## Problem

`useOrgScope` (`hooks/useOrgScope.ts:99-101`) read `role` and `firstOrgId` from `useSession()` — a client hook, pending during SSR. So it always resolved `personal` server-side, while the consultee home page computed `all` for org members / admins / staff.

The scope is part of the query key (`["consultee-events", id, scopeKey]`), so every such user got a **guaranteed hydration miss on first render**, then a second key flip once the session landed.

Same class of bug as #1105's `["user-details", undefined]`. That one has now bitten twice.

## Change

The dashboard layout already publishes the server-resolved user id for exactly this reason. This generalises that context to carry `role` and `firstOrgId`, and `useOrgScope` falls back to them.

`resolveDefaultScopeKey` puts the default rule in one place so hook and pages cannot drift — and it honours `?orgScope=`, which the consultee home page's local mirror did **not**. Every scope toggle was prefetching the wrong scope and discarding the result. That local copy is deleted in favour of the shared rule.

## Scoped deliberately

I checked which clients actually key a query off the hook before changing any page: **consultee home** and **consultee payments**.

The consultant appointments page carries a comment stating its client uses `useOrgScope({ defaultForOrgMember: "all" })` — **it does not**, and no component under that route does. I had already rewritten that page's prefetch on the strength of that comment before checking, and reverted it: with the hook fixed, seeding "all" there would have *inverted* a mismatch that does not exist, making first render worse. Its hard-coded "personal" prefetch is correct and untouched.

That stale comment is worth deleting separately; I left it rather than widen this PR.

## Verification

tsc clean, eslint clean, **2514 tests** green.

**Unverified until preview** — the bar is a hydration hit, not FCP:

- [ ] Sign in as an **org member** and load consultee home; confirm no immediate refetch of a second scope (currently guaranteed)
- [ ] Toggle scope so `?orgScope=` is present; confirm the server prefetches *that* scope rather than the default
- [ ] Confirm a B2C user with no orgs still resolves `personal` on both sides