### PR TITLE
perf(navbar): paint the remembered auth shape before the session resolves

### DIFF
--- a/__tests__/lib/auth-client-signout-clears-identity.test.ts
+++ b/__tests__/lib/auth-client-signout-clears-identity.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Every sign-out path in the app imports `signOut` from `@/lib/auth-client`
+ * (`grep -rn "signOut" app components lib providers` — nothing calls
+ * `authClient.signOut` directly). That makes the wrapper the one place the
+ * cached display identity has to be cleared, so this test pins it: without it,
+ * a shared or public device keeps the previous user's name and avatar in
+ * localStorage until someone else's session happens to resolve. #636
+ */
+jest.mock("better-auth/react", () => ({
+  createAuthClient: () => ({
+    signIn: {},
+    signUp: {},
+    // Declared inside the factory: `jest.mock` is hoisted above the imports,
+    // so a module-scope const would still be in its TDZ here.
+    signOut: jest.fn(() => Promise.resolve({ data: null })),
+    useSession: jest.fn(),
+    getSession: jest.fn(),
+    sendVerificationEmail: jest.fn(),
+  }),
+}));
+jest.mock("better-auth/client/plugins", () => ({
+  customSessionClient: () => ({}),
+}));
+jest.mock("@better-auth/sso/client", () => ({ ssoClient: () => ({}) }));
+
+import { authClient, signOut } from "@/lib/auth-client";
+import {
+  readAuthedFlag,
+  readAuthedIdentity,
+  writeAuthedFlag,
+} from "@/lib/auth-broadcast";
+
+const mockSignOut = authClient.signOut as unknown as jest.Mock;
+
+describe("signOut", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockSignOut.mockImplementation(() => Promise.resolve({ data: null }));
+  });
+
+  it("forgets the remembered identity and still delegates", () => {
+    writeAuthedFlag(true, {
+      name: "Zara Brown",
+      image: "https://cdn.test/z.png",
+    });
+
+    const options = { fetchOptions: { onSuccess: jest.fn() } };
+    void signOut(options);
+
+    expect(readAuthedIdentity()).toBeNull();
+    expect(readAuthedFlag()).toBe(false);
+    expect(mockSignOut).toHaveBeenCalledWith(options);
+  });
+
+  it("clears before the request, so a failed sign-out still forgets", () => {
+    writeAuthedFlag(true, { name: "Zara Brown", image: null });
+    mockSignOut.mockImplementationOnce(() =>
+      Promise.reject(new Error("network")),
+    );
+
+    void signOut().catch(() => {});
+
+    expect(readAuthedIdentity()).toBeNull();
+  });
+});

