### PR TITLE
perf: trim optimizePackageImports to packages Next does not already handle

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -160,20 +160,30 @@ const nextConfig = {
   // Reduce Webpack memory usage during builds (Next.js 15+, low-risk experimental)
   experimental: {
     webpackMemoryOptimizations: true,
+    // Only packages Next does NOT already optimize by default. Its built-in
+    // list covers lucide-react, recharts and date-fns among others, so listing
+    // those was inert config that read as if it were doing something.
+    // https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports
     optimizePackageImports: [
-      "lucide-react",
       "framer-motion",
       "@stream-io/video-react-sdk",
       "stream-chat-react",
-      "recharts",
-      "date-fns",
       "@radix-ui/react-icons",
+      // Imported by components/notifications/NotificationInbox.tsx and not in
+      // the default list.
+      "@novu/react",
+      "@novu/nextjs",
     ],
     // Next 15 defaults page segments to 0, which refetches RSC on every nav; this lets the client router cache hold payloads ~30s between navs.
     staleTimes: { dynamic: 30, static: 180 },
   },
 
   // This tells Next.js to explicitly process these packages during the build, which should resolve the module format conflict.
+  // NOTE: date-fns is now 4.1.0 and ships an exports map, so this is likely a
+  // leftover from the v2/v3 era — and transpiling a package may defeat Next's
+  // built-in optimizePackageImports handling for it (45 files import date-fns).
+  // Left in place deliberately: the claim above is unverified either way, and
+  // confirming it needs `npm run build:analyze`, not reasoning.
   transpilePackages: ["date-fns"],
 
   // Prevent pg (node-postgres) and related packages from being bundled into client-side code


### PR DESCRIPTION
Small config-level change; no runtime code touched.

## Change

`lucide-react`, `recharts` and `date-fns` are all in Next's [built-in optimizePackageImports list](https://nextjs.org/docs/app/api-reference/config/next-config-js/optimizePackageImports), so naming them was inert config that read as if it were doing something. `@novu/react` and `@novu/nextjs` **are** imported (`components/notifications/NotificationInbox.tsx`) and were absent.

## Recorded, not acted on

`transpilePackages: ["date-fns"]` looks stale — date-fns is **4.1.0 with an exports map**, and transpiling a package can defeat Next's built-in handling for it across the 45 files importing it. But the comment above that line claims it resolves a module-format conflict, and that claim is unverified in both directions. Confirming it needs `npm run build:analyze`, which is too RAM-heavy to run locally, so it stays put with a note rather than being removed on a hunch.

## Why ISR is NOT in this PR

The plan was to pair this with `export const revalidate` on the 11 public `force-dynamic` pages (there are currently **zero** `revalidate` exports repo-wide). Checking them first:

| Page | Server-side auth references |
|---|---|
| `app/page.tsx` | 0 — safe |
| `app/explore/experts/page.tsx` | 0 — safe |
| `app/explore/programs/page.tsx` | **2 — not safe** |

Caching that route's HTML would serve one viewer's authenticated content to everyone. That needs a per-page audit across all eleven, which is its own PR rather than a blanket switch bolted onto a config tidy.

## Verification

Config loads and resolves as expected; eslint clean. Bundle effect is unmeasured — the honest check is CI's build output, not local reasoning.