--- a/__tests__/lib/auth-remembered-shape.test.tsx
+++ b/__tests__/lib/auth-remembered-shape.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * The navbar's optimistic first paint (#636).
+ *
+ * Two properties are load-bearing and neither is obvious from reading the code:
+ *   1. `useRememberedAuth` MUST return null on the very first render, or the
+ *      server HTML and the first client render disagree and React discards the
+ *      tree. Asserted by recording every render's value.
+ *   2. Once the layout effect has run, the branch must render the remembered
+ *      shape instead of the skeleton.
+ *
+ * Paint ordering (layout effect lands before the browser paints) is a browser
+ * guarantee and is deliberately NOT asserted here — it cannot be.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  forgetAuthState,
+  readAuthedFlag,
+  readAuthedIdentity,
+  writeAuthedFlag,
+} from "@/lib/auth-broadcast";
+import {
+  resolveAuthView,
+  useRememberedAuth,
+  type RememberedAuth,
+} from "@/hooks/useRememberedAuth";
+
+const IDENTITY = { name: "Zara Brown", image: "https://cdn.test/zara.png" };
+
+describe("auth-broadcast remembered state", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("round-trips the flag and the display identity", () => {
+    writeAuthedFlag(true, IDENTITY);
+    expect(readAuthedFlag()).toBe(true);
+    expect(readAuthedIdentity()).toEqual(IDENTITY);
+  });
+
+  it("returns null for a visitor with nothing remembered", () => {
+    expect(readAuthedFlag()).toBeNull();
+    expect(readAuthedIdentity()).toBeNull();
+  });
+
+  it("drops the cached identity whenever the flag goes false", () => {
+    writeAuthedFlag(true, IDENTITY);
+    writeAuthedFlag(false);
+    expect(readAuthedFlag()).toBe(false);
+    // The privacy invariant: a shared device must not retain the previous
+    // user's name or avatar.
+    expect(readAuthedIdentity()).toBeNull();
+    expect(localStorage.getItem("familiarise.auth_identity")).toBeNull();
+  });
+
+  it("drops the cached identity when authed is written without one", () => {
+    writeAuthedFlag(true, IDENTITY);
+    writeAuthedFlag(true);
+    expect(readAuthedIdentity()).toBeNull();
+  });
+
+  it("forgetAuthState clears both halves", () => {
+    writeAuthedFlag(true, IDENTITY);
+    forgetAuthState();
+    expect(readAuthedFlag()).toBe(false);
+    expect(readAuthedIdentity()).toBeNull();
+  });
+
+  it("tolerates a corrupt or partial identity payload", () => {
+    localStorage.setItem("familiarise.auth_authed", "true");
+    localStorage.setItem("familiarise.auth_identity", "{not json");
+    expect(readAuthedIdentity()).toBeNull();
+
+    localStorage.setItem(
+      "familiarise.auth_identity",
+      JSON.stringify({ name: 7 }),
+    );
+    expect(readAuthedIdentity()).toEqual({ name: null, image: null });
+  });
+});
+
+describe("resolveAuthView", () => {
+  const remembered = (authed: boolean): RememberedAuth => ({
+    authed,
+    identity: authed ? IDENTITY : null,
+  });
+
+  it("shows the skeleton only when nothing is known", () => {
+    expect(
+      resolveAuthView({ isPending: true, user: null, remembered: null }).mode,
+    ).toBe("unknown");
+  });
+
+  it("adopts the remembered anonymous shape while pending", () => {
+    expect(
+      resolveAuthView({
+        isPending: true,
+        user: null,
+        remembered: remembered(false),
+      }),
+    ).toEqual({ mode: "anonymous", name: null, image: null });
+  });
+
+  it("adopts the remembered identity while pending", () => {
+    expect(
+      resolveAuthView({
+        isPending: true,
+        user: null,
+        remembered: remembered(true),
+      }),
+    ).toEqual({ mode: "authed", ...IDENTITY });
+  });
+
+  it("lets the resolved session override a stale remembered flag", () => {
+    // Expired session: remembered says authed, truth says otherwise.
+    expect(
+      resolveAuthView({
+        isPending: false,
+        user: null,
+        remembered: remembered(true),
+      }).mode,
+    ).toBe("anonymous");
+    // And the other direction — signed in on another tab.
+    expect(
+      resolveAuthView({
+        isPending: false,
+        user: { name: "Real", image: null },
+        remembered: remembered(false),
+      }),
+    ).toEqual({ mode: "authed", name: "Real", image: null });
+  });
+});
+
+describe("useRememberedAuth in a component", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let renders: Array<RememberedAuth | null>;
+
+  function Harness() {
+    const value = useRememberedAuth();
+    renders.push(value);
+    const view = resolveAuthView({
+      isPending: true,
+      user: null,
+      remembered: value,
+    });
+    if (view.mode === "unknown") return <span>skeleton</span>;
+    return <span>{`${view.mode}:${view.name ?? ""}`}</span>;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    renders = [];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders the remembered identity instead of the skeleton", () => {
+    writeAuthedFlag(true, IDENTITY);
+    act(() => root.render(<Harness />));
+
+    // Hydration safety: nothing was read from localStorage during the first
+    // render, so the server markup and the first client render match.
+    expect(renders[0]).toBeNull();
+    expect(renders.at(-1)).toEqual({ authed: true, identity: IDENTITY });
+    expect(container.textContent).toBe("authed:Zara Brown");
+  });
+
+  it("renders the signed-out shape for a remembered anonymous visitor", () => {
+    writeAuthedFlag(false);
+    act(() => root.render(<Harness />));
+    expect(container.textContent).toBe("anonymous:");
+  });
+
+  it("keeps the skeleton when nothing is remembered", () => {
+    act(() => root.render(<Harness />));
+    expect(renders).toEqual([null]);
+    expect(container.textContent).toBe("skeleton");
+  });
+});

--- a/__tests__/lib/auth-remembered-shape.test.tsx
+++ b/__tests__/lib/auth-remembered-shape.test.tsx
@@ -64,6 +64,27 @@ describe("auth-broadcast remembered state", () => {
     expect(readAuthedIdentity()).toBeNull();
   });
 
+  it("clears the previous identity when the replacement write throws", () => {
+    writeAuthedFlag(true, IDENTITY);
+    const original = Storage.prototype.setItem;
+    const spy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(function (this: Storage, key: string, value: string) {
+        if (key === "familiarise.auth_identity") {
+          throw new Error("QuotaExceededError");
+        }
+        original.call(this, key, value);
+      });
+    try {
+      writeAuthedFlag(true, { name: "Someone Else", image: null });
+    } finally {
+      spy.mockRestore();
+    }
+    // A failed write must not leave the previous account's identity behind.
+    expect(readAuthedIdentity()).toBeNull();
+    expect(readAuthedFlag()).toBe(false);
+  });
+
   it("tolerates a corrupt or partial identity payload", () => {
     localStorage.setItem("familiarise.auth_authed", "true");
     localStorage.setItem("familiarise.auth_identity", "{not json");

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -44,6 +44,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { useCurrency, SUPPORTED_CURRENCIES } from "@/hooks/useCurrency";
+import { resolveAuthView, useRememberedAuth } from "@/hooks/useRememberedAuth";
 import { hasDarkHero, isChromeHidden } from "@/lib/navigation/public-chrome";
 import { useAnnouncementBar } from "@/providers/AnnouncementBarProvider";
 import familiariseLogoTransparent from "@/public/avif/static/assets/logos/images/logos/Familiarise-logos_transparent.avif";
@@ -517,10 +518,19 @@ function DesktopNavItem({
 const Navbar = () => {
   const router = useRouter();
   const pathname = usePathname();
-  // The root layout is static (#932), so the session hydrates client-side here.
-  // While it resolves, `isPending` drives a neutral auth-area placeholder so a
-  // logged-in user doesn't flash the signed-out CTA on first paint.
+  // The root layout is static (#932), so the session hydrates client-side here,
+  // which makes the whole gap between FCP and this bar settling the /api/auth
+  // round trip itself. `useRememberedAuth` fills that gap with the last resolved
+  // shape (adopted before paint, never during render — hydration must match) and
+  // the real session overwrites it the moment it lands.
   const { data: session, isPending } = useSession();
+  const remembered = useRememberedAuth();
+  const authView = resolveAuthView({
+    isPending,
+    user: session?.user,
+    remembered,
+  });
+  const isAuthedView = authView.mode === "authed";
   const [isOpen, setIsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const { currency, symbol, setCurrency } = useCurrency();
@@ -563,8 +573,8 @@ const Navbar = () => {
   };
 
   const getUserImage = () => {
-    return session?.user?.image && session.user.image !== ""
-      ? session.user.image
+    return authView.image && authView.image !== ""
+      ? authView.image
       : defaultUserImage;
   };
 
@@ -608,7 +618,7 @@ const Navbar = () => {
 
             {/* Desktop Navigation */}
             <div className="hidden lg:flex items-center gap-0.5">
-              {session?.user && (
+              {isAuthedView && (
                 <Link href="/dashboard">
                   <Button
                     variant="ghost"
@@ -671,18 +681,18 @@ const Navbar = () => {
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              {isPending ? (
+              {authView.mode === "unknown" ? (
                 <div className="flex items-center gap-3">
                   <Skeleton className="h-9 w-9 rounded-full" />
                   <Skeleton className="h-9 w-28 rounded-md" />
                 </div>
-              ) : session?.user ? (
+              ) : isAuthedView ? (
                 <div className="flex items-center gap-3">
                   <Link href="/profile">
                     <Avatar className="h-9 w-9 border-2 border-zinc-200 hover:border-zinc-400 transition-colors cursor-pointer">
                       <AvatarImage src={getUserImage()} alt="Profile" />
                       <AvatarFallback className="bg-zinc-900 text-white text-sm">
-                        {session.user.name?.charAt(0) ?? "U"}
+                        {authView.name?.charAt(0) ?? "U"}
                       </AvatarFallback>
                     </Avatar>
                   </Link>
@@ -766,7 +776,7 @@ const Navbar = () => {
                 className="flex flex-col p-5 overflow-y-auto"
                 style={{ maxHeight: "calc(100% - 10rem)" }}
               >
-                {session?.user && (
+                {isAuthedView && (
                   <Link
                     href="/dashboard"
                     className="flex items-center gap-3 px-4 py-3 rounded-xl text-white hover:bg-zinc-800 transition-colors mb-1"
@@ -887,22 +897,22 @@ const Navbar = () => {
 
               {/* User Section */}
               <div className="absolute bottom-0 left-0 right-0 p-5 border-t border-zinc-800 bg-zinc-900 safe-bottom">
-                {isPending ? (
+                {authView.mode === "unknown" ? (
                   <div className="flex items-center gap-3">
                     <Skeleton className="h-10 w-10 rounded-full" />
                     <Skeleton className="h-4 w-32 rounded" />
                   </div>
-                ) : session?.user ? (
+                ) : isAuthedView ? (
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                       <Avatar className="h-10 w-10 border border-zinc-700">
                         <AvatarImage src={getUserImage()} alt="Profile" />
                         <AvatarFallback className="bg-zinc-800 text-white">
-                          {session.user.name?.charAt(0) ?? "U"}
+                          {authView.name?.charAt(0) ?? "U"}
                         </AvatarFallback>
                       </Avatar>
                       <span className="text-white font-medium text-sm truncate max-w-[140px]">
-                        {session.user.name}
+                        {authView.name}
                       </span>
                     </div>
                     <Button

--- a/hooks/useRememberedAuth.ts
+++ b/hooks/useRememberedAuth.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useState } from "react";
+import {
+  readAuthedFlag,
+  readAuthedIdentity,
+  type AuthIdentity,
+} from "@/lib/auth-broadcast";
+
+/**
+ * `useLayoutEffect` warns when React renders on the server; `useEffect` never
+ * runs there at all, so it is the correct no-op stand-in. Standard isomorphic
+ * pattern — this is the only copy in the repo, keep it that way.
+ */
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export type RememberedAuth = { authed: boolean; identity: AuthIdentity | null };
+
+/**
+ * The last resolved auth shape, read from localStorage AFTER commit but BEFORE
+ * paint, so the first painted frame can show "Sign in" or the user's avatar
+ * instead of a skeleton that lingers for the whole `/api/auth/get-session`
+ * round trip (measured warm on prod: ~350 ms logged out, ~1,000 ms logged in —
+ * the session fetch already dispatches within ±40 ms of FCP, so the delay IS
+ * the round trip and there is no earlier moment to dispatch from).
+ *
+ * Returns `null` on the server render and on the first client render, which is
+ * what keeps hydration byte-identical: reading localStorage during render would
+ * be a mismatch and React would discard the tree.
+ *
+ * PRESENTATION ONLY. This value is attacker-controlled (it is just
+ * localStorage) and may be stale for up to one round trip. Nothing may branch
+ * on it except which chrome to paint — `/dashboard` is gated in
+ * `middleware.ts` and again on the server.
+ */
+export function useRememberedAuth(): RememberedAuth | null {
+  const [remembered, setRemembered] = useState<RememberedAuth | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    const authed = readAuthedFlag();
+    // No flag = a genuinely unknown visitor (first ever visit, cleared storage,
+    // private mode). Keep the skeleton rather than guessing.
+    if (authed === null) return;
+    setRemembered({
+      authed,
+      identity: authed ? readAuthedIdentity() : null,
+    });
+  }, []);
+
+  return remembered;
+}
+
+export type AuthViewMode = "unknown" | "authed" | "anonymous";
+
+export interface AuthView {
+  mode: AuthViewMode;
+  name: string | null;
+  image: string | null;
+}
+
+/**
+ * Picks the auth chrome to render. Truth wins the moment the session resolves;
+ * until then the remembered shape stands in for it.
+ *
+ * Accepted risk: a returning user whose session expired server-side sees their
+ * avatar for up to ~1 s before it reverts to "Sign in". Cosmetic only — see the
+ * hook's contract above.
+ */
+export function resolveAuthView(input: {
+  isPending: boolean;
+  user: { name?: string | null; image?: string | null } | null | undefined;
+  remembered: RememberedAuth | null;
+}): AuthView {
+  const { isPending, user, remembered } = input;
+
+  if (!isPending) {
+    return user
+      ? { mode: "authed", name: user.name ?? null, image: user.image ?? null }
+      : { mode: "anonymous", name: null, image: null };
+  }
+  if (!remembered) return { mode: "unknown", name: null, image: null };
+  return remembered.authed
+    ? {
+        mode: "authed",
+        name: remembered.identity?.name ?? null,
+        image: remembered.identity?.image ?? null,
+      }
+    : { mode: "anonymous", name: null, image: null };
+}

--- a/lib/auth-broadcast.ts
+++ b/lib/auth-broadcast.ts
@@ -71,14 +71,24 @@ export function writeAuthedFlag(
 ): void {
   if (typeof window === "undefined") return;
   try {
+    // Clear before writing, never after: if the replacement write throws
+    // (quota, Safari private mode) a clear-last order would leave the PREVIOUS
+    // account's identity sitting next to a true flag, and the next pending
+    // session would paint their name and avatar.
+    localStorage.removeItem(AUTHED_IDENTITY_KEY);
     localStorage.setItem(AUTHED_FLAG_KEY, authed ? "true" : "false");
     if (authed && identity) {
       localStorage.setItem(AUTHED_IDENTITY_KEY, JSON.stringify(identity));
-    } else {
-      localStorage.removeItem(AUTHED_IDENTITY_KEY);
     }
   } catch {
-    // best-effort — ignore
+    // Best-effort, but the invariant is not optional. Fall back to the
+    // signed-out shape, which costs a skeleton frame and leaks nothing.
+    try {
+      localStorage.removeItem(AUTHED_IDENTITY_KEY);
+      localStorage.setItem(AUTHED_FLAG_KEY, "false");
+    } catch {
+      // Storage is unavailable outright, so nothing was ever cached.
+    }
   }
 }
 

--- a/lib/auth-broadcast.ts
+++ b/lib/auth-broadcast.ts
@@ -22,6 +22,14 @@ export type AuthSyncMessage = { type: "login" | "logout" };
 // no longer fires a synthetic broadcast that spams peer-tab refetches.
 const AUTHED_FLAG_KEY = "familiarise.auth_authed";
 
+// Display-only identity for the remembered shape, so the navbar can paint the
+// real avatar and name on the first frame instead of a silhouette. Deliberately
+// name + image ONLY: no id, no email, no role, no org. Nothing here may ever be
+// used as an authorization signal — see `hooks/useRememberedAuth.ts`.
+const AUTHED_IDENTITY_KEY = "familiarise.auth_identity";
+
+export type AuthIdentity = { name: string | null; image: string | null };
+
 export function readAuthedFlag(): boolean | null {
   if (typeof window === "undefined") return null;
   try {
@@ -32,13 +40,51 @@ export function readAuthedFlag(): boolean | null {
   }
 }
 
-export function writeAuthedFlag(authed: boolean): void {
+export function readAuthedIdentity(): AuthIdentity | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(AUTHED_IDENTITY_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const { name, image } = parsed as Partial<AuthIdentity>;
+    return {
+      name: typeof name === "string" ? name : null,
+      image: typeof image === "string" ? image : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Single choke point for the remembered auth state. Writing `false` ALWAYS
+ * removes the cached identity, so a shared or public device can never retain
+ * the previous user's name and avatar: the flag and the identity cannot
+ * disagree by construction. Every sign-out path in the app reaches this via the
+ * wrapped `signOut` in `lib/auth-client.ts`, and `AuthSyncProvider` calls it
+ * again on every resolved-null session.
+ */
+export function writeAuthedFlag(
+  authed: boolean,
+  identity?: AuthIdentity | null,
+): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(AUTHED_FLAG_KEY, authed ? "true" : "false");
+    if (authed && identity) {
+      localStorage.setItem(AUTHED_IDENTITY_KEY, JSON.stringify(identity));
+    } else {
+      localStorage.removeItem(AUTHED_IDENTITY_KEY);
+    }
   } catch {
     // best-effort — ignore
   }
+}
+
+/** Sign-out-facing alias; the clear is the point, so say so at the call site. */
+export function forgetAuthState(): void {
+  writeAuthedFlag(false);
 }
 
 export function postAuthSync(message: AuthSyncMessage): void {

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -2,6 +2,7 @@ import { createAuthClient } from "better-auth/react";
 import { customSessionClient } from "better-auth/client/plugins";
 import { ssoClient } from "@better-auth/sso/client";
 import type { auth } from "@/lib/auth";
+import { forgetAuthState } from "@/lib/auth-broadcast";
 
 export const authClient = createAuthClient({
   // Empty string would be a truthy-enough config that breaks URL resolution;
@@ -14,5 +15,24 @@ export const authClient = createAuthClient({
   plugins: [customSessionClient<typeof auth>(), ssoClient()],
 });
 
-export const { signIn, signUp, signOut, useSession, getSession, sendVerificationEmail } =
+export const { signIn, signUp, useSession, getSession, sendVerificationEmail } =
   authClient;
+
+/**
+ * `signOut` is wrapped so the navbar's remembered auth state (name + avatar in
+ * localStorage) can never outlive the session on a shared device. Every
+ * sign-out call site in the app imports this binding rather than
+ * `authClient.signOut`, so clearing here covers all of them — including the
+ * paths that hard-navigate away before any effect could run. Clearing before
+ * the request also fails safe: if the request errors the next resolved session
+ * simply rewrites the cache.
+ *
+ * Asserted rather than annotated because BetterAuth's `signOut` is generic in
+ * its fetch options; a spread wrapper erases that generic and the contextual
+ * annotation then fails to match. The runtime behaviour is a straight
+ * pass-through, so the assertion is the honest description.
+ */
+export const signOut = ((...args: Parameters<typeof authClient.signOut>) => {
+  forgetAuthState();
+  return authClient.signOut(...args);
+}) as typeof authClient.signOut;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -458,6 +458,58 @@ export const auth = betterAuth({
         sessionGeneration?: number | null;
       };
 
+      // SSO enforcement: mark sessions that bypassed SSO for enforced
+      // domains. Read-time defense-in-depth; the primary gate is in
+      // `databaseHooks.session.create.before` (above). Keeping a single
+      // enforcement path via the shared `lookupEnforcedOrg` helper
+      // means credential-signin and read-time reconciliation can't
+      // disagree on who counts as "enforced" — historically this was
+      // issue #673.
+      //
+      // An account satisfies enforcement only if `account.providerId`
+      // matches one of the `ssoProvider.providerId` rows registered
+      // for the enforcing org. Checking against `providerId != "credential"`
+      // is NOT enough — that would treat a personal Google or GitHub
+      // OAuth account as a valid SSO sign-in, bypassing the policy.
+      //
+      // Started here rather than awaited at its old position further down: it
+      // needs only `user.email` / `user.id`, reads a disjoint set of tables
+      // (OrgDomainClaim, OrganizationSSOSettings, SsoProvider, Account) and
+      // writes nothing, so it shares no data with the reads below and only ever
+      // cost sequencing. Overlapping it takes a whole cross-region wave
+      // (Netlify ap-southeast-1 -> Supabase ap-south-1) off EVERY authenticated
+      // request. It resolves rather than rejects — the try/catch is inside — so
+      // an early throw below can never surface as an unhandled rejection.
+      const ssoEnforcementFailedPromise: Promise<boolean> = (async () => {
+        try {
+          const email = user.email;
+          const domain = email?.split("@")[1]?.toLowerCase();
+          if (!domain) return false;
+          const enforced = await lookupEnforcedOrg(prisma, domain);
+          // `lookupEnforcedOrg` returns null when enforcement doesn't
+          // apply (unverified claim, inactive org, allowlist mismatch,
+          // enforceSSO=false). It also returns an empty
+          // `registeredProviderIds` array when the org has flipped
+          // enforceSSO on but hasn't added a provider yet — fail-open
+          // there, matching `shouldRejectSession`'s behaviour, so a
+          // half-configured org doesn't flag every session as failed.
+          if (!enforced || enforced.registeredProviderIds.length === 0) {
+            return false;
+          }
+          const linkedViaSSO = await prisma.account.findFirst({
+            where: {
+              userId: user.id,
+              providerId: { in: enforced.registeredProviderIds },
+            },
+            select: { id: true },
+          });
+          return !linkedViaSSO;
+        } catch {
+          // non-fatal — don't break session
+          return false;
+        }
+      })();
+
       // Read the user's current session-generation marker + the
       // profile FKs we'll need below for any bareMembers JIT auto-join.
       //
@@ -577,33 +629,41 @@ export const auth = betterAuth({
       }
 
       // Load active org memberships so OrgSwitcher + checkout can render
-      // without an extra roundtrip.
-      const memberships = await prisma.membership.findMany({
-        where: { status: "ACTIVE", userId: user.id },
-        select: {
-          role: true,
-          organizationId: true,
-          departmentLabel: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              slug: true,
-              brandingProfile: { select: { logo: true } },
-              status: true,
-              canSponsor: true,
-              canHost: true,
-              billingAccount: {
-                select: {
-                  id: true,
-                  fundingSource: true,
-                  walletBalance: true,
+      // without an extra roundtrip. This one genuinely depends on the JIT
+      // auto-join above — that loop CREATES the rows it reads — so it stays
+      // sequential. Only the SSO check, which shares no data with it, folds
+      // into the same wave.
+      const [memberships, ssoEnforcementFailed] = await Promise.all([
+        prisma.membership.findMany({
+          where: { status: "ACTIVE", userId: user.id },
+          select: {
+            role: true,
+            organizationId: true,
+            departmentLabel: true,
+            organization: {
+              select: {
+                id: true,
+                name: true,
+                slug: true,
+                brandingProfile: { select: { logo: true } },
+                status: true,
+                canSponsor: true,
+                canHost: true,
+                billingAccount: {
+                  select: {
+                    id: true,
+                    fundingSource: true,
+                    walletBalance: true,
+                  },
                 },
               },
             },
           },
-        },
-      });
+        }),
+        // Rejects only if `membership.findMany` does; the SSO promise always
+        // resolves, so `Promise.all`'s fail-fast cannot change error semantics.
+        ssoEnforcementFailedPromise,
+      ]);
 
       // Shape returned on every session. The session is hot — every
       // authenticated request reads it — so we keep the payload flat
@@ -627,47 +687,6 @@ export const auth = betterAuth({
           fundingSource: m.organization.billingAccount?.fundingSource ?? null,
           walletBalance: m.organization.billingAccount?.walletBalance ?? null,
         }));
-
-      // SSO enforcement: mark sessions that bypassed SSO for enforced
-      // domains. Read-time defense-in-depth; the primary gate is in
-      // `databaseHooks.session.create.before` (above). Keeping a single
-      // enforcement path via the shared `lookupEnforcedOrg` helper
-      // means credential-signin and read-time reconciliation can't
-      // disagree on who counts as "enforced" — historically this was
-      // issue #673.
-      //
-      // An account satisfies enforcement only if `account.providerId`
-      // matches one of the `ssoProvider.providerId` rows registered
-      // for the enforcing org. Checking against `providerId != "credential"`
-      // is NOT enough — that would treat a personal Google or GitHub
-      // OAuth account as a valid SSO sign-in, bypassing the policy.
-      let ssoEnforcementFailed = false;
-      try {
-        const email = user.email;
-        const domain = email?.split("@")[1]?.toLowerCase();
-        if (domain) {
-          const enforced = await lookupEnforcedOrg(prisma, domain);
-          // `lookupEnforcedOrg` returns null when enforcement doesn't
-          // apply (unverified claim, inactive org, allowlist mismatch,
-          // enforceSSO=false). It also returns an empty
-          // `registeredProviderIds` array when the org has flipped
-          // enforceSSO on but hasn't added a provider yet — fail-open
-          // there, matching `shouldRejectSession`'s behaviour, so a
-          // half-configured org doesn't flag every session as failed.
-          if (enforced && enforced.registeredProviderIds.length > 0) {
-            const linkedViaSSO = await prisma.account.findFirst({
-              where: {
-                userId: user.id,
-                providerId: { in: enforced.registeredProviderIds },
-              },
-              select: { id: true },
-            });
-            if (!linkedViaSSO) ssoEnforcementFailed = true;
-          }
-        }
-      } catch {
-        // non-fatal — don't break session
-      }
 
       return {
         user: {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -458,58 +458,6 @@ export const auth = betterAuth({
         sessionGeneration?: number | null;
       };
 
-      // SSO enforcement: mark sessions that bypassed SSO for enforced
-      // domains. Read-time defense-in-depth; the primary gate is in
-      // `databaseHooks.session.create.before` (above). Keeping a single
-      // enforcement path via the shared `lookupEnforcedOrg` helper
-      // means credential-signin and read-time reconciliation can't
-      // disagree on who counts as "enforced" — historically this was
-      // issue #673.
-      //
-      // An account satisfies enforcement only if `account.providerId`
-      // matches one of the `ssoProvider.providerId` rows registered
-      // for the enforcing org. Checking against `providerId != "credential"`
-      // is NOT enough — that would treat a personal Google or GitHub
-      // OAuth account as a valid SSO sign-in, bypassing the policy.
-      //
-      // Started here rather than awaited at its old position further down: it
-      // needs only `user.email` / `user.id`, reads a disjoint set of tables
-      // (OrgDomainClaim, OrganizationSSOSettings, SsoProvider, Account) and
-      // writes nothing, so it shares no data with the reads below and only ever
-      // cost sequencing. Overlapping it takes a whole cross-region wave
-      // (Netlify ap-southeast-1 -> Supabase ap-south-1) off EVERY authenticated
-      // request. It resolves rather than rejects — the try/catch is inside — so
-      // an early throw below can never surface as an unhandled rejection.
-      const ssoEnforcementFailedPromise: Promise<boolean> = (async () => {
-        try {
-          const email = user.email;
-          const domain = email?.split("@")[1]?.toLowerCase();
-          if (!domain) return false;
-          const enforced = await lookupEnforcedOrg(prisma, domain);
-          // `lookupEnforcedOrg` returns null when enforcement doesn't
-          // apply (unverified claim, inactive org, allowlist mismatch,
-          // enforceSSO=false). It also returns an empty
-          // `registeredProviderIds` array when the org has flipped
-          // enforceSSO on but hasn't added a provider yet — fail-open
-          // there, matching `shouldRejectSession`'s behaviour, so a
-          // half-configured org doesn't flag every session as failed.
-          if (!enforced || enforced.registeredProviderIds.length === 0) {
-            return false;
-          }
-          const linkedViaSSO = await prisma.account.findFirst({
-            where: {
-              userId: user.id,
-              providerId: { in: enforced.registeredProviderIds },
-            },
-            select: { id: true },
-          });
-          return !linkedViaSSO;
-        } catch {
-          // non-fatal — don't break session
-          return false;
-        }
-      })();
-
       // Read the user's current session-generation marker + the
       // profile FKs we'll need below for any bareMembers JIT auto-join.
       //
@@ -629,41 +577,33 @@ export const auth = betterAuth({
       }
 
       // Load active org memberships so OrgSwitcher + checkout can render
-      // without an extra roundtrip. This one genuinely depends on the JIT
-      // auto-join above — that loop CREATES the rows it reads — so it stays
-      // sequential. Only the SSO check, which shares no data with it, folds
-      // into the same wave.
-      const [memberships, ssoEnforcementFailed] = await Promise.all([
-        prisma.membership.findMany({
-          where: { status: "ACTIVE", userId: user.id },
-          select: {
-            role: true,
-            organizationId: true,
-            departmentLabel: true,
-            organization: {
-              select: {
-                id: true,
-                name: true,
-                slug: true,
-                brandingProfile: { select: { logo: true } },
-                status: true,
-                canSponsor: true,
-                canHost: true,
-                billingAccount: {
-                  select: {
-                    id: true,
-                    fundingSource: true,
-                    walletBalance: true,
-                  },
+      // without an extra roundtrip.
+      const memberships = await prisma.membership.findMany({
+        where: { status: "ACTIVE", userId: user.id },
+        select: {
+          role: true,
+          organizationId: true,
+          departmentLabel: true,
+          organization: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+              brandingProfile: { select: { logo: true } },
+              status: true,
+              canSponsor: true,
+              canHost: true,
+              billingAccount: {
+                select: {
+                  id: true,
+                  fundingSource: true,
+                  walletBalance: true,
                 },
               },
             },
           },
-        }),
-        // Rejects only if `membership.findMany` does; the SSO promise always
-        // resolves, so `Promise.all`'s fail-fast cannot change error semantics.
-        ssoEnforcementFailedPromise,
-      ]);
+        },
+      });
 
       // Shape returned on every session. The session is hot — every
       // authenticated request reads it — so we keep the payload flat
@@ -687,6 +627,47 @@ export const auth = betterAuth({
           fundingSource: m.organization.billingAccount?.fundingSource ?? null,
           walletBalance: m.organization.billingAccount?.walletBalance ?? null,
         }));
+
+      // SSO enforcement: mark sessions that bypassed SSO for enforced
+      // domains. Read-time defense-in-depth; the primary gate is in
+      // `databaseHooks.session.create.before` (above). Keeping a single
+      // enforcement path via the shared `lookupEnforcedOrg` helper
+      // means credential-signin and read-time reconciliation can't
+      // disagree on who counts as "enforced" — historically this was
+      // issue #673.
+      //
+      // An account satisfies enforcement only if `account.providerId`
+      // matches one of the `ssoProvider.providerId` rows registered
+      // for the enforcing org. Checking against `providerId != "credential"`
+      // is NOT enough — that would treat a personal Google or GitHub
+      // OAuth account as a valid SSO sign-in, bypassing the policy.
+      let ssoEnforcementFailed = false;
+      try {
+        const email = user.email;
+        const domain = email?.split("@")[1]?.toLowerCase();
+        if (domain) {
+          const enforced = await lookupEnforcedOrg(prisma, domain);
+          // `lookupEnforcedOrg` returns null when enforcement doesn't
+          // apply (unverified claim, inactive org, allowlist mismatch,
+          // enforceSSO=false). It also returns an empty
+          // `registeredProviderIds` array when the org has flipped
+          // enforceSSO on but hasn't added a provider yet — fail-open
+          // there, matching `shouldRejectSession`'s behaviour, so a
+          // half-configured org doesn't flag every session as failed.
+          if (enforced && enforced.registeredProviderIds.length > 0) {
+            const linkedViaSSO = await prisma.account.findFirst({
+              where: {
+                userId: user.id,
+                providerId: { in: enforced.registeredProviderIds },
+              },
+              select: { id: true },
+            });
+            if (!linkedViaSSO) ssoEnforcementFailed = true;
+          }
+        }
+      } catch {
+        // non-fatal — don't break session
+      }
 
       return {
         user: {

--- a/providers/AuthSyncProvider.tsx
+++ b/providers/AuthSyncProvider.tsx
@@ -50,7 +50,18 @@ export default function AuthSyncProvider() {
       postAuthSync({ type: authed ? "login" : "logout" });
     }
     previousAuthedRef.current = authed;
-    writeAuthedFlag(authed);
+    // Also the reconciliation point for the navbar's optimistic first paint:
+    // a resolved session rewrites the remembered shape in BOTH directions, and
+    // `writeAuthedFlag(false)` drops the cached identity outright.
+    writeAuthedFlag(
+      authed,
+      authed
+        ? {
+            name: session?.user?.name ?? null,
+            image: session?.user?.image ?? null,
+          }
+        : null,
+    );
   }, [isPending, session]);
 
   return null;


### PR DESCRIPTION
The navbar rendered a skeleton for the entire `/api/auth/get-session` round trip. This makes the first painted frame show the real thing instead.

A second change (parallelising two reads in `customSession`) was written, measured, found to move nothing, and reverted inside this PR. That finding is written up below and in #1117.

## What was measured first

On prod, warm, the gap between FCP and the avatar / sign-out appearing was about 350 ms logged out and about 1,000 ms logged in. The session fetch fires within plus or minus 40 ms of FCP every time, so hydration is not the bottleneck: the client dispatches as early as it can and the whole visible delay is the round trip.

`GET /api/auth/get-session` costs about 556 ms logged out, statistically identical to a 404 doing no work, because Better Auth returns null before invoking the `customSession` callback. There is no server work to cut for anonymous visitors, so the only lever left is not waiting for the answer.

## The change

`lib/auth-broadcast.ts` already maintained a `familiarise.auth_authed` flag in localStorage for cross-tab sync, written by `AuthSyncProvider` on every resolved session. The last known shape was already on disk and simply unused. It now also carries a display-only identity: `name` and `image`, nothing else.

The new `hooks/useRememberedAuth.ts` reads both in a layout effect, which runs after commit but before paint, so the first painted frame shows "Sign in" or the real avatar rather than a placeholder. The server render and the first client render both still return the skeleton, so hydration is byte-identical; nothing is read from storage during render. `resolveAuthView` is a pure function, which makes the branch selection directly testable, and the hook returning `null` on its first render is asserted rather than assumed.

### Privacy

Caching a display name and avatar URL means a shared or public device could retain the previous user's identity. Three things prevent that:

- `writeAuthedFlag(false)` always removes the cached identity, so the flag and the identity cannot disagree.
- The identity is cleared *before* the replacement write, and again in the `catch`. Clearing last would have left the previous account's identity next to a `true` flag if the write threw on quota or in Safari private mode. Thanks to CodeRabbit for catching this; the regression test is mutation-checked and fails against the old ordering.
- `signOut` is wrapped in `lib/auth-client.ts` to clear before delegating. Every sign-out call site in the app imports that binding rather than `authClient.signOut`, verified by grep across `app`, `components`, `lib` and `providers`, so this covers the paths that hard-navigate away before any effect could run.

Only `name` and `image` are cached. No id, no email, no role, no organisation. The flag is presentation only: `/dashboard` is gated in `middleware.ts` and again on the server, and nothing branches on it except which chrome to paint.

### Accepted risk

A returning user whose session expired sees their avatar for up to about one second before it reverts to "Sign in". This is cosmetic, and it was observed directly during verification (see below).

## Measured result

Deploy preview against the `dev` branch deploy, same page, function warmed, desktop viewport. The gap is FCP to the auth affordance being present in the DOM.

| | before (`dev`) | after (preview) |
|---|---|---|
| Logged out, returning visitor | 426 ms, 543 ms | **-19 ms, +31 ms** |
| Logged-in shape, returning visitor | about 1.1 s (derived) | **+45 ms** |
| CLS | 0.0017 | 0.0017 |
| Hydration warnings | none | none |

A negative gap means the navbar was already correct in the frame that fired FCP. The two console errors on the preview are the Netlify deploy-preview toolbar (a 403 and a report-only CSP frame violation), not the app.

The logged-in "before" is derived rather than directly observed: `BETTER_AUTH_TRUSTED_ORIGINS` is `https://familiarisenow.com` in every Netlify context, so a browser cannot sign in on a preview host. It follows from two measurements that were taken: authenticated `get-session` on `dev` is 1,142 ms median, and the logged-out gap tracks the round trip almost exactly (557 ms round trip, 426 to 543 ms observed gap).

The logged-in "after" was measured by seeding localStorage with exactly what `AuthSyncProvider` writes for that user, which is the returning-visitor state by construction. That run also verified the rest of the contract end to end: the cached GitHub avatar URL was used in the first painted frame, the real session resolved null at 1,355 ms and the navbar reverted to "Sign in", and both the flag and the identity were cleared from localStorage afterwards.

## The reverted change, and why

`customSession`'s SSO enforcement check shares no data with `membership.findMany` and ran last only by code order, so it was hoisted and joined with `Promise.all`. Twenty order-balanced interleaved rounds with a real session:

| | median | mean | p90 |
|---|---|---|---|
| `dev` | 1,142 ms | 1,149 ms | 1,241 ms |
| preview | 1,176 ms | 1,181 ms | 1,246 ms |

No improvement. Anonymous `get-session` was identical on both deployments (557 ms versus 558 ms), which rules out a deployment-level offset.

The mechanism is `PG_POOL_MAX=1`, set on production, deploy-preview and branch-deploy. `lib/prisma.ts` passes it straight to `pg.Pool` as `max`, so a function instance holds exactly one client and two concurrent Prisma queries serialise on it. `Promise.all` over Prisma reads cannot win anything on Netlify as configured. Filed as #1117, because it invalidates a whole class of optimisation this campaign would otherwise keep reaching for.

## What this deliberately does not do

No session read was added to a shared server layout. `app/layout.tsx` carries an explicit comment explaining why it does not, and doing so would pin every route beneath it dynamic and silently undo the ISR merged in #1110. The Better Auth cookie cache is untouched and no guard was weakened.

## Verification

`tsc --noEmit` clean on a cold run, `eslint` clean including warnings, `prettier --check` clean on every touched file, and the full Jest suite green at 229 suites / 2575 tests. New tests cover the flag and identity helpers, the failed-write clear, the sign-out clear, branch resolution in both directions, and a component-level assertion that the optimistic branch renders the remembered shape while the first render still returns `null`.

Paint ordering is a browser guarantee and is not unit-tested; the preview measurement above is the evidence for it.

Part of #636
